### PR TITLE
Store mixpanel files inside "Application Support/Mixpanel" on iOS

### DIFF
--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -290,6 +290,8 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
                     }
                 }
             }
+
+            Persistence.createMixpanelFolderIOS()
         #endif
         flushInstance.delegate = self
         distinctId = defaultDistinctId()


### PR DESCRIPTION
Apple best practice for iOS  is that support files are stored in subfolders inside the "Application Support" folder in the app sandbox. The code in this pull request will run on iOS only.

New installations will create the "Application Support/Mixpanel" folder and store all files there. Existing installations will create the "Application Support/ Mixpanel" folder and move existing "mixpanel-" files there.