### PR TITLE
Fix for building for Carthage/Release in Xcode 8 GM Seed

### DIFF
--- a/Mixpanel/InAppNotification.swift
+++ b/Mixpanel/InAppNotification.swift
@@ -14,15 +14,17 @@ struct InAppNotification {
     let type: String
     let style: String
     let imageURL: URL
-    lazy var image: Data? = {
-        var data: Data?
-        do {
-            data = try Data(contentsOf: self.imageURL, options: [.mappedIfSafe])
-        } catch {
-            Logger.error(message: "image failed to load from url \(self.imageURL)")
+    var image: Data? {
+        get {
+            var data: Data?
+            do {
+                data = try Data(contentsOf: self.imageURL, options: [.mappedIfSafe])
+            } catch {
+                Logger.error(message: "image failed to load from url \(self.imageURL)")
+            }
+            return data
         }
-        return data
-    }()
+    }
     let title: String
     let body: String
     let callToAction: String
@@ -115,7 +117,6 @@ extension InAppNotification {
                   type: type,
                   style: style,
                   imageURL: imageURLParsed,
-                  image: nil,
                   title: title,
                   body: body,
                   callToAction: callToAction,

--- a/Mixpanel/InAppNotifications.swift
+++ b/Mixpanel/InAppNotifications.swift
@@ -29,7 +29,7 @@ class InAppNotifications: NotificationViewControllerDelegate {
     var delegate: InAppNotificationsDelegate?
 
     func showNotification( _ notification: InAppNotification) {
-        var notification = notification
+        let notification = notification
         if notification.image != nil {
             DispatchQueue.main.async {
                 if self.currentlyShowingNotification != nil {


### PR DESCRIPTION
Carthage integration fails since it uses the Release configuration, causing the error below with the latest Xcode 8 GM Seed. 

Running this command: 
`carthage build --no-skip-current` within this repo, or simply:
`xcodebuild -scheme Mixpanel  build -configuration Release` causes the following error.  

```
/Users/timrobles/mastermind/mixpanel-swift/Mixpanel/InAppNotification.swift:113:9: error: ambiguous reference to member 'init(JSONObject:)'
        self.init(ID: ID,
        ^~~~
/Users/timrobles/mastermind/mixpanel-swift/Mixpanel/InAppNotification.swift:50:5: note: found this candidate
    init?(JSONObject: [String: Any]?) {
    ^
/Users/timrobles/mastermind/mixpanel-swift/Mixpanel/InAppNotification.swift:11:8: note: found this candidate
struct InAppNotification {
       ^

** BUILD FAILED **
```
