### PR TITLE
fix setCurrentRadio crash

### DIFF
--- a/Mixpanel/AutomaticProperties.swift
+++ b/Mixpanel/AutomaticProperties.swift
@@ -79,13 +79,11 @@ class AutomaticProperties {
     }()
 
     #if os(iOS)
-    class func getCurrentRadio() -> String? {
-        var radio = telephonyInfo.currentRadioAccessTechnology
+    class func getCurrentRadio() -> String {
+        var radio = telephonyInfo.currentRadioAccessTechnology ?? "None"
         let prefix = "CTRadioAccessTechnology"
-        if radio == nil {
-            radio = "None"
-        } else if radio!.hasPrefix(prefix) {
-            radio = (radio! as NSString).substring(from: prefix.count)
+        if radio.hasPrefix(prefix) {
+            radio = (radio as NSString).substring(from: prefix.count)
         }
         return radio
     }

--- a/Mixpanel/AutomaticProperties.swift
+++ b/Mixpanel/AutomaticProperties.swift
@@ -23,6 +23,8 @@ class AutomaticProperties {
     static let telephonyInfo = CTTelephonyNetworkInfo()
     #endif // os(iOS)
 
+    static let automaticPropertiesLock = ReadWriteLock(label: "automaticPropertiesLock")
+
     static var properties: InternalProperties = {
         objc_sync_enter(AutomaticProperties.self); defer { objc_sync_exit(AutomaticProperties.self) }
         var p = InternalProperties()

--- a/Mixpanel/DecideRequest.swift
+++ b/Mixpanel/DecideRequest.swift
@@ -29,7 +29,10 @@ class DecideRequest: Network {
             self.distinctId = URLQueryItem(name: "distinct_id", value: distinctId)
 
             // workaround for a/b testing
-            var peoplePropertiesCopy = AutomaticProperties.peopleProperties
+            var peoplePropertiesCopy = InternalProperties()
+            AutomaticProperties.automaticPropertiesLock.read {
+                peoplePropertiesCopy += AutomaticProperties.peopleProperties
+            }
             peoplePropertiesCopy["$ios_lib_version"] = "2.6"
             // end of workaround
 

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -563,7 +563,9 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
     @objc func setCurrentRadio() {
         let currentRadio = AutomaticProperties.getCurrentRadio()
         trackingQueue.async {
-            AutomaticProperties.properties["$radio"] = currentRadio
+            AutomaticProperties.automaticPropertiesLock.write {
+                AutomaticProperties.properties["$radio"] = currentRadio
+            }
         }
     }
 

--- a/Mixpanel/People.swift
+++ b/Mixpanel/People.swift
@@ -52,7 +52,9 @@ open class People {
                 r[action] = properties["$properties"]
             } else {
                 if action == "$set" || action == "$set_once" {
-                    p += AutomaticProperties.peopleProperties
+                    AutomaticProperties.automaticPropertiesLock.read {
+                        p += AutomaticProperties.peopleProperties
+                    }
                 }
                 p += properties
                 r[action] = p

--- a/Mixpanel/Track.swift
+++ b/Mixpanel/Track.swift
@@ -39,7 +39,9 @@ class Track {
         let epochSeconds = Int(round(epochInterval))
         let eventStartTime = timedEvents[ev!] as? Double
         var p = InternalProperties()
-        p += AutomaticProperties.properties
+        AutomaticProperties.automaticPropertiesLock.read {
+            p += AutomaticProperties.properties
+        }
         p["token"] = apiToken
         p["time"] = epochSeconds
         if let eventStartTime = eventStartTime {

--- a/MixpanelDemo/MixpanelDemo/AppDelegate.swift
+++ b/MixpanelDemo/MixpanelDemo/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
         var ADD_YOUR_MIXPANEL_TOKEN_BELOW_🛠🛠🛠🛠🛠🛠: String
-        Mixpanel.initialize(token: "f59d65e337997ccbb6d88cdbe813c467")
+        Mixpanel.initialize(token: "")
         Mixpanel.mainInstance().loggingEnabled = true
         Mixpanel.mainInstance().flushInterval = 5
         let allTweaks: [TweakClusterType] = [MixpanelTweaks.floatTweak,


### PR DESCRIPTION
ensure getCurrentRadio is non-nil even though it should have been before
lock `AutomaticProperties.properties` since it's shared across mixpanel instances