### PR TITLE
Prevent users from seeing duplicate inapps when logging out and back in

### DIFF
--- a/Mixpanel/InAppNotifications.swift
+++ b/Mixpanel/InAppNotifications.swift
@@ -78,6 +78,8 @@ class InAppNotifications: NotificationViewControllerDelegate {
             shownNotifications.insert(notification.ID)
             if (notification.hasDisplayTriggers()) {
                 triggeredNotifications = triggeredNotifications.filter { $0.ID != notification.ID }
+            } else {
+                inAppNotifications = inAppNotifications.filter { $0.ID != notification.ID }
             }
         }
     }

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -907,7 +907,21 @@ extension MixpanelInstance {
                     self.people.peopleQueue = Queue()
                     self.people.unidentifiedQueue = Queue()
                     #if DECIDE
-                    self.decideInstance.notificationsInstance.shownNotifications = Set()
+                    /*
+                     * TODO: Index `shownNotifications` on token+distinctId and never clear.
+                     *
+                     * Currently, are options are:
+                     *  1.  Clear `shownNotifications` on reset. This can result in a user seeing a duplicate notification if
+                     *      there is a data delay and they logout and back in.
+                     *  2.  Not clear `showNotifications` on reset. This can result in a notification not being shown to
+                     *      subsequent user in multi-user, same device scenarios.
+                     *
+                     *  The multi-user, same device scenario seems more of an edgecase thus justifying the change to not
+                     *  clear `shownNotifications` on logout.
+                     *
+                     */
+                    // self.decideInstance.notificationsInstance.shownNotifications = Set()
+
                     self.decideInstance.decideFetched = false
                     self.decideInstance.ABTestingInstance.variants = Set()
                     self.decideInstance.codelessInstance.codelessBindings = Set()


### PR DESCRIPTION
This PR fixes a bug that has the potential for users to see duplicate InApp messages. 

When we check `decide`, we append `InAppNotification`s to `inAppNotifications` and then filter out `shownNotifications` to determine what notifications are eligible to be displayed. There were two problems that allowed for duplicates to be shown:

1.  we not removing notifications from `inAppNotifications` list when they were shown.
2. we would clear `shownNotifications` when calling `reset()`.  

This meant that when a user logs in -> sees a notification -> logs out -> logs in, `inAppNotifications` will still contain notifications that were previously seen. Since `shownNotifications` was cleared by `reset()`, we don't filter them out and they become eligible again.

With this PR, we correctly remove shown InApps from the `inAppNotifications` list. That solves the primary problem.  However, that still leaves a race condition where a user could see a duplicate notification if the `decide` response still contains it. This could happen if there's a data ingestion delay, for example. To solve this, we no longer reset `shownNotifications` when calling `reset()`. There's a trade-off with that decision and I think there's a better long term solution but this is a reasonable "get out of trouble" solution.