### PR TITLE
Resolves issue #63

### DIFF
--- a/Mixpanel/AutomaticProperties.swift
+++ b/Mixpanel/AutomaticProperties.swift
@@ -24,6 +24,8 @@ class AutomaticProperties {
         if let infoDict = infoDict {
             p["$app_build_number"]     = infoDict["CFBundleVersion"]
             p["$app_version_string"]   = infoDict["CFBundleShortVersionString"]
+            p["$app_version"]          = infoDict["CFBundleVersion"]
+            p["$app_release"]          = infoDict["CFBundleShortVersionString"]
         }
         #if os(iOS)
             p["$carrier"] = AutomaticProperties.telephonyInfo.subscriberCellularProvider?.carrierName


### PR DESCRIPTION
This will resolve issue #63, populating the $app_version and $app_release variables as should be done per these instructions:
https://mixpanel.com/help/questions/articles/what-properties-do-mixpanels-libraries-store-by-default
