### PR TITLE
add automatic events parity between Obj-C and Swift

### DIFF
--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -1374,6 +1374,15 @@ extension MixpanelInstance {
             self.archiveProperties()
         }
     }
+    
+    // MARK: - AEDelegate
+    func increment(property: String, by: Double) {
+        people?.increment(property: property, by: by)
+    }
+    
+    func setOnce(properties: Properties) {
+        people?.setOnce(properties: properties)
+    }
 }
 
 #if DECIDE

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelAutomaticEventsTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelAutomaticEventsTests.swift
@@ -24,10 +24,15 @@ class MixpanelAutomaticEventsTests: MixpanelBaseTests {
 
     func testSession() {
         self.mixpanel.minimumSessionDuration = 0;
+        self.mixpanel.identify(distinctId: "d1")
         self.mixpanel.automaticEvents.perform(#selector(AutomaticEvents.appWillResignActive(_:)),
                                               with: Notification(name: Notification.Name(rawValue: "test")))
         self.waitForTrackingQueue()
         let event = self.mixpanel.eventsQueue.last
+        let people1 = self.mixpanel.people.peopleQueue[0]["$add"] as! InternalProperties
+        let people2 = self.mixpanel.people.peopleQueue[1]["$add"] as! InternalProperties
+        XCTAssertEqual(people1["$ae_total_app_sessions"] as? Double, 1, "total app sessions should be added by 1")
+        XCTAssertNotNil((people2["$ae_total_app_session_length"], "should have session length in $add queue"))
         XCTAssertNotNil(event, "Should have an event")
         XCTAssertEqual(event?["event"] as? String, "$ae_session", "should be app session event")
         XCTAssertNotNil((event?["properties"] as? [String: Any])?["$ae_session_length"], "should have session length")


### PR DESCRIPTION
This is to fix issues below:
Automatic Events disparity between Obj-C and Swift 
https://github.com/mixpanel/mixpanel-swift/issues/222 
(Store total app sessions, total app session length and first app open date as user properties, parity with ObjC)

Super properties are not sent with the common "First App Open" event 
https://github.com/mixpanel/mixpanel-swift/issues/189