### PR TITLE
add NSNumber support as a property value type

### DIFF
--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -1221,10 +1221,6 @@ extension MixpanelInstance {
             return
         }
         let epochInterval = Date().timeIntervalSince1970
-
-
-       // }
-
         trackingQueue.async { [weak self, event, properties, epochInterval] in
             guard let self = self else { return }
             var shadowEventsQueue = Queue()

--- a/Mixpanel/MixpanelType.swift
+++ b/Mixpanel/MixpanelType.swift
@@ -34,6 +34,21 @@ extension String: MixpanelType {
     }
 }
 
+extension NSNumber: MixpanelType {
+    /**
+     Checks if this object has nested object types that Mixpanel supports.
+     Will always return true.
+     */
+    public func isValidNestedType() -> Bool { return true }
+    
+    public func equals(rhs: MixpanelType) -> Bool {
+        if rhs is NSNumber {
+            return self.isEqual(rhs)
+        }
+        return false
+    }
+}
+
 extension Int: MixpanelType {
     /**
      Checks if this object has nested object types that Mixpanel supports.
@@ -48,6 +63,7 @@ extension Int: MixpanelType {
         return false
     }
 }
+
 extension UInt: MixpanelType {
     /**
      Checks if this object has nested object types that Mixpanel supports.

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
@@ -567,6 +567,35 @@ class MixpanelDemoTests: MixpanelBaseTests {
                       "people queue failed to reset after archive")
     }
 
+    func testArchiveNSNumberBoolIntProperty() {
+        let testToken = randomId()
+        mixpanel = Mixpanel.initialize(token: testToken, launchOptions: nil, flushInterval: 60)
+        let aBoolNumber: Bool = true
+        let aBoolNSNumber = NSNumber(value: aBoolNumber)
+        
+        let aIntNumber: Int = 1
+        let aIntNSNumber = NSNumber(value: aIntNumber)
+        
+        mixpanel.track(event: "e1", properties:  ["p1": aBoolNSNumber, "p2": aIntNSNumber])
+        mixpanel.archive()
+        waitForTrackingQueue()
+        mixpanel = Mixpanel.initialize(token: testToken, launchOptions: nil, flushInterval: 60)
+        waitForTrackingQueue()
+        let properties: [String: Any] = mixpanel.eventsQueue[0]["properties"] as! [String: Any]
+        
+        XCTAssertTrue(isBoolNumber(num: properties["p1"]! as! NSNumber),
+                          "The bool value should be unarchived as bool")
+        XCTAssertFalse(isBoolNumber(num: properties["p2"]! as! NSNumber),
+                          "The int value should not be unarchived as bool")
+    }
+    
+    private func isBoolNumber(num: NSNumber) -> Bool
+    {
+        let boolID = CFBooleanGetTypeID() // the type ID of CFBoolean
+        let numID = CFGetTypeID(num) // the type ID of num
+        return numID == boolID
+    }
+
     func testArchive() {
         let testToken = randomId()
         mixpanel = Mixpanel.initialize(token: testToken, launchOptions: nil, flushInterval: 60)


### PR DESCRIPTION
If you want to use Bool type for property value, please use NSNumber with Bool instead. This can avoid swift Bool type being decoded to Int from disk.
https://github.com/mixpanel/mixpanel-swift/issues/342