### PR TITLE
fix notification tracking crash related to @noescape

### DIFF
--- a/Mixpanel/AutomaticEvents.swift
+++ b/Mixpanel/AutomaticEvents.swift
@@ -251,7 +251,7 @@ extension UIResponder {
         let originalSelector = NSSelectorFromString("application:didReceiveRemoteNotification:fetchCompletionHandler:")
         if let originalMethod = class_getInstanceMethod(type(of: self), originalSelector),
             let swizzle = Swizzler.swizzles[originalMethod] {
-            typealias MyCFunction = @convention(c) (AnyObject, Selector, UIApplication, NSDictionary, (UIBackgroundFetchResult) -> Void) -> Void
+            typealias MyCFunction = @convention(c) (AnyObject, Selector, UIApplication, NSDictionary, @escaping (UIBackgroundFetchResult) -> Void) -> Void
             let curriedImplementation = unsafeBitCast(swizzle.originalMethod, to: MyCFunction.self)
             curriedImplementation(self, originalSelector, application, userInfo as NSDictionary, completionHandler)
 


### PR DESCRIPTION
the `typealias` in the swizzling block was missing `@escaping`