### PR TITLE
Opt-out default state won't override user opt out local persistence

### DIFF
--- a/Mixpanel/Persistence.swift
+++ b/Mixpanel/Persistence.swift
@@ -190,7 +190,7 @@ class Persistence {
                                             shownNotifications: Set<Int>,
                                             codelessBindings: Set<CodelessBinding>,
                                             variants: Set<Variant>,
-                                            optOutStatus: Bool,
+                                            optOutStatus: Bool?,
                                             automaticEventsEnabled: Bool?) {
         let eventsQueue = unarchiveEvents(token: token)
         let peopleQueue = unarchivePeople(token: token)
@@ -310,9 +310,8 @@ class Persistence {
         return data as? Queue ?? []
     }
 
-    class private func unarchiveOptOutStatus(token: String) -> Bool {
-        let data = unarchiveWithType(.optOutStatus, token: token) as? Bool
-        return data ?? false
+    class private func unarchiveOptOutStatus(token: String) -> Bool? {
+        return unarchiveWithType(.optOutStatus, token: token) as? Bool
     }
 
     #if DECIDE

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelOptOutTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelOptOutTests.swift
@@ -48,6 +48,20 @@ class MixpanelOptOutTests: MixpanelBaseTests {
         XCTAssertTrue(self.mixpanel.eventsQueue.count == 0, "When initialize with opted out flag set to YES, no event should be queued")
     }
 
+    func testAutoTrackEventsShouldBeQueuedDuringInitializedWithOptedOutYESAndOptInLater()
+    {
+        let launchOptions = [UIApplication.LaunchOptionsKey.remoteNotification:
+            ["mp":["m":"the_message_id","c": "the_campaign_id",
+                   "journey_id": 123456]
+            ]]
+        let tokenId = randomId()
+        mixpanel = Mixpanel.initialize(token: tokenId, launchOptions: launchOptions, optOutTrackingByDefault: true)
+        mixpanel.optInTracking()
+        mixpanel = Mixpanel.initialize(token: tokenId, launchOptions: launchOptions, optOutTrackingByDefault: true)
+        waitForMixpanelQueues()
+        XCTAssertTrue(self.mixpanel.eventsQueue.count == 1, "When initialize with opted out flag set to YES, event should be queued")
+    }
+    
     func testAutoTrackShouldBeTriggeredDuringInitializedWithOptedOutNO()
     {
         let launchOptions = [UIApplication.LaunchOptionsKey.remoteNotification:


### PR DESCRIPTION
Change the default behavior for setting `optOutTrackingByDefault` in  the Mixpanel initialization method.
- We will not override opt out persistence with `optOutTrackingByDefault` the flag since opt-out default state is supposed to be used as an initial state while GDPR information is being collected