### PR TITLE
Add completion closure to async apis `reset()`, `identify()` and `createAlias()` 

### DIFF
--- a/MixpanelDemo/MixpanelDemo/AppDelegate.swift
+++ b/MixpanelDemo/MixpanelDemo/AppDelegate.swift
@@ -31,6 +31,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         MixpanelTweaks.setTweaks(tweaks: allTweaks)
         registerNotification()
 
+
         return true
     }
 

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -756,15 +756,26 @@ extension MixpanelInstance {
      */
     open func identify(distinctId: String, usePeople: Bool = true, completion: (() -> Void)? = nil) {
         if hasOptedOutTracking() {
+            if let completion = completion {
+                DispatchQueue.main.async(execute: completion)
+            }
             return
         }
         if distinctId.isEmpty {
             Logger.error(message: "\(self) cannot identify blank distinct id")
+            if let completion = completion {
+                DispatchQueue.main.async(execute: completion)
+            }
             return
         }
 
         trackingQueue.async { [weak self, distinctId, usePeople] in
-            guard let self = self else { return }
+            guard let self = self else {
+                if let completion = completion {
+                    DispatchQueue.main.async(execute: completion)
+                }
+                return
+            }
 
             // If there's no anonymousId assigned yet, that means distinctId is stored in the storage. Assigning already stored
             // distinctId as anonymousId on identify and also setting a flag to notify that it might be previously logged in user
@@ -841,21 +852,33 @@ extension MixpanelInstance {
      */
     open func createAlias(_ alias: String, distinctId: String, usePeople: Bool = true, completion: (() -> Void)? = nil) {
         if hasOptedOutTracking() {
+            if let completion = completion {
+                DispatchQueue.main.async(execute: completion)
+            }
             return
         }
         if distinctId.isEmpty {
             Logger.error(message: "\(self) cannot identify blank distinct id")
+            if let completion = completion {
+                DispatchQueue.main.async(execute: completion)
+            }
             return
         }
 
         if alias.isEmpty {
             Logger.error(message: "\(self) create alias called with empty alias")
+            if let completion = completion {
+                DispatchQueue.main.async(execute: completion)
+            }
             return
         }
 
         if alias != distinctId {
             trackingQueue.async { [weak self, alias] in
                 guard let self = self else {
+                    if let completion = completion {
+                        DispatchQueue.main.async(execute: completion)
+                    }
                     return
                 }
 
@@ -894,6 +917,9 @@ extension MixpanelInstance {
             self?.networkQueue.sync { [weak self] in
                 self?.readWriteLock.write { [weak self] in
                     guard let self = self else {
+                        if let completion = completion {
+                            DispatchQueue.main.async(execute: completion)
+                        }
                         return
                     }
 

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -752,8 +752,9 @@ extension MixpanelInstance {
      - parameter distinctId: string that uniquely identifies the current user
      - parameter usePeople: boolean that controls whether or not to set the people distinctId to the event distinctId.
                             This should only be set to false if you wish to prevent people profile updates for that user.
+     - parameter completion: an optional completion handler for when the identify has completed.
      */
-    open func identify(distinctId: String, usePeople: Bool = true) {
+    open func identify(distinctId: String, usePeople: Bool = true, completion: (() -> Void)? = nil) {
         if hasOptedOutTracking() {
             return
         }
@@ -810,6 +811,9 @@ extension MixpanelInstance {
                                       userID: self.userId,
                                       alias: self.alias,
                                       hadPersistedDistinctId: self.hadPersistedDistinctId)
+            if let completion = completion {
+                DispatchQueue.main.async(execute: completion)
+            }
         }
 
         if MixpanelInstance.isiOSAppExtension() {
@@ -832,9 +836,10 @@ extension MixpanelInstance {
      - parameter alias:      A unique identifier that you want to use as an identifier for this user.
      - parameter distinctId: The current user identifier.
      - parameter usePeople: boolean that controls whether or not to set the people distinctId to the event distinctId.
+     - parameter completion: an optional completion handler for when the createAlias has completed.
      This should only be set to false if you wish to prevent people profile updates for that user.
      */
-    open func createAlias(_ alias: String, distinctId: String, usePeople: Bool = true) {
+    open func createAlias(_ alias: String, distinctId: String, usePeople: Bool = true, completion: (() -> Void)? = nil) {
         if hasOptedOutTracking() {
             return
         }
@@ -868,17 +873,22 @@ extension MixpanelInstance {
             let properties = ["distinct_id": distinctId, "alias": alias]
             track(event: "$create_alias", properties: properties)
             identify(distinctId: distinctId, usePeople: usePeople)
-            flush()
+            flush(completion: completion)
         } else {
             Logger.error(message: "alias: \(alias) matches distinctId: \(distinctId) - skipping api call.")
+            if let completion = completion {
+                DispatchQueue.main.async(execute: completion)
+            }
         }
     }
 
     /**
      Clears all stored properties including the distinct Id.
      Useful if your app's user logs out.
+     
+     - parameter completion: an optional completion handler for when the reset has completed.
      */
-    open func reset() {
+    open func reset(completion: (() -> Void)? = nil) {
         flush()
         trackingQueue.async { [weak self] in
             self?.networkQueue.sync { [weak self] in
@@ -921,6 +931,9 @@ extension MixpanelInstance {
                     self.connectIntegrations.reset()
                     MixpanelTweaks.defaultStore.reset()
                     #endif // DECIDE
+                    if let completion = completion {
+                        DispatchQueue.main.async(execute: completion)
+                    }
                 }
                 self?.archive()
             }


### PR DESCRIPTION
This is to address #465 