### PR TITLE
NSString isn't MixpanelType

### DIFF
--- a/Mixpanel/MixpanelType.swift
+++ b/Mixpanel/MixpanelType.swift
@@ -24,6 +24,13 @@ extension String: MixpanelType {
      */
     public func isValidNestedType() -> Bool { return true }
 }
+extension NSString: MixpanelType {
+    /**
+     Checks if this object has nested object types that Mixpanel supports.
+     Will always return true.
+     */
+    public func isValidNestedType() -> Bool { return true }
+}
 extension Int: MixpanelType {
     /**
      Checks if this object has nested object types that Mixpanel supports.


### PR DESCRIPTION
Hello,

Faced with the issue when String comes from ObjC as a NSString.

Behaviour:
```
(lldb) po ("Test" as NSString) as? MixpanelType
nil

(lldb) po ("Test" as String) as MixpanelType
"Test"
```

Expected:
```
(lldb) po ("Test" as NSString) as MixpanelType
Test

(lldb) po ("Test" as String) as MixpanelType
"Test"
```