### PR TITLE
Fix UITextField codeless

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: objective-c
 before_install:
+  - gem uninstall cocoapods --force -a -q -I -x
   - gem install cocoapods -v 1.4.0
 osx_image: xcode10
 before_script: cd MixpanelDemo

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -394,7 +394,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
                                            selector: #selector(appLinksNotificationRaised(_:)),
                                            name: NSNotification.Name("com.parse.bolts.measurement_event"),
                                            object: nil)
-            #if os(iOS) && DECIDE && DEBUG
+            #if os(iOS) && DECIDE && !NO_AB_TESTING_EDITOR
                 initializeGestureRecognizer()
             #endif // os(iOS) && DECIDE
         }

--- a/Mixpanel/UIControlBinding.swift
+++ b/Mixpanel/UIControlBinding.swift
@@ -22,7 +22,12 @@ class UIControlBinding: CodelessBinding {
         self.verified = NSHashTable(options: [NSHashTableWeakMemory, NSHashTableObjectPointerPersonality])
         self.appliedTo = NSHashTable(options: [NSHashTableWeakMemory, NSHashTableObjectPointerPersonality])
         super.init(eventName: eventName, path: path)
-        self.swizzleClass = UIControl.self
+        if #available(iOS 12.0, *) {
+            self.swizzleClass = path.range(of: "UITextField") != nil ? UITextField.self : UIControl.self
+        }
+        else {
+            self.swizzleClass = UIControl.self
+        }
     }
 
     convenience init?(object: [String: Any]) {
@@ -73,7 +78,6 @@ class UIControlBinding: CodelessBinding {
         aCoder.encode(verifyEvent.rawValue, forKey: "verifyEvent")
         super.encode(with: aCoder)
     }
-
 
     override func isEqual(_ object: Any?) -> Bool {
         guard let object = object as? UIControlBinding else {


### PR DESCRIPTION
- Enable an Active Compilation Condition `NO_AB_TESTING_EDITOR` to disable AB_TESTING web editor support, to disable gesture recognizer explicitly. Otherwise, it is enabled by default.
- Fix codeless tracking not able to track UITextField due to iOS 12 