### PR TITLE
Clear up `pod` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For iOS, tvOS, and macOS integrations:
 
 `pod 'Mixpanel-swift'`
 
-For App Extension integrations:
+For App Extension integrations (you may need both the above *and* this):
 
 `pod 'Mixpanel-swift-appex'`
 


### PR DESCRIPTION
If you want Mixpanel in both your app *and* your app-extension, you need both pods specified in the correct targets in your `Podfile`.