### PR TITLE
visionOS Operating System & Version along with Automatic Events

### DIFF
--- a/Sources/AutomaticEvents.swift
+++ b/Sources/AutomaticEvents.swift
@@ -12,7 +12,7 @@ protocol AEDelegate: AnyObject {
     func increment(property: String, by: Double)
 }
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 import Foundation
 import UIKit
 import StoreKit

--- a/Sources/AutomaticProperties.swift
+++ b/Sources/AutomaticProperties.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 import UIKit
 #elseif os(macOS)
 import Cocoa

--- a/Sources/AutomaticProperties.swift
+++ b/Sources/AutomaticProperties.swift
@@ -72,8 +72,6 @@ class AutomaticProperties {
         p["$manufacturer"]      = "Apple"
         p["$model"]             = AutomaticProperties.deviceModel()
         
-        print(p);
-        
         return p
     }()
 

--- a/Sources/AutomaticProperties.swift
+++ b/Sources/AutomaticProperties.swift
@@ -58,6 +58,9 @@ class AutomaticProperties {
             let screenSize = watchDevice.screenBounds.size
             p["$screen_width"]      = Int(screenSize.width)
             p["$screen_height"]     = Int(screenSize.height)
+        #elseif os(visionOS)
+            p["$os"]                = "visionOS"
+            p["$os_version"]        = UIDevice.current.systemVersion
         #endif
 
         let infoDict = Bundle.main.infoDictionary ?? [:]
@@ -68,6 +71,9 @@ class AutomaticProperties {
         p["$lib_version"]       = AutomaticProperties.libVersion()
         p["$manufacturer"]      = "Apple"
         p["$model"]             = AutomaticProperties.deviceModel()
+        
+        print(p);
+        
         return p
     }()
 

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -184,7 +184,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
     
     /// The minimum session duration (ms) that is tracked in automatic events.
     /// The default value is 10000 (10 seconds).
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
     open var minimumSessionDuration: UInt64 {
         get {
             return automaticEvents.minimumSessionDuration
@@ -223,7 +223,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
     let sessionMetadata: SessionMetadata
     let flushInstance: Flush
     let trackInstance: Track
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
     let automaticEvents = AutomaticEvents()
 #endif
     init(apiToken: String?, flushInterval: Double, name: String, trackAutomaticEvents: Bool, optOutTrackingByDefault: Bool = false,
@@ -307,7 +307,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
             registerSuperProperties(superProperties)
         }
         
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
         if !MixpanelInstance.isiOSAppExtension() && trackAutomaticEvents {
             automaticEvents.delegate = self
             automaticEvents.initializeEvents(instanceName: self.name)


### PR DESCRIPTION
This adds support for sending os and os_version for visionOS along with Automatic Events.

I'm sure there is more parts of mixpanel-swift that would function on visionOS that I've missed.