### PR TITLE
Setting explicit autorelease frequency

### DIFF
--- a/Sources/AutomaticEvents.swift
+++ b/Sources/AutomaticEvents.swift
@@ -45,7 +45,7 @@ class AutomaticEvents: NSObject, SKPaymentTransactionObserver, SKProductsRequest
     var sessionStartTime: TimeInterval = Date().timeIntervalSince1970
     var hasAddedObserver = false
     
-    let awaitingTransactionsWriteLock = DispatchQueue(label: "com.mixpanel.awaiting_transactions_writeLock", qos: .userInitiated)
+    let awaitingTransactionsWriteLock = DispatchQueue(label: "com.mixpanel.awaiting_transactions_writeLock", qos: .userInitiated, autoreleaseFrequency: .workItem)
     
     func initializeEvents(instanceName: String) {
         let legacyFirstOpenKey = "MPFirstOpen"

--- a/Sources/Flush.swift
+++ b/Sources/Flush.swift
@@ -44,7 +44,7 @@ class Flush: AppLifecycle {
 
     required init(basePathIdentifier: String) {
         self.flushRequest = FlushRequest(basePathIdentifier: basePathIdentifier)
-        flushIntervalReadWriteLock = DispatchQueue(label: "com.mixpanel.flush_interval.lock", qos: .utility, attributes: .concurrent)
+        flushIntervalReadWriteLock = DispatchQueue(label: "com.mixpanel.flush_interval.lock", qos: .utility, attributes: .concurrent, autoreleaseFrequency: .workItem)
     }
 
     func flushQueue(_ queue: Queue, type: FlushType) {

--- a/Sources/Mixpanel.swift
+++ b/Sources/Mixpanel.swift
@@ -163,7 +163,7 @@ final class MixpanelManager {
         instances = [String: MixpanelInstance]()
         Logger.addLogging(PrintLogging())
         readWriteLock = ReadWriteLock(label: "com.mixpanel.instance.manager.lock")
-        instanceQueue = DispatchQueue(label: "com.mixpanel.instance.manager.instance", qos: .utility)
+        instanceQueue = DispatchQueue(label: "com.mixpanel.instance.manager.instance", qos: .utility, autoreleaseFrequency: .workItem)
     }
     
     func initialize(token apiToken: String,

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -230,8 +230,8 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
         )
 #endif
         let label = "com.mixpanel.\(self.apiToken)"
-        trackingQueue = DispatchQueue(label: "\(label).tracking)", qos: .utility)
-        networkQueue = DispatchQueue(label: "\(label).network)", qos: .utility)
+        trackingQueue = DispatchQueue(label: "\(label).tracking)", qos: .utility, autoreleaseFrequency: .workItem)
+        networkQueue = DispatchQueue(label: "\(label).network)", qos: .utility, autoreleaseFrequency: .workItem)
         self.name = name
         
         mixpanelPersistence = MixpanelPersistence.init(instanceName: name)

--- a/Sources/ReadWriteLock.swift
+++ b/Sources/ReadWriteLock.swift
@@ -11,7 +11,7 @@ class ReadWriteLock {
     let concurentQueue: DispatchQueue
 
     init(label: String) {
-        self.concurentQueue = DispatchQueue(label: label, qos: .utility, attributes: .concurrent)
+        self.concurentQueue = DispatchQueue(label: label, qos: .utility, attributes: .concurrent, autoreleaseFrequency: .workItem)
     }
 
     func read(closure: () -> Void) {


### PR DESCRIPTION
I was seeing large memory growth when offline with _lots_ of items waiting to be flushed to the mp service. i had ~5000 events queued while offline, and the work done on these dispatch queues wasn't getting cleaned up, causing an explosion in otherwise collectable memory.

my understanding is that `DispatchQueue()` will default to `autoreleaseFrequency=.never`, which can leave those autoreleased objects hanging around in memory for undefined amounts of time.