### PR TITLE
enable JSONHandler to be able to serialize Mixpanel SessionMetadata c…

### DIFF
--- a/Mixpanel/JSONHandler.swift
+++ b/Mixpanel/JSONHandler.swift
@@ -50,7 +50,7 @@ class JSONHandler {
 
     private class func makeObjectSerializable(_ obj: MPObjectToParse) -> MPObjectToParse {
         switch obj {
-        case is String, is Int, is UInt, is Double, is Float, is Bool:
+        case is String, is Int, is UInt, is UInt64, is Double, is Float, is Bool:
             return obj
 
         case let obj as Array<Any>:


### PR DESCRIPTION
…ounter properties

SessionMetadata.swift has properties eventsCounter, peopleCounter and sessionStartEpoch that are defined as UInt64. When JSONHandler tries to serialize these MixPanel properties, it throws a warning:

[Mixpanel - JSONHandler.swift - func makeObjectSerializable] (info) - enforcing string on object

The commit fixes this by explicitly allowing UInt64 to be serialized in the same way that Int, UInt, etc are already allowed.