### PR TITLE
check for ios app on mac in automatic props

### DIFF
--- a/Sources/AutomaticProperties.swift
+++ b/Sources/AutomaticProperties.swift
@@ -30,8 +30,8 @@ class AutomaticProperties {
                 p["$os"]                = "macOS"
                 p["$os_version"]        = ProcessInfo.processInfo.operatingSystemVersionString
             #else
-                // iOS App Running on Apple Silicon Mac
                 if AutomaticProperties.isiOSAppOnMac() {
+                    // iOS App Running on Apple Silicon Mac
                     p["$os"]                = "macOS"
                     p["$os_version"]        = ProcessInfo.processInfo.operatingSystemVersionString
                 } else {
@@ -90,6 +90,7 @@ class AutomaticProperties {
     class func deviceModel() -> String {
         var modelCode : String
         if AutomaticProperties.isiOSAppOnMac() {
+            // iOS App Running on Apple Silicon Mac
             var size = 0
             sysctlbyname("hw.model", nil, &size, nil, 0)
             var model = [CChar](repeating: 0,  count: size)

--- a/Sources/AutomaticProperties.swift
+++ b/Sources/AutomaticProperties.swift
@@ -137,7 +137,7 @@ class AutomaticProperties {
     
     class func isiOSAppOnMac() -> Bool {
         var isiOSAppOnMac = false
-        if #available(iOS 14.0, macOS 11.0, watchOS 7.0, *) {
+        if #available(iOS 14.0, macOS 11.0, watchOS 7.0, tvOS 14.0, *) {
             isiOSAppOnMac = ProcessInfo.processInfo.isiOSAppOnMac
         }
         return isiOSAppOnMac

--- a/Sources/AutomaticProperties.swift
+++ b/Sources/AutomaticProperties.swift
@@ -137,7 +137,7 @@ class AutomaticProperties {
     
     class func isiOSAppOnMac() -> Bool {
         var isiOSAppOnMac = false
-        if #available(iOS 14.0, watchOS 7.0, *) {
+        if #available(iOS 14.0, macOS 11.0, watchOS 7.0, *) {
             isiOSAppOnMac = ProcessInfo.processInfo.isiOSAppOnMac
         }
         return isiOSAppOnMac

--- a/Sources/AutomaticProperties.swift
+++ b/Sources/AutomaticProperties.swift
@@ -137,7 +137,7 @@ class AutomaticProperties {
     
     class func isiOSAppOnMac() -> Bool {
         var isiOSAppOnMac = false
-        if #available(iOS 14.0, *) {
+        if #available(iOS 14.0, watchOS 7.0, *) {
             isiOSAppOnMac = ProcessInfo.processInfo.isiOSAppOnMac
         }
         return isiOSAppOnMac

--- a/Sources/AutomaticProperties.swift
+++ b/Sources/AutomaticProperties.swift
@@ -33,7 +33,8 @@ class AutomaticProperties {
                 if AutomaticProperties.isiOSAppOnMac() {
                     // iOS App Running on Apple Silicon Mac
                     p["$os"]                = "macOS"
-                    p["$os_version"]        = ProcessInfo.processInfo.operatingSystemVersionString
+                    // unfortunately, there is no API that reports the correct macOS version
+                    // for "Designed for iPad" apps running on macOS, so we omit it here rather than mis-report
                 } else {
                     p["$os"]                = UIDevice.current.systemName
                     p["$os_version"]        = UIDevice.current.systemVersion

--- a/Sources/AutomaticProperties.swift
+++ b/Sources/AutomaticProperties.swift
@@ -30,7 +30,7 @@ class AutomaticProperties {
                 p["$os"]                = "macOS"
                 p["$os_version"]        = ProcessInfo.processInfo.operatingSystemVersionString
             #else
-                // iOS App Running on M1 Mac
+                // iOS App Running on Apple Silicon Mac
                 if AutomaticProperties.isiOSAppOnMac() {
                     p["$os"]                = "macOS"
                     p["$os_version"]        = ProcessInfo.processInfo.operatingSystemVersionString


### PR DESCRIPTION
This PR adds logic to check if the app is a "Designed for iPad" app running on macOS and if so, sets the `$os` to macOS. Unfortunately, there is no API that reports the correct macOS version for "Designed for iPad" apps running on macOS, so we omit it rather than mis-report