### PR TITLE
Static funcs + mono-archive queue + Async Dispatch 

### DIFF
--- a/Mixpanel/AutomaticProperties.swift
+++ b/Mixpanel/AutomaticProperties.swift
@@ -81,7 +81,7 @@ class AutomaticProperties {
         return p
     }()
 
-    class func deviceModel() -> String {
+    static func deviceModel() -> String {
         var systemInfo = utsname()
         uname(&systemInfo)
         let size = MemoryLayout<CChar>.size
@@ -97,7 +97,7 @@ class AutomaticProperties {
     }
 
     #if WATCH_OS
-    class func watchModel() -> String {
+    static func watchModel() -> String {
         let watchSize38mm = Int(136)
         let watchSize40mm = Int(162)
         let watchSize42mm = Int(156)
@@ -119,7 +119,7 @@ class AutomaticProperties {
     }
     #endif
 
-    class func libVersion() -> String? {
+    static func libVersion() -> String? {
         return Bundle(for: self).infoDictionary?["CFBundleShortVersionString"] as? String
     }
 

--- a/Mixpanel/CGAffineTransformToNSDictionary.swift
+++ b/Mixpanel/CGAffineTransformToNSDictionary.swift
@@ -11,11 +11,11 @@ import UIKit
 
 @objc(CGAffineTransformToNSDictionary) class CGAffineTransformToNSDictionary: ValueTransformer {
 
-    override class func transformedValueClass() -> AnyClass {
+    override static func transformedValueClass() -> AnyClass {
         return NSDictionary.self
     }
 
-    override class func allowsReverseTransformation() -> Bool {
+    override static func allowsReverseTransformation() -> Bool {
         return true
     }
 

--- a/Mixpanel/CGPointToNSDictionary.swift
+++ b/Mixpanel/CGPointToNSDictionary.swift
@@ -10,11 +10,11 @@ import Foundation
 import UIKit
 
 @objc(CGPointToNSDictionary) class CGPointToNSDictionary: ValueTransformer {
-    override class func transformedValueClass() -> AnyClass {
+    override static func transformedValueClass() -> AnyClass {
         return NSDictionary.self
     }
 
-    override class func allowsReverseTransformation() -> Bool {
+    override static func allowsReverseTransformation() -> Bool {
         return true
     }
 

--- a/Mixpanel/CGRectToNSDictionary.swift
+++ b/Mixpanel/CGRectToNSDictionary.swift
@@ -10,11 +10,11 @@ import Foundation
 import UIKit
 
 @objc(CGRectToNSDictionary) class CGRectToNSDictionary: ValueTransformer {
-    override class func transformedValueClass() -> AnyClass {
+    override static func transformedValueClass() -> AnyClass {
         return NSDictionary.self
     }
 
-    override class func allowsReverseTransformation() -> Bool {
+    override static func allowsReverseTransformation() -> Bool {
         return true
     }
 

--- a/Mixpanel/CGSizeToNSDictionary.swift
+++ b/Mixpanel/CGSizeToNSDictionary.swift
@@ -11,11 +11,11 @@ import UIKit
 
 @objc(CGSizeToNSDictionary) class CGSizeToNSDictionary: ValueTransformer {
 
-    override class func transformedValueClass() -> AnyClass {
+    override static func transformedValueClass() -> AnyClass {
         return NSDictionary.self
     }
 
-    override class func allowsReverseTransformation() -> Bool {
+    override static func allowsReverseTransformation() -> Bool {
         return true
     }
 

--- a/Mixpanel/Codeless.swift
+++ b/Mixpanel/Codeless.swift
@@ -17,7 +17,7 @@ class Codeless {
         case tableViewBinding = "ui_table_view"
     }
 
-    class func createBinding(object: [String: Any]) -> CodelessBinding? {
+    static func createBinding(object: [String: Any]) -> CodelessBinding? {
         guard let bindingType = object["event_type"] as? String,
               let bindingTypeEnum = BindingType.init(rawValue: bindingType) else {
             return UIControlBinding(object: object)

--- a/Mixpanel/Error.swift
+++ b/Mixpanel/Error.swift
@@ -25,7 +25,7 @@ func MPAssert(_ condition: @autoclosure() -> Bool,
 }
 
 class ErrorHandler {
-    class func wrap<ReturnType>(_ f: () throws -> ReturnType?) -> ReturnType? {
+    static func wrap<ReturnType>(_ f: () throws -> ReturnType?) -> ReturnType? {
         do {
             return try f()
         } catch let error {
@@ -34,7 +34,7 @@ class ErrorHandler {
         }
     }
 
-    class func logError(_ error: Error) {
+    static func logError(_ error: Error) {
         let stackSymbols = Thread.callStackSymbols
         Logger.error(message: "Error: \(error) \n Stack Symbols: \(stackSymbols)")
     }

--- a/Mixpanel/IdentityTransformer.swift
+++ b/Mixpanel/IdentityTransformer.swift
@@ -10,11 +10,11 @@ import Foundation
 
 @objc(IdentityTransformer) class IdentityTransformer: ValueTransformer {
 
-    override class func transformedValueClass() -> AnyClass {
+    override static func transformedValueClass() -> AnyClass {
         return NSObject.self
     }
 
-    override class func allowsReverseTransformation() -> Bool {
+    override static func allowsReverseTransformation() -> Bool {
         return false
     }
 

--- a/Mixpanel/JSONHandler.swift
+++ b/Mixpanel/JSONHandler.swift
@@ -12,7 +12,7 @@ class JSONHandler {
 
     typealias MPObjectToParse = Any
 
-    class func encodeAPIData(_ obj: MPObjectToParse) -> String? {
+    static func encodeAPIData(_ obj: MPObjectToParse) -> String? {
         let data: Data? = serializeJSONObject(obj)
 
         guard let d = data else {
@@ -31,7 +31,7 @@ class JSONHandler {
         return b64
     }
 
-     class func serializeJSONObject(_ obj: MPObjectToParse) -> Data? {
+     static func serializeJSONObject(_ obj: MPObjectToParse) -> Data? {
         let serializableJSONObject = makeObjectSerializable(obj)
 
         guard JSONSerialization.isValidJSONObject(serializableJSONObject) else {
@@ -48,7 +48,7 @@ class JSONHandler {
         return serializedObject
     }
 
-    private class func makeObjectSerializable(_ obj: MPObjectToParse) -> MPObjectToParse {
+    private static func makeObjectSerializable(_ obj: MPObjectToParse) -> MPObjectToParse {
         switch obj {
         case let obj as Double where obj.isFinite:
             return obj

--- a/Mixpanel/Logger.swift
+++ b/Mixpanel/Logger.swift
@@ -62,21 +62,21 @@ class Logger {
     private static let readWriteLock: ReadWriteLock = ReadWriteLock(label: "loggerLock")
 
     /// Add a `Logging` object to receive all log messages
-    class func addLogging(_ logging: Logging) {
+    static func addLogging(_ logging: Logging) {
         readWriteLock.write {
             loggers.append(logging)
         }
     }
 
     /// Enable log messages of a specific `LogLevel` to be added to the log
-    class func enableLevel(_ level: LogLevel) {
+    static func enableLevel(_ level: LogLevel) {
         readWriteLock.write {
             enabledLevels.insert(level)
         }
     }
 
     /// Disable log messages of a specific `LogLevel` to prevent them from being logged
-    class func disableLevel(_ level: LogLevel) {
+    static func disableLevel(_ level: LogLevel) {
         readWriteLock.write {
             enabledLevels.remove(level)
         }
@@ -84,7 +84,7 @@ class Logger {
 
     /// debug: Adds a debug message to the Mixpanel log
     /// - Parameter message: The message to be added to the log
-    class func debug(message: @autoclosure() -> Any, _ path: String = #file, _ function: String = #function) {
+    static func debug(message: @autoclosure() -> Any, _ path: String = #file, _ function: String = #function) {
         var enabledLevels = Set<LogLevel>()
         readWriteLock.read {
             enabledLevels = self.enabledLevels
@@ -96,7 +96,7 @@ class Logger {
 
     /// info: Adds an informational message to the Mixpanel log
     /// - Parameter message: The message to be added to the log
-    class func info(message: @autoclosure() -> Any, _ path: String = #file, _ function: String = #function) {
+    static func info(message: @autoclosure() -> Any, _ path: String = #file, _ function: String = #function) {
         var enabledLevels = Set<LogLevel>()
         readWriteLock.read {
             enabledLevels = self.enabledLevels
@@ -108,7 +108,7 @@ class Logger {
 
     /// warn: Adds a warning message to the Mixpanel log
     /// - Parameter message: The message to be added to the log
-    class func warn(message: @autoclosure() -> Any, _ path: String = #file, _ function: String = #function) {
+    static func warn(message: @autoclosure() -> Any, _ path: String = #file, _ function: String = #function) {
         var enabledLevels = Set<LogLevel>()
         readWriteLock.read {
             enabledLevels = self.enabledLevels
@@ -120,7 +120,7 @@ class Logger {
 
     /// error: Adds an error message to the Mixpanel log
     /// - Parameter message: The message to be added to the log
-    class func error(message: @autoclosure() -> Any, _ path: String = #file, _ function: String = #function) {
+    static func error(message: @autoclosure() -> Any, _ path: String = #file, _ function: String = #function) {
         var enabledLevels = Set<LogLevel>()
         readWriteLock.read {
             enabledLevels = self.enabledLevels
@@ -131,7 +131,7 @@ class Logger {
     }
 
     /// This forwards a `LogMessage` to each logger that has been added
-    class private func forwardLogMessage(_ message: LogMessage) {
+    static private func forwardLogMessage(_ message: LogMessage) {
         // Forward the log message to every registered Logging instance
         var loggers = [Logging]()
         readWriteLock.read {

--- a/Mixpanel/Mixpanel.swift
+++ b/Mixpanel/Mixpanel.swift
@@ -70,7 +70,7 @@ open class Mixpanel {
      */
 
     @discardableResult
-    open static func initialize(token apiToken: String,
+    public static func initialize(token apiToken: String,
                                flushInterval: Double = 60,
                                instanceName: String = UUID().uuidString,
                                optOutTrackingByDefault: Bool = false) -> MixpanelInstance {

--- a/Mixpanel/Mixpanel.swift
+++ b/Mixpanel/Mixpanel.swift
@@ -36,7 +36,7 @@ open class Mixpanel {
      You can always get the instance by calling getInstance(name)
      */
     @discardableResult
-    open class func initialize(token apiToken: String,
+    public static func initialize(token apiToken: String,
                                launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil,
                                flushInterval: Double = 60,
                                instanceName: String = UUID().uuidString,
@@ -70,7 +70,7 @@ open class Mixpanel {
      */
 
     @discardableResult
-    open class func initialize(token apiToken: String,
+    open static func initialize(token apiToken: String,
                                flushInterval: Double = 60,
                                instanceName: String = UUID().uuidString,
                                optOutTrackingByDefault: Bool = false) -> MixpanelInstance {
@@ -87,7 +87,7 @@ open class Mixpanel {
 
      - returns: returns the mixpanel instance
      */
-    open class func getInstance(name: String) -> MixpanelInstance? {
+    public static func getInstance(name: String) -> MixpanelInstance? {
         return MixpanelManager.sharedInstance.getInstance(name: name)
     }
 
@@ -98,7 +98,7 @@ open class Mixpanel {
 
      - returns: returns the main Mixpanel instance
      */
-    open class func mainInstance() -> MixpanelInstance {
+    public static func mainInstance() -> MixpanelInstance {
         if let instance = MixpanelManager.sharedInstance.getMainInstance() {
             return instance
         } else {
@@ -113,7 +113,7 @@ open class Mixpanel {
 
      - parameter name: the instance name
      */
-    open class func setMainInstance(name: String) {
+    public static func setMainInstance(name: String) {
         MixpanelManager.sharedInstance.setMainInstance(name: name)
     }
 
@@ -122,7 +122,7 @@ open class Mixpanel {
 
      - parameter name: the instance name
      */
-    open class func removeInstance(name: String) {
+    public static func removeInstance(name: String) {
         MixpanelManager.sharedInstance.removeInstance(name: name)
     }
 }

--- a/Mixpanel/NSAttributedStringToNSDictionary.swift
+++ b/Mixpanel/NSAttributedStringToNSDictionary.swift
@@ -10,11 +10,11 @@ import Foundation
 import UIKit
 
 @objc(NSAttributedStringToNSDictionary) class NSAttributedStringToNSDictionary: ValueTransformer {
-    override class func transformedValueClass() -> AnyClass {
+    override static func transformedValueClass() -> AnyClass {
         return NSDictionary.self
     }
 
-    override class func allowsReverseTransformation() -> Bool {
+    override static func allowsReverseTransformation() -> Bool {
         return true
     }
 

--- a/Mixpanel/Network.swift
+++ b/Mixpanel/Network.swift
@@ -57,7 +57,7 @@ class Network {
         self.basePathIdentifier = basePathIdentifier
     }
 
-    class func apiRequest<A>(base: String,
+    static func apiRequest<A>(base: String,
                           resource: Resource<A>,
                           failure: @escaping (Reason, Data?, URLResponse?) -> (),
                           success: @escaping (A, URLResponse?) -> ()) {
@@ -92,7 +92,7 @@ class Network {
         }.resume()
     }
 
-    private class func buildURLRequest<A>(_ base: String, resource: Resource<A>) -> URLRequest? {
+    private static func buildURLRequest<A>(_ base: String, resource: Resource<A>) -> URLRequest? {
         guard let url = BasePath.buildURL(base: base,
                                           path: resource.path,
                                           queryItems: resource.queryItems) else {
@@ -111,7 +111,7 @@ class Network {
         return request as URLRequest
     }
 
-    class func buildResource<A>(path: String,
+    static func buildResource<A>(path: String,
                              method: RequestMethod,
                              requestBody: Data? = nil,
                              queryItems: [URLQueryItem]? = nil,
@@ -125,7 +125,7 @@ class Network {
                         parse: parse)
     }
 
-    class func trackIntegration(apiToken: String, serverURL: String, completion: @escaping (Bool) -> ()) {
+    static func trackIntegration(apiToken: String, serverURL: String, completion: @escaping (Bool) -> ()) {
         let requestData = JSONHandler.encodeAPIData([["event": "Integration",
                                                       "properties": ["token": "85053bf24bba75239b16a601d9387e17",
                                                                      "mp_lib": "swift",

--- a/Mixpanel/ObjectSerializerConfig.swift
+++ b/Mixpanel/ObjectSerializerConfig.swift
@@ -204,7 +204,7 @@ class PropertyDescription {
         self.predicate = predicate
     }
 
-    class func valueTransformer(for typeName: String) -> ValueTransformer? {
+    static func valueTransformer(for typeName: String) -> ValueTransformer? {
         for toTypeName in ["NSDictionary", "NSNumber", "NSString"] {
             let toTransformerName = NSValueTransformerName(rawValue: "\(typeName)To\(toTypeName)")
             if let toTransformer = ValueTransformer(forName: toTransformerName) {

--- a/Mixpanel/Persistence.swift
+++ b/Mixpanel/Persistence.swift
@@ -43,11 +43,11 @@ class Persistence {
         case optOutStatus
     }
 
-    class func filePathWithType(_ type: ArchiveType, token: String) -> String? {
+    static func filePathWithType(_ type: ArchiveType, token: String) -> String? {
         return filePathFor(type.rawValue, token: token)
     }
 
-    class private func filePathFor(_ archiveType: String, token: String) -> String? {
+    static private func filePathFor(_ archiveType: String, token: String) -> String? {
         let filename = "mixpanel-\(token)-\(archiveType)"
         let manager = FileManager.default
 
@@ -65,7 +65,7 @@ class Persistence {
     }
 
     #if DECIDE
-    class func archive(eventsQueue: Queue,
+    static func archive(eventsQueue: Queue,
                        peopleQueue: Queue,
                        groupsQueue: Queue,
                        properties: ArchivedProperties,
@@ -80,7 +80,7 @@ class Persistence {
         archiveCodelessBindings(codelessBindings, token: token)
     }
     #else
-    class func archive(eventsQueue: Queue,
+    static func archive(eventsQueue: Queue,
                        peopleQueue: Queue,
                        groupsQueue: Queue,
                        properties: ArchivedProperties,
@@ -92,31 +92,31 @@ class Persistence {
     }
     #endif // DECIDE
 
-    class func archiveEvents(_ eventsQueue: Queue, token: String) {
+    static func archiveEvents(_ eventsQueue: Queue, token: String) {
         archiveEventQueue.sync { [eventsQueue, token] in
             archiveToFile(.events, object: eventsQueue, token: token)
         }
     }
 
-    class func archivePeople(_ peopleQueue: Queue, token: String) {
+    static func archivePeople(_ peopleQueue: Queue, token: String) {
         archivePeopleQueue.sync { [peopleQueue, token] in
             archiveToFile(.people, object: peopleQueue, token: token)
         }
     }
 
-    class func archiveGroups(_ groupsQueue: Queue, token: String) {
+    static func archiveGroups(_ groupsQueue: Queue, token: String) {
         archiveGroupsQueue.sync { [groupsQueue, token] in
             archiveToFile(.groups, object: groupsQueue, token: token)
         }
     }
 
-    class func archiveOptOutStatus(_ optOutStatus: Bool, token: String) {
+    static func archiveOptOutStatus(_ optOutStatus: Bool, token: String) {
         archiveOptOutStatusQueue.sync { [optOutStatus, token] in
             archiveToFile(.optOutStatus, object: optOutStatus, token: token)
         }
     }
 
-    class func archiveProperties(_ properties: ArchivedProperties, token: String) {
+    static func archiveProperties(_ properties: ArchivedProperties, token: String) {
         archivePropertiesQueue.sync { [properties, token] in
             var p = InternalProperties()
             p["distinctId"] = properties.distinctId
@@ -137,20 +137,20 @@ class Persistence {
     }
 
     #if DECIDE
-    class func archiveVariants(_ variants: Set<Variant>, token: String) {
+    static func archiveVariants(_ variants: Set<Variant>, token: String) {
         archiveVariantQueue.sync { [variants, token] in
             archiveToFile(.variants, object: variants, token: token)
         }
     }
 
-    class func archiveCodelessBindings(_ codelessBindings: Set<CodelessBinding>, token: String) {
+    static func archiveCodelessBindings(_ codelessBindings: Set<CodelessBinding>, token: String) {
         archiveCodelessQueue.sync { [codelessBindings, token] in
             archiveToFile(.codelessBindings, object: codelessBindings, token: token)
         }
     }
     #endif // DECIDE
 
-    class private func archiveToFile(_ type: ArchiveType, object: Any, token: String) {
+    static private func archiveToFile(_ type: ArchiveType, object: Any, token: String) {
         let filePath = filePathWithType(type, token: token)
         guard let path = filePath else {
             Logger.error(message: "bad file path, cant fetch file")
@@ -170,7 +170,7 @@ class Persistence {
         addSkipBackupAttributeToItem(at: path)
     }
 
-    class private func addSkipBackupAttributeToItem(at path: String) {
+    static private func addSkipBackupAttributeToItem(at path: String) {
         var url = URL.init(fileURLWithPath: path)
         var resourceValues = URLResourceValues()
         resourceValues.isExcludedFromBackup = true
@@ -182,7 +182,7 @@ class Persistence {
     }
 
     #if DECIDE
-    class func unarchive(token: String) -> (eventsQueue: Queue,
+    static func unarchive(token: String) -> (eventsQueue: Queue,
                                             peopleQueue: Queue,
                                             groupsQueue: Queue,
                                             superProperties: InternalProperties,
@@ -237,7 +237,7 @@ class Persistence {
                 automaticEventsEnabled)
     }
     #else
-    class func unarchive(token: String) -> (eventsQueue: Queue,
+    static func unarchive(token: String) -> (eventsQueue: Queue,
                                             peopleQueue: Queue,
                                             groupsQueue: Queue,
                                             superProperties: InternalProperties,
@@ -279,7 +279,7 @@ class Persistence {
     }
     #endif // DECIDE
 
-    class private func unarchiveWithFilePath(_ filePath: String) -> Any? {
+    static private func unarchiveWithFilePath(_ filePath: String) -> Any? {
         var unarchivedData: Any? = nil
         ExceptionWrapper.try({ [filePath] in
             unarchivedData = NSKeyedUnarchiver.unarchiveObject(withFile: filePath)
@@ -294,7 +294,7 @@ class Persistence {
         return unarchivedData
     }
 
-    class private func removeArchivedFile(atPath filePath: String) {
+    static private func removeArchivedFile(atPath filePath: String) {
         do {
             try FileManager.default.removeItem(atPath: filePath)
         } catch let err {
@@ -302,27 +302,27 @@ class Persistence {
         }
     }
 
-    class private func unarchiveEvents(token: String) -> Queue {
+    static private func unarchiveEvents(token: String) -> Queue {
         let data = unarchiveWithType(.events, token: token)
         return data as? Queue ?? []
     }
 
-    class private func unarchivePeople(token: String) -> Queue {
+    static private func unarchivePeople(token: String) -> Queue {
         let data = unarchiveWithType(.people, token: token)
         return data as? Queue ?? []
     }
 
-    class private func unarchiveGroups(token: String) -> Queue {
+    static private func unarchiveGroups(token: String) -> Queue {
         let data = unarchiveWithType(.groups, token: token)
         return data as? Queue ?? []
     }
 
-    class private func unarchiveOptOutStatus(token: String) -> Bool? {
+    static private func unarchiveOptOutStatus(token: String) -> Bool? {
         return unarchiveWithType(.optOutStatus, token: token) as? Bool
     }
 
     #if DECIDE
-    class private func unarchiveProperties(token: String) -> (InternalProperties,
+    static private func unarchiveProperties(token: String) -> (InternalProperties,
                                                               InternalProperties,
                                                               String,
                                                               String?,
@@ -360,7 +360,7 @@ class Persistence {
                 automaticEventsEnabled)
     }
     #else
-    class private func unarchiveProperties(token: String) -> (InternalProperties,
+    static private func unarchiveProperties(token: String) -> (InternalProperties,
         InternalProperties,
         String,
         String?,
@@ -374,7 +374,7 @@ class Persistence {
     }
     #endif // DECIDE
 
-    class private func unarchivePropertiesHelper(token: String) -> (InternalProperties,
+    static private func unarchivePropertiesHelper(token: String) -> (InternalProperties,
         InternalProperties,
         String,
         String?,
@@ -423,18 +423,18 @@ class Persistence {
     }
 
     #if DECIDE
-    class private func unarchiveCodelessBindings(token: String) -> Set<CodelessBinding> {
+    static private func unarchiveCodelessBindings(token: String) -> Set<CodelessBinding> {
         let data = unarchiveWithType(.codelessBindings, token: token)
         return data as? Set<CodelessBinding> ?? Set()
     }
 
-    class private func unarchiveVariants(token: String) -> Set<Variant> {
+    static private func unarchiveVariants(token: String) -> Set<Variant> {
         let data = unarchiveWithType(.variants, token: token) as? Set<Variant>
         return data ?? Set()
     }
     #endif // DECIDE
 
-    class private func unarchiveWithType(_ type: ArchiveType, token: String) -> Any? {
+    static private func unarchiveWithType(_ type: ArchiveType, token: String) -> Any? {
         let filePath = filePathWithType(type, token: token)
         guard let path = filePath else {
             Logger.info(message: "bad file path, cant fetch file")
@@ -449,7 +449,7 @@ class Persistence {
         return unarchivedData
     }
 
-    class func storeIdentity(token: String, distinctID: String, peopleDistinctID: String?, anonymousID: String?, userID: String?, alias: String?, hadPersistedDistinctId: Bool?) {
+    static func storeIdentity(token: String, distinctID: String, peopleDistinctID: String?, anonymousID: String?, userID: String?, alias: String?, hadPersistedDistinctId: Bool?) {
         guard let defaults = UserDefaults(suiteName: "Mixpanel") else {
             return
         }
@@ -463,7 +463,7 @@ class Persistence {
         defaults.synchronize()
     }
 
-    class func restoreIdentity(token: String) -> (String, String?, String?, String?, String?, Bool?) {
+    static func restoreIdentity(token: String) -> (String, String?, String?, String?, String?, Bool?) {
         guard let defaults = UserDefaults(suiteName: "Mixpanel") else {
             return ("", nil, nil, nil, nil, nil)
         }
@@ -476,7 +476,7 @@ class Persistence {
                 defaults.bool(forKey: prefix + "MPHadPersistedDistinctId"))
     }
 
-    class func deleteMPUserDefaultsData(token: String) {
+    static func deleteMPUserDefaultsData(token: String) {
         guard let defaults = UserDefaults(suiteName: "Mixpanel") else {
             return
         }

--- a/Mixpanel/Persistence.swift
+++ b/Mixpanel/Persistence.swift
@@ -25,13 +25,8 @@ struct ArchivedProperties {
 }
 
 class Persistence {
-    private static let archiveEventQueue: DispatchQueue = DispatchQueue(label: "com.mixpanel.event.archive", qos: .utility)
-    private static let archivePeopleQueue: DispatchQueue = DispatchQueue(label: "com.mixpanel.people.archive", qos: .utility)
-    private static let archiveGroupsQueue: DispatchQueue = DispatchQueue(label: "com.mixpanel.groups.archive", qos: .utility)
-    private static let archiveOptOutStatusQueue: DispatchQueue = DispatchQueue(label: "com.mixpanel.optout.archive", qos: .utility)
-    private static let archiveCodelessQueue: DispatchQueue = DispatchQueue(label: "com.mixpanel.codeless.archive", qos: .utility)
-    private static let archivePropertiesQueue: DispatchQueue = DispatchQueue(label: "com.mixpanel.properties.archive", qos: .utility)
-    private static let archiveVariantQueue: DispatchQueue = DispatchQueue(label: "com.mixpanel.variant.archive", qos: .utility)
+
+    private static let archiveQueue: DispatchQueue = DispatchQueue(label: "com.mixpanel.archiveQueue", qos: .utility)
 
     enum ArchiveType: String {
         case events
@@ -93,31 +88,31 @@ class Persistence {
     #endif // DECIDE
 
     static func archiveEvents(_ eventsQueue: Queue, token: String) {
-        archiveEventQueue.sync { [eventsQueue, token] in
+        archiveQueue.async { [eventsQueue, token] in
             archiveToFile(.events, object: eventsQueue, token: token)
         }
     }
 
     static func archivePeople(_ peopleQueue: Queue, token: String) {
-        archivePeopleQueue.sync { [peopleQueue, token] in
+        archiveQueue.async { [peopleQueue, token] in
             archiveToFile(.people, object: peopleQueue, token: token)
         }
     }
 
     static func archiveGroups(_ groupsQueue: Queue, token: String) {
-        archiveGroupsQueue.sync { [groupsQueue, token] in
+        archiveQueue.async { [groupsQueue, token] in
             archiveToFile(.groups, object: groupsQueue, token: token)
         }
     }
 
     static func archiveOptOutStatus(_ optOutStatus: Bool, token: String) {
-        archiveOptOutStatusQueue.sync { [optOutStatus, token] in
+        archiveQueue.async { [optOutStatus, token] in
             archiveToFile(.optOutStatus, object: optOutStatus, token: token)
         }
     }
 
     static func archiveProperties(_ properties: ArchivedProperties, token: String) {
-        archivePropertiesQueue.sync { [properties, token] in
+        archiveQueue.async { [properties, token] in
             var p = InternalProperties()
             p["distinctId"] = properties.distinctId
             p["anonymousId"] = properties.anonymousId
@@ -138,13 +133,13 @@ class Persistence {
 
     #if DECIDE
     static func archiveVariants(_ variants: Set<Variant>, token: String) {
-        archiveVariantQueue.sync { [variants, token] in
+        archiveQueue.async { [variants, token] in
             archiveToFile(.variants, object: variants, token: token)
         }
     }
 
     static func archiveCodelessBindings(_ codelessBindings: Set<CodelessBinding>, token: String) {
-        archiveCodelessQueue.sync { [codelessBindings, token] in
+        archiveQueue.async { [codelessBindings, token] in
             archiveToFile(.codelessBindings, object: codelessBindings, token: token)
         }
     }

--- a/Mixpanel/SelectorEvaluator.swift
+++ b/Mixpanel/SelectorEvaluator.swift
@@ -65,11 +65,11 @@ class SelectorEvaluator {
     private static let RIGHT = 1
     
     // For testing purposes
-    class func getCurrentDate() -> Date {
+    static func getCurrentDate() -> Date {
         return Date();
     }
     
-    class func toNumber(value: Any?) -> Double? {
+    static func toNumber(value: Any?) -> Double? {
         if let val = value {
             switch val {
             case let bool as Bool:
@@ -93,7 +93,7 @@ class SelectorEvaluator {
         return nil
     }
     
-    class func toBoolean(value: Any?) -> Bool {
+    static func toBoolean(value: Any?) -> Bool {
         if let val = value {
             switch val {
             case let bool as Bool:
@@ -115,7 +115,7 @@ class SelectorEvaluator {
         return false
     }
     
-    class func evaluateNumber(node: [String: Any], properties: InternalProperties) -> Double? {
+    static func evaluateNumber(node: [String: Any], properties: InternalProperties) -> Double? {
         guard let op = node[OPERATOR_KEY] as? String, op == NUMBER_OPERATOR else {
             Logger.error(message: "invalid operator: number")
             return nil
@@ -128,7 +128,7 @@ class SelectorEvaluator {
         return toNumber(value: evaluateNode(node: children[LEFT], properties: properties))
     }
     
-    class func evaluateBoolean(node: [String: Any], properties: InternalProperties) -> Bool? {
+    static func evaluateBoolean(node: [String: Any], properties: InternalProperties) -> Bool? {
         guard let op = node[OPERATOR_KEY] as? String, op == BOOLEAN_OPERATOR else {
             Logger.error(message: "invalid operator: boolean")
             return nil
@@ -141,7 +141,7 @@ class SelectorEvaluator {
         return toBoolean(value: evaluateNode(node: children[LEFT], properties: properties))
     }
     
-    class func evaluateDateTime(node: [String: Any], properties: InternalProperties) -> Date? {
+    static func evaluateDateTime(node: [String: Any], properties: InternalProperties) -> Date? {
         guard let op = node[OPERATOR_KEY] as? String, op == DATETIME_OPERATOR else {
             Logger.error(message: "invalid operator: datetime")
             return nil
@@ -172,7 +172,7 @@ class SelectorEvaluator {
         return nil
     }
     
-    class func evaluateList(node: [String: Any], properties: InternalProperties) -> [Any]? {
+    static func evaluateList(node: [String: Any], properties: InternalProperties) -> [Any]? {
         guard let op = node[OPERATOR_KEY] as? String, op == LIST_OPERATOR else {
             Logger.error(message: "invalid operator: list")
             return nil
@@ -188,7 +188,7 @@ class SelectorEvaluator {
         return nil
     }
     
-    private class func jsonStringify(value: Any) -> String? {
+    private static func jsonStringify(value: Any) -> String? {
         guard let jsonData = try? JSONSerialization.data(withJSONObject: value) else {
             Logger.error(message: "Error encoding as JSON")
             return nil
@@ -196,7 +196,7 @@ class SelectorEvaluator {
         return String(data: jsonData, encoding: .utf8)
     }
     
-    class func evaluateString(node: [String: Any], properties: InternalProperties) -> String? {
+    static func evaluateString(node: [String: Any], properties: InternalProperties) -> String? {
         guard let op = node[OPERATOR_KEY] as? String, op == STRING_OPERATOR else {
             Logger.error(message: "invalid operator: string")
             return nil
@@ -227,7 +227,7 @@ class SelectorEvaluator {
         return nil
     }
     
-    class func evaluateAnd(node: [String: Any], properties: InternalProperties) -> Bool? {
+    static func evaluateAnd(node: [String: Any], properties: InternalProperties) -> Bool? {
         guard let op = node[OPERATOR_KEY] as? String, op == AND_OPERATOR else {
             Logger.error(message: "invalid operator: and")
             return nil
@@ -240,7 +240,7 @@ class SelectorEvaluator {
         return toBoolean(value: evaluateNode(node: children[LEFT], properties: properties)) && toBoolean(value: evaluateNode(node: children[RIGHT], properties: properties))
     }
     
-    class func evaluateOr(node: [String: Any], properties: InternalProperties) -> Bool? {
+    static func evaluateOr(node: [String: Any], properties: InternalProperties) -> Bool? {
         guard let op = node[OPERATOR_KEY] as? String, op == OR_OPERATOR else {
             Logger.error(message: "invalid operator: or")
             return nil
@@ -253,7 +253,7 @@ class SelectorEvaluator {
         return toBoolean(value: evaluateNode(node: children[LEFT], properties: properties)) || toBoolean(value: evaluateNode(node: children[RIGHT], properties: properties))
     }
     
-    class func evaluateIn(node: [String: Any], properties: InternalProperties) -> Bool? {
+    static func evaluateIn(node: [String: Any], properties: InternalProperties) -> Bool? {
         let inOperators = [IN_OPERATOR, NOT_IN_OPERATOR]
         guard let op = node[OPERATOR_KEY] as? String, inOperators.contains(op) else {
             Logger.error(message: "invalid operator: in")
@@ -284,7 +284,7 @@ class SelectorEvaluator {
         return op == IN_OPERATOR ? b : !b
     }
     
-    class func evaluatePlus(node: [String: Any], properties: InternalProperties) -> Any? {
+    static func evaluatePlus(node: [String: Any], properties: InternalProperties) -> Any? {
         guard let op = node[OPERATOR_KEY] as? String, op == PLUS_OPERATOR else {
             Logger.error(message: "invalid operator: +")
             return nil
@@ -307,7 +307,7 @@ class SelectorEvaluator {
         }
     }
     
-    class func evaluateArithmetic(node: [String: Any], properties: InternalProperties) -> Double? {
+    static func evaluateArithmetic(node: [String: Any], properties: InternalProperties) -> Double? {
         let arithmeticOperators = [MINUS_OPERATOR, MUL_OPERATOR, DIV_OPERATOR, MOD_OPERATOR]
         guard let op = node[OPERATOR_KEY] as? String, arithmeticOperators.contains(op) else {
             Logger.error(message: "invalid arithmetic operator")
@@ -351,7 +351,7 @@ class SelectorEvaluator {
         }
     }
     
-    private class func equals(l: Any?, r: Any?) -> Bool {
+    private static func equals(l: Any?, r: Any?) -> Bool {
         switch (l, r) {
         case (nil, nil):
             return true
@@ -372,7 +372,7 @@ class SelectorEvaluator {
         }
     }
     
-    class func evaluateEquality(node: [String: Any], properties: InternalProperties) -> Bool? {
+    static func evaluateEquality(node: [String: Any], properties: InternalProperties) -> Bool? {
         let supportedOperators = [EQUALS_OPERATOR, NOT_EQUALS_OPERATOR]
         guard let op = node[OPERATOR_KEY] as? String, supportedOperators.contains(op) else {
             Logger.error(message: "invalid (not) equality operator")
@@ -390,7 +390,7 @@ class SelectorEvaluator {
         return op == NOT_EQUALS_OPERATOR ? !b : b
     }
     
-    private class func compareDoubles(ld: Double, rd: Double, op: String) -> Bool? {
+    private static func compareDoubles(ld: Double, rd: Double, op: String) -> Bool? {
         switch(op) {
         case GREATER_THAN_OPERATOR:
             return ld > rd
@@ -405,7 +405,7 @@ class SelectorEvaluator {
         }
     }
     
-    class func evaluateComparison(node: [String: Any], properties: InternalProperties) -> Bool? {
+    static func evaluateComparison(node: [String: Any], properties: InternalProperties) -> Bool? {
         let supportedOperators = [GREATER_THAN_OPERATOR, GREATER_THAN_EQUAL_OPERATOR, LESS_THAN_OPERATOR, LESS_THAN_EQUAL_OPERATOR]
         guard let op = node[OPERATOR_KEY] as? String, supportedOperators.contains(op) else {
             Logger.error(message: "invalid comparison operator")
@@ -441,7 +441,7 @@ class SelectorEvaluator {
         }
     }
     
-    class func evaluateDefined(node: [String: Any], properties: InternalProperties) -> Bool? {
+    static func evaluateDefined(node: [String: Any], properties: InternalProperties) -> Bool? {
         let supportedOperators = [DEFINED_OPERATOR, NOT_DEFINED_OPERATOR]
         guard let op = node[OPERATOR_KEY] as? String, supportedOperators.contains(op) else {
             Logger.error(message: "invalid operator: (not) defined")
@@ -456,7 +456,7 @@ class SelectorEvaluator {
         return op == DEFINED_OPERATOR ? b : !b
     }
     
-    class func evaluateNot(node: [String: Any], properties: InternalProperties) -> Bool? {
+    static func evaluateNot(node: [String: Any], properties: InternalProperties) -> Bool? {
         guard let op = node[OPERATOR_KEY] as? String, op == NOT_OPERATOR else {
             Logger.error(message: "invalid operator: not")
             return nil
@@ -477,7 +477,7 @@ class SelectorEvaluator {
         }
     }
     
-    class func evaluateWindow(value: [String: Any]) -> Date? {
+    static func evaluateWindow(value: [String: Any]) -> Date? {
         guard let window = value[WINDOW_KEY] as? [String: Any] else {
             Logger.error(message: "missing window")
             return nil
@@ -508,7 +508,7 @@ class SelectorEvaluator {
         }
     }
     
-    class func evaluateOperand(node: [String: Any], properties: InternalProperties) -> Any? {
+    static func evaluateOperand(node: [String: Any], properties: InternalProperties) -> Any? {
         guard let property = node[PROPERTY_KEY] as? String else {
             Logger.error(message: "missing key property")
             return nil
@@ -543,7 +543,7 @@ class SelectorEvaluator {
         }
     }
     
-    class func evaluateOperator(node: [String: Any], properties: InternalProperties) -> Any? {
+    static func evaluateOperator(node: [String: Any], properties: InternalProperties) -> Any? {
         guard let op = node[OPERATOR_KEY] as? String else {
             Logger.error(message: "invalid operator key")
             return nil
@@ -584,7 +584,7 @@ class SelectorEvaluator {
         }
     }
     
-    class func evaluateNode(node: [String: Any], properties: InternalProperties) -> Any? {
+    static func evaluateNode(node: [String: Any], properties: InternalProperties) -> Any? {
         if let _ = node[PROPERTY_KEY] {
             return evaluateOperand(node: node, properties: properties)
         }
@@ -592,7 +592,7 @@ class SelectorEvaluator {
         return evaluateOperator(node: node, properties: properties)
     }
     
-    public class func evaluate(selector: [String: Any], properties: InternalProperties) -> Bool? {
+    public static func evaluate(selector: [String: Any], properties: InternalProperties) -> Bool? {
         if let value = SelectorEvaluator.evaluateOperator(node: selector, properties: properties) {
             return SelectorEvaluator.toBoolean(value: value)
         }

--- a/Mixpanel/Swizzle.swift
+++ b/Mixpanel/Swizzle.swift
@@ -11,7 +11,7 @@ import Foundation
 extension DispatchQueue {
     private static var _onceTracker = [String]()
 
-    class func once(token: String, block: () -> Void) {
+    static func once(token: String, block: () -> Void) {
         objc_sync_enter(self); defer { objc_sync_exit(self) }
         if _onceTracker.contains(token) {
             return
@@ -24,25 +24,25 @@ extension DispatchQueue {
 class Swizzler {
     static var swizzles = [Method: Swizzle]()
 
-    class func printSwizzles() {
+    static func printSwizzles() {
         for (_, swizzle) in swizzles {
             Logger.debug(message: "\(swizzle)")
         }
     }
 
-    class func getSwizzle(for method: Method) -> Swizzle? {
+    static func getSwizzle(for method: Method) -> Swizzle? {
         return swizzles[method]
     }
 
-    class func removeSwizzle(for method: Method) {
+    static func removeSwizzle(for method: Method) {
         swizzles.removeValue(forKey: method)
     }
 
-    class func setSwizzle(_ swizzle: Swizzle, for method: Method) {
+    static func setSwizzle(_ swizzle: Swizzle, for method: Method) {
         swizzles[method] = swizzle
     }
 
-    class func swizzleSelector(_ originalSelector: Selector,
+    static func swizzleSelector(_ originalSelector: Selector,
                                withSelector newSelector: Selector,
                                for aClass: AnyClass,
                                name: String,
@@ -84,7 +84,7 @@ class Swizzler {
         }
     }
 
-    class func unswizzleSelector(_ selector: Selector, aClass: AnyClass, name: String? = nil) {
+    static func unswizzleSelector(_ selector: Selector, aClass: AnyClass, name: String? = nil) {
         if let method = class_getInstanceMethod(aClass, selector),
             let swizzle = getSwizzle(for: method) {
             if let name = name {

--- a/Mixpanel/UIColorToNSString.swift
+++ b/Mixpanel/UIColorToNSString.swift
@@ -11,11 +11,11 @@ import UIKit
 
 @objc(UIColorToNSString) class UIColorToNSString: ValueTransformer {
 
-    override class func transformedValueClass() -> AnyClass {
+    override static func transformedValueClass() -> AnyClass {
         return NSString.self
     }
 
-    override class func allowsReverseTransformation() -> Bool {
+    override static func allowsReverseTransformation() -> Bool {
         return true
     }
 

--- a/Mixpanel/UIEdgeInsetsToNSDictionary.swift
+++ b/Mixpanel/UIEdgeInsetsToNSDictionary.swift
@@ -11,11 +11,11 @@ import UIKit
 
 @objc(UIEdgeInsetsToNSDictionary) class UIEdgeInsetsToNSDictionary: ValueTransformer {
 
-    override class func transformedValueClass() -> AnyClass {
+    override static func transformedValueClass() -> AnyClass {
         return NSDictionary.self
     }
 
-    override class func allowsReverseTransformation() -> Bool {
+    override static func allowsReverseTransformation() -> Bool {
         return true
     }
 

--- a/Mixpanel/UIFontToNSDictionary.swift
+++ b/Mixpanel/UIFontToNSDictionary.swift
@@ -10,11 +10,11 @@ import Foundation
 import UIKit
 
 @objc(UIFontToNSDictionary) class UIFontToNSDictionary: ValueTransformer {
-    override class func transformedValueClass() -> AnyClass {
+    override static func transformedValueClass() -> AnyClass {
         return NSDictionary.self
     }
 
-    override class func allowsReverseTransformation() -> Bool {
+    override static func allowsReverseTransformation() -> Bool {
         return true
     }
 

--- a/Mixpanel/UIImageToNSDictionary.swift
+++ b/Mixpanel/UIImageToNSDictionary.swift
@@ -13,11 +13,11 @@ import UIKit
 
     static var imageCache = [String: UIImage]()
 
-    override class func transformedValueClass() -> AnyClass {
+    override static func transformedValueClass() -> AnyClass {
         return NSDictionary.self
     }
 
-    override class func allowsReverseTransformation() -> Bool {
+    override static func allowsReverseTransformation() -> Bool {
         return true
     }
 

--- a/Mixpanel/VariantAction.swift
+++ b/Mixpanel/VariantAction.swift
@@ -200,7 +200,7 @@ class VariantAction: NSObject, NSCoding {
         return self.name.hash
     }
 
-    class func executeSelector(_ selector: Selector,
+    static func executeSelector(_ selector: Selector,
                                args: [Any],
                                path: ObjectSelector,
                                root: AnyObject,
@@ -217,7 +217,7 @@ class VariantAction: NSObject, NSCoding {
     }
 
     @discardableResult
-    class func executeSelector(_ selector: Selector, args: [Any], on objects: [AnyObject]) -> [(AnyObject, AnyObject?)] {
+    static func executeSelector(_ selector: Selector, args: [Any], on objects: [AnyObject]) -> [(AnyObject, AnyObject?)] {
         var targetRetValuePairs = [(AnyObject, AnyObject?)]()
         var transformedArgs = [Any]()
         var doesHaveNSValue = false
@@ -283,7 +283,7 @@ class VariantAction: NSObject, NSCoding {
         return targetRetValuePairs
     }
 
-    class func extractAndRunMethodFromSelector(selector: Selector, implementation: IMP?, object: AnyObject, args: [Any]) -> AnyObject? {
+    static func extractAndRunMethodFromSelector(selector: Selector, implementation: IMP?, object: AnyObject, args: [Any]) -> AnyObject? {
         if selector.description == "setImage:forState:" {
             typealias Function = @convention(c) (AnyObject, Selector, UIImage, UIControl.State) -> Void
             let function = unsafeBitCast(implementation, to: Function.self)

--- a/Mixpanel/WebSocketWrapper.swift
+++ b/Mixpanel/WebSocketWrapper.swift
@@ -124,7 +124,7 @@ class WebSocketWrapper: WebSocketDelegate {
         }
     }
 
-    class func getMessageType(for message: Data) -> BaseWebSocketMessage? {
+    static func getMessageType(for message: Data) -> BaseWebSocketMessage? {
         Logger.info(message: "raw message \(message)")
         var webSocketMessage: BaseWebSocketMessage? = nil
 


### PR DESCRIPTION
This PR includes #360, and adds the following:

-Move to mono-queue: Instead of multi queue for archiving

-Move to async dispatch to serial queue and use iOS's guaranteed barrier between dispatches to guarantee time sorting.

What I think you wanted:

Something like:
archiveEvents() 
archivePeople()
... etc

to each synchronously occur, ensuring A before B etc. A few problems are that .sync is scary because of deadlock potential, and also that having a bunch of queues means if somehow you ever called archiveEvents() and archivePeople() on different threads now they're both calling archiveToFile() so you'll get two (or more) expensive NSKeyedArchiver.archiveRootObject calls in parallel. 

```
This method archives the graph formed by the root object to a data object, then atomically writes it to the given path. The format of the archive is PropertyListSerialization.PropertyListFormat.binary.
```
Also, if you did call these functions from different threads it's not clear to me what would happen (could the file system object get corrupted?)

Anyways, this new design fixes all of this (I think) by having a single serial queue. Calls to archiveEvents(), archivePeople() etc are now non-blocking and *guaranteed* by the operating system to get called sequentially. This is nice because it should do what you want where they'll get called sequentially, but also in that you are now guaranteed to only ever have one at most NSKeyedArchiver.archiveRootObject() call at any given time. 

I ran the tests in the demo project and everything seemed to work, minus this one override test that failed because you can't override a static function anymore (perhaps that test could be adjusted? It didn't seem super important)

