### PR TITLE
Ported identify safety check from js lib

### DIFF
--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -42,7 +42,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate {
     open var distinctId = ""
 
     /// alias string that uniquely identifies the current user.
-    open var alias = ""
+    open var alias: String? = nil
 
     /// Accessor to the Mixpanel People API object.
     open var people: People!

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -41,7 +41,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate {
     /// distinctId string that uniquely identifies the current user.
     open var distinctId = ""
     
-    /// distinctId string that uniquely identifies the current user.
+    /// alias string that uniquely identifies the current user.
     open var alias = ""
 
     /// Accessor to the Mixpanel People API object.

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -524,13 +524,13 @@ extension MixpanelInstance {
         }
         
         if alias != distinctId {
-            let properties = ["distinct_id": distinctId, "alias": alias]
-            track(event: "$create_alias", properties: properties)
-            flush()
             serialQueue.async() {
                 self.alias = alias
                 self.archiveProperties()
             }
+            let properties = ["distinct_id": distinctId, "alias": alias]
+            track(event: "$create_alias", properties: properties)
+            flush()
         } else {
             Logger.error(message: "alias: \(alias) matches distinctId: \(distinctId) - skipping api call.")
         }

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -579,6 +579,7 @@ extension MixpanelInstance {
         let properties = ArchivedProperties(superProperties: superProperties,
                                             timedEvents: timedEvents,
                                             distinctId: distinctId,
+                                            alias: alias,
                                             peopleDistinctId: people.distinctId,
                                             peopleUnidentifiedQueue: people.unidentifiedQueue,
                                             shownNotifications: decideInstance.notificationsInstance.shownNotifications)
@@ -596,6 +597,7 @@ extension MixpanelInstance {
          superProperties,
          timedEvents,
          distinctId,
+         alias,
          people.distinctId,
          people.unidentifiedQueue,
          decideInstance.notificationsInstance.shownNotifications,

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -525,8 +525,7 @@ extension MixpanelInstance {
         
         if alias != distinctId {
             let properties = ["distinct_id": distinctId, "alias": alias]
-            track(event: "$create_alias",
-                  properties: properties)
+            track(event: "$create_alias", properties: properties)
             flush()
             serialQueue.async() {
                 self.alias = alias

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -43,7 +43,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate {
     
     /// alias string that uniquely identifies the current user.
     open var alias = ""
-
+    
     /// Accessor to the Mixpanel People API object.
     open var people: People!
 
@@ -534,8 +534,6 @@ extension MixpanelInstance {
         } else {
             Logger.error(message: "alias matches distinctId - skipping api call.")
         }
-
-        
     }
 
     /**

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -40,10 +40,10 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate {
 
     /// distinctId string that uniquely identifies the current user.
     open var distinctId = ""
-    
+
     /// alias string that uniquely identifies the current user.
     open var alias = ""
-    
+
     /// Accessor to the Mixpanel People API object.
     open var people: People!
 

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -482,7 +482,7 @@ extension MixpanelInstance {
             }
             if !self.people.unidentifiedQueue.isEmpty {
                 for var r in self.people.unidentifiedQueue {
-                    r["$distinct_id"] = distinctId
+                    r["$distinct_id"] = self.distinctId
                     self.people.peopleQueue.append(r)
                 }
                 self.people.unidentifiedQueue.removeAll()
@@ -522,17 +522,18 @@ extension MixpanelInstance {
             Logger.error(message: "\(self) create alias called with empty alias")
             return
         }
+        
         if alias != distinctId {
-            self.alias = alias
             let properties = ["distinct_id": distinctId, "alias": alias]
             track(event: "$create_alias",
                   properties: properties)
+            flush()
             serialQueue.async() {
+                self.alias = alias
                 self.archiveProperties()
             }
-            flush()
         } else {
-            Logger.error(message: "alias matches distinctId - skipping api call.")
+            Logger.error(message: "alias: \(alias) matches distinctId: \(distinctId) - skipping api call.")
         }
     }
 

--- a/Mixpanel/Persistence.swift
+++ b/Mixpanel/Persistence.swift
@@ -164,7 +164,13 @@ class Persistence {
         return data as? Queue ?? []
     }
 
-    class private func unarchiveProperties(token: String) -> (InternalProperties, InternalProperties, String, String?, String?, Queue, Set<Int>) {
+    class private func unarchiveProperties(token: String) -> (InternalProperties,
+                                                              InternalProperties,
+                                                              String,
+                                                              String?,
+                                                              String?,
+                                                              Queue,
+                                                              Set<Int>) {
         let properties = unarchiveWithType(.properties, token: token) as? InternalProperties
         let superProperties =
             properties?["superProperties"] as? InternalProperties ?? InternalProperties()

--- a/Mixpanel/Persistence.swift
+++ b/Mixpanel/Persistence.swift
@@ -72,6 +72,7 @@ class Persistence {
     class func archiveProperties(_ properties: ArchivedProperties, token: String) {
         var p = InternalProperties()
         p["distinctId"] = properties.distinctId
+        p["alias"] = properties.alias
         p["superProperties"] = properties.superProperties
         p["peopleDistinctId"] = properties.peopleDistinctId
         p["peopleUnidentifiedQueue"] = properties.peopleUnidentifiedQueue

--- a/Mixpanel/Persistence.swift
+++ b/Mixpanel/Persistence.swift
@@ -12,6 +12,7 @@ struct ArchivedProperties {
     let superProperties: InternalProperties
     let timedEvents: InternalProperties
     let distinctId: String
+    let alias: String?
     let peopleDistinctId: String?
     let peopleUnidentifiedQueue: Queue
     let shownNotifications: Set<Int>
@@ -107,6 +108,7 @@ class Persistence {
                                             superProperties: InternalProperties,
                                             timedEvents: InternalProperties,
                                             distinctId: String,
+                                            alias: String?,
                                             peopleDistinctId: String?,
                                             peopleUnidentifiedQueue: Queue,
                                             shownNotifications: Set<Int>,
@@ -121,6 +123,7 @@ class Persistence {
         let (superProperties,
             timedEvents,
             distinctId,
+            alias,
             peopleDistinctId,
             peopleUnidentifiedQueue,
             shownNotifications) = unarchiveProperties(token: token)
@@ -130,6 +133,7 @@ class Persistence {
                 superProperties,
                 timedEvents,
                 distinctId,
+                alias,
                 peopleDistinctId,
                 peopleUnidentifiedQueue,
                 shownNotifications,
@@ -168,6 +172,8 @@ class Persistence {
             properties?["timedEvents"] as? InternalProperties ?? InternalProperties()
         let distinctId =
             properties?["distinctId"] as? String ?? ""
+        let alias =
+            properties?["alias"] as? String ?? nil
         let peopleDistinctId =
             properties?["peopleDistinctId"] as? String ?? nil
         let peopleUnidentifiedQueue =
@@ -178,6 +184,7 @@ class Persistence {
         return (superProperties,
                 timedEvents,
                 distinctId,
+                alias,
                 peopleDistinctId,
                 peopleUnidentifiedQueue,
                 shownNotifications)

--- a/Mixpanel/Persistence.swift
+++ b/Mixpanel/Persistence.swift
@@ -164,7 +164,7 @@ class Persistence {
         return data as? Queue ?? []
     }
 
-    class private func unarchiveProperties(token: String) -> (InternalProperties, InternalProperties, String, String?, Queue, Set<Int>) {
+    class private func unarchiveProperties(token: String) -> (InternalProperties, InternalProperties, String, String?, String?, Queue, Set<Int>) {
         let properties = unarchiveWithType(.properties, token: token) as? InternalProperties
         let superProperties =
             properties?["superProperties"] as? InternalProperties ?? InternalProperties()


### PR DESCRIPTION
Added safety check so that identify only changes the distinct_id if the given distinct_id is different from both the existing distinct_id and the alias. Required the creation of an alias property.

For reference: https://github.com/mixpanel/mixpanel-js/blob/master/src/mixpanel-core.js#L1339-L1343