### PR TITLE
add a new property 'flushBatchSize' for fine tuning the network request

### DIFF
--- a/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
@@ -58,6 +58,8 @@ class MixpanelDemoTests: MixpanelBaseTests {
         XCTAssertTrue(testMixpanel.flushInterval == 60, "flush interval is set correctly")
         testMixpanel.flushBatchSize = 10
         XCTAssertTrue(testMixpanel.flushBatchSize == 10, "flush batch size is set correctly")
+        testMixpanel.flushBatchSize = 60
+        XCTAssertTrue(testMixpanel.flushBatchSize == 50, "flush batch size is max at 50")
         testMixpanel.flushInterval = 30
         XCTAssertTrue(testMixpanel.flushInterval == 30, "flush interval is set correctly")
     }

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
@@ -27,7 +27,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
         XCTAssert(waitTime >= 110, "Network backoff time is less than 2 minutes.")
         XCTAssert(testMixpanel.flushInstance.flushRequest.networkConsecutiveFailures == 2,
                   "Network failures did not equal 2")
-
+        
         XCTAssert(eventQueue(token: testMixpanel.apiToken).count == 2,
                   "Removed an event from the queue that was not sent")
         removeDBfile(testMixpanel.apiToken)
@@ -50,6 +50,16 @@ class MixpanelDemoTests: MixpanelBaseTests {
         XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).isEmpty,
                       "events should have been flushed")
         removeDBfile(testMixpanel.apiToken)
