### PR TITLE
Fix crash on tapping notification when built by Xcode 10

### DIFF
--- a/Mixpanel/AutomaticEvents.swift
+++ b/Mixpanel/AutomaticEvents.swift
@@ -284,7 +284,7 @@ extension NSObject {
         let originalSelector = NSSelectorFromString("userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:")
         if let originalMethod = class_getInstanceMethod(type(of: self), originalSelector),
             let swizzle = Swizzler.swizzles[originalMethod] {
-            typealias MyCFunction = @convention(c) (AnyObject, Selector, UNUserNotificationCenter, UNNotificationResponse, () -> Void) -> Void
+            typealias MyCFunction = @convention(c) (AnyObject, Selector, UNUserNotificationCenter, UNNotificationResponse, @escaping () -> Void) -> Void
             let curriedImplementation = unsafeBitCast(swizzle.originalMethod, to: MyCFunction.self)
             curriedImplementation(self, originalSelector, center, response, completionHandler)
 


### PR DESCRIPTION
Add @escaping attribute on closure type argument of typealiased MyCFunction