### PR TITLE
Set the number of events per flush to 1,000 to reduce memory footprint

### DIFF
--- a/Sources/Constants.swift
+++ b/Sources/Constants.swift
@@ -17,6 +17,7 @@ struct QueueConstants {
 
 struct APIConstants {
     static let batchSize = 50
+    static let flushSize = 1000
     static let minRetryBackoff = 60.0
     static let maxRetryBackoff = 600.0
     static let failuresTillBackoff = 2

--- a/Sources/Flush.swift
+++ b/Sources/Flush.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol FlushDelegate: AnyObject {
-    func flush(completion: (() -> Void)?)
+    func flush(performFullFlush: Bool, completion: (() -> Void)?)
     func flushSuccess(type: FlushType, ids: [Int32])
     
     #if os(iOS)
@@ -37,7 +37,7 @@ class Flush: AppLifecycle {
                 _flushInterval = newValue
             })
 
-            delegate?.flush(completion: nil)
+            delegate?.flush(performFullFlush: false, completion: nil)
             startFlushTimer()
         }
     }
@@ -73,7 +73,7 @@ class Flush: AppLifecycle {
     }
 
     @objc func flushSelector() {
-        delegate?.flush(completion: nil)
+        delegate?.flush(performFullFlush: false, completion: nil)
     }
 
     func stopFlushTimer() {

--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -67,7 +67,7 @@ open class Group {
         }
 
         if MixpanelInstance.isiOSAppExtension() {
-            delegate?.flush(completion: nil)
+            delegate?.flush(performFullFlush: false, completion: nil)
         }
     }
 

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -925,11 +925,11 @@ extension MixpanelInstance {
             
             // automatic events will NOT be flushed until one of the flags is non-nil
             let eventQueue = self.mixpanelPersistence.loadEntitiesInBatch(
-                type: self.persistenceTypeFromFlushType(.events),
+                type: self.persistenceTypeFromFlushType(.events), batchSize: APIConstants.flushSize,
                 excludeAutomaticEvents: !self.trackAutomaticEventsEnabled
             )
-            let peopleQueue = self.mixpanelPersistence.loadEntitiesInBatch(type: self.persistenceTypeFromFlushType(.people))
-            let groupsQueue = self.mixpanelPersistence.loadEntitiesInBatch(type: self.persistenceTypeFromFlushType(.groups))
+            let peopleQueue = self.mixpanelPersistence.loadEntitiesInBatch(type: self.persistenceTypeFromFlushType(.people), batchSize: APIConstants.flushSize)
+            let groupsQueue = self.mixpanelPersistence.loadEntitiesInBatch(type: self.persistenceTypeFromFlushType(.groups), batchSize: APIConstants.flushSize)
             
             self.networkQueue.async { [weak self, completion] in
                 guard let self = self else {

--- a/Sources/People.swift
+++ b/Sources/People.swift
@@ -99,7 +99,7 @@ open class People {
         }
 
         if MixpanelInstance.isiOSAppExtension() {
-            delegate?.flush(completion: nil)
+            delegate?.flush(performFullFlush: false, completion: nil)
         }
     }
 


### PR DESCRIPTION
This will greatly improve the performance and reduce crashes. Thanks @thibauddavid, #594