### PR TITLE
SwiftUI preview fix

### DIFF
--- a/Sources/Mixpanel.swift
+++ b/Sources/Mixpanel.swift
@@ -121,8 +121,11 @@ open class Mixpanel {
         if let instance = MixpanelManager.sharedInstance.getMainInstance() {
             return instance
         } else {
+            #if !targetEnvironment(simulator)
             assert(false, "You have to call initialize(token:trackAutomaticEvents:) before calling the main instance, " +
                    "or define a new main instance if removing the main one")
+            #endif
+            
 #if !os(OSX) && !os(watchOS)
             return Mixpanel.initialize(token: "", trackAutomaticEvents: true)
 #else


### PR DESCRIPTION
Don't fire this assert in the simulator (SwiftUI Preview), as the new SwiftUI lifecycle doesn't initialize Main view controller in child views so the SDK will likely not be configured