### PR TITLE
Temporarily remove the radio listener

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
   - WORKSPACE=MixpanelDemo.xcworkspace
   - SCHEME=MixpanelDemo
   matrix:
-    - DESTINATION="OS=13.0,name=iPhone 8 Plus"    SCHEME="$SCHEME"    RUN_TESTS="YES"     POD_LINT="YES"
     - DESTINATION="OS=13.0,name=iPhone 11"   SCHEME="$SCHEME"    RUN_TESTS="YES"     POD_LINT="YES"
 script:
   - set -o pipefail

--- a/Mixpanel/MixpanelInstance.swift
+++ b/Mixpanel/MixpanelInstance.swift
@@ -391,10 +391,12 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
         trackIntegration()
         #if os(iOS) && !targetEnvironment(macCatalyst)
             setCurrentRadio()
-            notificationCenter.addObserver(self,
-                                           selector: #selector(setCurrentRadio),
-                                           name: .CTRadioAccessTechnologyDidChange,
-                                           object: nil)
+        // Temporarily remove the ability to monitor the radio change due to a crash issue might relate to the api from Apple
+        // https://openradar.appspot.com/46873673
+        //    notificationCenter.addObserver(self,
+        //                                   selector: #selector(setCurrentRadio),
+        //                                   name: .CTRadioAccessTechnologyDidChange,
+        //                                   object: nil)
             #if DECIDE
                 notificationCenter.addObserver(self,
                                                selector: #selector(executeTweaks),


### PR DESCRIPTION
We currently listen to the radio changes during an app session for customers, i.e. LTE, GPRS, Edge, etc.(https://developer.apple.com/documentation/coretelephony/cttelephonynetworkinfo/radio_access_technology_constants)
We record this to `$radio`, a default event property collected by Mixpanel. However this will lead to noticeable  crashes since iOS 13. https://github.com/mixpanel/mixpanel-swift/issues/367

This might seem to be an issue from Apple and there is an existing open radar: https://openradar.appspot.com/46873673.  Given the relative high occurrences of crashes, we now temporarily remove the radio listener, this will only impact the scenario where the radio actually changes during an app session. `$radio` is still going to be recorded at the start of each app session and the value won't be changed for the entire app session.