### PR TITLE
Fix race conditions crashes

### DIFF
--- a/Mixpanel/Decide.swift
+++ b/Mixpanel/Decide.swift
@@ -63,7 +63,10 @@ class Decide {
 
         if !decideFetched || forceFetch {
             let semaphore = DispatchSemaphore(value: 0)
-            decideRequest.sendRequest(distinctId: distinctId, token: token) { decideResult in
+            decideRequest.sendRequest(distinctId: distinctId, token: token) { [weak self] decideResult in
+                guard let self = self else {
+                    return
+                }
                 guard let result = decideResult else {
                     semaphore.signal()
                     completion(nil)

--- a/Mixpanel/Flush.swift
+++ b/Mixpanel/Flush.swift
@@ -54,22 +54,23 @@ class Flush: AppLifecycle {
         }
         return mutableEventsQueue
     }
-
-    func orderAutomaticEvents(queue: Queue, automaticEventsEnabled: Bool?) -> (automaticEventQueue: Queue?, eventsQueue: Queue) {
-        var eventsQueue = queue
-        if automaticEventsEnabled == nil || !automaticEventsEnabled! {
-            var discardedItems = Queue()
-            for (i, ev) in eventsQueue.enumerated().reversed() {
-                if let eventName = ev["event"] as? String, eventName.hasPrefix("$ae_") {
-                    discardedItems.append(ev)
-                    eventsQueue.remove(at: i)
+    
+    func orderAutomaticEvents(queue: Queue, automaticEventsEnabled: Bool?) ->
+        (automaticEventQueue: Queue?, eventsQueue: Queue) {
+            var eventsQueue = queue
+            if automaticEventsEnabled == nil || !automaticEventsEnabled! {
+                var discardedItems = Queue()
+                for (i, ev) in eventsQueue.enumerated().reversed() {
+                    if let eventName = ev["event"] as? String, eventName.hasPrefix("$ae_") {
+                        discardedItems.append(ev)
+                        eventsQueue.remove(at: i)
+                    }
+                }
+                if automaticEventsEnabled == nil {
+                    return (discardedItems, eventsQueue)
                 }
             }
-            if automaticEventsEnabled == nil {
-                return (discardedItems, eventsQueue)
-            }
-        }
-        return (nil, eventsQueue)
+            return (nil, eventsQueue)
     }
 
     func flushPeopleQueue(_ peopleQueue: Queue) -> Queue? {

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -254,7 +254,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
     let readWriteLock: ReadWriteLock
     #if os(iOS)
     var reachability: SCNetworkReachability?
-    let telephonyInfo = CTTelephonyNetworkInfo()
+    static let telephonyInfo = CTTelephonyNetworkInfo()
     #endif
     #if !os(OSX) && !WATCH_OS
     var taskId = UIBackgroundTaskIdentifier.invalid
@@ -662,7 +662,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
     }
     #if os(iOS)
     @objc func setCurrentRadio() {
-        var radio = telephonyInfo.currentRadioAccessTechnology ?? "None"
+        var radio = MixpanelInstance.telephonyInfo.currentRadioAccessTechnology ?? "None"
         let prefix = "CTRadioAccessTechnology"
         if radio.hasPrefix(prefix) {
             radio = (radio as NSString).substring(from: prefix.count)
@@ -671,11 +671,11 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
             AutomaticProperties.automaticPropertiesLock.write { [weak self, radio] in
                 AutomaticProperties.properties["$radio"] = radio
 
-                guard let self = self else {
+                guard self != nil else {
                     return
                 }
 
-                if let carrierName = self.telephonyInfo.subscriberCellularProvider?.carrierName {
+                if let carrierName = MixpanelInstance.telephonyInfo.subscriberCellularProvider?.carrierName {
                     AutomaticProperties.properties["$carrier"] = carrierName
 
                 } else {

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -253,7 +253,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
     var optOutStatus: Bool?
     let readWriteLock: ReadWriteLock
     #if os(iOS)
-    var reachability: SCNetworkReachability?
+    static let reachability = SCNetworkReachabilityCreateWithName(nil, "api.mixpanel.com")
     static let telephonyInfo = CTTelephonyNetworkInfo()
     #endif
     #if !os(OSX) && !WATCH_OS
@@ -290,8 +290,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
         networkQueue = DispatchQueue(label: label)
 
         #if os(iOS)
-            reachability = SCNetworkReachabilityCreateWithName(nil, "api.mixpanel.com")
-            if let reachability = reachability {
+            if let reachability = MixpanelInstance.reachability {
                 var context = SCNetworkReachabilityContext(version: 0, info: nil, retain: nil, release: nil, copyDescription: nil)
                 func reachabilityCallback(reachability: SCNetworkReachability, flags: SCNetworkReachabilityFlags, unsafePointer: UnsafeMutableRawPointer?) -> Void {
                     let wifi = flags.contains(SCNetworkReachabilityFlags.reachable) && !flags.contains(SCNetworkReachabilityFlags.isWWAN)
@@ -449,7 +448,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
     deinit {
         NotificationCenter.default.removeObserver(self)
         #if os(iOS) && !WATCH_OS
-            if let reachability = reachability {
+            if let reachability = MixpanelInstance.reachability {
                 if !SCNetworkReachabilitySetCallback(reachability, nil, nil) {
                     Logger.error(message: "\(self) error unsetting reachability callback")
                 }

--- a/Mixpanel/Track.swift
+++ b/Mixpanel/Track.swift
@@ -49,9 +49,9 @@ class Track {
         }
         p["token"] = apiToken
         p["time"] = epochSeconds
-        var timedEvents = timedEvents
+        var shadowTimedEvents = timedEvents
         if let eventStartTime = eventStartTime {
-            timedEvents.removeValue(forKey: ev!)
+            shadowTimedEvents.removeValue(forKey: ev!)
             p["$duration"] = Double(String(format: "%.3f", epochInterval - eventStartTime))
         }
         p["distinct_id"] = distinctId
@@ -69,17 +69,17 @@ class Track {
         if let properties = properties {
             p += properties
         }
-        
+
         var trackEvent: InternalProperties = ["event": ev!, "properties": p]
         metadata.toDict().forEach { (k,v) in trackEvent[k] = v }
-        var eventsQueue = eventsQueue
+        var shadowEventsQueue = eventsQueue
         
-        eventsQueue.append(trackEvent)
-        if eventsQueue.count > QueueConstants.queueSize {
-            eventsQueue.remove(at: 0)
+        shadowEventsQueue.append(trackEvent)
+        if shadowEventsQueue.count > QueueConstants.queueSize {
+            shadowEventsQueue.remove(at: 0)
         }
         
-        return (eventsQueue, timedEvents, p)
+        return (shadowEventsQueue, shadowTimedEvents, p)
     }
 
     func registerSuperProperties(_ properties: Properties,

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelAutomaticEventsTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelAutomaticEventsTests.swift
@@ -25,10 +25,11 @@ class MixpanelAutomaticEventsTests: MixpanelBaseTests {
     func testSession() {
         self.mixpanel.minimumSessionDuration = 0;
         self.mixpanel.identify(distinctId: "d1")
+        sleep(1)
         self.mixpanel.automaticEvents.perform(#selector(AutomaticEvents.appWillResignActive(_:)),
                                               with: Notification(name: Notification.Name(rawValue: "test")))
-        self.waitForTrackingQueue()
-        let event = self.mixpanel.eventsQueue.first
+        self.waitForMixpanelQueues()
+        let event = self.mixpanel.eventsQueue.last
         let people1 = self.mixpanel.people.peopleQueue[0]["$add"] as! InternalProperties
         let people2 = self.mixpanel.people.peopleQueue[1]["$add"] as! InternalProperties
         XCTAssertEqual(people1["$ae_total_app_sessions"] as? Double, 1, "total app sessions should be added by 1")

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
@@ -790,7 +790,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
     }
 
     func testTelephonyInfoInitialized() {
-        XCTAssertNotNil(mixpanel.telephonyInfo, "telephonyInfo wasn't initialized")
+        XCTAssertNotNil(MixpanelInstance.telephonyInfo, "telephonyInfo wasn't initialized")
     }
 
     func testReadWriteLock() {

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
@@ -589,7 +589,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
         XCTAssertEqual(mixpanel.distinctId, "d1", "custom distinct archive failed")
         XCTAssertTrue(mixpanel.currentSuperProperties().count == 1,
                       "custom super properties archive failed")
-        XCTAssertEqual(mixpanel.eventsQueue[mixpanel.eventsQueue.count - 1]["event"] as? String, "e1",
+        XCTAssertEqual(mixpanel.eventsQueue[0]["event"] as? String, "e1",
                        "event was not successfully archived/unarchived")
         XCTAssertEqual(mixpanel.people.distinctId, "d1",
                        "custom people distinct id archive failed")

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
@@ -578,8 +578,17 @@ class MixpanelDemoTests: MixpanelBaseTests {
         XCTAssertTrue(mixpanel.people.peopleQueue.isEmpty, "default people queue archive failed")
         let p: Properties = ["p1": "a"]
         mixpanel.identify(distinctId: "d1")
+        sleep(1)
         mixpanel.registerSuperProperties(p)
         mixpanel.track(event: "e1")
+        mixpanel.track(event: "e3")
+        mixpanel.track(event: "e4")
+        mixpanel.track(event: "e5")
+        mixpanel.track(event: "e6")
+        mixpanel.track(event: "e7")
+        mixpanel.track(event: "e8")
+        mixpanel.track(event: "e9")
+        mixpanel.track(event: "e10")
         mixpanel.people.set(properties: p)
         mixpanel.timedEvents["e2"] = 5.0
         waitForTrackingQueue()
@@ -589,8 +598,24 @@ class MixpanelDemoTests: MixpanelBaseTests {
         XCTAssertEqual(mixpanel.distinctId, "d1", "custom distinct archive failed")
         XCTAssertTrue(mixpanel.currentSuperProperties().count == 1,
                       "custom super properties archive failed")
-        XCTAssertEqual(mixpanel.eventsQueue[0]["event"] as? String, "e1",
+        XCTAssertEqual(mixpanel.eventsQueue[1]["event"] as? String, "e1",
                        "event was not successfully archived/unarchived")
+        XCTAssertEqual(mixpanel.eventsQueue[2]["event"] as? String, "e3",
+                       "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(mixpanel.eventsQueue[3]["event"] as? String, "e4",
+                       "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(mixpanel.eventsQueue[4]["event"] as? String, "e5",
+                       "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(mixpanel.eventsQueue[5]["event"] as? String, "e6",
+                       "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(mixpanel.eventsQueue[6]["event"] as? String, "e7",
+                       "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(mixpanel.eventsQueue[7]["event"] as? String, "e8",
+                       "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(mixpanel.eventsQueue[8]["event"] as? String, "e9",
+                       "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(mixpanel.eventsQueue[9]["event"] as? String, "e10",
+                       "event was not successfully archived/unarchived or order is incorrect")
         XCTAssertEqual(mixpanel.people.distinctId, "d1",
                        "custom people distinct id archive failed")
         XCTAssertTrue(mixpanel.people.peopleQueue.count == 1, "pending people queue archive failed")
@@ -611,7 +636,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
         XCTAssertTrue(mixpanel.currentSuperProperties().count == 1,
                       "default super properties expected to have 1 item")
         XCTAssertNotNil(mixpanel.eventsQueue, "default events queue from no file is nil")
-        XCTAssertTrue(mixpanel.eventsQueue.count == 2, "default events queue expecting 2 items ($identify call added)")
+        XCTAssertTrue(mixpanel.eventsQueue.count == 10, "default events queue expecting 10 items ($identify call added)")
         XCTAssertNotNil(mixpanel.people.distinctId,
                         "default people distinct id from no file failed")
         XCTAssertNotNil(mixpanel.people.peopleQueue, "default people queue from no file is nil")

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
@@ -589,7 +589,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
         XCTAssertEqual(mixpanel.distinctId, "d1", "custom distinct archive failed")
         XCTAssertTrue(mixpanel.currentSuperProperties().count == 1,
                       "custom super properties archive failed")
-        XCTAssertEqual(mixpanel.eventsQueue[mixpanel.eventsQueue.count - 2]["event"] as? String, "e1",
+        XCTAssertEqual(mixpanel.eventsQueue[mixpanel.eventsQueue.count - 1]["event"] as? String, "e1",
                        "event was not successfully archived/unarchived")
         XCTAssertEqual(mixpanel.people.distinctId, "d1",
                        "custom people distinct id archive failed")

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelNotificationTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelNotificationTests.swift
@@ -114,6 +114,7 @@ class MixpanelNotificationTests: MixpanelBaseTests {
         mixpanel.decideInstance.notificationsInstance.showNotification(notif!)
         //wait for notifs to be shown from main queue
         waitForAsyncTasks()
+        waitForMixpanelQueues()
         XCTAssertTrue(UIApplication.shared.windows.count == numberOfWindows + 1, "Notification was not presented")
         XCTAssertTrue(mixpanel.eventsQueue.count == 1, "should only show same notification once (and track 1 notif shown event)")
         XCTAssertEqual(mixpanel.eventsQueue.last?["event"] as? String, "$campaign_delivery", "last event should be campaign delivery")

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelOptOutTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelOptOutTests.swift
@@ -119,7 +119,7 @@ class MixpanelOptOutTests: MixpanelBaseTests {
             "$app_version": "override"]
         mixpanel.optInTracking(distinctId: "testDistinctId", properties: testProperties)
         waitForTrackingQueue()
-        let props = mixpanel.eventsQueue.last!["properties"] as? InternalProperties
+        let props = mixpanel.eventsQueue.first!["properties"] as? InternalProperties
         XCTAssertEqual(props!["string"] as? String, "yello")
         XCTAssertEqual(props!["number"] as? NSNumber, 3)
         XCTAssertEqual(props!["date"] as? Date, now)


### PR DESCRIPTION
Fixes for the following issues:
- Crash with Set.contains(_:) 
https://github.com/mixpanel/mixpanel-swift/issues/321
- MixpanelInstance.checkDecide crash
https://github.com/mixpanel/mixpanel-swift/issues/312
- (2.6.3) Crash in Persistence
https://github.com/mixpanel/mixpanel-swift/issues/310
- (2.6.3) Bad Access in Global Lock
https://github.com/mixpanel/mixpanel-swift/issues/309