### PR TITLE
add an option for 'createAlias' for not calling identify

### DIFF
--- a/MixpanelDemo/MixpanelDemo.xcodeproj/xcshareddata/xcschemes/MixpanelDemoWatch (Notification).xcscheme
+++ b/MixpanelDemo/MixpanelDemo.xcodeproj/xcshareddata/xcschemes/MixpanelDemoWatch (Notification).xcscheme
@@ -55,10 +55,8 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "8">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/MixpanelDemo">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "86F86E8A22440C5C00B69832"
@@ -66,7 +64,7 @@
             BlueprintName = "MixpanelDemoWatch"
             ReferencedContainer = "container:MixpanelDemo.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -75,10 +73,8 @@
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
       launchAutomaticallySubstyle = "8">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/MixpanelDemo">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "86F86E8A22440C5C00B69832"
@@ -86,16 +82,7 @@
             BlueprintName = "MixpanelDemoWatch"
             ReferencedContainer = "container:MixpanelDemo.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "86F86E8A22440C5C00B69832"
-            BuildableName = "MixpanelDemoWatch.app"
-            BlueprintName = "MixpanelDemoWatch"
-            ReferencedContainer = "container:MixpanelDemo.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/MixpanelDemo/MixpanelDemo.xcodeproj/xcshareddata/xcschemes/MixpanelDemoWatch.xcscheme
+++ b/MixpanelDemo/MixpanelDemo.xcodeproj/xcshareddata/xcschemes/MixpanelDemoWatch.xcscheme
@@ -54,10 +54,8 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/MixpanelDemo">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "86F86E8A22440C5C00B69832"
@@ -65,7 +63,7 @@
             BlueprintName = "MixpanelDemoWatch"
             ReferencedContainer = "container:MixpanelDemo.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -73,10 +71,8 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/MixpanelDemo">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "86F86E8A22440C5C00B69832"
@@ -84,16 +80,7 @@
             BlueprintName = "MixpanelDemoWatch"
             ReferencedContainer = "container:MixpanelDemo.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "86F86E8A22440C5C00B69832"
-            BuildableName = "MixpanelDemoWatch.app"
-            BlueprintName = "MixpanelDemoWatch"
-            ReferencedContainer = "container:MixpanelDemo.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -612,6 +612,12 @@ extension MixpanelInstance {
                 self.hadPersistedDistinctId = true
             }
             
+            if self.userId == nil {
+                self.readWriteLock.write {
+                    self.userId = distinctId
+                }
+            }
+            
             if distinctId != self.distinctId {
                 let oldDistinctId = self.distinctId
                 self.readWriteLock.write {

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -652,6 +652,9 @@ extension MixpanelInstance {
      The alias method creates an alias which Mixpanel will use to remap one id to another.
      Multiple aliases can point to the same identifier.
      
+     Please note: With Mixpanel Identity Merge enabled, calling alias is no longer required
+     but can be used to merge two IDs in scenarios where identify() would fail
+     
      
      `mixpanelInstance.createAlias("New ID", distinctId: mixpanelInstance.distinctId)`
      
@@ -663,10 +666,12 @@ extension MixpanelInstance {
      - parameter alias:      A unique identifier that you want to use as an identifier for this user.
      - parameter distinctId: The current user identifier.
      - parameter usePeople: boolean that controls whether or not to set the people distinctId to the event distinctId.
+     - parameter andIdentify: an optional boolean that controls whether or not to call 'identify' with your current
+     user identifier(not alias). Default to true for keeping your signup funnels working correctly in most cases.
      - parameter completion: an optional completion handler for when the createAlias has completed.
      This should only be set to false if you wish to prevent people profile updates for that user.
      */
-    open func createAlias(_ alias: String, distinctId: String, usePeople: Bool = true, completion: (() -> Void)? = nil) {
+    open func createAlias(_ alias: String, distinctId: String, usePeople: Bool = true, andIdentify: Bool = true, completion: (() -> Void)? = nil) {
         if hasOptedOutTracking() {
             if let completion = completion {
                 DispatchQueue.main.async(execute: completion)
@@ -731,7 +736,9 @@ extension MixpanelInstance {
             
             let properties = ["distinct_id": distinctId, "alias": alias]
             track(event: "$create_alias", properties: properties)
-            identify(distinctId: distinctId, usePeople: usePeople)
+            if andIdentify {
+                identify(distinctId: distinctId, usePeople: usePeople)
+            }
             flush(completion: completion)
         } else {
             Logger.error(message: "alias: \(alias) matches distinctId: \(distinctId) - skipping api call.")


### PR DESCRIPTION
When you call the API `createAlias`, there is an implicit `identify` call inside the API done for you. This will keep your signup funnels working correctly in most cases. However, if that is not what you want, this PR will allow you to not call `identify` by specifying `andIdentify` to `false`.

 Please also note: With Mixpanel Identity Merge enabled, calling alias is no longer required but can be used to merge two IDs in scenarios where `identify` would fail