### PR TITLE
add support for multiple instances under the same token

### DIFF
--- a/MixpanelDemo/MixpanelDemoTests/MixpanelBaseTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelBaseTests.swift
@@ -100,19 +100,19 @@ class MixpanelBaseTests: XCTestCase, MixpanelDelegate {
     }
     
     func eventQueue(token: String) -> Queue {
-        return MixpanelPersistence.init(token: token).loadEntitiesInBatch(type: .events)
+        return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(type: .events)
     }
 
     func peopleQueue(token: String) -> Queue {
-        return MixpanelPersistence.init(token: token).loadEntitiesInBatch(type: .people)
+        return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(type: .people)
     }
     
     func unIdentifiedPeopleQueue(token: String) -> Queue {
-        return MixpanelPersistence.init(token: token).loadEntitiesInBatch(type: .people, flag: PersistenceConstant.unIdentifiedFlag)
+        return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(type: .people, flag: PersistenceConstant.unIdentifiedFlag)
     }
     
     func groupQueue(token: String) -> Queue {
-        return MixpanelPersistence.init(token: token).loadEntitiesInBatch(type: .groups)
+        return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(type: .groups)
     }
     
     func flushAndWaitForTrackingQueue(_ mixpanel: MixpanelInstance) {

--- a/Sources/AutomaticEvents.swift
+++ b/Sources/AutomaticEvents.swift
@@ -47,9 +47,9 @@ class AutomaticEvents: NSObject, SKPaymentTransactionObserver, SKProductsRequest
     
     let awaitingTransactionsWriteLock = DispatchQueue(label: "com.mixpanel.awaiting_transactions_writeLock", qos: .utility)
     
-    func initializeEvents(apiToken: String) {
+    func initializeEvents(instanceName: String) {
         let legacyFirstOpenKey = "MPFirstOpen"
-        let firstOpenKey = "MPFirstOpen-\(apiToken)"
+        let firstOpenKey = "MPFirstOpen-\(instanceName)"
         // do not track `$ae_first_open` again if the legacy key exist,
         // but we will start using the key with the mixpanel token in favour of multiple instances support
         if let defaults = defaults, !defaults.bool(forKey: legacyFirstOpenKey) {

--- a/Sources/Mixpanel.swift
+++ b/Sources/Mixpanel.swift
@@ -24,7 +24,8 @@ open class Mixpanel {
 
      - parameter token:                     your project token
      - parameter flushInterval:             Optional. Interval to run background flushing
-     - parameter instanceName:              Optional. The name you want to call this instance, must be unique 1:1 for each instance's project token. Defaults to project token.
+     - parameter instanceName:              Optional. The name you want to uniquely identify the Mixpanel Instance.
+                                            It is useful when you want more than one Mixpanel instance under the same project token.
      - parameter optOutTrackingByDefault:   Optional. Whether or not to be opted out from tracking by default
      - parameter trackAutomaticEvents:      Optional. Whether or not to collect common mobile events, it takes precedence over Autotrack settings from the Mixpanel server.
      - parameter useUniqueDistinctId:       Optional. whether or not to use the unique device identifier as the distinct_id

--- a/Sources/MixpanelPersistence.swift
+++ b/Sources/MixpanelPersistence.swift
@@ -53,12 +53,12 @@ struct MixpanelUserDefaultsKeys {
 
 class MixpanelPersistence {
     
-    let apiToken: String
+    let instanceName: String
     let mpdb: MPDB
     
-    init(token: String) {
-        apiToken = token
-        mpdb = MPDB.init(token: apiToken)
+    init(instanceName: String) {
+        self.instanceName = instanceName
+        mpdb = MPDB.init(token: instanceName)
     }
     
     deinit {
@@ -87,7 +87,7 @@ class MixpanelPersistence {
             entities = entities.filter { !($0["event"] as! String).hasPrefix("$ae_") }
         }
         if type == PersistenceType.people {
-            let distinctId = MixpanelPersistence.loadIdentity(apiToken: apiToken).distinctID
+            let distinctId = MixpanelPersistence.loadIdentity(instanceName: instanceName).distinctID
             return entities.map { entityWithDistinctId($0, distinctId: distinctId) }
         }
         return entities
@@ -122,20 +122,20 @@ class MixpanelPersistence {
         }
     }
     
-    static func saveOptOutStatusFlag(value: Bool, apiToken: String) {
+    static func saveOptOutStatusFlag(value: Bool, instanceName: String) {
         guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
             return
         }
-        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(apiToken)-"
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
         defaults.setValue(value, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.optOutStatus)")
         defaults.synchronize()
     }
     
-    static func loadOptOutStatusFlag(apiToken: String) -> Bool? {
+    static func loadOptOutStatusFlag(instanceName: String) -> Bool? {
         guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
             return nil
         }
-        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(apiToken)-"
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
         return defaults.object(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.optOutStatus)") as? Bool
     }
     
@@ -152,11 +152,11 @@ class MixpanelPersistence {
         defaults.synchronize()
     }
     
-    static func loadAutomaticEventsEnabledFlag(apiToken: String) -> Bool {
+    static func loadAutomaticEventsEnabledFlag(instanceName: String) -> Bool {
         #if TV_AUTO_EVENTS
         return true
         #else
-        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(apiToken)-"
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
         guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
             return true
         }
@@ -172,11 +172,11 @@ class MixpanelPersistence {
         #endif
     }
     
-    static func automaticEventsFlagIsSet(apiToken: String) -> Bool {
+    static func automaticEventsFlagIsSet(instanceName: String) -> Bool {
         #if TV_AUTO_EVENTS
         return true
         #else
-        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(apiToken)-"
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
         guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
             return false // no user defaults at all
         }
@@ -188,53 +188,53 @@ class MixpanelPersistence {
         #endif
     }
  
-    static func saveTimedEvents(timedEvents: InternalProperties, apiToken: String) {
+    static func saveTimedEvents(timedEvents: InternalProperties, instanceName: String) {
         guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
             return
         }
-        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(apiToken)-"
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
         let timedEventsData = NSKeyedArchiver.archivedData(withRootObject: timedEvents)
         defaults.set(timedEventsData, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.timedEvents)")
         defaults.synchronize()
     }
     
-    static func loadTimedEvents(apiToken: String) -> InternalProperties {
+    static func loadTimedEvents(instanceName: String) -> InternalProperties {
         guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
             return InternalProperties()
         }
-        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(apiToken)-"
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
         guard let timedEventsData  = defaults.data(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.timedEvents)") else {
             return InternalProperties()
         }
         return NSKeyedUnarchiver.unarchiveObject(with: timedEventsData) as? InternalProperties ?? InternalProperties()
     }
     
-    static func saveSuperProperties(superProperties: InternalProperties, apiToken: String) {
+    static func saveSuperProperties(superProperties: InternalProperties, instanceName: String) {
         guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
             return
         }
-        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(apiToken)-"
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
         let superPropertiesData = NSKeyedArchiver.archivedData(withRootObject: superProperties)
         defaults.set(superPropertiesData, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.superProperties)")
         defaults.synchronize()
     }
     
-    static func loadSuperProperties(apiToken: String) -> InternalProperties {
+    static func loadSuperProperties(instanceName: String) -> InternalProperties {
         guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
             return InternalProperties()
         }
-        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(apiToken)-"
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
         guard let superPropertiesData  = defaults.data(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.superProperties)") else {
             return InternalProperties()
         }
         return NSKeyedUnarchiver.unarchiveObject(with: superPropertiesData) as? InternalProperties ?? InternalProperties()
     }
     
-    static func saveIdentity(_ mixpanelIdentity: MixpanelIdentity, apiToken: String) {
+    static func saveIdentity(_ mixpanelIdentity: MixpanelIdentity, instanceName: String) {
         guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
             return
         }
-        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(apiToken)-"
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
         defaults.set(mixpanelIdentity.distinctID, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.distinctID)")
         defaults.set(mixpanelIdentity.peopleDistinctID, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.peopleDistinctID)")
         defaults.set(mixpanelIdentity.anonymousId, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.anonymousId)")
@@ -244,7 +244,7 @@ class MixpanelPersistence {
         defaults.synchronize()
     }
     
-    static func loadIdentity(apiToken: String) -> MixpanelIdentity {
+    static func loadIdentity(instanceName: String) -> MixpanelIdentity {
         guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
             return MixpanelIdentity.init(distinctID: "",
                                          peopleDistinctID: nil,
@@ -253,7 +253,7 @@ class MixpanelPersistence {
                                          alias: nil,
                                          hadPersistedDistinctId: nil)
         }
-        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(apiToken)-"
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
         return MixpanelIdentity.init(
             distinctID: defaults.string(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.distinctID)") ?? "",
             peopleDistinctID: defaults.string(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.peopleDistinctID)"),
@@ -263,11 +263,11 @@ class MixpanelPersistence {
             hadPersistedDistinctId: defaults.bool(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.hadPersistedDistinctId)"))
     }
     
-    static func deleteMPUserDefaultsData(apiToken: String) {
+    static func deleteMPUserDefaultsData(instanceName: String) {
         guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
             return
         }
-        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(apiToken)-"
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
         defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.distinctID)")
         defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.peopleDistinctID)")
         defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.anonymousId)")
@@ -305,26 +305,26 @@ class MixpanelPersistence {
         saveEntities(peopleUnidentifiedQueue, type: PersistenceType.people, flag: PersistenceConstant.unIdentifiedFlag)
         saveEntities(peopleQueue, type: PersistenceType.people)
         saveEntities(groupsQueue, type: PersistenceType.groups)
-        MixpanelPersistence.saveSuperProperties(superProperties: superProperties, apiToken: apiToken)
-        MixpanelPersistence.saveTimedEvents(timedEvents: timedEvents, apiToken: apiToken)
+        MixpanelPersistence.saveSuperProperties(superProperties: superProperties, instanceName: instanceName)
+        MixpanelPersistence.saveTimedEvents(timedEvents: timedEvents, instanceName: instanceName)
         MixpanelPersistence.saveIdentity(MixpanelIdentity.init(
                         distinctID: distinctId,
                         peopleDistinctID: peopleDistinctId,
                         anonymousId: anonymousId,
                         userId: userId,
                         alias: alias,
-                        hadPersistedDistinctId: hadPersistedDistinctId), apiToken: apiToken)
+                        hadPersistedDistinctId: hadPersistedDistinctId), instanceName: instanceName)
         if let optOutFlag = optOutStatus {
-            MixpanelPersistence.saveOptOutStatusFlag(value: optOutFlag, apiToken: apiToken)
+            MixpanelPersistence.saveOptOutStatusFlag(value: optOutFlag, instanceName: instanceName)
         }
         if let automaticEventsFlag = automaticEventsEnabled {
-            MixpanelPersistence.saveAutomaticEventsEnabledFlag(value: automaticEventsFlag, fromDecide: false, apiToken: apiToken)
+            MixpanelPersistence.saveAutomaticEventsEnabledFlag(value: automaticEventsFlag, fromDecide: false, apiToken: self.mpdb.apiToken)
         }
         return
     }
     
     private func filePathWithType(_ type: String) -> String? {
-        let filename = "mixpanel-\(apiToken)-\(type)"
+        let filename = "mixpanel-\(instanceName)-\(type)"
         let manager = FileManager.default
 
         #if os(iOS)

--- a/Sources/Track.swift
+++ b/Sources/Track.swift
@@ -15,6 +15,7 @@ func += <K, V> (left: inout [K: V], right: [K: V]) {
 }
 
 class Track {
+    let instanceName: String
     let apiToken: String
     let lock: ReadWriteLock
     let metadata: SessionMetadata
@@ -22,11 +23,12 @@ class Track {
     weak var mixpanelInstance: MixpanelInstance?
     
     var isAutomaticEventEnabled: Bool {
-        return MixpanelPersistence.loadAutomaticEventsEnabledFlag(apiToken: apiToken)
+        return MixpanelPersistence.loadAutomaticEventsEnabledFlag(instanceName: self.instanceName)
     }
 
-    init(apiToken: String, lock: ReadWriteLock, metadata: SessionMetadata,
+    init(apiToken: String, instanceName: String, lock: ReadWriteLock, metadata: SessionMetadata,
          mixpanelPersistence: MixpanelPersistence) {
+        self.instanceName = instanceName
         self.apiToken = apiToken
         self.lock = lock
         self.metadata = metadata
@@ -87,7 +89,7 @@ class Track {
         metadata.toDict().forEach { (k, v) in trackEvent[k] = v }
         
         self.mixpanelPersistence.saveEntity(trackEvent, type: .events)
-        MixpanelPersistence.saveTimedEvents(timedEvents: shadowTimedEvents, apiToken: apiToken)
+        MixpanelPersistence.saveTimedEvents(timedEvents: shadowTimedEvents, instanceName: instanceName)
         return shadowTimedEvents
     }
 


### PR DESCRIPTION
This PR will add support for multiple instances under the same token. Just specify an `instanceName` in `initialize`.
```
...

  /**
     Initializes an instance of the API with the given project token.
     Returns a new Mixpanel instance API object. This allows you to create more than one instance
     of the API object, which is convenient if you'd like to send data to more than
     one Mixpanel project from a single app.

     ...
     parameter instanceName:    Optional. The name you want to uniquely identify the Mixpanel Instance.
                                            It is useful when you want more than one Mixpanel instance under the same project token.
     ...
  */
    @discardableResult
    open class func initialize(token apiToken: String,
                               flushInterval: Double = 60,
                               instanceName: String? = nil,
                               optOutTrackingByDefault: Bool = false,
                               trackAutomaticEvents: Bool? = nil,
                               useUniqueDistinctId: Bool = false,
                               superProperties: Properties? = nil,
                               serverURL: String? = nil) -> MixpanelInstance {
```
