### PR TITLE
critical fix for issues with flush and archive

### DIFF
--- a/Mixpanel/Flush.swift
+++ b/Mixpanel/Flush.swift
@@ -10,6 +10,7 @@ import Foundation
 
 protocol FlushDelegate {
     func flush(completion: (() -> Void)?)
+    func updateQueue(_ queue: Queue, type: FlushType)
     #if os(iOS)
     func updateNetworkActivityIndicator(_ on: Bool)
     #endif // os(iOS)
@@ -153,6 +154,7 @@ class Flush: AppLifecycle {
                                                 } else {
                                                     shadowQueue.removeAll()
                                                 }
+                                                self?.delegate?.updateQueue(shadowQueue, type: type)
                                             }
                                             shouldContinue = success
                                             semaphore.signal()

--- a/Mixpanel/JSONHandler.swift
+++ b/Mixpanel/JSONHandler.swift
@@ -50,6 +50,13 @@ class JSONHandler {
 
     private class func makeObjectSerializable(_ obj: MPObjectToParse) -> MPObjectToParse {
         switch obj {
+        case let obj as NSNumber:
+            if isBoolNumber(obj) {
+                return obj.boolValue
+            } else {
+                return obj
+            }
+
         case let obj as Double where obj.isFinite:
             return obj
             
@@ -82,4 +89,11 @@ class JSONHandler {
         }
     }
 
+
+    private class func isBoolNumber(_ num: NSNumber) -> Bool
+    {
+        let boolID = CFBooleanGetTypeID()
+        let numID = CFGetTypeID(num)
+        return numID == boolID
+    }
 }


### PR DESCRIPTION
This PR fix potential issues with large event queues due to the unstable network and too many events being tracked within short period of time.
- make archive/unarchive always respect queue size limit (since we merge the flush queue and the tracking queue together, without this change, there is a possibility to go over the limit)
- save progress during flushing a queue,  call archive right after each batch of events being flushed successfully, this is to prevent sending duplicated events or losing events when app being terminated during the flush before it has a chance to archive the whole thing. 
- make archive always to be called inside a network queue, this is to prevent race conditions for both the flush queue and the track queue. The flush queue and track queue transitions happens in network queue so archive should always be in the same queue.

