### PR TITLE
Add support for display triggers in inapp notifications

### DIFF
--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		05A0200E2202724A00D04A3A /* DisplayTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A0200D2202724A00D04A3A /* DisplayTrigger.swift */; };
+		05D4C3E6222F322100D30FC2 /* SelectorEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D4C3E5222F322100D30FC2 /* SelectorEvaluator.swift */; };
 		51DD567C1D306B740045D3DB /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD56791D306B740045D3DB /* Logger.swift */; };
 		51DD56831D306B7B0045D3DB /* PrintLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD56801D306B7B0045D3DB /* PrintLogging.swift */; };
 		51DD56841D306B7B0045D3DB /* FileLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD56811D306B7B0045D3DB /* FileLogging.swift */; };
@@ -150,6 +151,7 @@
 
 /* Begin PBXFileReference section */
 		05A0200D2202724A00D04A3A /* DisplayTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayTrigger.swift; sourceTree = "<group>"; };
+		05D4C3E5222F322100D30FC2 /* SelectorEvaluator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectorEvaluator.swift; sourceTree = "<group>"; };
 		51DD56791D306B740045D3DB /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		51DD56801D306B7B0045D3DB /* PrintLogging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrintLogging.swift; sourceTree = "<group>"; };
 		51DD56811D306B7B0045D3DB /* FileLogging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileLogging.swift; sourceTree = "<group>"; };
@@ -512,6 +514,7 @@
 		E18C77A51E381ED00006CBB9 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				05D4C3E5222F322100D30FC2 /* SelectorEvaluator.swift */,
 				E19312661D5A7848007CE1E9 /* InAppNotification.swift */,
 				E118E9FF1E37E28400223C47 /* InAppButton.swift */,
 				E118E9FD1E37DE3B00223C47 /* TakeoverNotification.swift */,
@@ -750,6 +753,7 @@
 				E142DBD11D75F86300F34C12 /* ObjectSerializer.swift in Sources */,
 				E115948E1D000709007F8B4F /* MixpanelInstance.swift in Sources */,
 				E15422191D6FBFA6009421A0 /* WebSocketWrapper.swift in Sources */,
+				05D4C3E6222F322100D30FC2 /* SelectorEvaluator.swift in Sources */,
 				E154222D1D71059D009421A0 /* BindingMessage.swift in Sources */,
 				E11801AE1D7F86320006DD2B /* NSAttributedStringToNSDictionary.swift in Sources */,
 				E174DAE51DA3373600FED703 /* TweakBinding.swift in Sources */,

--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		05A0200E2202724A00D04A3A /* DisplayTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A0200D2202724A00D04A3A /* DisplayTrigger.swift */; };
 		51DD567C1D306B740045D3DB /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD56791D306B740045D3DB /* Logger.swift */; };
 		51DD56831D306B7B0045D3DB /* PrintLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD56801D306B7B0045D3DB /* PrintLogging.swift */; };
 		51DD56841D306B7B0045D3DB /* FileLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD56811D306B7B0045D3DB /* FileLogging.swift */; };
@@ -148,6 +149,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		05A0200D2202724A00D04A3A /* DisplayTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayTrigger.swift; sourceTree = "<group>"; };
 		51DD56791D306B740045D3DB /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		51DD56801D306B7B0045D3DB /* PrintLogging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrintLogging.swift; sourceTree = "<group>"; };
 		51DD56811D306B7B0045D3DB /* FileLogging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileLogging.swift; sourceTree = "<group>"; };
@@ -514,6 +516,7 @@
 				E118E9FF1E37E28400223C47 /* InAppButton.swift */,
 				E118E9FD1E37DE3B00223C47 /* TakeoverNotification.swift */,
 				E118EA011E37F3A700223C47 /* MiniNotification.swift */,
+				05A0200D2202724A00D04A3A /* DisplayTrigger.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -786,6 +789,7 @@
 				E174DAE31DA3370300FED703 /* TweakableType.swift in Sources */,
 				E165228F1D6781DF000D5949 /* MixpanelType.swift in Sources */,
 				E19D12961D9C5E6600A8016D /* VariantTweak.swift in Sources */,
+				05A0200E2202724A00D04A3A /* DisplayTrigger.swift in Sources */,
 				E11801B01D7F92F10006DD2B /* UIFontToNSDictionary.swift in Sources */,
 				E118EA021E37F3A700223C47 /* MiniNotification.swift in Sources */,
 				E174DADD1DA336C000FED703 /* TweakLibrary.swift in Sources */,

