### PR TITLE
bump podspec deployment targets

### DIFF
--- a/Mixpanel-swift.podspec
+++ b/Mixpanel-swift.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.author       = { 'Mixpanel, Inc' => 'support@mixpanel.com' }
   s.source       = { :git => 'https://github.com/mixpanel/mixpanel-swift.git',
                      :tag => "v#{s.version}" }
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '11.0'
   s.ios.frameworks = 'UIKit', 'Foundation', 'CoreTelephony'
   s.ios.pod_target_xcconfig = {
     'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) IOS'
@@ -21,12 +21,12 @@ Pod::Spec.new do |s|
     'Sources/Flush.swift','Sources/Track.swift', 'Sources/People.swift', 'Sources/AutomaticEvents.swift',
     'Sources/Group.swift',
     'Sources/ReadWriteLock.swift', 'Sources/SessionMetadata.swift', 'Sources/MPDB.swift', 'Sources/MixpanelPersistence.swift']
-  s.tvos.deployment_target = '9.0'
+  s.tvos.deployment_target = '11.0'
   s.tvos.frameworks = 'UIKit', 'Foundation'
   s.tvos.pod_target_xcconfig = {
     'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) TV_OS'
   }
-  s.osx.deployment_target = '10.10'
+  s.osx.deployment_target = '10.13'
   s.osx.frameworks = 'Cocoa', 'Foundation'
   s.osx.pod_target_xcconfig = {
     'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) MAC_OS'

--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -787,7 +787,7 @@
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mixpanel.Mixpanel;
@@ -835,7 +835,7 @@
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mixpanel.Mixpanel;
@@ -875,7 +875,7 @@
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Debug;
 		};
@@ -903,7 +903,7 @@
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Release;
 		};
@@ -924,7 +924,7 @@
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mixpanel.Mixpanel;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = Mixpanel;
@@ -953,7 +953,7 @@
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mixpanel.Mixpanel;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = Mixpanel;


### PR DESCRIPTION
Fix for...

```
➜  mixpanel-swift git:(master) pod trunk push Mixpanel-swift.podspec --allow-warnings                                                                                                                                                 git:(master|)
Updating spec repo `trunk`
Validating podspec
 -> Mixpanel-swift (4.0.4)
    - NOTE  | [Mixpanel-swift/Complete,Mixpanel-swift/Core] xcodebuild:  note: Using codesigning identity override: -
    - NOTE  | [Mixpanel-swift/Complete,Mixpanel-swift/Core] xcodebuild:  note: Building targets in dependency order
    - NOTE  | [Mixpanel-swift/Complete,Mixpanel-swift/Core] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.2.99. (in target 'Pods-App' from project 'Pods')
    - NOTE  | [Mixpanel-swift/Complete,Mixpanel-swift/Core] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.2.99. (in target 'Mixpanel-swift' from project 'Pods')
    - NOTE  | [Mixpanel-swift/Complete,Mixpanel-swift/Core] xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'Mixpanel-swift' from project 'Pods')
    - NOTE  | [Mixpanel-swift/Complete,Mixpanel-swift/Core] xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'App' from project 'App')
    - NOTE  | [Mixpanel-swift/Complete,Mixpanel-swift/Core] xcodebuild:  /var/folders/n7/w5f8m1yx2qq9w6g3_3kc3l8w0000gp/T/CocoaPods-Lint-20221214-54069-nlb0dg-Mixpanel-swift/App.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.2.99. (in target 'App' from project 'App')
    - NOTE  | [Mixpanel-swift/Complete,Mixpanel-swift/Core] xcodebuild:  Pods.xcodeproj: warning: The tvOS Simulator deployment target 'TVOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.1.99. (in target 'Pods-App' from project 'Pods')
    - NOTE  | [Mixpanel-swift/Complete,Mixpanel-swift/Core] xcodebuild:  Pods.xcodeproj: warning: The tvOS Simulator deployment target 'TVOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.1.99. (in target 'Mixpanel-swift' from project 'Pods')
    - NOTE  | [Mixpanel-swift/Complete,Mixpanel-swift/Core] xcodebuild:  /var/folders/n7/w5f8m1yx2qq9w6g3_3kc3l8w0000gp/T/CocoaPods-Lint-20221214-54069-nlb0dg-Mixpanel-swift/App.xcodeproj: warning: The tvOS Simulator deployment target 'TVOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.1.99. (in target 'App' from project 'App')
    - NOTE  | [Mixpanel-swift/Complete,Mixpanel-swift/Core] xcodebuild:  note: Using codesigning identity override:
    - NOTE  | [Mixpanel-swift/Complete,Mixpanel-swift/Core] xcodebuild:  Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.10, but the range of supported deployment target versions is 10.13 to 13.1.99. (in target 'Mixpanel-swift' from project 'Pods')
    - NOTE  | [Mixpanel-swift/Complete,Mixpanel-swift/Core] xcodebuild:  Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.10, but the range of supported deployment target versions is 10.13 to 13.1.99. (in target 'Pods-App' from project 'Pods')
    - NOTE  | [Mixpanel-swift/Complete,Mixpanel-swift/Core] xcodebuild:  /var/folders/n7/w5f8m1yx2qq9w6g3_3kc3l8w0000gp/T/CocoaPods-Lint-20221214-54069-nlb0dg-Mixpanel-swift/App.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.10, but the range of supported deployment target versions is 10.13 to 13.1.99. (in target 'App' from project 'App')
    - ERROR | [Mixpanel-swift/Complete,Mixpanel-swift/Core] xcodebuild: Returned an unsuccessful exit code. You can use `--verbose` for more information.
    - NOTE  | [Mixpanel-swift/Complete,Mixpanel-swift/Core] xcodebuild:  xcodebuild: error: Unable to find a destination matching the provided destination specifier:

[!] The spec did not pass validation, due to 1 error.
```