### PR TITLE
fix  `First App Open` not always being able to be triggered

### DIFF
--- a/MixpanelDemo/MixpanelDemo/AppDelegate.swift
+++ b/MixpanelDemo/MixpanelDemo/AppDelegate.swift
@@ -20,7 +20,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Mixpanel.initialize(token: "MIXPANEL_TOKEN")
         Mixpanel.mainInstance().loggingEnabled = true
 
-
         return true
     }
 }

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelBaseTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelBaseTests.swift
@@ -21,6 +21,8 @@ class MixpanelBaseTests: XCTestCase, MixpanelDelegate {
         super.setUp()
         stubCalls()
         mixpanelWillFlush = false
+        let defaults = UserDefaults(suiteName: "Mixpanel")
+        defaults?.removeObject(forKey: "MPFirstOpen")
 
         NSLog("finished test setup")
     }

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelOptOutTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelOptOutTests.swift
@@ -168,10 +168,10 @@ class MixpanelOptOutTests: MixpanelBaseTests {
         let testMixpanel = Mixpanel.initialize(token: randomId())
         testMixpanel.track(event: "a normal event")
         waitForTrackingQueue(testMixpanel)
-        XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).count == 1, "events should be queued")
+        XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).count == 2, "events should be queued")
         testMixpanel.optOutTracking()
         waitForTrackingQueue(testMixpanel)
-        XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).count == 1, "When opted out, any events tracked before opted out should not be cleared")
+        XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).count == 2, "When opted out, any events tracked before opted out should not be cleared")
         removeDBfile(testMixpanel.apiToken)
     }
 

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelPeopleTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelPeopleTests.swift
@@ -75,8 +75,8 @@ class MixpanelPeopleTests: MixpanelBaseTests {
         }
         waitForTrackingQueue(testMixpanel)
         sleep(1)
-        XCTAssertTrue(unIdentifiedPeopleQueue(token: testMixpanel.apiToken).count == 505)
-        var r: InternalProperties = unIdentifiedPeopleQueue(token: testMixpanel.apiToken).first!
+        XCTAssertTrue(unIdentifiedPeopleQueue(token: testMixpanel.apiToken).count == 506)
+        var r: InternalProperties = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)[1]
         XCTAssertEqual((r["$set"] as? InternalProperties)?["i"] as? Int, 0)
         r = unIdentifiedPeopleQueue(token: testMixpanel.apiToken).last!
         XCTAssertEqual((r["$set"] as? InternalProperties)?["i"] as? Int, 504)

