### PR TITLE
Fixes so project builds for visionOS

### DIFF
--- a/Sources/AutomaticProperties.swift
+++ b/Sources/AutomaticProperties.swift
@@ -12,7 +12,7 @@ import Foundation
 import UIKit
 #elseif os(macOS)
 import Cocoa
-#else
+#elseif canImport(WatchKit)
 import WatchKit
 #endif
 
@@ -79,7 +79,7 @@ class AutomaticProperties {
             p["$ios_app_release"] = infoDict["CFBundleShortVersionString"]
         }
         p["$ios_device_model"]  = AutomaticProperties.deviceModel()
-        #if !os(OSX) && !os(watchOS)
+        #if !os(OSX) && !os(watchOS) && !os(visionOS)
         p["$ios_version"]       = UIDevice.current.systemVersion
         #else
         p["$ios_version"]       = ProcessInfo.processInfo.operatingSystemVersionString

--- a/Sources/Constants.swift
+++ b/Sources/Constants.swift
@@ -37,7 +37,7 @@ struct InternalKeys {
 }
 
 
-#if !os(OSX) && !os(watchOS)
+#if !os(OSX) && !os(watchOS) && !os(visionOS)
 extension UIDevice {
     var iPhoneX: Bool {
         return UIScreen.main.nativeBounds.height == 2436


### PR DESCRIPTION
Fixes so Mixpanel builds in both Xcode 15 prod and betas, making it possible to work with visionOS targets.

fixes mixpanel/mixpanel-swift#612