### PR TITLE
properties for $campaign_open for the cta url and if the button was p…

### DIFF
--- a/Mixpanel/BaseNotificationViewController.swift
+++ b/Mixpanel/BaseNotificationViewController.swift
@@ -10,7 +10,10 @@ import UIKit
 
 protocol NotificationViewControllerDelegate {
     @discardableResult
-    func notificationShouldDismiss(controller: BaseNotificationViewController, callToActionURL: URL?) -> Bool
+    func notificationShouldDismiss(controller: BaseNotificationViewController,
+                                   callToActionURL: URL?,
+                                   shouldTrack: Bool,
+                                   additionalTrackingProperties: Properties?) -> Bool
 }
 
 class BaseNotificationViewController: UIViewController {

--- a/Mixpanel/InAppNotifications.swift
+++ b/Mixpanel/InAppNotifications.swift
@@ -11,7 +11,7 @@ import UIKit
 
 protocol InAppNotificationsDelegate {
     func notificationDidShow(_ notification: InAppNotification)
-    func notificationDidCTA(_ notification: InAppNotification, event: String)
+    func trackNotification(_ notification: InAppNotification, event: String, properties: Properties?)
 }
 
 enum InAppType: String {
@@ -66,7 +66,10 @@ class InAppNotifications: NotificationViewControllerDelegate {
         miniNotificationVC.show(animated: true)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + miniNotificationPresentationTime) {
-            self.notificationShouldDismiss(controller: miniNotificationVC, callToActionURL: nil)
+            self.notificationShouldDismiss(controller: miniNotificationVC,
+                                           callToActionURL: nil,
+                                           shouldTrack: false,
+                                           additionalTrackingProperties: nil)
         }
         return true
     }
@@ -79,12 +82,25 @@ class InAppNotifications: NotificationViewControllerDelegate {
     }
 
     @discardableResult
-    func notificationShouldDismiss(controller: BaseNotificationViewController, callToActionURL: URL?) -> Bool {
+    func notificationShouldDismiss(controller: BaseNotificationViewController,
+                                   callToActionURL: URL?,
+                                   shouldTrack: Bool,
+                                   additionalTrackingProperties: Properties?) -> Bool {
         if currentlyShowingNotification?.ID != controller.notification.ID {
             return false
         }
 
         let completionBlock = {
+            if shouldTrack {
+                var properties = additionalTrackingProperties
+                if let urlString = callToActionURL?.absoluteString {
+                    if properties == nil {
+                        properties = [:]
+                    }
+                    properties!["url"] = urlString
+                }
+                self.delegate?.trackNotification(controller.notification, event: "$campaign_open", properties: properties)
+            }
             self.currentlyShowingNotification = nil
         }
 
@@ -92,7 +108,6 @@ class InAppNotifications: NotificationViewControllerDelegate {
             controller.hide(animated: true) {
                 Logger.info(message: "opening CTA URL: \(callToActionURL)")
                 MixpanelInstance.sharedUIApplication()?.performSelector(onMainThread: NSSelectorFromString("openURL:"), with: callToActionURL, waitUntilDone: true)
-                self.delegate?.notificationDidCTA(controller.notification, event: "$campaign_open")
                 completionBlock()
             }
         } else {

--- a/Mixpanel/MiniNotificationViewController.swift
+++ b/Mixpanel/MiniNotificationViewController.swift
@@ -102,7 +102,10 @@ class MiniNotificationViewController: BaseNotificationViewController {
 
     func didTap(gesture: UITapGestureRecognizer) {
         if !isDismissing && gesture.state == UIGestureRecognizerState.ended {
-            delegate?.notificationShouldDismiss(controller: self, callToActionURL: miniNotification.callToActionURL)
+            delegate?.notificationShouldDismiss(controller: self,
+                                                callToActionURL: miniNotification.callToActionURL,
+                                                shouldTrack: true,
+                                                additionalTrackingProperties: nil)
         }
     }
 
@@ -118,7 +121,10 @@ class MiniNotificationViewController: BaseNotificationViewController {
                 window.layer.position = CGPoint(x: window.layer.position.x, y: position.y)
             case UIGestureRecognizerState.ended, UIGestureRecognizerState.cancelled:
                 if window.layer.position.y > position.y + (InAppNotificationsConstants.miniInAppHeight / 2) {
-                    delegate?.notificationShouldDismiss(controller: self, callToActionURL: miniNotification.callToActionURL)
+                    delegate?.notificationShouldDismiss(controller: self,
+                                                        callToActionURL: miniNotification.callToActionURL,
+                                                        shouldTrack: false,
+                                                        additionalTrackingProperties: nil)
                 } else {
                     UIView.animate(withDuration: 0.2, animations: {
                         window.layer.position = self.position

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -1262,19 +1262,20 @@ extension MixpanelInstance: InAppNotificationsDelegate {
                             "type": "inapp",
                             "time": Date()]]
         people.append(properties: properties)
-        trackNotification(notification, event: "$campaign_delivery")
+        trackNotification(notification, event: "$campaign_delivery", properties: nil)
     }
 
-    func notificationDidCTA(_ notification: InAppNotification, event: String) {
-        trackNotification(notification, event: event)
-    }
-
-    func trackNotification(_ notification: InAppNotification, event: String) {
-        let properties: Properties = ["campaign_id": notification.ID,
-                                      "message_id": notification.messageID,
-                                      "message_type": "inapp",
-                                      "message_subtype": notification.type]
-        track(event: event, properties: properties)
+    func trackNotification(_ notification: InAppNotification, event: String, properties: Properties?) {
+        var notificationProperties: Properties = ["campaign_id": notification.ID,
+                                                  "message_id": notification.messageID,
+                                                  "message_type": "inapp",
+                                                  "message_subtype": notification.type]
+        if let properties = properties {
+            for (k, v) in properties {
+                notificationProperties[k] = v
+            }
+        }
+        track(event: event, properties: notificationProperties)
     }
 }
 #endif // DECIDE

--- a/Mixpanel/TakeoverNotificationViewController.swift
+++ b/Mixpanel/TakeoverNotificationViewController.swift
@@ -172,12 +172,22 @@ class TakeoverNotificationViewController: BaseNotificationViewController {
     }
 
     func buttonTapped(_ sender: AnyObject) {
-        delegate?.notificationShouldDismiss(controller: self, callToActionURL: takeoverNotification.buttons[sender.tag].callToActionURL)
+        var whichButton = "primary"
+        if self.takeoverNotification.buttons.count == 2 {
+            whichButton = sender.tag == 0 ? "secondary" : "primary"
+        }
+        delegate?.notificationShouldDismiss(controller: self,
+                                            callToActionURL: takeoverNotification.buttons[sender.tag].callToActionURL,
+                                            shouldTrack: true,
+                                            additionalTrackingProperties: ["button": whichButton])
     }
 
 
     @IBAction func tappedClose(_ sender: AnyObject) {
-        delegate?.notificationShouldDismiss(controller: self, callToActionURL: nil)
+        delegate?.notificationShouldDismiss(controller: self,
+                                            callToActionURL: nil,
+                                            shouldTrack: false,
+                                            additionalTrackingProperties: nil)
     }
 
     override var shouldAutorotate: Bool {


### PR DESCRIPTION
…rimary or secondary. also now always track $campaign_open if they tap on either button or mini, instead of only if there was a cta url