### PR TITLE
Allow tracking journey_id in push open 

### DIFF
--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -896,6 +896,11 @@ extension MixpanelInstance {
         if let mpPayload = userInfo["mp"] as? InternalProperties {
             if let m = mpPayload["m"], let c = mpPayload["c"] {
                 var properties = Properties()
+                for (key, value) in mpPayload {
+                    if key != "m" && key != "c" {
+                        properties[key] = value
+                    }
+                }
                 properties["campaign_id"]  = c as? Int
                 properties["message_id"]   = m as? Int
                 properties["message_type"] = "push"

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -898,9 +898,10 @@ extension MixpanelInstance {
                 var properties = Properties()
                 for (key, value) in mpPayload {
                     if key != "m" && key != "c" {
-                        if let typedValue = value as? MixpanelType {
-                            properties[key] = typedValue;
-                        }
+                        // Check Int first, since a number in the push payload is parsed as __NCSFNumber
+                        // which fails to convert to MixpanelType.
+                        if let typedValue = value as? Int { properties[key] = typedValue }
+                        if let typedValue = value as? MixpanelType { properties[key] = typedValue }
                     }
                 }
                 properties["campaign_id"]  = c as? Int

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -898,7 +898,9 @@ extension MixpanelInstance {
                 var properties = Properties()
                 for (key, value) in mpPayload {
                     if key != "m" && key != "c" {
-                        properties[key] = value
+                        if let typedValue = value as? MixpanelType {
+                            properties[key] = typedValue;
+                        }
                     }
                 }
                 properties["campaign_id"]  = c as? Int

--- a/Mixpanel/MixpanelType.swift
+++ b/Mixpanel/MixpanelType.swift
@@ -31,6 +31,13 @@ extension Int: MixpanelType {
      */
     public func isValidNestedType() -> Bool { return true }
 }
+extension NSNumber: MixpanelType {
+    /**
+     Checks if this object has nested object types that Mixpanel supports.
+     Will always return true.
+     */
+    public func isValidNestedType() -> Bool { return true }
+}
 extension UInt: MixpanelType {
     /**
      Checks if this object has nested object types that Mixpanel supports.

--- a/Mixpanel/MixpanelType.swift
+++ b/Mixpanel/MixpanelType.swift
@@ -31,13 +31,6 @@ extension Int: MixpanelType {
      */
     public func isValidNestedType() -> Bool { return true }
 }
-extension NSNumber: MixpanelType {
-    /**
-     Checks if this object has nested object types that Mixpanel supports.
-     Will always return true.
-     */
-    public func isValidNestedType() -> Bool { return true }
-}
 extension UInt: MixpanelType {
     /**
      Checks if this object has nested object types that Mixpanel supports.

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
@@ -326,7 +326,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
     }
 
     func testTrackLaunchOptions() {
-        let nsJourneyId: NSNumber = 1;
+        let nsJourneyId: NSNumber = 1
         let launchOptions: [UIApplicationLaunchOptionsKey: Any] = [UIApplicationLaunchOptionsKey.remoteNotification: ["mp":
             ["m": 12345, "c": 54321, "journey_id": nsJourneyId, "additional_param": "abcd"]]]
         mixpanel = Mixpanel.initialize(token: kTestToken,
@@ -344,7 +344,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
     }
 
     func testTrackPushNotification() {
-        let nsJourneyId: NSNumber = 1;
+        let nsJourneyId: NSNumber = 1
         mixpanel.trackPushNotification(["mp": ["m": 98765, "c": 56789, "journey_id": nsJourneyId, "additional_param": "abcd"]])
         waitForSerialQueue()
         var e: InternalProperties = mixpanel.eventsQueue.last!

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
@@ -326,8 +326,9 @@ class MixpanelDemoTests: MixpanelBaseTests {
     }
 
     func testTrackLaunchOptions() {
+        let nsJourneyId: NSNumber = 1;
         let launchOptions: [UIApplicationLaunchOptionsKey: Any] = [UIApplicationLaunchOptionsKey.remoteNotification: ["mp":
-            ["m": 12345, "c": 54321, "journey_id": 1]]]
+            ["m": 12345, "c": 54321, "journey_id": nsJourneyId, "additional_param": "abcd"]]]
         mixpanel = Mixpanel.initialize(token: kTestToken,
                                        launchOptions: launchOptions,
                                        flushInterval: 60)
@@ -338,17 +339,21 @@ class MixpanelDemoTests: MixpanelBaseTests {
         XCTAssertEqual(p["campaign_id"] as? Int, 54321, "campaign_id not equal")
         XCTAssertEqual(p["message_id"] as? Int, 12345, "message_id not equal")
         XCTAssertEqual(p["journey_id"] as? Int, 1, "journey_id not equal")
+        XCTAssertEqual(p["additional_param"] as? String, "abcd", "additional_param not equal")
         XCTAssertEqual(p["message_type"] as? String, "push", "type does not equal inapp")
     }
 
     func testTrackPushNotification() {
-        mixpanel.trackPushNotification(["mp": ["m": 98765, "c": 56789]])
+        let nsJourneyId: NSNumber = 1;
+        mixpanel.trackPushNotification(["mp": ["m": 98765, "c": 56789, "journey_id": nsJourneyId, "additional_param": "abcd"]])
         waitForSerialQueue()
         var e: InternalProperties = mixpanel.eventsQueue.last!
         XCTAssertEqual(e["event"] as? String, "$campaign_received", "incorrect event name")
         var p: InternalProperties = e["properties"] as! InternalProperties
         XCTAssertEqual(p["campaign_id"] as? Int, 56789, "campaign_id not equal")
         XCTAssertEqual(p["message_id"] as? Int, 98765, "message_id not equal")
+        XCTAssertEqual(p["journey_id"] as? Int, 1, "journey_id not equal")
+        XCTAssertEqual(p["additional_param"] as? String, "abcd", "additional_param not equal")
         XCTAssertEqual(p["message_type"] as? String, "push", "type does not equal inapp")
     }
 

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
@@ -327,7 +327,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
 
     func testTrackLaunchOptions() {
         let launchOptions: [UIApplicationLaunchOptionsKey: Any] = [UIApplicationLaunchOptionsKey.remoteNotification: ["mp":
-            ["m": 12345, "c": 54321]]]
+            ["m": 12345, "c": 54321, "journey_id": 1]]]
         mixpanel = Mixpanel.initialize(token: kTestToken,
                                        launchOptions: launchOptions,
                                        flushInterval: 60)
@@ -337,6 +337,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
         var p: InternalProperties = e["properties"] as! InternalProperties
         XCTAssertEqual(p["campaign_id"] as? Int, 54321, "campaign_id not equal")
         XCTAssertEqual(p["message_id"] as? Int, 12345, "message_id not equal")
+        XCTAssertEqual(p["journey_id"] as? Int, 1, "journey_id not equal")
         XCTAssertEqual(p["message_type"] as? String, "push", "type does not equal inapp")
     }
 


### PR DESCRIPTION
### Current Format
#### Push payload
```
{
	‘mp’: {
                 ‘c’: $campaign_id,
 	         ‘m’: $message_id,
        }
}
```
 
#### Track call
```
{
	event: $campaign_received,
  	properties: {
		‘campaign_id': $campaign_id,
		‘message_id’: $message_id
	}
}
```
 
### New Format
#### Push payload
```
{
	‘mp’: {
                ‘c’: $campaign_id,
 	        ‘m’: $message_id,
		‘additional_params_1’: $param1,
	        ‘additional_params_2’: $param2,
        }
}
```
 
### Track call
```
{
	event: $campaign_received,
  	properties: {
		‘campaign_id': $campaign_id,
		‘message_id’: $message_id,
		‘additional_params_1’: $param1,
		‘additional_params_2’: $param2,
	}
}
```