### PR TITLE
Flush all queued events in batches (#1)

### DIFF
--- a/Mixpanel/Flush.swift
+++ b/Mixpanel/Flush.swift
@@ -132,7 +132,7 @@ class Flush: AppLifecycle {
                                                 }
                                             #endif // os(iOS)
                                             if success {
-                                                if let lastIndex = range.last, shadowQueue.count < lastIndex {
+                                                if let lastIndex = range.last, shadowQueue.count - 1 > lastIndex {
                                                     shadowQueue.removeSubrange(range)
                                                 } else {
                                                     shadowQueue.removeAll()


### PR DESCRIPTION
The check for removing events from the queue after a successful flushRequest is removing all events from the shadowQueue. When queue.count is greater than APIConstants.batchSize, it will cause the first batch of events up to the batchSize to be sent and the remaining events in the queue to be dropped.