--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -20,6 +20,7 @@ open class Group {
     weak var delegate: FlushDelegate?
     let metadata: SessionMetadata
     let mixpanelPersistence: MixpanelPersistence
+    weak var mixpanelInstance: MixpanelInstance?
 
     init(apiToken: String,
          serialQueue: DispatchQueue,
@@ -27,7 +28,8 @@ open class Group {
          groupKey: String,
          groupID: MixpanelType,
          metadata: SessionMetadata,
-         mixpanelPersistence: MixpanelPersistence) {
+         mixpanelPersistence: MixpanelPersistence,
+         mixpanelInstance: MixpanelInstance) {
         self.apiToken = apiToken
         self.serialQueue = serialQueue
         self.lock = lock
@@ -35,10 +37,11 @@ open class Group {
         self.groupID  = groupID
         self.metadata = metadata
         self.mixpanelPersistence = mixpanelPersistence
+        self.mixpanelInstance = mixpanelInstance
     }
 
     func addGroupRecordToQueueWithAction(_ action: String, properties: InternalProperties) {
-        if Mixpanel.mainInstance().hasOptedOutTracking() {
+        if mixpanelInstance?.hasOptedOutTracking() ?? false {
             return
         }
         let epochMilliseconds = round(Date().timeIntervalSince1970 * 1000)
@@ -155,6 +158,6 @@ open class Group {
      */
     open func deleteGroup() {
         addGroupRecordToQueueWithAction("$delete", properties: [:])
-        Mixpanel.mainInstance().removeCachedGroup(groupKey: groupKey, groupID: groupID)
+        mixpanelInstance?.removeCachedGroup(groupKey: groupKey, groupID: groupID)
     }
 }

--- a/Sources/Mixpanel.swift
+++ b/Sources/Mixpanel.swift
@@ -26,6 +26,7 @@ open class Mixpanel {
      - parameter flushInterval:             Optional. Interval to run background flushing
      - parameter instanceName:              Optional. The name you want to call this instance
      - parameter optOutTrackingByDefault:   Optional. Whether or not to be opted out from tracking by default
+     - parameter trackAutomaticEvents:      Optional. Whether or not to collect common mobile events
 
      - important: If you have more than one Mixpanel instance, it is beneficial to initialize
      the instances with an instanceName. Then they can be reached by calling getInstance with name.
@@ -37,11 +38,13 @@ open class Mixpanel {
     open class func initialize(token apiToken: String,
                                flushInterval: Double = 60,
                                instanceName: String = UUID().uuidString,
-                               optOutTrackingByDefault: Bool = false) -> MixpanelInstance {
+                               optOutTrackingByDefault: Bool = false,
+                               trackAutomaticEvents: Bool = true) -> MixpanelInstance {
         return MixpanelManager.sharedInstance.initialize(token: apiToken,
                                                          flushInterval: flushInterval,
                                                          instanceName: instanceName,
-                                                         optOutTrackingByDefault: optOutTrackingByDefault)
+                                                         optOutTrackingByDefault: optOutTrackingByDefault,
+                                                         trackAutomaticEvents: trackAutomaticEvents)
     }
     #else
     /**
@@ -139,11 +142,13 @@ class MixpanelManager {
     func initialize(token apiToken: String,
                     flushInterval: Double,
                     instanceName: String,
-                    optOutTrackingByDefault: Bool = false) -> MixpanelInstance {
+                    optOutTrackingByDefault: Bool = false,
+                    trackAutomaticEvents: Bool = true) -> MixpanelInstance {
         let instance = MixpanelInstance(apiToken: apiToken,
                                         flushInterval: flushInterval,
                                         name: instanceName,
-                                        optOutTrackingByDefault: optOutTrackingByDefault)
+                                        optOutTrackingByDefault: optOutTrackingByDefault,
+                                        trackAutomaticEvents: trackAutomaticEvents)
         mainInstance = instance
         readWriteLock.write {
             instances[instanceName] = instance

--- a/Sources/People.swift
+++ b/Sources/People.swift
@@ -26,7 +26,8 @@ open class People {
     weak var delegate: FlushDelegate?
     let metadata: SessionMetadata
     let mixpanelPersistence: MixpanelPersistence
-    
+    weak var mixpanelInstance: MixpanelInstance?
+  
     init(apiToken: String,
          serialQueue: DispatchQueue,
          lock: ReadWriteLock,
@@ -40,7 +41,7 @@ open class People {
     }
 
     func addPeopleRecordToQueueWithAction(_ action: String, properties: InternalProperties) {
-        if Mixpanel.mainInstance().hasOptedOutTracking() {
+        if mixpanelInstance?.hasOptedOutTracking() ?? false {
             return
         }
         let epochMilliseconds = round(Date().timeIntervalSince1970 * 1000)
@@ -71,15 +72,15 @@ open class People {
             }
             self.metadata.toDict(isEvent: false).forEach { (k, v) in r[k] = v }
 
-            if let anonymousId = Mixpanel.mainInstance().anonymousId {
+            if let anonymousId = self.mixpanelInstance?.anonymousId {
                r["$device_id"] = anonymousId
             }
 
-            if let userId = Mixpanel.mainInstance().userId {
+            if let userId = self.mixpanelInstance?.userId {
                 r["$user_id"] = userId
             }
 
-            if let hadPersistedDistinctId = Mixpanel.mainInstance().hadPersistedDistinctId {
+            if let hadPersistedDistinctId = self.mixpanelInstance?.hadPersistedDistinctId {
                 r["$had_persisted_distinct_id"] = hadPersistedDistinctId
             }
 

--- a/Sources/Track.swift
+++ b/Sources/Track.swift
@@ -19,12 +19,14 @@ class Track {
     let lock: ReadWriteLock
     let metadata: SessionMetadata
     let mixpanelPersistence: MixpanelPersistence
+    weak var mixpanelInstance: MixpanelInstance?
     
     var isAutomaticEventEnabled: Bool {
         return MixpanelPersistence.loadAutomacticEventsEnabledFlag(apiToken: apiToken)
     }
 
-    init(apiToken: String, lock: ReadWriteLock, metadata: SessionMetadata, mixpanelPersistence: MixpanelPersistence) {
+    init(apiToken: String, lock: ReadWriteLock, metadata: SessionMetadata,
+         mixpanelPersistence: MixpanelPersistence) {
         self.apiToken = apiToken
         self.lock = lock
         self.metadata = metadata
@@ -86,7 +88,7 @@ class Track {
 
     func registerSuperProperties(_ properties: Properties,
                                  superProperties: InternalProperties) -> InternalProperties {
-        if Mixpanel.mainInstance().hasOptedOutTracking() {
+        if mixpanelInstance?.hasOptedOutTracking() ?? false {
             return superProperties
         }
 
@@ -100,7 +102,7 @@ class Track {
     func registerSuperPropertiesOnce(_ properties: Properties,
                                      superProperties: InternalProperties,
                                      defaultValue: MixpanelType?) -> InternalProperties {
-        if Mixpanel.mainInstance().hasOptedOutTracking() {
+        if mixpanelInstance?.hasOptedOutTracking() ?? false {
             return superProperties
         }
 
@@ -135,7 +137,7 @@ class Track {
     }
 
     func time(event: String?, timedEvents: InternalProperties, startTime: Double) -> InternalProperties {
-        if Mixpanel.mainInstance().hasOptedOutTracking() {
+        if mixpanelInstance?.hasOptedOutTracking() ?? false {
             return timedEvents
         }
         var updatedTimedEvents = timedEvents


### PR DESCRIPTION
- Fix  `First App Open` not always being able to be triggered
- Add additional param `trackAutomaticEvents` in `initialize`: Whether or not to collect common mobile events