### PR TITLE
Update unit tests for push notification open tracking

### DIFF
--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -862,8 +862,8 @@ extension MixpanelInstance {
         if let mpPayload = userInfo["mp"] as? InternalProperties {
             if let m = mpPayload["m"], let c = mpPayload["c"] {
                 var properties = Properties()
-                properties["campaign_id"]  = c as? String
-                properties["message_id"]   = m as? String
+                properties["campaign_id"]  = c as? Int
+                properties["message_id"]   = m as? Int
                 properties["message_type"] = "push"
                 track(event: event,
                       properties: properties)

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
@@ -335,8 +335,8 @@ class MixpanelDemoTests: MixpanelBaseTests {
         var e: InternalProperties = mixpanel.eventsQueue.last!
         XCTAssertEqual(e["event"] as? String, "$app_open", "incorrect event name")
         var p: InternalProperties = e["properties"] as! InternalProperties
-        XCTAssertEqual(p["campaign_id"] as? Int, "the_campaign_id", "campaign_id not equal")
-        XCTAssertEqual(p["message_id"] as? Int, "the_message_id", "message_id not equal")
+        XCTAssertEqual(p["campaign_id"] as? Int, 54321, "campaign_id not equal")
+        XCTAssertEqual(p["message_id"] as? Int, 12345, "message_id not equal")
         XCTAssertEqual(p["message_type"] as? String, "push", "type does not equal inapp")
     }
 
@@ -346,8 +346,8 @@ class MixpanelDemoTests: MixpanelBaseTests {
         var e: InternalProperties = mixpanel.eventsQueue.last!
         XCTAssertEqual(e["event"] as? String, "$campaign_received", "incorrect event name")
         var p: InternalProperties = e["properties"] as! InternalProperties
-        XCTAssertEqual(p["campaign_id"] as? Int, "the_campaign_id", "campaign_id not equal")
-        XCTAssertEqual(p["message_id"] as? Int, "the_message_id", "message_id not equal")
+        XCTAssertEqual(p["campaign_id"] as? Int, 56789, "campaign_id not equal")
+        XCTAssertEqual(p["message_id"] as? Int, 98765, "message_id not equal")
         XCTAssertEqual(p["message_type"] as? String, "push", "type does not equal inapp")
     }
 

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
@@ -327,7 +327,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
 
     func testTrackLaunchOptions() {
         let launchOptions: [UIApplicationLaunchOptionsKey: Any] = [UIApplicationLaunchOptionsKey.remoteNotification: ["mp":
-            ["m": "the_message_id", "c": "the_campaign_id"]]]
+            ["m": 12345, "c": 54321]]]
         mixpanel = Mixpanel.initialize(token: kTestToken,
                                        launchOptions: launchOptions,
                                        flushInterval: 60)
@@ -335,25 +335,25 @@ class MixpanelDemoTests: MixpanelBaseTests {
         var e: InternalProperties = mixpanel.eventsQueue.last!
         XCTAssertEqual(e["event"] as? String, "$app_open", "incorrect event name")
         var p: InternalProperties = e["properties"] as! InternalProperties
-        XCTAssertEqual(p["campaign_id"] as? String, "the_campaign_id", "campaign_id not equal")
-        XCTAssertEqual(p["message_id"] as? String, "the_message_id", "message_id not equal")
+        XCTAssertEqual(p["campaign_id"] as? Int, "the_campaign_id", "campaign_id not equal")
+        XCTAssertEqual(p["message_id"] as? Int, "the_message_id", "message_id not equal")
         XCTAssertEqual(p["message_type"] as? String, "push", "type does not equal inapp")
     }
 
     func testTrackPushNotification() {
-        mixpanel.trackPushNotification(["mp": ["m": "the_message_id", "c": "the_campaign_id"]])
+        mixpanel.trackPushNotification(["mp": ["m": 98765, "c": 56789]])
         waitForSerialQueue()
         var e: InternalProperties = mixpanel.eventsQueue.last!
         XCTAssertEqual(e["event"] as? String, "$campaign_received", "incorrect event name")
         var p: InternalProperties = e["properties"] as! InternalProperties
-        XCTAssertEqual(p["campaign_id"] as? String, "the_campaign_id", "campaign_id not equal")
-        XCTAssertEqual(p["message_id"] as? String, "the_message_id", "message_id not equal")
+        XCTAssertEqual(p["campaign_id"] as? Int, "the_campaign_id", "campaign_id not equal")
+        XCTAssertEqual(p["message_id"] as? Int, "the_message_id", "message_id not equal")
         XCTAssertEqual(p["message_type"] as? String, "push", "type does not equal inapp")
     }
 
     func testTrackPushNotificationMalformed() {
         mixpanel.trackPushNotification(["mp":
-            ["m": "the_message_id", "cid": "the_campaign_id"]])
+            ["m": 11111, "cid": 22222]])
         waitForSerialQueue()
         XCTAssertTrue(mixpanel.eventsQueue.isEmpty,
                       "Invalid push notification was incorrectly queued.")


### PR DESCRIPTION
Updating unit tests to reflect ints in remote notification payload for campaign_id and message_id keys.
cc: @yarneo 