### PR TITLE
Support having a different server url for each MixpanelInstance

### DIFF
--- a/Mixpanel/Decide.swift
+++ b/Mixpanel/Decide.swift
@@ -25,7 +25,7 @@ struct DecideResponse {
 
 class Decide {
 
-    var decideRequest = DecideRequest()
+    let decideRequest: DecideRequest
     var decideFetched = false
     var notificationsInstance = InAppNotifications()
     var codelessInstance = Codeless()
@@ -43,6 +43,10 @@ class Decide {
     var enableVisualEditorForCodeless = true
 
     let switchboardURL = "wss://switchboard.mixpanel.com"
+
+    required init(basePathIdentifier: String) {
+        self.decideRequest = DecideRequest(basePathIdentifier: basePathIdentifier)
+    }
 
     func checkDecide(forceFetch: Bool = false,
                      distinctId: String,

--- a/Mixpanel/DecideRequest.swift
+++ b/Mixpanel/DecideRequest.swift
@@ -64,17 +64,15 @@ class DecideRequest: Network {
                                              headers: ["Accept-Encoding": "gzip"],
                                              parse: responseParser)
 
-        decideRequestHandler(BasePath.MixpanelAPI,
-                             resource: resource,
+        decideRequestHandler(resource: resource,
                              completion: { result in
                                 completion(result)
         })
     }
 
-    private func decideRequestHandler(_ base: String,
-                                      resource: Resource<DecideResult>,
+    private func decideRequestHandler(resource: Resource<DecideResult>,
                                       completion: @escaping (DecideResult?) -> Void) {
-        Network.apiRequest(base: base, resource: resource,
+        Network.apiRequest(base: BasePath.getServerURL(identifier: basePathIdentifier), resource: resource,
             failure: { (reason, data, response) in
                 Logger.warn(message: "API request to \(resource.path) has failed with reason \(reason)")
                 completion(nil)

--- a/Mixpanel/Flush.swift
+++ b/Mixpanel/Flush.swift
@@ -20,7 +20,7 @@ class Flush: AppLifecycle {
     var timer: Timer?
     var delegate: FlushDelegate?
     var useIPAddressForGeoLocation = true
-    var flushRequest = FlushRequest()
+    var flushRequest: FlushRequest
     var flushOnBackground = true
     var _flushInterval = 0.0
     var flushInterval: Double {
@@ -38,6 +38,10 @@ class Flush: AppLifecycle {
 
             return _flushInterval
         }
+    }
+
+    required init(basePathIdentifier: String) {
+        self.flushRequest = FlushRequest(basePathIdentifier: basePathIdentifier)
     }
 
     func flushEventsQueue(_ eventsQueue: inout Queue) {

--- a/Mixpanel/FlushRequest.swift
+++ b/Mixpanel/FlushRequest.swift
@@ -40,7 +40,7 @@ class FlushRequest: Network {
                                              headers: ["Accept-Encoding": "gzip"],
                                              parse: responseParser)
 
-        flushRequestHandler(BasePath.MixpanelAPI,
+        flushRequestHandler(BasePath.getServerURL(identifier: basePathIdentifier),
                             resource: resource,
                             completion: { success in
                                 completion(success)

--- a/Mixpanel/Mixpanel.swift
+++ b/Mixpanel/Mixpanel.swift
@@ -106,7 +106,8 @@ class MixpanelManager {
                     instanceName: String) -> MixpanelInstance {
         let instance = MixpanelInstance(apiToken: apiToken,
                                         launchOptions: launchOptions,
-                                        flushInterval: flushInterval)
+                                        flushInterval: flushInterval,
+                                        name: instanceName)
         mainInstance = instance
         instances[instanceName] = instance
 

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -201,7 +201,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate {
     let trackInstance: Track
     let decideInstance: Decide
 
-    init(apiToken: String?, launchOptions: [UIApplicationLaunchOptionsKey : Any]?, flushInterval: Double, name: String=UUID().uuidString) {
+    init(apiToken: String?, launchOptions: [UIApplicationLaunchOptionsKey : Any]?, flushInterval: Double, name: String) {
         if let apiToken = apiToken, !apiToken.isEmpty {
             self.apiToken = apiToken
         }
@@ -608,7 +608,7 @@ extension MixpanelInstance {
         let defaultsKey = "trackedKey"
         if !UserDefaults.standard.bool(forKey: defaultsKey) {
             serialQueue.async() {
-                Network.trackIntegration(apiToken: self.apiToken, serverURL: self.serverURL) {
+                Network.trackIntegration(apiToken: self.apiToken, serverURL: BasePath.DefaultMixpanelAPI) {
                     (success) in
                     if success {
                         UserDefaults.standard.set(true, forKey: defaultsKey)

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -608,7 +608,7 @@ extension MixpanelInstance {
         let defaultsKey = "trackedKey"
         if !UserDefaults.standard.bool(forKey: defaultsKey) {
             serialQueue.async() {
-                Network.trackIntegration(apiToken: self.apiToken, serverURL: BasePath.DefaultMixpanelAPI) {
+                Network.trackIntegration(apiToken: self.apiToken, serverURL: self.serverURL) {
                     (success) in
                     if success {
                         UserDefaults.standard.set(true, forKey: defaultsKey)


### PR DESCRIPTION
As master stands right now, all `MixpanelInstance` objects will use the last `serverURL` that was set on any of them.

This PR initializes `MixpanelInstance` objects with a `name` property.

* `MixpanelManager` will initialize them with the `instanceName` argument.
* The `MixpanelInstance` initializer has a default value for `name` of `UUID.uuidString()` so as not to break existing code that may bypass `MixpanelManager`.