### PR TITLE
Replaces fatalError with assert

### DIFF
--- a/Mixpanel/Mixpanel.swift
+++ b/Mixpanel/Mixpanel.swift
@@ -91,13 +91,13 @@ open class Mixpanel {
      - returns: returns the main Mixpanel instance
      */
     open class func mainInstance() -> MixpanelInstance {
-        let instance = MixpanelManager.sharedInstance.getMainInstance()
-        if instance == nil {
-            fatalError("You have to call initialize(token:) before calling the main instance, " +
+        if let instance = MixpanelManager.sharedInstance.getMainInstance() {
+            return instance
+        } else {
+            assert(false, "You have to call initialize(token:) before calling the main instance, " +
                 "or define a new main instance if removing the main one")
+            return Mixpanel.initialize(token: "")
         }
-
-        return instance!
     }
 
     /**


### PR DESCRIPTION
I had an edge case where Mixpanel was not initalized before something needed to report an event on Mixpanel - although this is my fault entirely, it would be nice if Mixpanel only crashes if a method is called on a null instance in debug.

In the event that an event is reported to mixpanel in release - use a placeholder blank instance, until a real instance with a valid token is initialized.