### PR TITLE
Remove alias check

### DIFF
--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -768,31 +768,31 @@ extension MixpanelInstance {
             }
 
 
-                if distinctId != self.distinctId {
-                    let oldDistinctId = self.distinctId
-                    self.alias = nil
-                    self.distinctId = distinctId
-                    self.userId = distinctId
-                    self.track(event: "$identify", properties: ["$anon_distinct_id": oldDistinctId])
-                }
+            if distinctId != self.distinctId {
+                let oldDistinctId = self.distinctId
+                self.alias = nil
+                self.distinctId = distinctId
+                self.userId = distinctId
+                self.track(event: "$identify", properties: ["$anon_distinct_id": oldDistinctId])
+            }
 
-                if usePeople {
-                    self.people.distinctId = distinctId
-                    if !self.people.unidentifiedQueue.isEmpty {
-                        self.readWriteLock.write {
-                            for var r in self.people.unidentifiedQueue {
-                                r["$distinct_id"] = self.distinctId
-                                self.people.peopleQueue.append(r)
-                            }
-                            self.people.unidentifiedQueue.removeAll()
+            if usePeople {
+                self.people.distinctId = distinctId
+                if !self.people.unidentifiedQueue.isEmpty {
+                    self.readWriteLock.write {
+                        for var r in self.people.unidentifiedQueue {
+                            r["$distinct_id"] = self.distinctId
+                            self.people.peopleQueue.append(r)
                         }
-                        self.readWriteLock.read {
-                            Persistence.archivePeople(self.people.peopleQueue, token: self.apiToken)
-                        }
+                        self.people.unidentifiedQueue.removeAll()
                     }
-                } else {
-                    self.people.distinctId = nil
+                    self.readWriteLock.read {
+                        Persistence.archivePeople(self.people.peopleQueue, token: self.apiToken)
+                    }
                 }
+            } else {
+                self.people.distinctId = nil
+            }
             
             self.archiveProperties()
             Persistence.storeIdentity(token: self.apiToken,

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -767,9 +767,7 @@ extension MixpanelInstance {
                self.hadPersistedDistinctId = true
             }
 
-            // identify only changes the distinct id if it doesn't match either the existing or the alias;
-            // if it's new, blow away the alias as well.
-            if distinctId != self.alias {
+
                 if distinctId != self.distinctId {
                     let oldDistinctId = self.distinctId
                     self.alias = nil
@@ -795,7 +793,7 @@ extension MixpanelInstance {
                 } else {
                     self.people.distinctId = nil
                 }
-            }
+            
             self.archiveProperties()
             Persistence.storeIdentity(token: self.apiToken,
                                       distinctID: self.distinctId,

--- a/Sources/Network.swift
+++ b/Sources/Network.swift
@@ -22,6 +22,8 @@ struct BasePath {
         }
         components.path = path
         components.queryItems = queryItems
+        //adding workaround to replece + for %2B as it's not done by default within URLComponents
+        components.percentEncodedQuery = components.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")
         return components.url
     }
 


### PR DESCRIPTION
Removing a check for the alias within the identify function as it can prevent the ID from changing if alias has been called already.