### PR TITLE
Swift 4 migration

### DIFF
--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -636,7 +636,7 @@
 						CreatedOnToolsVersion = 7.3.1;
 						DevelopmentTeam = E8FVX7QLET;
 						DevelopmentTeamName = "Mixpanel, Inc.";
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 0900;
 					};
 					E12782B21D4AB4B30025FB05 = {
 						CreatedOnToolsVersion = 8.0;
@@ -971,7 +971,8 @@
 				SWIFT_INCLUDE_PATHS = "${SRCROOT}";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				USER_HEADER_SEARCH_PATHS = "";
 			};
 			name = Debug;
@@ -999,7 +1000,8 @@
 				SWIFT_INCLUDE_PATHS = "${SRCROOT}";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				USER_HEADER_SEARCH_PATHS = "";
 			};
 			name = Release;

--- a/Mixpanel/AutomaticEvents.swift
+++ b/Mixpanel/AutomaticEvents.swift
@@ -245,7 +245,7 @@ extension UNUserNotificationCenter {
 }
 
 extension UIResponder {
-    func application(_ application: UIApplication, newDidReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Swift.Void) {
+    @objc func application(_ application: UIApplication, newDidReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Swift.Void) {
         let originalSelector = NSSelectorFromString("application:didReceiveRemoteNotification:fetchCompletionHandler:")
         if let originalMethod = class_getInstanceMethod(type(of: self), originalSelector),
             let swizzle = Swizzler.swizzles[originalMethod] {
@@ -259,7 +259,7 @@ extension UIResponder {
         }
     }
 
-    func application(_ application: UIApplication, newDidReceiveRemoteNotification userInfo: [AnyHashable : Any]) {
+    @objc func application(_ application: UIApplication, newDidReceiveRemoteNotification userInfo: [AnyHashable : Any]) {
         let originalSelector = NSSelectorFromString("application:didReceiveRemoteNotification:")
         if let originalMethod = class_getInstanceMethod(type(of: self), originalSelector),
             let swizzle = Swizzler.swizzles[originalMethod] {
@@ -276,7 +276,7 @@ extension UIResponder {
 
 @available(iOS 10.0, *)
 extension NSObject {
-    func userNotificationCenter(_ center: UNUserNotificationCenter, newDidReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+    @objc func userNotificationCenter(_ center: UNUserNotificationCenter, newDidReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         let originalSelector = NSSelectorFromString("userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:")
         if let originalMethod = class_getInstanceMethod(type(of: self), originalSelector),
             let swizzle = Swizzler.swizzles[originalMethod] {

--- a/Mixpanel/Clip.swift
+++ b/Mixpanel/Clip.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-internal func clip<U: SignedNumber>(_ value: U, _ minimum: U?, _ maximum: U?) -> U {
+internal func clip<U: SignedNumeric & Comparable>(_ value: U, _ minimum: U?, _ maximum: U?) -> U {
 	var result = value
 
 	if let minimum = minimum {

--- a/Mixpanel/MD5.swift
+++ b/Mixpanel/MD5.swift
@@ -253,9 +253,9 @@ extension Collection where Self.Iterator.Element == UInt8, Self.Index == Int {
         return result
     }
 
-    func toInteger<T: Integer>() -> T where T: ByteConvertible, T: BitshiftOperationsType {
+    func toInteger<T: BinaryInteger>() -> T where T: ByteConvertible, T: BitshiftOperationsType {
         if self.isEmpty {
-            return 0
+            return 0 as T
         }
 
         var bytes = self.reversed() //FIXME: check it this is equivalent of Array(...)
@@ -270,7 +270,7 @@ extension Collection where Self.Iterator.Element == UInt8, Self.Index == Int {
             return T(truncatingBitPattern: UInt64(bytes[0]))
         }
 
-        var result: T = 0
+        var result: T = 0 as T
         for byte in bytes.reversed() {
             result = result << 8 | T(byte)
         }

--- a/Mixpanel/MiniNotificationViewController.swift
+++ b/Mixpanel/MiniNotificationViewController.swift
@@ -100,7 +100,7 @@ class MiniNotificationViewController: BaseNotificationViewController {
         }
     }
 
-    func didTap(gesture: UITapGestureRecognizer) {
+    @objc func didTap(gesture: UITapGestureRecognizer) {
         if !isDismissing && gesture.state == UIGestureRecognizerState.ended {
             delegate?.notificationShouldDismiss(controller: self,
                                                 callToActionURL: miniNotification.callToActionURL,
@@ -109,7 +109,7 @@ class MiniNotificationViewController: BaseNotificationViewController {
         }
     }
 
-    func didPan(gesture: UIPanGestureRecognizer) {
+    @objc func didPan(gesture: UIPanGestureRecognizer) {
         if canPan, let window = window {
             switch gesture.state {
             case UIGestureRecognizerState.began:

--- a/Mixpanel/NSAttributedStringToNSDictionary.swift
+++ b/Mixpanel/NSAttributedStringToNSDictionary.swift
@@ -26,7 +26,7 @@ import UIKit
         do {
             let data = try attributedString.data(from: NSRange(location: 0,
                                                                length: attributedString.length),
-                                                 documentAttributes: [NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType])
+                                                 documentAttributes: [NSAttributedString.DocumentAttributeKey.documentType: NSAttributedString.DocumentType.html])
             if let dataString = String(data: data, encoding: String.Encoding.utf8) {
                 return ["mime_type": "text/html",
                         "data": dataString]
@@ -49,7 +49,7 @@ import UIKit
             if let data = dataString.data(using: String.Encoding.utf8) {
                 do {
                     return try NSAttributedString(data: data,
-                                                  options: [NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType],
+                                                  options: [.documentType: NSAttributedString.DocumentType.html],
                                                   documentAttributes: nil)
                 } catch {
                     Logger.debug(message: "Failed to convert HTML to NSAttributedString")

--- a/Mixpanel/ObjectSerializerConfig.swift
+++ b/Mixpanel/ObjectSerializerConfig.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 extension Bool {
-    init?<T: Integer>(_ integer: T?) {
+    init?<T: BinaryInteger>(_ integer: T?) {
         guard let integer = integer else {
             return nil
         }

--- a/Mixpanel/Swizzle.swift
+++ b/Mixpanel/Swizzle.swift
@@ -52,9 +52,9 @@ class Swizzler {
                                                   _ param2: AnyObject?) -> Void)) {
 
         if let originalMethod = class_getInstanceMethod(aClass, originalSelector),
-            let swizzledMethod = class_getInstanceMethod(aClass, newSelector),
-            let swizzledMethodImplementation = method_getImplementation(swizzledMethod),
-            let originalMethodImplementation = method_getImplementation(originalMethod) {
+            let swizzledMethod = class_getInstanceMethod(aClass, newSelector) {
+            let swizzledMethodImplementation = method_getImplementation(swizzledMethod)
+            let originalMethodImplementation = method_getImplementation(originalMethod)
 
             var swizzle = getSwizzle(for: originalMethod)
             if swizzle == nil {
@@ -73,7 +73,7 @@ class Swizzler {
                                                swizzledMethodImplementation,
                                                method_getTypeEncoding(swizzledMethod))
             if didAddMethod {
-                setSwizzle(swizzle!, for: class_getInstanceMethod(aClass, originalSelector))
+                setSwizzle(swizzle!, for: class_getInstanceMethod(aClass, originalSelector)!)
             } else {
                 method_setImplementation(originalMethod, swizzledMethodImplementation)
             }

--- a/Mixpanel/TakeoverNotificationViewController.swift
+++ b/Mixpanel/TakeoverNotificationViewController.swift
@@ -171,7 +171,7 @@ class TakeoverNotificationViewController: BaseNotificationViewController {
         })
     }
 
-    func buttonTapped(_ sender: AnyObject) {
+    @objc func buttonTapped(_ sender: AnyObject) {
         var whichButton = "primary"
         if self.takeoverNotification.buttons.count == 2 {
             whichButton = sender.tag == 0 ? "secondary" : "primary"

--- a/Mixpanel/Tweak.swift
+++ b/Mixpanel/Tweak.swift
@@ -67,7 +67,7 @@ extension Tweak {
 	}
 }
 
-extension Tweak where T: SignedNumber {
+extension Tweak where T: SignedNumeric & Comparable {
     /**
      Creates a Tweak<T> where T: SignedNumberType
      You can optionally provide a min / max / stepSize to restrict the bounds and behavior of a tweak.

--- a/Mixpanel/TweakPersistency.swift
+++ b/Mixpanel/TweakPersistency.swift
@@ -32,7 +32,7 @@ internal final class TweakPersistency {
 		return persistedValueForTweakIdentifiable(AnyTweak(tweak: tweak)) as? T
 	}
 
-	internal func currentValueForTweak<T>(_ tweak: Tweak<T>) -> T? where T: SignedNumber {
+	internal func currentValueForTweak<T>(_ tweak: Tweak<T>) -> T? where T: SignedNumeric & Comparable {
 		if let currentValue = persistedValueForTweakIdentifiable(AnyTweak(tweak: tweak)) as? T {
 				// If the tweak can be clipped, then we'll need to clip it - because
 				// the tweak might've been persisted without a min / max, but then you changed the tweak definition.

--- a/Mixpanel/UIControlBinding.swift
+++ b/Mixpanel/UIControlBinding.swift
@@ -186,7 +186,7 @@ class UIControlBinding: CodelessBinding {
         return false
     }
 
-    func preVerify(sender: UIControl, event: UIEvent) {
+    @objc func preVerify(sender: UIControl, event: UIEvent) {
         if verifyControlMatchesPath(sender) {
             verified.add(sender)
         } else {
@@ -194,7 +194,7 @@ class UIControlBinding: CodelessBinding {
         }
     }
 
-    func execute(sender: UIControl, event: UIEvent) {
+    @objc func execute(sender: UIControl, event: UIEvent) {
         var shouldTrack = false
         if verifyEvent != UIControlEvents(rawValue: 0) && verifyEvent != controlEvent {
             shouldTrack = verified.contains(sender)

--- a/Mixpanel/UIViewSelectors.swift
+++ b/Mixpanel/UIViewSelectors.swift
@@ -108,9 +108,23 @@ extension UIView {
             for i in 0..<32 {
                 let j = 2*i
                 let k = 2*i + 1
-                let part1 = ((data32[j] & 0x80000000) >> 24) | ((data32[j] & 0x800000) >> 17) | ((data32[j] & 0x8000) >> 10)
-                let part2 = ((data32[j] & 0x80) >> 3) | ((data32[k] & 0x80000000) >> 28) | ((data32[k] & 0x800000) >> 21)
-                let part3 = ((data32[k] & 0x8000) >> 14) | ((data32[k] & 0x80) >> 7)
+                let part1: UInt32 = {
+                    let subpart1 = (data32[j] & 0x80000000) >> 24
+                    let subpart2 = (data32[j] & 0x800000) >> 17
+                    let subpart3 = (data32[j] & 0x8000) >> 10
+                    return subpart1 | subpart2 | subpart3
+                }()
+                let part2: UInt32 = {
+                    let subpart1 = (data32[j] & 0x80) >> 3
+                    let subpart2 = (data32[k] & 0x80000000) >> 28
+                    let subpart3 = (data32[k] & 0x800000) >> 21
+                    return subpart1 | subpart2 | subpart3
+                }()
+                let part3: UInt32 = {
+                    let subpart1 = (data32[k] & 0x8000) >> 14
+                    let subpart2 = (data32[k] & 0x80) >> 7
+                    return subpart1 | subpart2
+                }()
                 data4[i] = UInt8(part1 | part2 | part3)
             }
             let arr = Array(UnsafeBufferPointer(start: data4, count: 32))

--- a/Mixpanel/VariantAction.swift
+++ b/Mixpanel/VariantAction.swift
@@ -241,8 +241,8 @@ class VariantAction: NSObject, NSCoding {
         for object in objects {
             var retValue: AnyObject? = nil
             let method: Method!
-            if object is AnyClass {
-                method = class_getClassMethod(object as! AnyClass, selector)
+            if let classObject = object as? AnyClass {
+                method = class_getClassMethod(classObject, selector)
             } else {
                 method = class_getInstanceMethod(type(of: object), selector)
             }
@@ -385,7 +385,7 @@ class VariantAction: NSObject, NSCoding {
     }
 
     static func transformValue(_ value: AnyObject, to type: String) -> NSObject? {
-        if let classType = NSClassFromString(type), type(of: value) == classType {
+        if let classType = NSClassFromString(type), Swift.type(of: value) == classType {
             return ValueTransformer(forName: NSValueTransformerName(rawValue: "IdentityTransformer"))?.transformedValue(value) as? NSObject
         }
 


### PR DESCRIPTION
This PR is a naïve migration to Swift 4. I did the following:
- Automatic Swift 4 migration using @objc inference
- Use `SignedNumeric & Comparable` instead of `SignedNumber`
- The return of `method_getImplementation` is now `IMP` (non-Optional)
- [Force unwrap `class_getInstanceMethod(aClass, originalSelector)`](https://github.com/mixpanel/mixpanel-swift/compare/master...fpg1503:master#diff-1b0e72597ae916cee81cc2c0db9a9016L76) - I don't like this but it seems to be the best alternative -- thoughts?
- Break [these expressions](https://github.com/mixpanel/mixpanel-swift/compare/master...fpg1503:master#diff-095cae2f7c8661880e6909dab634fe3dL111) into smaller expressions that the compiler can handle (it was having trouble understanding them).
- Use [conditional cast instead of type check + force cast](https://github.com/mixpanel/mixpanel-swift/compare/master...fpg1503:master#diff-1ccd97e1344422a46dba131f9bb7f67eL244) - was there any reason for not conditionally casting before? The code seems more idiomatic now.

