### PR TITLE
set content-type to application/json

### DIFF
--- a/MixpanelDemo/MixpanelDemoMacTests/TestConstants.swift
+++ b/MixpanelDemo/MixpanelDemoMacTests/TestConstants.swift
@@ -19,19 +19,19 @@ let kDefaultServerGroupsString = "https://api.mixpanel.com/groups/"
 let kDefaultServerDecideString = "^https://api.mixpanel.com/decide(.*?)".regex
 
 @discardableResult func stubEngage() -> LSStubRequestDSL {
-    return stubRequest("POST", kDefaultServerEngageString as LSMatcheable).withHeader("Accept-Encoding", "gzip")!
+    return stubRequest("POST", kDefaultServerEngageString as LSMatcheable).withHeader("Content-Type", "application/json")!
 }
 
 @discardableResult func stubGroups() -> LSStubRequestDSL {
-    return stubRequest("POST", kDefaultServerGroupsString as LSMatcheable?).withHeader("Accept-Encoding", "gzip")!
+    return stubRequest("POST", kDefaultServerGroupsString as LSMatcheable?).withHeader("Content-Type", "application/json")!
 }
 
 @discardableResult func stubTrack() -> LSStubRequestDSL {
-    return stubRequest("POST", kDefaultServerTrackString as LSMatcheable).withHeader("Accept-Encoding", "gzip")!
+    return stubRequest("POST", kDefaultServerTrackString as LSMatcheable).withHeader("Content-Type", "application/json")!
 }
 
 @discardableResult func stubDecide() -> LSStubRequestDSL {
-    return stubRequest("GET", kDefaultServerDecideString()).withHeader("Accept-Encoding", "gzip")!
+    return stubRequest("GET", kDefaultServerDecideString()).withHeader("Content-Type", "application/json")!
 }
 
 extension XCTestCase {

--- a/MixpanelDemo/MixpanelDemoTests/TestConstants.swift
+++ b/MixpanelDemo/MixpanelDemoTests/TestConstants.swift
@@ -19,19 +19,19 @@ let kDefaultServerGroupsString = "^https://api.mixpanel.com/groups/".regex
 let kDefaultServerDecideString = "^https://api.mixpanel.com/decide(.*?)".regex
 
 @discardableResult func stubEngage() -> LSStubRequestDSL {
-    return stubRequest("POST", kDefaultServerEngageString()).withHeader("Accept-Encoding", "gzip")!
+    return stubRequest("POST", kDefaultServerEngageString()).withHeader("Content-Type", "application/json")!
 }
 
 @discardableResult func stubGroups() -> LSStubRequestDSL {
-    return stubRequest("POST", kDefaultServerGroupsString()).withHeader("Accept-Encoding", "gzip")!
+    return stubRequest("POST", kDefaultServerGroupsString()).withHeader("Content-Type", "application/json")!
 }
 
 @discardableResult func stubTrack() -> LSStubRequestDSL {
-    return stubRequest("POST", kDefaultServerTrackString()).withHeader("Accept-Encoding", "gzip")!
+    return stubRequest("POST", kDefaultServerTrackString()).withHeader("Content-Type", "application/json")!
 }
 
 @discardableResult func stubDecide() -> LSStubRequestDSL {
-    return stubRequest("GET", kDefaultServerDecideString()).withHeader("Accept-Encoding", "gzip")!
+    return stubRequest("GET", kDefaultServerDecideString()).withHeader("Content-Type", "application/json")!
 }
 
 extension XCTestCase {

--- a/Sources/FlushRequest.swift
+++ b/Sources/FlushRequest.swift
@@ -31,14 +31,13 @@ class FlushRequest: Network {
             }
             return nil
         }
-
-        let requestBody = "ip=\(useIP ? 1 : 0)&data=\(requestData)"
-            .data(using: String.Encoding.utf8)
-
+        
+        let ipString = useIP ? "1" : "0"
         let resource = Network.buildResource(path: type.rawValue,
                                              method: .post,
-                                             requestBody: requestBody,
-                                             headers: ["Accept-Encoding": "gzip"],
+                                             requestBody: requestData.data(using: .utf8),
+                                             queryItems: [URLQueryItem(name: "ip", value: ipString)],
+                                             headers: ["Content-Type": "application/json"],
                                              parse: responseParser)
 
         flushRequestHandler(BasePath.getServerURL(identifier: basePathIdentifier),


### PR DESCRIPTION
set the content-type header to application/json to prevent certain payloads from being rejected by the server