### PR TITLE
change deployment target to iOS 9 to support Xcode 12

### DIFF
--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -1234,7 +1234,7 @@
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = Mixpanel/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_SWIFT_FLAGS = "-D DECIDE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mixpanel.Mixpanel;
@@ -1282,7 +1282,7 @@
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = Mixpanel/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_SWIFT_FLAGS = "-D DECIDE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mixpanel.Mixpanel;

--- a/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
+++ b/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
@@ -1621,7 +1621,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = E8FVX7QLET;
 				INFOPLIST_FILE = MixpanelDemo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1652,7 +1652,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = E8FVX7QLET;
 				INFOPLIST_FILE = MixpanelDemo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
In order to do an Archive build of an app, using Xcode 12, the minimum deployment target must at least be iOS 9.