### PR TITLE
Fix automatic events settings

### DIFF
--- a/.github/workflows/iOS.yml
+++ b/.github/workflows/iOS.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        destination: ['OS=15.0,name="iPhone 11"']
+        destination: ['OS=15.2,name="iPhone 13 Pro"']
 
     steps:
     - uses: actions/checkout@v2

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelAutomaticEventsTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelAutomaticEventsTests.swift
@@ -57,6 +57,19 @@ class MixpanelAutomaticEventsTests: MixpanelBaseTests {
     }
 
     func testFlushAutomaticEventsIftrackAutomaticEventsEnabledIsTrue() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60, trackAutomaticEvents: true)
+        testMixpanel.minimumSessionDuration = 0;
+        testMixpanel.automaticEvents.perform(#selector(AutomaticEvents.appWillResignActive(_:)),
+                                              with: Notification(name: Notification.Name(rawValue: "test")))
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).count == 2, "automatic events should be tracked")
+        
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).count == 0, "automatic events should be flushed")
+        removeDBfile(testMixpanel.apiToken)
+    }
+    
+    func testFlushAutomaticEventsIftrackAutomaticEventsEnabledIsNotSet() {
         let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
         testMixpanel.minimumSessionDuration = 0;
         testMixpanel.automaticEvents.perform(#selector(AutomaticEvents.appWillResignActive(_:)),
@@ -73,12 +86,11 @@ class MixpanelAutomaticEventsTests: MixpanelBaseTests {
     func testDiscardAutomaticEventsIfDecideIsFalse() {
         let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
         testMixpanel.minimumSessionDuration = 0;
-        MixpanelPersistence.saveAutomacticEventsEnabledFlag(value: false, fromDecide: true, apiToken: testMixpanel.apiToken)
+        MixpanelPersistence.saveAutomacticEventsEnabledFlag(value: false, fromDecide: false, apiToken: testMixpanel.apiToken)
         testMixpanel.automaticEvents.perform(#selector(AutomaticEvents.appWillResignActive(_:)),
                                               with: Notification(name: Notification.Name(rawValue: "test")))
-
-        flushAndWaitForTrackingQueue(testMixpanel)
-        XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).count == 0, "automatic events should be discarded")
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).count == 0, "automatic events should not be tracked")
         removeDBfile(testMixpanel.apiToken)
     }
     
@@ -93,6 +105,28 @@ class MixpanelAutomaticEventsTests: MixpanelBaseTests {
         
         flushAndWaitForTrackingQueue(testMixpanel)
         XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).count == 0, "automatic events should be flushed")
+        removeDBfile(testMixpanel.apiToken)
+    }
+    
+    func testDiscardAutomaticEventsIfDecideIsTrueSettingIsFalse() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60, trackAutomaticEvents: false)
+        testMixpanel.minimumSessionDuration = 0;
+        MixpanelPersistence.saveAutomacticEventsEnabledFlag(value: true, fromDecide: true, apiToken: testMixpanel.apiToken)
+        testMixpanel.automaticEvents.perform(#selector(AutomaticEvents.appWillResignActive(_:)),
+                                              with: Notification(name: Notification.Name(rawValue: "test")))
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).count == 0, "automatic events should not be tracked")
+        removeDBfile(testMixpanel.apiToken)
+    }
+    
+    func testFlushAutomaticEventsIfDecideIsFalseSettingIsTrue() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60, trackAutomaticEvents: true)
+        testMixpanel.minimumSessionDuration = 0;
+        MixpanelPersistence.saveAutomacticEventsEnabledFlag(value: false, fromDecide: true, apiToken: testMixpanel.apiToken)
+        testMixpanel.automaticEvents.perform(#selector(AutomaticEvents.appWillResignActive(_:)),
+                                              with: Notification(name: Notification.Name(rawValue: "test")))
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).count == 2, "automatic events should be tracked")
         removeDBfile(testMixpanel.apiToken)
     }
 

--- a/Sources/Mixpanel.swift
+++ b/Sources/Mixpanel.swift
@@ -41,7 +41,7 @@ open class Mixpanel {
                                flushInterval: Double = 60,
                                instanceName: String = UUID().uuidString,
                                optOutTrackingByDefault: Bool = false,
-                               trackAutomaticEvents: Bool = true,
+                               trackAutomaticEvents: Bool? = nil,
                                useUniqueDistinctId: Bool = false,
                                superProperties: Properties? = nil) -> MixpanelInstance {
         return MixpanelManager.sharedInstance.initialize(token: apiToken,
@@ -152,7 +152,7 @@ class MixpanelManager {
                     flushInterval: Double,
                     instanceName: String,
                     optOutTrackingByDefault: Bool = false,
-                    trackAutomaticEvents: Bool = true,
+                    trackAutomaticEvents: Bool? = nil,
                     useUniqueDistinctId: Bool = false,
                     superProperties: Properties? = nil) -> MixpanelInstance {
         let instance = MixpanelInstance(apiToken: apiToken,

--- a/Sources/Mixpanel.swift
+++ b/Sources/Mixpanel.swift
@@ -26,7 +26,7 @@ open class Mixpanel {
      - parameter flushInterval:             Optional. Interval to run background flushing
      - parameter instanceName:              Optional. The name you want to call this instance
      - parameter optOutTrackingByDefault:   Optional. Whether or not to be opted out from tracking by default
-     - parameter trackAutomaticEvents:      Optional. Whether or not to collect common mobile events
+     - parameter trackAutomaticEvents:      Optional. Whether or not to collect common mobile events, it takes precedence over Autotrack settings from the Mixpanel server.
      - parameter superProperties:           Optional. Super properties dictionary to register during initialization
      - parameter useUniqueDistinctId:       Optional. whether or not to use the unique device identifier as the distinct_id
 

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -79,7 +79,8 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
     /// data to the Mixpanel servers. Defaults to true.
     open var showNetworkActivityIndicator = true
     
-    /// This allows enabling or disabling collecting common mobile events
+    /// This allows enabling or disabling collecting common mobile events,
+    /// it takes precedence over Autotrack settings from the Mixpanel server.
     /// If this is not set, it will query the Autotrack settings from the Mixpanel server
     open var trackAutomaticEventsEnabled: Bool? {
         didSet {

--- a/Sources/MixpanelPersistence.swift
+++ b/Sources/MixpanelPersistence.swift
@@ -86,6 +86,13 @@ class MixpanelPersistence {
         return result
     }
     
+    func removeAutomaticEvents() {
+        let events = loadEntitiesInBatch(type: .events)
+        let ids = events.filter { ($0["event"] as! String).hasPrefix("$ae_") }
+            .map { $0["id"] as! Int32 }
+        removeEntitiesInBatch(type: .events, ids: ids)
+    }
+
     func removeEntitiesInBatch(type: PersistenceType, ids: [Int32]) {
         mpdb.deleteRows(type, ids: ids)
     }


### PR DESCRIPTION
`trackAutomaticEvents` param in `initialize`  should take precedence over `Autotrack` settings from the Mixpanel, but if `trackAutomaticEvents` is not set, should respect `Autotrack` settings from the Mixpanel.