### PR TITLE
Cmriboldi/add event i ds

### DIFF
--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -37,8 +37,8 @@ public protocol MixpanelDelegate: AnyObject {
 
 public typealias Properties = [String: MixpanelType]
 typealias InternalProperties = [String: Any]
-typealias EventID = String
-typealias TimedEvents = [EventID: TimeInterval]
+typealias TimedEventID = String
+typealias TimedEvents = [TimedEventID: TimeInterval]
 typealias Queue = [InternalProperties]
 
 protocol AppLifecycle {
@@ -1004,6 +1004,7 @@ extension MixpanelInstance {
 }
 
 extension MixpanelInstance {
+    
     // MARK: - Track
     
     /**
@@ -1019,13 +1020,30 @@ extension MixpanelInstance {
      - parameter properties: properties dictionary
      */
     public func track(event: String?, properties: Properties? = nil) {
+        track(event: event, withID: nil, properties: properties)
+    }
+    
+    /**
+     Tracks an event with properties.
+     Properties are optional and can be added only if needed.
+     
+     Properties will allow you to segment your events in your Mixpanel reports.
+     Property keys must be String objects and the supported value types need to conform to MixpanelType.
+     MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
+     If the event is being timed, the timer will stop and be added as a property.
+     
+     - parameter event:      event name
+     - parameter withID:     eventID used to link timed events previously timed using `time(eventID)`
+     - parameter properties: properties dictionary
+     */
+    public func track(event: String?, withID eventID: String?, properties: Properties? = nil) {
         if hasOptedOutTracking() {
             return
         }
         
         let epochInterval = Date().timeIntervalSince1970
         
-        trackingQueue.async { [weak self, event, properties, epochInterval] in
+        trackingQueue.async { [weak self, event, eventID, properties, epochInterval] in
             guard let self = self else {
                 return
             }
@@ -1044,6 +1062,7 @@ extension MixpanelInstance {
                                                          alias: nil,
                                                          hadPersistedDistinctId: self.hadPersistedDistinctId)
             let timedEventsSnapshot = self.trackInstance.track(event: event,
+                                                               eventID: eventID,
                                                                properties: properties,
                                                                timedEvents: shadowTimedEvents,
                                                                superProperties: shadowSuperProperties,
@@ -1172,10 +1191,36 @@ extension MixpanelInstance {
      
      */
     public func time(event: String) {
+        time(eventID: event)
+    }
+    
+    /**
+     Starts a timer that will be stopped and added as a property when a
+     corresponding event with the identidal eventID is tracked.
+     
+     This method is intended to be used in advance of events that have
+     a duration. For example, if a developer were to track an "Image Upload" event
+     she might want to also know how long the upload took. Calling this method
+     before the upload code would implicitly cause the `track`
+     call to record its duration.
+     
+     - precondition:
+     // begin timing the image upload:
+     mixpanelInstance.time(eventID:"some-unique-id")
+     // upload the image:
+     self.uploadImageWithSuccessHandler() { _ in
+     // track the event
+     mixpanelInstance.track("Image Upload", withID: "some-unique-id")
+     }
+     
+     - parameter eventID: the id of the event to be timed
+     
+     */
+    public func time(eventID: String) {
         let startTime = Date().timeIntervalSince1970
-        trackingQueue.async { [weak self, startTime, event] in
+        trackingQueue.async { [weak self, startTime, eventID] in
             guard let self = self else { return }
-            let timedEvents = self.trackInstance.time(event: event, timedEvents: self.timedEvents, startTime: startTime)
+            let timedEvents = self.trackInstance.time(eventID: eventID, timedEvents: self.timedEvents, startTime: startTime)
             self.readWriteLock.write {
                 self.timedEvents = timedEvents
             }
@@ -1189,12 +1234,21 @@ extension MixpanelInstance {
      - parameter event: the name of the event to be tracked that was passed to time(event:)
      */
     public func eventElapsedTime(event: String) -> Double {
+        eventElapsedTime(eventID: event)
+    }
+    
+    /**
+     Retrieves the time elapsed for the event given it's ID since time(eventID:) was called.
+     
+     - parameter event: the id of the event to be tracked that was passed to time(eventID:)
+     */
+    public func eventElapsedTime(eventID: String) -> Double {
         var timedEvents = TimedEvents()
         self.readWriteLock.read {
             timedEvents = self.timedEvents
         }
         
-        if let startTime = timedEvents[event] {
+        if let startTime = timedEvents[eventID] {
             return Date().timeIntervalSince1970 - startTime
         }
         return 0
@@ -1219,10 +1273,19 @@ extension MixpanelInstance {
      - parameter event: the name of the event to clear the timer for
      */
     public func clearTimedEvent(event: String) {
-        trackingQueue.async { [weak self, event] in
+        clearTimedEvent(eventId: event)
+    }
+    
+    /**
+     Clears the event timer for the provided eventID.
+     
+     - parameter event: the id of the event to clear the timer for
+     */
+    public func clearTimedEvent(eventId: String) {
+        trackingQueue.async { [weak self, eventId] in
             guard let self = self else { return }
             
-            let updatedTimedEvents = self.trackInstance.clearTimedEvent(event: event, timedEvents: self.timedEvents)
+            let updatedTimedEvents = self.trackInstance.clearTimedEvent(eventId: eventId, timedEvents: self.timedEvents)
             MixpanelPersistence.saveTimedEvents(timedEvents: updatedTimedEvents, instanceName: self.name)
         }
     }

--- a/Sources/MixpanelPersistence.swift
+++ b/Sources/MixpanelPersistence.swift
@@ -129,7 +129,7 @@ class MixpanelPersistence {
         return defaults.object(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.optOutStatus)") as? Bool
     }
     
-    static func saveTimedEvents(timedEvents: InternalProperties, instanceName: String) {
+    static func saveTimedEvents(timedEvents: TimedEvents, instanceName: String) {
         guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
             return
         }
@@ -143,19 +143,19 @@ class MixpanelPersistence {
         }
     }
     
-    static func loadTimedEvents(instanceName: String) -> InternalProperties {
+    static func loadTimedEvents(instanceName: String) -> TimedEvents {
         guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
-            return InternalProperties()
+            return TimedEvents()
         }
         let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
         guard let timedEventsData  = defaults.data(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.timedEvents)") else {
-            return InternalProperties()
+            return TimedEvents()
         }
         do {
-            return try NSKeyedUnarchiver.unarchivedObject(ofClasses: archivedClasses, from: timedEventsData) as? InternalProperties ?? InternalProperties()
+            return try NSKeyedUnarchiver.unarchivedObject(ofClasses: archivedClasses, from: timedEventsData) as? TimedEvents ?? TimedEvents()
         } catch {
             Logger.warn(message: "Failed to unarchive timed events")
-            return InternalProperties()
+            return TimedEvents()
         }
     }
     
@@ -296,7 +296,7 @@ class MixpanelPersistence {
                                            peopleQueue: Queue,
                                            groupsQueue: Queue,
                                            superProperties: InternalProperties,
-                                           timedEvents: InternalProperties,
+                                           timedEvents: TimedEvents,
                                            distinctId: String,
                                            anonymousId: String?,
                                            userId: String?,
@@ -398,7 +398,7 @@ class MixpanelPersistence {
     }
     
     private func unarchiveProperties() -> (InternalProperties,
-                                           InternalProperties,
+                                           TimedEvents,
                                            String,
                                            String?,
                                            String?,
@@ -410,7 +410,7 @@ class MixpanelPersistence {
         let superProperties =
         properties?["superProperties"] as? InternalProperties ?? InternalProperties()
         let timedEvents =
-        properties?["timedEvents"] as? InternalProperties ?? InternalProperties()
+        properties?["timedEvents"] as? TimedEvents ?? TimedEvents()
         let distinctId =
         properties?["distinctId"] as? String ?? ""
         let anonymousId =


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/mixpanel/mixpanel-swift/issues/614) there is no way to time events independently of their name. This is a HUGE issue for any serious user of Mixpanel events because there is no way to follow the [Best Practice Naming Guidelines](https://docs.mixpanel.com/docs/data-structure/events-and-properties#best-practices) and be certain your durations are correct.

For example, if I were to have a generic System event that I want to time as long as I have one of those events I'm fine, but if I ever need to time multiple system events there is no way for me to organize them or distinguish using Mixpanel which `.track(event:)` call matches with the original `time(event:)` call. This means that durations will be completely missing or inaccurate.

The that I'm adding in this MR is to link the tracking of timed events to an EventID instead of to the event name. That means callers of the SDK can provide their own unique id's for id's of events and be guaranteed that when the duration completes for that generic event the duration is completely accurate.

I added a new function signature for these timed and tracked events that allow users to provide a String eventID to link the two events. I would have liked to create a more type safe ID so that it's not just any string but because of the way the SDK works with events I didn't want to change too much besides separating the idea of an eventName with the idea of an eventID. I also separated out the idea of a `TimedEvents` dictionary from the `InternalProperties` dictionary that existed previously, this adds some small type safety around the dictionary and adds purpose clarity in the code.

The original method signatures still exist and work just as they did before they simply call the eventID versions of these methods so that there aren't two places that the logic needs to be maintained.