### PR TITLE
Optimize `.reduce` usage on Array

### DIFF
--- a/Mixpanel/SSLSecurity.swift
+++ b/Mixpanel/SSLSecurity.swift
@@ -47,12 +47,10 @@ class SSLSecurity {
     convenience init(usePublicKeys: Bool = false) {
         let paths = Bundle.main.paths(forResourcesOfType: "cer", inDirectory: ".")
 
-        let certs = paths.reduce([SSLCert]()) { (certs: [SSLCert], path: String) -> [SSLCert] in
-            var certs = certs
+        let certs = paths.reduce(into: [SSLCert]()) { (certs: inout [SSLCert], path: String) in
             if let data = NSData(contentsOfFile: path) {
                 certs.append(SSLCert(data: data as Data))
             }
-            return certs
         }
 
         self.init(certs: certs, usePublicKeys: usePublicKeys)
@@ -63,27 +61,23 @@ class SSLSecurity {
 
         if self.usePublicKeys {
             DispatchQueue.global(qos: .default).async {
-                let pubKeys = certs.reduce([SecKey]()) { (pubKeys: [SecKey], cert: SSLCert) -> [SecKey] in
-                    var pubKeys = pubKeys
+                let pubKeys = certs.reduce(into: [SecKey]()) { (pubKeys: inout [SecKey], cert: SSLCert) in
                     if let data = cert.certData, cert.key == nil {
                         cert.key = self.extractPublicKey(data)
                     }
                     if let key = cert.key {
                         pubKeys.append(key)
                     }
-                    return pubKeys
                 }
 
                 self.pubKeys = pubKeys
                 self.isReady = true
             }
         } else {
-            let certificates = certs.reduce([Data]()) { (certificates: [Data], cert: SSLCert) -> [Data] in
-                var certificates = certificates
+            let certificates = certs.reduce(into: [Data]()) { (certificates: inout [Data], cert: SSLCert) in
                 if let data = cert.certData {
                     certificates.append(data)
                 }
-                return certificates
             }
             self.certificates = certificates
             self.isReady = true
@@ -163,11 +157,9 @@ class SSLSecurity {
     }
 
     func certificateChain(_ trust: SecTrust) -> [Data] {
-        let certificates = (0..<SecTrustGetCertificateCount(trust)).reduce([Data]()) { (certificates: [Data], index: Int) -> [Data] in
-            var certificates = certificates
+        let certificates = (0..<SecTrustGetCertificateCount(trust)).reduce(into: [Data]()) { (certificates: inout [Data], index: Int) in
             let cert = SecTrustGetCertificateAtIndex(trust, index)
             certificates.append(SecCertificateCopyData(cert!) as Data)
-            return certificates
         }
 
         return certificates
@@ -175,14 +167,11 @@ class SSLSecurity {
 
     func publicKeyChain(_ trust: SecTrust) -> [SecKey] {
         let policy = SecPolicyCreateBasicX509()
-        let keys = (0..<SecTrustGetCertificateCount(trust)).reduce([SecKey]()) { (keys: [SecKey], index: Int) -> [SecKey] in
-            var keys = keys
+        let keys = (0..<SecTrustGetCertificateCount(trust)).reduce(into: [SecKey]()) { (keys: inout [SecKey], index: Int) in
             let cert = SecTrustGetCertificateAtIndex(trust, index)
             if let key = extractPublicKey(cert!, policy: policy) {
                 keys.append(key)
             }
-
-            return keys
         }
 
         return keys

--- a/Mixpanel/TweakCollection.swift
+++ b/Mixpanel/TweakCollection.swift
@@ -34,8 +34,8 @@ extension TweakCollection {
 	/// A flat list of all the tweaks in a TweakCollection.
 	/// Used for sharing out the contents of a TweakStore.
 	internal var allTweaks: [AnyTweak] {
-		return sortedTweakGroups.reduce([]) {
-			$0 + $1.sortedTweaks
+		return sortedTweakGroups.reduce(into: []) {
+			$0.append(contentsOf: $1.sortedTweaks)
 		}
 	}
 }

--- a/Mixpanel/TweakStore.swift
+++ b/Mixpanel/TweakStore.swift
@@ -50,7 +50,7 @@ public final class TweakStore {
 
     /// A method for adding Tweaks to the environment
     func addTweaks(_ tweaks: [TweakClusterType]) {
-        self.allTweaks.formUnion(Set(tweaks.reduce([]) { $0 + $1.tweakCluster }))
+        self.allTweaks.formUnion(Set(tweaks.reduce(into: []) { $0.append(contentsOf: $1.tweakCluster) }))
         self.allTweaks.forEach { tweak in
             // Find or create its TweakCollection
             var tweakCollection: TweakCollection
@@ -119,10 +119,12 @@ public final class TweakStore {
 		persistence.clearAllData()
 
 		// Go through all tweaks in our library, and call any bindings they're attached to.
-		tweakCollections.values.reduce([]) { $0 + $1.sortedTweakGroups.reduce([]) { $0 + $1.sortedTweaks } }
-			.forEach { updateBindingsForTweak($0)
+		tweakCollections.values.reduce(into: []) {
+			$0.append(contentsOf: $1.sortedTweakGroups.reduce(into: []) { 
+				$0.append(contentsOf: $1.sortedTweaks) 
+			})
 		}
-
+		.forEach { updateBindingsForTweak($0) }
 	}
 
 	internal func currentValueForTweak<T>(_ tweak: Tweak<T>) -> T {


### PR DESCRIPTION
✋ Just a small fix that can improve `.reduce` performance
In previous implementation it would copy array on every iteration
In new one only one instance is created and `.append` is just linear operation
So it should go from `O(n^2)` -> `O(n)`