### PR TITLE
Access the timedEvents property inside of a readWriteLock.

### DIFF
--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -1156,7 +1156,12 @@ extension MixpanelInstance {
      - parameter event: the name of the event to be tracked that was passed to time(event:)
      */
     public func eventElapsedTime(event: String) -> Double {
-        if let startTime = self.timedEvents[event] as? TimeInterval {
+        var timedEvents = InternalProperties()
+        self.readWriteLock.read {
+            timedEvents = self.timedEvents
+        }
+        
+        if let startTime = timedEvents[event] as? TimeInterval {
             return Date().timeIntervalSince1970 - startTime
         }
         return 0


### PR DESCRIPTION
Access the timedEvents property inside of a readWriteLock.  Fixes crashes when client tries to read and write to timedEvents property at the same time.