### PR TITLE
Cast campaign_id and message_id to ints

### DIFF
--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -862,8 +862,8 @@ extension MixpanelInstance {
         if let mpPayload = userInfo["mp"] as? InternalProperties {
             if let m = mpPayload["m"], let c = mpPayload["c"] {
                 var properties = Properties()
-                properties["campaign_id"]  = c as? String
-                properties["message_id"]   = m as? String
+                properties["campaign_id"]  = c as? Int
+                properties["message_id"]   = m as? Int
                 properties["message_type"] = "push"
                 track(event: event,
                       properties: properties)


### PR DESCRIPTION
`mpPayload["m"]` and `mpPayload["c"]` are ints. To avoid indavertently evaluating `c` and `m` to `nil` we cast to Int instead. This is consistent with our [Obj-C SDK](https://github.com/mixpanel/mixpanel-iphone/blob/master/Mixpanel/Mixpanel.m#L412-L414).