### PR TITLE
Allow serverURL to be set with a baseURL containing full url path

### DIFF
--- a/Sources/Network.swift
+++ b/Sources/Network.swift
@@ -19,7 +19,7 @@ struct BasePath {
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
             return nil
         }
-        components.path = path
+        components.path += path
         components.queryItems = queryItems
         // adding workaround to replece + for %2B as it's not done by default within URLComponents
         components.percentEncodedQuery = components.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")


### PR DESCRIPTION
Currently `serverURL` can only set a baseURl without path like `https://yourserver.com`, with this fix, now we can set a full path `https://yourserver.com/proxypath`