--- a/Mixpanel/Decide.swift
+++ b/Mixpanel/Decide.swift
@@ -154,10 +154,17 @@ class Decide {
         decideResponse.unshownInAppNotifications = notificationsInstance.inAppNotifications.filter {
             !notificationsInstance.shownNotifications.contains($0.ID)
         }
+        
+        let unshownTriggeredInapps = notificationsInstance.triggeredNotifications.filter {
+            !notificationsInstance.shownNotifications.contains($0.ID)
+        }
 
         Logger.info(message: "decide check found \(decideResponse.unshownInAppNotifications.count) " +
             "available notifications out of " +
             "\(notificationsInstance.inAppNotifications.count) total")
+        Logger.info(message: "decide check found \(unshownTriggeredInapps.count) " +
+            "available triggered notifications out of " +
+            "\(notificationsInstance.triggeredNotifications.count) total")
         Logger.info(message: "decide check found \(decideResponse.newCodelessBindings.count) " +
             "new codeless bindings out of \(codelessInstance.codelessBindings)")
         Logger.info(message: "decide check found \(decideResponse.newVariants.count) " +

--- a/Mixpanel/Decide.swift
+++ b/Mixpanel/Decide.swift
@@ -86,8 +86,15 @@ class Decide {
                 } else {
                     Logger.error(message: "in-app notifications check response format error")
                 }
-                self.notificationsInstance.inAppNotifications = parsedNotifications
-
+                
+                for parsedNotification in parsedNotifications {
+                    if (parsedNotification.hasDisplayTriggers()) {
+                        self.notificationsInstance.triggeredNotifications.append(parsedNotification)
+                    } else {
+                        self.notificationsInstance.inAppNotifications.append(parsedNotification)
+                    }
+                }
+                
                 var parsedCodelessBindings = Set<CodelessBinding>()
                 if let rawCodelessBindings = result["event_bindings"] as? [[String: Any]] {
                     for rawBinding in rawCodelessBindings {

--- a/Mixpanel/DisplayTrigger.swift
+++ b/Mixpanel/DisplayTrigger.swift
@@ -1,0 +1,59 @@
+//
+//  DisplayTrigger.swift
+//  Mixpanel
+//
+//  Created by Madhu Palani on 1/30/19.
+//  Copyright © 2019 Mixpanel. All rights reserved.
+//
+
+import Foundation
+
+class DisplayTrigger {
+    enum PayloadKey {
+        static let event = "event"
+        static let selector = "selector"
+    }
+    
+    static let ANY_EVENT = "$any_event"
+    
+    let event: String?
+    let selector: [String: Any]?
+    
+    init?(JSONObject: [String: Any]?) {
+        guard let object = JSONObject else {
+            Logger.error(message: "display trigger json object should not be nil")
+            return nil
+        }
+        
+        guard let event = object[PayloadKey.event] as? String else {
+            Logger.error(message: "invalid event name type")
+            return nil
+        }
+        
+        guard let selector = object[PayloadKey.selector] as? [String: Any]? else {
+            Logger.error(message: "invalid selector section")
+            return nil
+        }
+        
+        self.event = event
+        self.selector = selector
+    }
+    
+    func matchesEvent(eventName: String?, properties: Properties? = nil) -> Bool {
+        if let event = self.event {
+            if (eventName == DisplayTrigger.ANY_EVENT || eventName == "" || eventName?.caseInsensitiveCompare(event) == ComparisonResult.orderedSame) {
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+    func payload() -> [String: AnyObject] {
+        var payload = [String: AnyObject]()
+        payload[PayloadKey.event] = event as AnyObject
+        payload[PayloadKey.selector] = selector as AnyObject
+        
+        return payload
+    }
+}

--- a/Mixpanel/DisplayTrigger.swift
+++ b/Mixpanel/DisplayTrigger.swift
@@ -17,10 +17,10 @@ class DisplayTrigger {
     static let ANY_EVENT = "$any_event"
     
     let event: String?
-    let selector: [String: Any]?
+    let selectorOpt: [String: Any]?
     
-    init?(JSONObject: [String: Any]?) {
-        guard let object = JSONObject else {
+    init?(jsonObject: [String: Any]?) {
+        guard let object = jsonObject else {
             Logger.error(message: "display trigger json object should not be nil")
             return nil
         }
@@ -36,13 +36,18 @@ class DisplayTrigger {
         }
         
         self.event = event
-        self.selector = selector
+        self.selectorOpt = selector
     }
     
     func matchesEvent(eventName: String?, properties: Properties? = nil) -> Bool {
         if let event = self.event {
-            if (eventName == DisplayTrigger.ANY_EVENT || eventName == "" || eventName?.caseInsensitiveCompare(event) == ComparisonResult.orderedSame) {
-                return true
+            if (eventName == DisplayTrigger.ANY_EVENT || eventName == "" || eventName?.compare(event) == ComparisonResult.orderedSame) {
+                if let selector = selectorOpt {
+                    if let value = SelectorEvaluator.evaluate(selector: selector, properties: properties) {
+                        return value
+                    }
+                    return false
+                }
             }
         }
         
@@ -52,7 +57,7 @@ class DisplayTrigger {
     func payload() -> [String: AnyObject] {
         var payload = [String: AnyObject]()
         payload[PayloadKey.event] = event as AnyObject
-        payload[PayloadKey.selector] = selector as AnyObject
+        payload[PayloadKey.selector] = selectorOpt as AnyObject
         
         return payload
     }

--- a/Mixpanel/InAppNotification.swift
+++ b/Mixpanel/InAppNotification.swift
@@ -61,10 +61,10 @@ class InAppNotification {
             return nil
         }
         
-        if let rawDisplayTriggers = object[PayloadKey.displayTriggers] as? [[String: Any]]? {
-            if let rawDisplayTriggers = rawDisplayTriggers {
+        if let rawDisplayTriggersOpt = object[PayloadKey.displayTriggers] as? [[String: Any]]? {
+            if let rawDisplayTriggers = rawDisplayTriggersOpt {
                 for rawDisplayTrigger in rawDisplayTriggers {
-                    if let displayTrigger = DisplayTrigger(JSONObject: rawDisplayTrigger) {
+                    if let displayTrigger = DisplayTrigger(jsonObject: rawDisplayTrigger) {
                         displayTriggers.append(displayTrigger)
                     } else {
                         Logger.error(message: "invalid display trigger \(rawDisplayTrigger)")
@@ -141,11 +141,11 @@ class InAppNotification {
         payload[PayloadKey.bodyColor] = bodyColor as AnyObject
         payload[PayloadKey.type] = type as AnyObject
         payload[PayloadKey.body] = body as AnyObject
-        var pldDisplayTriggers = [[String: AnyObject]]()
+        var payloadDisplayTriggers = [[String: AnyObject]]()
         for displayTrigger in displayTriggers {
-            pldDisplayTriggers.append(displayTrigger.payload())
+            payloadDisplayTriggers.append(displayTrigger.payload())
         }
-        payload[PayloadKey.displayTriggers] = pldDisplayTriggers as AnyObject
+        payload[PayloadKey.displayTriggers] = payloadDisplayTriggers as AnyObject
         
         return payload
     }

--- a/Mixpanel/InAppNotifications.swift
+++ b/Mixpanel/InAppNotifications.swift
@@ -25,6 +25,7 @@ class InAppNotifications: NotificationViewControllerDelegate {
     var showNotificationOnActive = true
     var miniNotificationPresentationTime = 6.0
     var shownNotifications = Set<Int>()
+    var triggeredNotifications = [InAppNotification]()
     var inAppNotifications = [InAppNotification]()
     var currentlyShowingNotification: InAppNotification?
     var delegate: InAppNotificationsDelegate?
@@ -33,6 +34,15 @@ class InAppNotifications: NotificationViewControllerDelegate {
         self.lock = lock
     }
 
+    func showNotification(event: String?, properties: Properties? = nil) {
+        for triggeredNotification in triggeredNotifications {
+            if (triggeredNotification.matchesEvent(event: event, properties: properties)) {
+                showNotification(triggeredNotification)
+                break;
+            }
+        }
+    }
+    
     func showNotification( _ notification: InAppNotification) {
         let notification = notification
         if notification.image != nil {
@@ -53,7 +63,11 @@ class InAppNotifications: NotificationViewControllerDelegate {
                 }
             }
         } else {
-            inAppNotifications = inAppNotifications.filter { $0.ID != notification.ID }
+            if (notification.hasDisplayTriggers()) {
+                triggeredNotifications = triggeredNotifications.filter { $0.ID != notification.ID }
+            } else {
+                inAppNotifications = inAppNotifications.filter { $0.ID != notification.ID }
+            }
         }
     }
 

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -1140,12 +1140,18 @@ extension MixpanelInstance {
             }
         }
 
+        #if DECIDE
+        
+        self.decideInstance.notificationsInstance.showNotification(event: event, properties: properties)
+        
+        #endif  // DECIDE
         if MixpanelInstance.isiOSAppExtension() {
             self.flush()
         }
     }
 
     #if DECIDE
+    
     func trackPushNotification(_ userInfo: [AnyHashable: Any],
                                       event: String = "$campaign_received") {
         if self.hasOptedOutTracking() {

--- a/Mixpanel/SelectorEvaluator.swift
+++ b/Mixpanel/SelectorEvaluator.swift
@@ -1,0 +1,599 @@
+//
+//  Selector.swift
+//  Mixpanel
+//
+//  Created by Madhu Palani on 3/1/19.
+//  Copyright © 2019 Mixpanel. All rights reserved.
+//
+
+import Foundation
+
+extension DateFormatter {
+    static func formatterForJSONDate() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
+    }
+}
+
+class SelectorEvaluator {
+    // Key words
+    static let OPERATOR_KEY = "operator"
+    static let CHILDREN_KEY = "children"
+    static let PROPERTY_KEY = "property"
+    static let VALUE_KEY = "value"
+    static let EVENT_KEY = "event"
+    static let LITERAL_KEY = "literal"
+    static let WINDOW_KEY = "window"
+    static let UNIT_KEY = "unit"
+    static let HOUR_KEY = "hour"
+    static let DAY_KEY = "day"
+    static let WEEK_KEY = "week"
+    static let MONTH_KEY = "month"
+    // Typecast operators
+    static let BOOLEAN_OPERATOR = "boolean"
+    static let DATETIME_OPERATOR = "datetime"
+    static let LIST_OPERATOR = "list"
+    static let NUMBER_OPERATOR = "number"
+    static let STRING_OPERATOR = "string"
+    // Binary operators
+    static let AND_OPERATOR = "and"
+    static let OR_OPERATOR = "or"
+    static let IN_OPERATOR = "in"
+    static let NOT_IN_OPERATOR = "not in"
+    static let PLUS_OPERATOR = "+"
+    static let MINUS_OPERATOR = "-"
+    static let MUL_OPERATOR = "*"
+    static let DIV_OPERATOR = "/"
+    static let MOD_OPERATOR = "%"
+    static let EQUALS_OPERATOR = "=="
+    static let NOT_EQUALS_OPERATOR = "!="
+    static let GREATER_THAN_OPERATOR = ">"
+    static let GREATER_THAN_EQUAL_OPERATOR = ">="
+    static let LESS_THAN_OPERATOR = "<"
+    static let LESS_THAN_EQUAL_OPERATOR = "<="
+    // Unary operators
+    static let NOT_OPERATOR = "not"
+    static let DEFINED_OPERATOR = "defined"
+    static let NOT_DEFINED_OPERATOR = "not defined"
+    // Special words
+    static let NOW_LITERAL = "now"
+    
+    // private const
+    private static let LEFT = 0
+    private static let RIGHT = 1
+    
+    // For testing purposes
+    class func getCurrentDate() -> Date {
+        return Date();
+    }
+    
+    class func toNumber(value: Any?) -> Double? {
+        if let val = value {
+            switch val {
+            case let bool as Bool:
+                return bool ? 1 : 0
+            case let date as Date:
+                return date.timeIntervalSince1970 > 0 ? date.timeIntervalSince1970 : nil
+            case let num as NSNumber:
+                return num.doubleValue
+            case let str as String:
+                if let int = Int(str) {
+                    return Double(int)
+                }
+                if let double = Double(str) {
+                    return double
+                }
+                return 0.0
+            default:
+                return nil
+            }
+        }
+        return nil
+    }
+    
+    class func toBoolean(value: Any?) -> Bool {
+        if let val = value {
+            switch val {
+            case let bool as Bool:
+                return bool
+            case let num as NSNumber:
+                return num.doubleValue != 0 ? true : false
+            case let str as String:
+                return str.count > 0 ? true : false
+            case let arr as [Any?]:
+                return arr.count > 0 ? true : false
+            case let dict as [String: Any]:
+                return dict.count > 0 ? true : false
+            case let date as Date:
+                return date.timeIntervalSince1970 > 0 ? true : false
+            default:
+                return false
+            }
+        }
+        return false
+    }
+    
+    class func evaluateNumber(node: [String: Any], properties: Properties?) -> Double? {
+        guard let op = node[OPERATOR_KEY] as? String, op == NUMBER_OPERATOR else {
+            Logger.error(message: "invalid operator: number")
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 1 else {
+            Logger.error(message: "invalid operator: number")
+            return nil
+        }
+        
+        return toNumber(value: evaluateNode(node: children[LEFT], properties: properties))
+    }
+    
+    class func evaluateBoolean(node: [String: Any], properties: Properties?) -> Bool? {
+        guard let op = node[OPERATOR_KEY] as? String, op == BOOLEAN_OPERATOR else {
+            Logger.error(message: "invalid operator: boolean")
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 1 else {
+            Logger.error(message: "invalid operator: boolean")
+            return nil
+        }
+        
+        return toBoolean(value: evaluateNode(node: children[LEFT], properties: properties))
+    }
+    
+    class func evaluateDateTime(node: [String: Any], properties: Properties?) -> Date? {
+        guard let op = node[OPERATOR_KEY] as? String, op == DATETIME_OPERATOR else {
+            Logger.error(message: "invalid operator: datetime")
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 1 else {
+            Logger.error(message: "invalid operator: datetime")
+            return nil
+        }
+        
+        if let value = evaluateNode(node: children[LEFT], properties: properties) {
+            switch value {
+            case _ as Bool:
+                return nil
+            case let num as NSNumber:
+                return Date(timeIntervalSince1970: num.doubleValue)
+            case let str as String:
+                let dateFormatter = DateFormatter.formatterForJSONDate()
+                if let date = dateFormatter.date(from: str) {
+                    return date
+                }
+                return nil
+            case let date as Date:
+                return date
+            default:
+                return nil
+            }
+        }
+        return nil
+    }
+    
+    class func evaluateList(node: [String: Any], properties: Properties?) -> [Any]? {
+        guard let op = node[OPERATOR_KEY] as? String, op == LIST_OPERATOR else {
+            Logger.error(message: "invalid operator: list")
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 1 else {
+            Logger.error(message: "invalid operator: list")
+            return nil
+        }
+        
+        if let value = evaluateNode(node: children[LEFT], properties: properties) as? [Any] {
+            return value
+        }
+        return nil
+    }
+    
+    private class func jsonStringify(value: Any) -> String? {
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: value) else {
+            Logger.error(message: "Error encoding as JSON")
+            return nil
+        }
+        return String(data: jsonData, encoding: .utf8)
+    }
+    
+    class func evaluateString(node: [String: Any], properties: Properties?) -> String? {
+        guard let op = node[OPERATOR_KEY] as? String, op == STRING_OPERATOR else {
+            Logger.error(message: "invalid operator: string")
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 1 else {
+            Logger.error(message: "invalid operator: string")
+            return nil
+        }
+        
+        if let value = evaluateNode(node: children[LEFT], properties: properties) {
+            switch value {
+            case let bool as Bool:
+                return String(bool)
+            case let dt as Date:
+                return DateFormatter.formatterForJSONDate().string(from: dt)
+            case let num as NSNumber:
+                return num.stringValue
+            case let arr as [Any]:
+                return jsonStringify(value: arr)
+            case let obj as [String: Any]:
+                return jsonStringify(value: obj)
+            default:
+                return nil
+            }
+        }
+        return nil
+    }
+    
+    class func evaluateAnd(node: [String: Any], properties: Properties?) -> Bool? {
+        guard let op = node[OPERATOR_KEY] as? String, op == AND_OPERATOR else {
+            Logger.error(message: "invalid operator: and")
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 2 else {
+            Logger.error(message: "invalid operator: and")
+            return nil
+        }
+        
+        return toBoolean(value: evaluateNode(node: children[LEFT], properties: properties)) && toBoolean(value: evaluateNode(node: children[RIGHT], properties: properties))
+    }
+    
+    class func evaluateOr(node: [String: Any], properties: Properties?) -> Bool? {
+        guard let op = node[OPERATOR_KEY] as? String, op == OR_OPERATOR else {
+            Logger.error(message: "invalid operator: or")
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 2 else {
+            Logger.error(message: "invalid operator: or")
+            return nil
+        }
+        
+        return toBoolean(value: evaluateNode(node: children[LEFT], properties: properties)) || toBoolean(value: evaluateNode(node: children[RIGHT], properties: properties))
+    }
+    
+    class func evaluateIn(node: [String: Any], properties: Properties?) -> Bool? {
+        let inOperators = [IN_OPERATOR, NOT_IN_OPERATOR]
+        guard let op = node[OPERATOR_KEY] as? String, inOperators.contains(op) else {
+            Logger.error(message: "invalid operator: in")
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 2 else {
+            Logger.error(message: "invalid operator: in")
+            return nil
+        }
+        
+        let l = evaluateNode(node: children[LEFT], properties: properties)
+        let r = evaluateNode(node: children[RIGHT], properties: properties)
+        var b = false
+        
+        switch (l, r) {
+        case (let lStr as String, let rStr as String):
+            b = rStr.contains(lStr)
+            break
+        case (_, let rArr as [Any]):
+            if let l = l {
+                b = NSSet(array: rArr).contains(l)
+            }
+            break
+        default:
+            b = false
+        }
+    
+        return op == IN_OPERATOR ? b : !b
+    }
+    
+    class func evaluatePlus(node: [String: Any], properties: Properties?) -> Any? {
+        guard let op = node[OPERATOR_KEY] as? String, op == PLUS_OPERATOR else {
+            Logger.error(message: "invalid operator: +")
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 2 else {
+            Logger.error(message: "invalid operator: +")
+            return nil
+        }
+        
+        let l = evaluateNode(node: children[LEFT], properties: properties)
+        let r = evaluateNode(node: children[RIGHT], properties: properties)
+        
+        switch (l, r) {
+        case (let lStr as String, let rStr as String):
+            return "\(lStr)\(rStr)"
+        case (let lNum as NSNumber, let rNum as NSNumber):
+            return lNum.doubleValue + rNum.doubleValue
+        default:
+            return nil
+        }
+    }
+    
+    class func evaluateArithmetic(node: [String: Any], properties: Properties?) -> Double? {
+        let arithmeticOperators = [MINUS_OPERATOR, MUL_OPERATOR, DIV_OPERATOR, MOD_OPERATOR]
+        guard let op = node[OPERATOR_KEY] as? String, arithmeticOperators.contains(op) else {
+            Logger.error(message: "invalid arithmetic operator")
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 2 else {
+            Logger.error(message: "invalid arithmetic operator")
+            return nil
+        }
+        
+        let l = evaluateNode(node: children[LEFT], properties: properties)
+        let r = evaluateNode(node: children[RIGHT], properties: properties)
+        
+        switch (l, r) {
+        case (let lNum as NSNumber, let rNum as NSNumber):
+            let ld = lNum.doubleValue
+            let rd = rNum.doubleValue
+            switch op {
+            case MINUS_OPERATOR:
+                return ld - rd
+            case MUL_OPERATOR:
+                return ld * rd
+            case DIV_OPERATOR:
+                return rd != 0 ? ld / rd : nil
+            case MOD_OPERATOR:
+                if (rd == 0) {
+                    return nil
+                }
+                if (ld == 0) {
+                    return 0
+                }
+                if ((ld < 0 && rd > 0) || (ld > 0 && rd < 0)) {
+                    return -(floor(ld/rd) * rd - ld)
+                }
+                return ld.truncatingRemainder(dividingBy: rd)
+            default:
+                return nil
+            }
+        default:
+            return nil
+        }
+    }
+    
+    private class func equals(l: Any?, r: Any?) -> Bool {
+        switch (l, r) {
+        case (nil, nil):
+            return true
+        case (let lBool as Bool, let rBool as Bool):
+            return lBool == rBool
+        case (let lNum as NSNumber, let rNum as NSNumber):
+            return lNum.isEqual(to: rNum)
+        case (let lStr as String, let rStr as String):
+            return lStr == rStr
+        case (let lDate as Date, let rDate as Date):
+            return lDate == rDate
+        case (let lDict as [String: Any], let rDict as [String: Any]):
+            return NSDictionary(dictionary: lDict).isEqual(to: rDict)
+        case (let lArr as [Any], let rArr as [Any]):
+            return NSArray(array: lArr).isEqual(to: rArr)
+        default:
+            return false
+        }
+    }
+    
+    class func evaluateEquality(node: [String: Any], properties: Properties?) -> Bool? {
+        let supportedOperators = [EQUALS_OPERATOR, NOT_EQUALS_OPERATOR]
+        guard let op = node[OPERATOR_KEY] as? String, supportedOperators.contains(op) else {
+            Logger.error(message: "invalid (not) equality operator")
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 2 else {
+            Logger.error(message: "invalid (not) equality operator")
+            return nil
+        }
+        
+        let l = evaluateNode(node: children[LEFT], properties: properties)
+        let r = evaluateNode(node: children[RIGHT], properties: properties)
+        let b = equals(l: l, r: r)
+        
+        return op == NOT_EQUALS_OPERATOR ? !b : b
+    }
+    
+    private class func compareDoubles(ld: Double, rd: Double, op: String) -> Bool? {
+        switch(op) {
+        case GREATER_THAN_OPERATOR:
+            return ld > rd
+        case GREATER_THAN_EQUAL_OPERATOR:
+            return ld >= rd
+        case LESS_THAN_OPERATOR:
+            return ld < rd
+        case LESS_THAN_EQUAL_OPERATOR:
+            return ld <= rd
+        default:
+            return nil
+        }
+    }
+    
+    class func evaluateComparison(node: [String: Any], properties: Properties?) -> Bool? {
+        let supportedOperators = [GREATER_THAN_OPERATOR, GREATER_THAN_EQUAL_OPERATOR, LESS_THAN_OPERATOR, LESS_THAN_EQUAL_OPERATOR]
+        guard let op = node[OPERATOR_KEY] as? String, supportedOperators.contains(op) else {
+            Logger.error(message: "invalid comparison operator")
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 2 else {
+            Logger.error(message: "invalid comparison operator")
+            return nil
+        }
+        
+        let l = evaluateNode(node: children[LEFT], properties: properties)
+        let r = evaluateNode(node: children[RIGHT], properties: properties)
+        switch (l, r) {
+        case (let lNum as NSNumber, let rNum as NSNumber):
+            return compareDoubles(ld: lNum.doubleValue, rd: rNum.doubleValue, op: op)
+        case (let lDate as Date, let rDate as Date):
+            return compareDoubles(ld: lDate.timeIntervalSince1970, rd: rDate.timeIntervalSince1970, op: op)
+        case (let lStr as String, let rStr as String):
+            switch op {
+            case GREATER_THAN_OPERATOR:
+                return lStr.lowercased() > rStr.lowercased()
+            case GREATER_THAN_EQUAL_OPERATOR:
+                return lStr.lowercased() >= rStr.lowercased()
+            case LESS_THAN_OPERATOR:
+                return lStr.lowercased() < rStr.lowercased()
+            case LESS_THAN_EQUAL_OPERATOR:
+                return lStr.lowercased() <= rStr.lowercased()
+            default:
+                return nil
+            }
+        default:
+            return nil
+        }
+    }
+    
+    class func evaluateDefined(node: [String: Any], properties: Properties?) -> Bool? {
+        let supportedOperators = [DEFINED_OPERATOR, NOT_DEFINED_OPERATOR]
+        guard let op = node[OPERATOR_KEY] as? String, supportedOperators.contains(op) else {
+            Logger.error(message: "invalid operator: (not) defined")
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 1 else {
+            Logger.error(message: "invalid operator: (not) defined")
+            return nil
+        }
+        
+        let b = evaluateNode(node: children[LEFT], properties: properties) != nil ? true : false
+        return op == DEFINED_OPERATOR ? b : !b
+    }
+    
+    class func evaluateNot(node: [String: Any], properties: Properties?) -> Bool? {
+        guard let op = node[OPERATOR_KEY] as? String, op == NOT_OPERATOR else {
+            Logger.error(message: "invalid operator: not")
+            return nil
+        }
+        guard let children = node[CHILDREN_KEY] as? [[String: Any]], children.count == 1 else {
+            Logger.error(message: "invalid operator: not")
+            return nil
+        }
+        
+        let v = evaluateNode(node: children[LEFT], properties: properties)
+        switch (v) {
+        case let b as Bool:
+            return !b
+        case nil:
+            return true
+        default:
+            return nil
+        }
+    }
+    
+    class func evaluateWindow(value: [String: Any]) -> Date? {
+        guard let window = value[WINDOW_KEY] as? [String: Any] else {
+            Logger.error(message: "missing window")
+            return nil
+        }
+        
+        guard let value = window[VALUE_KEY] as? NSNumber else {
+            Logger.error(message: "missing value")
+            return nil
+        }
+        
+        guard let unit = window[UNIT_KEY] as? String else {
+            Logger.error(message: "missing unit")
+            return nil
+        }
+        let date = getCurrentDate()
+        switch unit {
+        case HOUR_KEY:
+            return date.addingTimeInterval(-1 * value.doubleValue * 60 * 60)
+        case DAY_KEY:
+            return date.addingTimeInterval(-1 * value.doubleValue * 24 * 60 * 60)
+        case WEEK_KEY:
+            return date.addingTimeInterval(-1 * value.doubleValue * 7 * 24 * 60 * 60)
+        case MONTH_KEY:
+            return date.addingTimeInterval(-1 * value.doubleValue * 30 * 24 * 60 * 60)
+        default:
+            Logger.error(message: "Invalid unit for window")
+            return nil
+        }
+    }
+    
+    class func evaluateOperand(node: [String: Any], properties: Properties?) -> Any? {
+        guard let property = node[PROPERTY_KEY] as? String else {
+            Logger.error(message: "missing key property")
+            return nil
+        }
+        
+        guard let value = node[VALUE_KEY] else {
+            Logger.error(message: "missing key value")
+            return nil
+        }
+        
+        switch property {
+        case EVENT_KEY:
+            guard let valueStr = value as? String else {
+                Logger.error(message: "unexpected type for event property")
+                return nil
+            }
+            return properties?[valueStr]
+        case LITERAL_KEY:
+            switch value {
+            case let valueStr as String:
+                if valueStr == NOW_LITERAL {
+                    return getCurrentDate()
+                }
+                return valueStr
+            case let valueObj as [String: Any]:
+                return evaluateWindow(value: valueObj)
+            default:
+                return value
+            }
+        default:
+            return nil
+        }
+    }
+    
+    class func evaluateOperator(node: [String: Any], properties: Properties?) -> Any? {
+        guard let op = node[OPERATOR_KEY] as? String else {
+            Logger.error(message: "invalid operator key")
+            return nil
+        }
+        
+        switch op {
+        case AND_OPERATOR:
+            return evaluateAnd(node: node, properties: properties)
+        case OR_OPERATOR:
+            return evaluateOr(node: node, properties: properties)
+        case IN_OPERATOR, NOT_IN_OPERATOR:
+            return evaluateIn(node: node, properties: properties)
+        case PLUS_OPERATOR:
+            return evaluatePlus(node: node, properties: properties)
+        case MINUS_OPERATOR, MUL_OPERATOR, MOD_OPERATOR, DIV_OPERATOR:
+            return evaluateArithmetic(node: node, properties: properties)
+        case EQUALS_OPERATOR, NOT_EQUALS_OPERATOR:
+            return evaluateEquality(node: node, properties: properties)
+        case GREATER_THAN_OPERATOR, GREATER_THAN_EQUAL_OPERATOR, LESS_THAN_OPERATOR, LESS_THAN_EQUAL_OPERATOR:
+            return evaluateComparison(node: node, properties: properties)
+        case BOOLEAN_OPERATOR:
+            return evaluateBoolean(node: node, properties: properties)
+        case STRING_OPERATOR:
+            return evaluateString(node: node, properties: properties)
+        case LIST_OPERATOR:
+            return evaluateList(node: node, properties: properties)
+        case NUMBER_OPERATOR:
+            return evaluateNumber(node: node, properties: properties)
+        case DATETIME_OPERATOR:
+            return evaluateDateTime(node: node, properties: properties)
+        case DEFINED_OPERATOR, NOT_DEFINED_OPERATOR:
+            return evaluateDefined(node: node, properties: properties)
+        case NOT_OPERATOR:
+            return evaluateNot(node: node, properties: properties)
+        default:
+            Logger.error(message: "Unknown operator \(op)")
+            return nil
+        }
+    }
+    
+    class func evaluateNode(node: [String: Any], properties: Properties?) -> Any? {
+        if let _ = node[PROPERTY_KEY] {
+            return evaluateOperand(node: node, properties: properties)
+        }
+        
+        return evaluateOperator(node: node, properties: properties)
+    }
+    
+    public class func evaluate(selector: [String: Any], properties: Properties?) -> Bool? {
+        if let value = SelectorEvaluator.evaluateOperator(node: selector, properties: properties) {
+            return SelectorEvaluator.toBoolean(value: value)
+        }
+        return nil
+    }
+}

--- a/Mixpanel/SelectorEvaluator.swift
+++ b/Mixpanel/SelectorEvaluator.swift
@@ -1,5 +1,5 @@
 //
-//  Selector.swift
+//  SelectorEvaluator.swift
 //  Mixpanel
 //
 //  Created by Madhu Palani on 3/1/19.

--- a/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
+++ b/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
@@ -291,7 +291,6 @@
 				E15FF7E41D0461130076CDE3 /* Frameworks */,
 				E15FF7E51D0461130076CDE3 /* Resources */,
 				23A073632FB9DC26C9B98ABF /* [CP] Embed Pods Frameworks */,
-				14A6BFB53FD8FB99E2B3D2F6 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -419,28 +418,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-MixpanelDemoTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		14A6BFB53FD8FB99E2B3D2F6 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MixpanelDemoTests/Pods-MixpanelDemoTests-resources.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		23A073632FB9DC26C9B98ABF /* [CP] Embed Pods Frameworks */ = {
@@ -449,9 +436,12 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-MixpanelDemoTests/Pods-MixpanelDemoTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Nocilla/Nocilla.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nocilla.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
+++ b/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		021F142821B8EA1313088AB6 /* Pods_MixpanelDemoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37433CF0620BC6A0A5EFC541 /* Pods_MixpanelDemoTests.framework */; };
+		05D4C3E2222E1C6800D30FC2 /* SelectorEvaluaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D4C3E1222E1C6800D30FC2 /* SelectorEvaluaterTests.swift */; };
+		05D4C3E82230A8AD00D30FC2 /* InAppNotificationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D4C3E72230A8AD00D30FC2 /* InAppNotificationTest.swift */; };
 		51DD568A1D3077390045D3DB /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD56891D3077390045D3DB /* LoggerTests.swift */; };
 		860BE3132072B85D00C12F18 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 860BE30F2072B83E00C12F18 /* CoreTelephony.framework */; };
 		860BE3712076FBCC00C12F18 /* GDPRViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 860BE3702076FBCC00C12F18 /* GDPRViewController.swift */; };
@@ -92,6 +94,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		05D4C3E1222E1C6800D30FC2 /* SelectorEvaluaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectorEvaluaterTests.swift; sourceTree = "<group>"; };
+		05D4C3E72230A8AD00D30FC2 /* InAppNotificationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppNotificationTest.swift; sourceTree = "<group>"; };
 		37433CF0620BC6A0A5EFC541 /* Pods_MixpanelDemoTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MixpanelDemoTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		51DD56891D3077390045D3DB /* LoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
 		5609994314AFCE2B8FF1705B /* Pods-MixpanelDemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MixpanelDemoTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MixpanelDemoTests/Pods-MixpanelDemoTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -246,6 +250,8 @@
 				E1C61EBD1D22F9F60056C56C /* TestConstants.swift */,
 				51DD56891D3077390045D3DB /* LoggerTests.swift */,
 				E12BD03A1D8A14D6008989C9 /* Supporting Files */,
+				05D4C3E1222E1C6800D30FC2 /* SelectorEvaluaterTests.swift */,
+				05D4C3E72230A8AD00D30FC2 /* InAppNotificationTest.swift */,
 			);
 			path = MixpanelDemoTests;
 			sourceTree = "<group>";
@@ -470,6 +476,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E12BD0371D89FE6A008989C9 /* MixpanelCodelessTests.swift in Sources */,
+				05D4C3E2222E1C6800D30FC2 /* SelectorEvaluaterTests.swift in Sources */,
 				E131C43C1DB56B1000FAEE37 /* MixpanelABTestingTests.swift in Sources */,
 				E1E8F8B01D626BE80081295D /* MixpanelNotificationTests.swift in Sources */,
 				51DD568A1D3077390045D3DB /* LoggerTests.swift in Sources */,
@@ -477,6 +484,7 @@
 				E1C61EBA1D22F6470056C56C /* MixpanelPeopleTests.swift in Sources */,
 				E1C61EBE1D22F9F60056C56C /* TestConstants.swift in Sources */,
 				E12406201D249B2500383635 /* MixpanelBaseTests.swift in Sources */,
+				05D4C3E82230A8AD00D30FC2 /* InAppNotificationTest.swift in Sources */,
 				E17AA05E1EC6234E0066EFE8 /* MixpanelAutomaticEventsTests.swift in Sources */,
 				E15FF7EC1D0461130076CDE3 /* MixpanelDemoTests.swift in Sources */,
 			);

--- a/MixpanelDemo/MixpanelDemoTests/InAppNotificationTest.swift
+++ b/MixpanelDemo/MixpanelDemoTests/InAppNotificationTest.swift
@@ -15,7 +15,7 @@ import XCTest
 class InAppNotificationTest : XCTestCase {
     
     func testMatchesEvent() {
-        let displayTriggers = [["event": "test_event_1", "selector": ["operator": "<", "children": [["property": "event", "value": "created_at"], ["property": "literal", "value": ["window": ["value": 1, "unit": "hour"]]]]]], ["event": "test_event_2", "selector": ["operator": "==", "children": [["property": "event", "value": "city"], ["property": "literal", "value": "San Francisco"]]]]]
+        let displayTriggers = [["event": "test_event_1", "selector": ["operator": "<", "children": [["property": "event", "value": "created_at"], ["property": "literal", "value": ["window": ["value": -1, "unit": "hour"]]]]]], ["event": "test_event_2", "selector": ["operator": "==", "children": [["property": "event", "value": "city"], ["property": "literal", "value": "San Francisco"]]]]]
         
         let inapp = InAppNotification(JSONObject: ["id": 1, "message_id": 1, "extras": [:], "display_triggers": displayTriggers, "bg_color": UInt(101), "body_color": UInt(101), "image_url": "https://www.test.com/test.jpg", "type": "mini"])
         let inappWithoutTriggers = InAppNotification(JSONObject: ["id": 1, "message_id": 1, "extras": [:], "bg_color": UInt(101), "body_color": UInt(101), "image_url": "https://www.test.com/test.jpg", "type": "mini"])

--- a/MixpanelDemo/MixpanelDemoTests/InAppNotificationTest.swift
+++ b/MixpanelDemo/MixpanelDemoTests/InAppNotificationTest.swift
@@ -1,0 +1,34 @@
+//
+//  DisplayTriggersTest.swift
+//  MixpanelDemoTests
+//
+//  Created by Madhu Palani on 3/6/19.
+//  Copyright © 2019 Mixpanel. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+@testable import Mixpanel
+@testable import MixpanelDemo
+
+class InAppNotificationTest : XCTestCase {
+    
+    func testMatchesEvent() {
+        let displayTriggers = [["event": "test_event_1", "selector": ["operator": "<", "children": [["property": "event", "value": "created_at"], ["property": "literal", "value": ["window": ["value": 1, "unit": "hour"]]]]]], ["event": "test_event_2", "selector": ["operator": "==", "children": [["property": "event", "value": "city"], ["property": "literal", "value": "San Francisco"]]]]]
+        
+        let inapp = InAppNotification(JSONObject: ["id": 1, "message_id": 1, "extras": [:], "display_triggers": displayTriggers, "bg_color": UInt(101), "body_color": UInt(101), "image_url": "https://www.test.com/test.jpg", "type": "mini"])
+        let inappWithoutTriggers = InAppNotification(JSONObject: ["id": 1, "message_id": 1, "extras": [:], "bg_color": UInt(101), "body_color": UInt(101), "image_url": "https://www.test.com/test.jpg", "type": "mini"])
+        XCTAssertNotNil(inapp)
+        XCTAssertNotNil(inapp?.payload()["display_triggers"] as? [Any])
+        XCTAssertNotNil(inappWithoutTriggers?.payload()["display_triggers"] as? [Any])
+        
+        XCTAssertFalse(inappWithoutTriggers!.matchesEvent(event: "test_event_1", properties: nil))
+        XCTAssertTrue(inapp!.matchesEvent(event: "test_event_1", properties: ["created_at": Date()]))
+        XCTAssertFalse(inapp!.matchesEvent(event: "test_event_1", properties: ["created_at": Date().addingTimeInterval(2*60*60)]))
+        XCTAssertFalse(inapp!.matchesEvent(event: "test_event_1", properties: ["city": "San Francisco"]))
+        XCTAssertTrue(inapp!.matchesEvent(event: "test_event_2", properties: ["created_at": Date().addingTimeInterval(2*60*60), "city": "San Francisco"]))
+        XCTAssertFalse(inapp!.matchesEvent(event: "test_event_2", properties: ["created_at": Date(), "city": "Los Angeles"]))
+        XCTAssertFalse(inapp!.matchesEvent(event: "test_event_2", properties: ["city": "Los Angeles"]))
+    }
+}

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelNotificationTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelNotificationTests.swift
@@ -42,7 +42,13 @@ class MixpanelNotificationTests: MixpanelBaseTests {
                             "buttons": buttons,
                             "extras": [
                                 "image_fade": false
-                            ]] as [String : Any]
+                            ],
+                            "display_triggers": [
+                                [
+                                    "event": "test_event",
+                                    "selector": [:] as [String: Any],
+                                ] as [String: Any]] as [[String: Any]],
+                           ] as [String : Any]
     }
 
     func testMalformedImageURL() {
@@ -63,6 +69,7 @@ class MixpanelNotificationTests: MixpanelBaseTests {
         let testingInApp = TakeoverNotification(JSONObject: ["gar": "bage"])
         XCTAssertNil(testingInApp)
         var testDict: [String: Any]!
+        var testNotif: TakeoverNotification?
         // invalid id
         testDict = notificationDict
         testDict["id"] = false
@@ -92,7 +99,11 @@ class MixpanelNotificationTests: MixpanelBaseTests {
         // invalid color
         testDict = notificationDict
         testDict["bg_color"] = false
+        
         XCTAssertNil(TakeoverNotification(JSONObject: testDict))
+        testNotif = TakeoverNotification(JSONObject: notificationDict)
+        XCTAssertNotNil(testNotif)
+        XCTAssertTrue(testNotif!.hasDisplayTriggers())
     }
 
     func testNoDoubleShowNotification() {

--- a/MixpanelDemo/MixpanelDemoTests/SelectorEvaluaterTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/SelectorEvaluaterTests.swift
@@ -1,0 +1,514 @@
+//
+//  SelectorTests.swift
+//  MixpanelDemoTests
+//
+//  Created by Madhu Palani on 3/4/19.
+//  Copyright © 2019 Mixpanel. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import Mixpanel
+@testable import MixpanelDemo
+
+class SelectorEvaluatorTests: XCTestCase {
+    var logger: TestLogging!
+    override func setUp() {
+        super.setUp()
+        logger = TestLogging()
+        Logger.addLogging(logger)
+    }
+    
+    func testToNumber() {
+        XCTAssertNil(SelectorEvaluator.toNumber(value: nil))
+        XCTAssertNil(SelectorEvaluator.toNumber(value: Date(timeIntervalSince1970: 0)))
+        XCTAssertEqual(SelectorEvaluator.toNumber(value: true), 1)
+        XCTAssertEqual(SelectorEvaluator.toNumber(value: false), 0)
+        XCTAssertEqual(SelectorEvaluator.toNumber(value: Double(100.1)), 100.1)
+        XCTAssertEqual(SelectorEvaluator.toNumber(value: Int(101)), 101)
+        XCTAssertEqual(SelectorEvaluator.toNumber(value: NSNumber(value: 101.1)), 101.1)
+        XCTAssertEqual(SelectorEvaluator.toNumber(value: "100"), 100)
+        XCTAssertEqual(SelectorEvaluator.toNumber(value: "101.1"), 101.1)
+        XCTAssertEqual(SelectorEvaluator.toNumber(value: "abc"), 0)
+    }
+    
+    func testToBoolean() {
+        XCTAssertFalse(SelectorEvaluator.toBoolean(value: nil))
+        XCTAssertTrue(SelectorEvaluator.toBoolean(value: true))
+        XCTAssertFalse(SelectorEvaluator.toBoolean(value: false))
+        XCTAssertTrue(SelectorEvaluator.toBoolean(value: 100))
+        XCTAssertTrue(SelectorEvaluator.toBoolean(value: 0.1))
+        XCTAssertTrue(SelectorEvaluator.toBoolean(value: -1))
+        XCTAssertFalse(SelectorEvaluator.toBoolean(value: 0))
+        XCTAssertFalse(SelectorEvaluator.toBoolean(value: 0.0))
+        XCTAssertTrue(SelectorEvaluator.toBoolean(value: "abc"))
+        XCTAssertFalse(SelectorEvaluator.toBoolean(value: ""))
+        XCTAssertTrue(SelectorEvaluator.toBoolean(value: [1,2]))
+        XCTAssertFalse(SelectorEvaluator.toBoolean(value: []))
+        XCTAssertTrue(SelectorEvaluator.toBoolean(value: ["abc": 1]))
+        XCTAssertFalse(SelectorEvaluator.toBoolean(value: [:]))
+        XCTAssertTrue(SelectorEvaluator.toBoolean(value: Date(timeIntervalSince1970: 1)))
+        XCTAssertFalse(SelectorEvaluator.toBoolean(value: Date(timeIntervalSince1970: 0)))
+        XCTAssertFalse(SelectorEvaluator.toBoolean(value: TakeoverNotification(JSONObject: nil)))
+    }
+    
+    func testEvaluateNumber() {
+        XCTAssertNil(SelectorEvaluator.evaluateNumber(node: [:], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: number")
+        XCTAssertNil(SelectorEvaluator.evaluateNumber(node: ["operator": "or"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: number")
+        XCTAssertNil(SelectorEvaluator.evaluateNumber(node: ["operator": "number"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: number")
+        XCTAssertNil(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": []], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: number")
+        XCTAssertNil(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [[], []]], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: number")
+        
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": Date(timeIntervalSince1970: 1)]), 1)
+        XCTAssertNil(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [:]]))
+        XCTAssertNil(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": []]))
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": true]), 1)
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": false]), 0)
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": Double(100)]), 100)
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": Double(100.1)]), 100.1)
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": Int(101)]), 101)
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "101"]), 101)
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "10.1"]), 10.1)
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "abc"]), 0)
+        XCTAssertEqual(SelectorEvaluator.evaluateNumber(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": ""]), 0)
+    }
+    
+    func testEvaluateBoolean() {
+        XCTAssertNil(SelectorEvaluator.evaluateBoolean(node: [:], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: boolean")
+        XCTAssertNil(SelectorEvaluator.evaluateBoolean(node: ["operator": "or"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: boolean")
+        XCTAssertNil(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: boolean")
+        XCTAssertNil(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": []], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: boolean")
+        XCTAssertNil(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [[], []]], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: boolean")
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: [:])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": true])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": false])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": 100])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": 0])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "100"])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": ""])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [1,2,3]])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": []])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": ["a":1]])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [:]])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": Date(timeIntervalSince1970: 1)])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateBoolean(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": Date(timeIntervalSince1970: 0)])!)
+    }
+    
+    func testEvaluateDatetime() {
+        XCTAssertNil(SelectorEvaluator.evaluateDateTime(node: [:], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: datetime")
+        XCTAssertNil(SelectorEvaluator.evaluateDateTime(node: ["operator": "or"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: datetime")
+        XCTAssertNil(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: datetime")
+        XCTAssertNil(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime", "children": []], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: datetime")
+        XCTAssertNil(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime", "children": [[], []]], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: datetime")
+        
+        XCTAssertNil(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime", "children": [["property": "event", "value": "prop"]]], properties: [:]))
+        XCTAssertNil(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime", "children": [["property": "event", "value": "prop"]]], properties: ["prop": true]))
+        XCTAssertEqual(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime", "children": [["property": "event", "value": "prop"]]], properties: ["prop": 10]), Date(timeIntervalSince1970: 10))
+        let df = DateFormatter.formatterForJSONDate();
+        let dt = df.date(from: "2019-02-01T12:01:01")
+        XCTAssertNotNil(dt)
+        XCTAssertEqual(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "2019-02-01T12:01:01"]), dt)
+        XCTAssertEqual(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime", "children": [["property": "event", "value": "prop"]]], properties: ["prop": dt!]), dt)
+        XCTAssertNil(SelectorEvaluator.evaluateDateTime(node: ["operator": "datetime", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "2019-02-01T32:01:01"]))
+    }
+    
+    func testEvaluateList() {
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: [:], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: list")
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: ["operator": "or"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: list")
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: ["operator": "list"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: list")
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: ["operator": "list", "children": []], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: list")
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: ["operator": "list", "children": [[], []]], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: list")
+        
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: ["operator": "list", "children": [["property": "event", "value": "prop"]]], properties: [:]))
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: ["operator": "list", "children": [["property": "event", "value": "prop"]]], properties: ["prop": 1]))
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: ["operator": "list", "children": [["property": "event", "value": "prop"]]], properties: ["prop": ""]))
+        XCTAssertNil(SelectorEvaluator.evaluateList(node: ["operator": "list", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [:]]))
+        
+        XCTAssertEqual(NSSet(array: SelectorEvaluator.evaluateList(node: ["operator": "list", "children": [["property": "event", "value": "prop"]]], properties: ["prop": []])!), NSSet(array: []))
+        XCTAssertEqual(NSSet(array: SelectorEvaluator.evaluateList(node: ["operator": "list", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [1,2,3]])!), NSSet(array: [1,2,3]))
+    }
+    
+    func testEvaluateString() {
+        XCTAssertNil(SelectorEvaluator.evaluateString(node: [:], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: string")
+        XCTAssertNil(SelectorEvaluator.evaluateString(node: ["operator": "or"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: string")
+        XCTAssertNil(SelectorEvaluator.evaluateString(node: ["operator": "string"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: string")
+        XCTAssertNil(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": []], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: string")
+        XCTAssertNil(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": [[], []]], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: string")
+        
+        let df = DateFormatter.formatterForJSONDate()
+        let dt = df.date(from: "2019-01-01T00:00:00")
+        XCTAssertNotNil(dt)
+        XCTAssertEqual(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": [["property": "event", "value": "prop"]]], properties: ["prop": dt!]), "2019-01-01T00:00:00")
+        XCTAssertEqual(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": [["property": "event", "value": "prop"]]], properties: ["prop": 100]), "100")
+        XCTAssertEqual(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": [["property": "event", "value": "prop"]]], properties: ["prop": []]), "[]")
+        XCTAssertEqual(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [1,2,3]]), "[1,2,3]")
+        XCTAssertEqual(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [:]]), "{}")
+        XCTAssertEqual(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": [["property": "event", "value": "prop"]]], properties: ["prop": ["a":"b"]]), "{\"a\":\"b\"}")
+        XCTAssertEqual(SelectorEvaluator.evaluateString(node: ["operator": "string", "children": [["property": "event", "value": "prop"]]], properties: ["prop": true]), "true")
+    }
+    
+    func testEvaluateAnd() {
+        XCTAssertNil(SelectorEvaluator.evaluateAnd(node: [:], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: and")
+        XCTAssertNil(SelectorEvaluator.evaluateAnd(node: ["operator": "or"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: and")
+        XCTAssertNil(SelectorEvaluator.evaluateAnd(node: ["operator": "and"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: and")
+        XCTAssertNil(SelectorEvaluator.evaluateAnd(node: ["operator": "and", "children": []], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: and")
+        XCTAssertNil(SelectorEvaluator.evaluateAnd(node: ["operator": "and", "children": [[]]], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: and")
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateAnd(node: ["operator": "and", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": true])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateAnd(node: ["operator": "and", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": false])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateAnd(node: ["operator": "and", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": true])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateAnd(node: ["operator": "and", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": false])!)
+    }
+    
+    func testEvaluateOr() {
+        XCTAssertNil(SelectorEvaluator.evaluateOr(node: [:], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: or")
+        XCTAssertNil(SelectorEvaluator.evaluateOr(node: ["operator": "and"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: or")
+        XCTAssertNil(SelectorEvaluator.evaluateOr(node: ["operator": "or"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: or")
+        XCTAssertNil(SelectorEvaluator.evaluateOr(node: ["operator": "or", "children": []], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: or")
+        XCTAssertNil(SelectorEvaluator.evaluateOr(node: ["operator": "or", "children": [[]]], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: or")
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateOr(node: ["operator": "or", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": true])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateOr(node: ["operator": "or", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": false])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateOr(node: ["operator": "or", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": true])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateOr(node: ["operator": "or", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": false])!)
+    }
+    
+    func testEvaluateIn() {
+        XCTAssertNil(SelectorEvaluator.evaluateIn(node: [:], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: in")
+        XCTAssertNil(SelectorEvaluator.evaluateIn(node: ["operator": "and"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: in")
+        XCTAssertNil(SelectorEvaluator.evaluateIn(node: ["operator": "in"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: in")
+        XCTAssertNil(SelectorEvaluator.evaluateIn(node: ["operator": "in", "children": []], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: in")
+        XCTAssertNil(SelectorEvaluator.evaluateIn(node: ["operator": "in", "children": [[]]], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: in")
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateIn(node: ["operator": "in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": [1,2]])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateIn(node: ["operator": "in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "ab", "prop2": "abc"])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateIn(node: ["operator": "in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": [11]])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateIn(node: ["operator": "in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "ab", "prop2": "bac"])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateIn(node: ["operator": "not in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": [1,2]])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateIn(node: ["operator": "not in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "ab", "prop2": "abc"])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateIn(node: ["operator": "not in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": [11]])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateIn(node: ["operator": "not in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "ab", "prop2": "bac"])!)
+    }
+    
+    func testEvaluatePlus() {
+        XCTAssertNil(SelectorEvaluator.evaluatePlus(node: [:], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: +")
+        XCTAssertNil(SelectorEvaluator.evaluatePlus(node: ["operator": "and"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: +")
+        XCTAssertNil(SelectorEvaluator.evaluatePlus(node: ["operator": "+"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: +")
+        XCTAssertNil(SelectorEvaluator.evaluatePlus(node: ["operator": "+", "children": []], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: +")
+        XCTAssertNil(SelectorEvaluator.evaluatePlus(node: ["operator": "+", "children": [[]]], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: +")
+        
+        XCTAssertNil(SelectorEvaluator.evaluatePlus(node: ["operator": "+", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": [1,2]]))
+        XCTAssertEqual(SelectorEvaluator.evaluatePlus(node: ["operator": "+", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]) as? Double, 3)
+        XCTAssertEqual(SelectorEvaluator.evaluatePlus(node: ["operator": "+", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "1", "prop2": "2"]) as? String, "12")
+    }
+    
+    func testEvaluateArithmetic() {
+        XCTAssertNil(SelectorEvaluator.evaluateArithmetic(node: [:], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid arithmetic operator")
+        XCTAssertNil(SelectorEvaluator.evaluateArithmetic(node: ["operator": "and"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid arithmetic operator")
+        XCTAssertNil(SelectorEvaluator.evaluateArithmetic(node: ["operator": "-"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid arithmetic operator")
+        XCTAssertNil(SelectorEvaluator.evaluateArithmetic(node: ["operator": "-", "children": []], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid arithmetic operator")
+        XCTAssertNil(SelectorEvaluator.evaluateArithmetic(node: ["operator": "-", "children": [[]]], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid arithmetic operator")
+        
+        XCTAssertEqual(SelectorEvaluator.evaluateArithmetic(node: ["operator": "-", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]), -1)
+        XCTAssertEqual(SelectorEvaluator.evaluateArithmetic(node: ["operator": "*", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]), 2)
+        XCTAssertEqual(SelectorEvaluator.evaluateArithmetic(node: ["operator": "/", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]), 0.5)
+        XCTAssertNil(SelectorEvaluator.evaluateArithmetic(node: ["operator": "/", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 0]))
+        XCTAssertNil(SelectorEvaluator.evaluateArithmetic(node: ["operator": "%", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 0]))
+        XCTAssertEqual(SelectorEvaluator.evaluateArithmetic(node: ["operator": "%", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 0, "prop2": 1]), 0)
+        XCTAssertEqual(SelectorEvaluator.evaluateArithmetic(node: ["operator": "%", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": -1, "prop2": 2]), 1)
+        XCTAssertEqual(SelectorEvaluator.evaluateArithmetic(node: ["operator": "%", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": -1, "prop2": -2]), -1)
+        XCTAssertEqual(SelectorEvaluator.evaluateArithmetic(node: ["operator": "%", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": -2]), -1)
+    }
+    
+    func testEvaluateEquality() {
+        XCTAssertNil(SelectorEvaluator.evaluateEquality(node: [:], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid (not) equality operator")
+        XCTAssertNil(SelectorEvaluator.evaluateEquality(node: ["operator": "and"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid (not) equality operator")
+        XCTAssertNil(SelectorEvaluator.evaluateEquality(node: ["operator": "=="], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid (not) equality operator")
+        XCTAssertNil(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": []], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid (not) equality operator")
+        XCTAssertNil(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [[]]], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid (not) equality operator")
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: [:])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": "1"])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 1])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": true])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": false])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": false])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": true])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "abc", "prop2": "abc"])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "abc", "prop2": "acb"])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 100), "prop2": Date(timeIntervalSince1970: 100)])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 100), "prop2": Date(timeIntervalSince1970: 101)])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": ["a": 1, "b": 2], "prop2": ["b": 2, "a": 1]])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": ["a": 1, "b": 2], "prop2": ["b": 1, "a": 2]])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: [:])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": "1"])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 1])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": true])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": false])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": false])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": true])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "abc", "prop2": "abc"])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "abc", "prop2": "acb"])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 100), "prop2": Date(timeIntervalSince1970: 100)])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 100), "prop2": Date(timeIntervalSince1970: 101)])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": ["a": 1, "b": 2], "prop2": ["b": 2, "a": 1]])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateEquality(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": ["a": 1, "b": 2], "prop2": ["b": 1, "a": 2]])!)
+    }
+    
+    func testEvaluateComparison() {
+        XCTAssertNil(SelectorEvaluator.evaluateComparison(node: [:], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid comparison operator")
+        XCTAssertNil(SelectorEvaluator.evaluateComparison(node: ["operator": "and"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid comparison operator")
+        XCTAssertNil(SelectorEvaluator.evaluateComparison(node: ["operator": "<"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid comparison operator")
+        XCTAssertNil(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": []], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid comparison operator")
+        XCTAssertNil(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": [[]]], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid comparison operator")
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 1])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 1), "prop2": Date(timeIntervalSince1970: 1)])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 1), "prop2": Date(timeIntervalSince1970: 2)])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 2, "prop2": 1])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 2), "prop2": Date(timeIntervalSince1970: 1)])!)
+
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": ">=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 1])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": ">=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 1), "prop2": Date(timeIntervalSince1970: 1)])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": ">=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": ">=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 1), "prop2": Date(timeIntervalSince1970: 2)])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": ">=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 2, "prop2": 1])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": ">=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 2), "prop2": Date(timeIntervalSince1970: 1)])!)
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 1])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 1), "prop2": Date(timeIntervalSince1970: 1)])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 1), "prop2": Date(timeIntervalSince1970: 2)])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 2, "prop2": 1])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 2), "prop2": Date(timeIntervalSince1970: 1)])!)
+
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 1])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 1), "prop2": Date(timeIntervalSince1970: 1)])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 1), "prop2": Date(timeIntervalSince1970: 2)])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 2, "prop2": 1])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateComparison(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": Date(timeIntervalSince1970: 2), "prop2": Date(timeIntervalSince1970: 1)])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "abc", "prop2": "abc"])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": ">=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "abc", "prop2": "abc"])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "abc", "prop2": "ab"])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateComparison(node: ["operator": "<", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": "ab", "prop2": "abc"])!)
+        
+        XCTAssertNil(SelectorEvaluator.evaluateComparison(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": [1,2,3], "prop2": 1]))
+    }
+    
+    func testEvaluateDefined() {
+        XCTAssertNil(SelectorEvaluator.evaluateDefined(node: [:], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: (not) defined")
+        XCTAssertNil(SelectorEvaluator.evaluateDefined(node: ["operator": "or"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: (not) defined")
+        XCTAssertNil(SelectorEvaluator.evaluateDefined(node: ["operator": "defined"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: (not) defined")
+        XCTAssertNil(SelectorEvaluator.evaluateDefined(node: ["operator": "defined", "children": []], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: (not) defined")
+        XCTAssertNil(SelectorEvaluator.evaluateDefined(node: ["operator": "defined", "children": [[], []]], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: (not) defined")
+        
+        XCTAssertFalse(SelectorEvaluator.evaluateDefined(node: ["operator": "defined", "children": [["property": "event", "value": "prop"]]], properties: [:])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateDefined(node: ["operator": "defined", "children": [["property": "event", "value": "prop"]]], properties: ["prop": []])!)
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateDefined(node: ["operator": "not defined", "children": [["property": "event", "value": "prop"]]], properties: [:])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateDefined(node: ["operator": "not defined", "children": [["property": "event", "value": "prop"]]], properties: ["prop": []])!)
+    }
+    
+    func testEvaluateNot() {
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: [:], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: not")
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: ["operator": "or"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: not")
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: ["operator": "not"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: not")
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": []], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: not")
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": [[], []]], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator: not")
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": [["property": "event", "value": "prop"]]], properties: [:])!)
+        XCTAssertTrue(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": [["property": "event", "value": "prop"]]], properties: ["prop": false])!)
+        XCTAssertFalse(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": [["property": "event", "value": "prop"]]], properties: ["prop": true])!)
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": [["property": "event", "value": "prop"]]], properties: ["prop": []]))
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": [["property": "event", "value": "prop"]]], properties: ["prop": 1]))
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "1"]))
+        XCTAssertNil(SelectorEvaluator.evaluateNot(node: ["operator": "not", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [:]]))
+    }
+    
+    func testEvaluateWindow() {
+        XCTAssertNil(TestSelectorEvaluator.evaluateWindow(value: [:]))
+        XCTAssertEqual(logger.logMessage?.text, "missing window")
+        XCTAssertNil(TestSelectorEvaluator.evaluateWindow(value: ["window":[:]]))
+        XCTAssertEqual(logger.logMessage?.text, "missing value")
+        XCTAssertNil(TestSelectorEvaluator.evaluateWindow(value: ["window":["value":[]]]))
+        XCTAssertEqual(logger.logMessage?.text, "missing value")
+        XCTAssertNil(TestSelectorEvaluator.evaluateWindow(value: ["window":["value":1]]))
+        XCTAssertEqual(logger.logMessage?.text, "missing unit")
+        XCTAssertNil(TestSelectorEvaluator.evaluateWindow(value: ["window":["value":1, "unit": "blah"]]))
+        XCTAssertEqual(logger.logMessage?.text, "Invalid unit for window")
+        
+        XCTAssertEqual(TestSelectorEvaluator.evaluateWindow(value: ["window": ["value": -2, "unit": "hour"]]), Date(timeIntervalSince1970: 10000+(2*60*60)))
+        XCTAssertEqual(TestSelectorEvaluator.evaluateWindow(value: ["window": ["value": -2, "unit": "day"]]), Date(timeIntervalSince1970: 10000+(2*24*60*60)))
+        XCTAssertEqual(TestSelectorEvaluator.evaluateWindow(value: ["window": ["value": -2, "unit": "week"]]), Date(timeIntervalSince1970: 10000+(2*7*24*60*60)))
+        XCTAssertEqual(TestSelectorEvaluator.evaluateWindow(value: ["window": ["value": -2, "unit": "month"]]), Date(timeIntervalSince1970: 10000+(2*30*24*60*60)))
+        XCTAssertEqual(TestSelectorEvaluator.evaluateWindow(value: ["window": ["value": 2, "unit": "hour"]]), Date(timeIntervalSince1970: 10000+(-2*60*60)))
+    }
+    
+    func testEvaluateOperand() {
+        XCTAssertNil(SelectorEvaluator.evaluateOperand(node: [:], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "missing key property")
+        XCTAssertNil(SelectorEvaluator.evaluateOperand(node: ["property": 1], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "missing key property")
+        XCTAssertNil(SelectorEvaluator.evaluateOperand(node: ["property": "event"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "missing key value")
+        XCTAssertNil(SelectorEvaluator.evaluateOperand(node: ["property": "event", "value": 1], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "unexpected type for event property")
+        
+        XCTAssertEqual(SelectorEvaluator.evaluateOperand(node: ["property": "event", "value": "prop"], properties: ["prop": Double(100)]) as? Double, 100)
+        XCTAssertEqual(SelectorEvaluator.evaluateOperand(node: ["property": "literal", "value": "prop"], properties: ["prop": Double(100)]) as? String, "prop")
+        XCTAssertEqual(TestSelectorEvaluator.evaluateOperand(node: ["property": "literal", "value": "now"], properties: ["prop": Double(100)]) as? Date, Date(timeIntervalSince1970: 10000))
+        XCTAssertEqual(TestSelectorEvaluator.evaluateOperand(node: ["property": "literal", "value": ["window": ["value": -1, "unit": "hour"]]], properties: ["prop": Double(100)]) as? Date, Date(timeIntervalSince1970: 10000+(60*60)))
+    }
+    
+    func testEvaluateOperator() {
+        XCTAssertNil(SelectorEvaluator.evaluateOperator(node: [:], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator key")
+        XCTAssertNil(SelectorEvaluator.evaluateOperator(node: ["operator": 1], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "invalid operator key")
+        XCTAssertNil(SelectorEvaluator.evaluateOperator(node: ["operator": "blah"], properties: nil))
+        XCTAssertEqual(logger.logMessage?.text, "Unknown operator blah")
+        
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "and", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": true]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "or", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": false]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": [1,2]]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "not in", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 12, "prop2": [1,2]]) as! Bool)
+        XCTAssertEqual(SelectorEvaluator.evaluateOperator(node: ["operator": "+", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]) as! Double, 3)
+        XCTAssertEqual(SelectorEvaluator.evaluateOperator(node: ["operator": "-", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]) as! Double, -1)
+        XCTAssertEqual(SelectorEvaluator.evaluateOperator(node: ["operator": "*", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]) as! Double, 2)
+        XCTAssertEqual(SelectorEvaluator.evaluateOperator(node: ["operator": "/", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]) as! Double, 0.5)
+        XCTAssertEqual(SelectorEvaluator.evaluateOperator(node: ["operator": "%", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 2]) as! Double, 1)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "==", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": false, "prop2": false]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "!=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": true, "prop2": false]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 2, "prop2": 1]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": ">=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 2, "prop2": 2]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "<", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 0, "prop2": 1]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "<=", "children": [["property": "event", "value": "prop1"], ["property": "event", "value": "prop2"]]], properties: ["prop1": 1, "prop2": 1]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "boolean", "children": [["property": "event", "value": "prop"]]], properties: ["prop": true]) as! Bool)
+        XCTAssertEqual(SelectorEvaluator.evaluateOperator(node: ["operator": "string", "children": [["property": "event", "value": "prop"]]], properties: ["prop": 100]) as! String, "100")
+        XCTAssertEqual(NSSet(array: SelectorEvaluator.evaluateOperator(node: ["operator": "list", "children": [["property": "event", "value": "prop"]]], properties: ["prop": [1,2,3]]) as! Array), NSSet(array: [1,2,3]))
+        XCTAssertEqual(SelectorEvaluator.evaluateOperator(node: ["operator": "number", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "101"]) as! Double, 101)
+        let df = DateFormatter.formatterForJSONDate();
+        let dt = df.date(from: "2019-02-01T12:01:01")
+        XCTAssertNotNil(dt)
+        XCTAssertEqual(SelectorEvaluator.evaluateOperator(node: ["operator": "datetime", "children": [["property": "event", "value": "prop"]]], properties: ["prop": "2019-02-01T12:01:01"]) as? Date, dt)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "defined", "children": [["property": "event", "value": "prop"]]], properties: ["prop": []]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "not defined", "children": [["property": "event", "value": "prop"]]], properties: [:]) as! Bool)
+        XCTAssertTrue(SelectorEvaluator.evaluateOperator(node: ["operator": "not", "children": [["property": "event", "value": "prop"]]], properties: ["prop": false]) as! Bool)
+    }
+    
+    func testEvaluate() {
+        XCTAssertNil(SelectorEvaluator.evaluate(selector: [:], properties: nil))
+        XCTAssertNil(SelectorEvaluator.evaluate(selector: ["operator": "unknown"], properties: ["prop": 1]))
+        let value = SelectorEvaluator.evaluate(selector: ["operator": ">", "children": [["property": "event", "value": "prop1"], ["property": "literal", "value": ["window": ["value": 1, "unit": "hour"]]]]], properties: ["prop1": Date()])
+        XCTAssertNotNil(value)
+        XCTAssertTrue(value!)
+    }
+}
+
+class TestSelectorEvaluator: SelectorEvaluator {
+    override class func getCurrentDate() -> Date {
+        return Date(timeIntervalSince1970: 10000)
+    }
+}
+
+class TestLogging: Logging {
+    var logMessage: LogMessage?
+    
+    init?() {
+        logMessage = nil
+    }
+    
+    func addMessage(message: LogMessage) {
+        logMessage = message
+    }
+}


### PR DESCRIPTION
**Event Triggered InApps**

Currently users have no control over when an InApp notification shows up. With this release users can now control when an InApp gets displayed based on an event that they track within their app. This "trigger" event is defined during message creation. You can additionally filter the event based on properties that are tracked along with the event for even finer controls.