### PR TITLE
Issue 272: Handle archiveToFile exception and log the issue

### DIFF
--- a/Mixpanel/Persistence.swift
+++ b/Mixpanel/Persistence.swift
@@ -137,10 +137,16 @@ class Persistence {
             return
         }
 
-        if !NSKeyedArchiver.archiveRootObject(object, toFile: path) {
-            Logger.error(message: "failed to archive \(type.rawValue)")
+        ExceptionWrapper.try({
+            if !NSKeyedArchiver.archiveRootObject(object, toFile: path) {
+                Logger.error(message: "failed to archive \(type.rawValue)")
+                return
+            }
+        }, catch: { (error) in
+            Logger.error(message: "failed to archive \(type.rawValue) due to an uncaught exception")
             return
-        }
+        }, finally: {})
+        
         addSkipBackupAttributeToItem(at: path)
     }
 


### PR DESCRIPTION
This uses the Obj-C ExceptionWrapper to catch the exception when trying to use NSKeyedArchiver. This also logs what happened so we can see what the issue is.