### PR TITLE
Add automaticPushTracking parameter to be parity with ObjC version

### DIFF
--- a/Mixpanel/AutomaticEvents.swift
+++ b/Mixpanel/AutomaticEvents.swift
@@ -45,6 +45,7 @@ class AutomaticEvents: NSObject, SKPaymentTransactionObserver, SKProductsRequest
     var sessionLength: TimeInterval = 0
     var sessionStartTime: TimeInterval = Date().timeIntervalSince1970
     var hasAddedObserver = false
+    var automaticPushTracking = true
 
     func initializeEvents() {
         let firstOpenKey = "MPFirstOpen"
@@ -84,7 +85,9 @@ class AutomaticEvents: NSObject, SKPaymentTransactionObserver, SKProductsRequest
 
         SKPaymentQueue.default().add(self)
         DispatchQueue.main.async {
-            self.setupAutomaticPushTracking()
+            if self.automaticPushTracking {
+                self.setupAutomaticPushTracking()
+            }
         }
     }
 

--- a/Mixpanel/Mixpanel.swift
+++ b/Mixpanel/Mixpanel.swift
@@ -26,6 +26,7 @@ open class Mixpanel {
      - parameter launchOptions:             Optional. App delegate launchOptions
      - parameter flushInterval:             Optional. Interval to run background flushing
      - parameter instanceName:              Optional. The name you want to call this instance
+     - parameter automaticPushTracking      whether or not to automatically track pushes sent from Mixpanel
      - parameter optOutTrackingByDefault:   Optional. Whether or not to be opted out from tracking by default
 
      - important: If you have more than one Mixpanel instance, it is beneficial to initialize
@@ -39,11 +40,13 @@ open class Mixpanel {
                                launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil,
                                flushInterval: Double = 60,
                                instanceName: String = UUID().uuidString,
+                               automaticPushTracking: Bool = true,
                                optOutTrackingByDefault: Bool = false) -> MixpanelInstance {
         return MixpanelManager.sharedInstance.initialize(token:         apiToken,
                                                          launchOptions: launchOptions,
                                                          flushInterval: flushInterval,
                                                          instanceName:  instanceName,
+                                                         automaticPushTracking: automaticPushTracking,
                                                          optOutTrackingByDefault: optOutTrackingByDefault)
     }
     #else
@@ -141,11 +144,13 @@ class MixpanelManager {
                     launchOptions: [UIApplicationLaunchOptionsKey : Any]?,
                     flushInterval: Double,
                     instanceName: String,
+                    automaticPushTracking: Bool = true,
                     optOutTrackingByDefault: Bool = false) -> MixpanelInstance {
         let instance = MixpanelInstance(apiToken: apiToken,
                                         launchOptions: launchOptions,
                                         flushInterval: flushInterval,
                                         name: instanceName,
+                                        automaticPushTracking: automaticPushTracking,
                                         optOutTrackingByDefault: optOutTrackingByDefault)
         mainInstance = instance
         instances[instanceName] = instance

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -249,7 +249,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
     #endif // DECIDE
 
     #if !os(OSX)
-    init(apiToken: String?, launchOptions: [UIApplicationLaunchOptionsKey : Any]?, flushInterval: Double, name: String, optOutTrackingByDefault: Bool = false) {
+    init(apiToken: String?, launchOptions: [UIApplicationLaunchOptionsKey : Any]?, flushInterval: Double, name: String, automaticPushTracking: Bool = true, optOutTrackingByDefault: Bool = false) {
         if let apiToken = apiToken, !apiToken.isEmpty {
             self.apiToken = apiToken
         }
@@ -304,6 +304,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
         #if DECIDE
             if !MixpanelInstance.isiOSAppExtension() {
                 automaticEvents.delegate = self
+                automaticEvents.automaticPushTracking = automaticPushTracking
                 automaticEvents.initializeEvents()
                 decideInstance.inAppDelegate = self
                 executeCachedVariants()


### PR DESCRIPTION
This is to give our users the flexibility to turn automatic push tracking on and off based on needs.