+    }
+    
+    func testFlushProperties() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        XCTAssertTrue(testMixpanel.flushBatchSize == 50, "the default flush batch size is set to 50")
+        XCTAssertTrue(testMixpanel.flushInterval == 60, "flush interval is set correctly")
+        testMixpanel.flushBatchSize = 10
+        XCTAssertTrue(testMixpanel.flushBatchSize == 10, "flush batch size is set correctly")
+        testMixpanel.flushInterval = 30
+        XCTAssertTrue(testMixpanel.flushInterval == 30, "flush interval is set correctly")
     }
 
     func testFlushPeople() {

--- a/Sources/Constants.swift
+++ b/Sources/Constants.swift
@@ -16,7 +16,7 @@ struct QueueConstants {
 }
 
 struct APIConstants {
-    static let batchSize = 50
+    static let maxBatchSize = 50
     static let flushSize = 1000
     static let minRetryBackoff = 60.0
     static let maxRetryBackoff = 600.0

--- a/Sources/Flush.swift
+++ b/Sources/Flush.swift
@@ -24,7 +24,7 @@ class Flush: AppLifecycle {
     var flushRequest: FlushRequest
     var flushOnBackground = true
     var _flushInterval = 0.0
-    var _flushBatchSize = APIConstants.batchSize
+    var _flushBatchSize = APIConstants.maxBatchSize
     private let flushIntervalReadWriteLock: DispatchQueue
 
     var flushInterval: Double {

--- a/Sources/Flush.swift
+++ b/Sources/Flush.swift
@@ -24,6 +24,7 @@ class Flush: AppLifecycle {
     var flushRequest: FlushRequest
     var flushOnBackground = true
     var _flushInterval = 0.0
+    var _flushBatchSize = APIConstants.batchSize
     private let flushIntervalReadWriteLock: DispatchQueue
 
     var flushInterval: Double {
@@ -39,6 +40,15 @@ class Flush: AppLifecycle {
 
             delegate?.flush(performFullFlush: false, completion: nil)
             startFlushTimer()
+        }
+    }
+    
+    var flushBatchSize: Int {
+        get {
+            return _flushBatchSize
+        }
+        set {
+            _flushBatchSize = newValue
         }
     }
 
@@ -88,7 +98,7 @@ class Flush: AppLifecycle {
     func flushQueueInBatches(_ queue: Queue, type: FlushType) {
         var mutableQueue = queue
         while !mutableQueue.isEmpty {
-            let batchSize = min(mutableQueue.count, APIConstants.batchSize)
+            let batchSize = min(mutableQueue.count, flushBatchSize)
             let range = 0..<batchSize
             let batch = Array(mutableQueue[range])
             let ids: [Int32] = batch.map { entity in

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -119,15 +119,15 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
         }
     }
     
-    /// The flushBatchSize property controls the number of events sent in a single network request to the Mixpanel server.
-    /// Batch size affects how data is flushed from the client to Mixpanel. By configuring the size of the batch, you can
-    /// optimize network usage and control how frequently the client communicates with the server.
+    /// The `flushBatchSize` property determines the number of events sent in a single network request to the Mixpanel server.
+    /// By configuring this value, you can optimize network usage and manage the frequency of communication between the client
+    /// and the server. The maximum size is 50; any value over 50 will default to 50.
     open var flushBatchSize: Int {
         get {
             return flushInstance.flushBatchSize
         }
         set {
-            flushInstance.flushBatchSize = newValue
+            flushInstance.flushBatchSize = min(newValue, APIConstants.maxBatchSize)
         }
     }
     

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -119,6 +119,19 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
         }
     }
     
+    /// The flushBatchSize property controls the number of events sent in a single network request to the Mixpanel server.
+    /// Batch size affects how data is flushed from the client to Mixpanel. By configuring the size of the batch, you can
+    /// optimize network usage and control how frequently the client communicates with the server.
+    open var flushBatchSize: Int {
+        get {
+            return flushInstance.flushBatchSize
+        }
+        set {
+            flushInstance.flushBatchSize = newValue
+        }
+    }
+    
+    
     /// The base URL used for Mixpanel API requests.
     /// Useful if you need to proxy Mixpanel requests. Defaults to
     /// https://api.mixpanel.com.
@@ -198,6 +211,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
     var optOutStatus: Bool?
     var useUniqueDistinctId: Bool
     var timedEvents = InternalProperties()
+    
     let readWriteLock: ReadWriteLock
 #if os(iOS) && !targetEnvironment(macCatalyst)
     static let reachability = SCNetworkReachabilityCreateWithName(nil, "api.mixpanel.com")
@@ -928,16 +942,16 @@ extension MixpanelInstance {
             // automatic events will NOT be flushed until one of the flags is non-nil
             let eventQueue = self.mixpanelPersistence.loadEntitiesInBatch(
                 type: self.persistenceTypeFromFlushType(.events),
-                batchSize: performFullFlush ? Int.max : APIConstants.flushSize,
+                batchSize: performFullFlush ? Int.max : self.flushBatchSize,
                 excludeAutomaticEvents: !self.trackAutomaticEventsEnabled
             )
             let peopleQueue = self.mixpanelPersistence.loadEntitiesInBatch(
                 type: self.persistenceTypeFromFlushType(.people),
-                batchSize: performFullFlush ? Int.max : APIConstants.flushSize
+                batchSize: performFullFlush ? Int.max : self.flushBatchSize
             )
             let groupsQueue = self.mixpanelPersistence.loadEntitiesInBatch(
                 type: self.persistenceTypeFromFlushType(.groups),
-                batchSize: performFullFlush ? Int.max : APIConstants.flushSize
+                batchSize: performFullFlush ? Int.max : self.flushBatchSize
             )
             
             self.networkQueue.async { [weak self, completion] in
@@ -1514,4 +1528,5 @@ extension MixpanelInstance {
     func setOnce(properties: Properties) {
         people?.setOnce(properties: properties)
     }
+    
 }


### PR DESCRIPTION
Add the following property `flushBatchSize`:

The flushBatchSize property controls the number of events sent in a single network request to the Mixpanel server.
Batch size affects how data is flushed from the client to Mixpanel. By configuring the size of the batch, you can
optimize network usage and control how frequently the client communicates with the server.

Usage: 

`mixpanel.flushBatchSize = 20`