### PR TITLE
Avoid deadlock during first time initialisation

### DIFF
--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -909,7 +909,7 @@ extension MixpanelInstance {
     }
     
     func unarchive() {
-        self.readWriteLock.write {
+        let didCreateIdentity = self.readWriteLock.write {
             optOutStatus = MixpanelPersistence.loadOptOutStatusFlag(instanceName: self.name)
             superProperties = MixpanelPersistence.loadSuperProperties(instanceName: self.name)
             timedEvents = MixpanelPersistence.loadTimedEvents(instanceName: self.name)
@@ -927,6 +927,14 @@ extension MixpanelInstance {
                 distinctId = addPrefixToDeviceId(deviceId: anonymousId)
                 hadPersistedDistinctId = true
                 userId = nil
+                return true
+            } else {
+                return false
+            }
+        }
+
+        if didCreateIdentity {
+            self.readWriteLock.read {
                 MixpanelPersistence.saveIdentity(MixpanelIdentity.init(
                     distinctID: distinctId,
                     peopleDistinctID: people.distinctId,

--- a/Sources/ReadWriteLock.swift
+++ b/Sources/ReadWriteLock.swift
@@ -19,7 +19,7 @@ class ReadWriteLock {
             closure()
         }
     }
-    func write(closure: () -> Void) {
+    func write<T>(closure: () -> T) -> T {
         concurrentQueue.sync(flags: .barrier, execute: {
             closure()
         })


### PR DESCRIPTION
## Summary

Since the `UserDefaults` calls made by `saveIdentity` cause blocking `NSNotifications` to be emitted to the main thread, calling `saveIdentity` under the write lock can cause deadlocks.

Since the `saveIdentity` call only reads state it’s now moved to only take a read lock instead of being under the write lock.

## The problem

In my Mac app I initialise Mixpanel on a background thread to avoid blocking the main thread during launch. This works fine for most users, however when the app loses focusses immediately during the very first launch Mixpanel deadlocks. Freezing the app completely. (This happens most often when users install the app through the App Store en then click the "Open" button in the App Store itself, this launches the app, but als takes back the focus immediately.)

Attached here you can find the stacktrace where the app hangs: [MixpanelHangStackTrace.txt](https://github.com/user-attachments/files/18035867/MixpanelHangStackTrace.txt)

### The cause

Turns out that the `MixpanelInstance.unarchive` method calls `MixpanelPersistence.saveIdentity` while inside `ReadWriteLock.write`. This in turn writes to `UserDefaults` which blocks until it's `NSNotification` for the defaults updates are picked up by the runloop on the main thread.

However at the moment that unarchive is doing its thing, the main thread is busy handing the `NSApplication.willResignActiveNotification` this wants to check the opt-out state and therefore is waiting for the `ReadWriteLock` to become available again. Causing a deadlock.

## Solution

Since strictly all state writing is already done by the time `saveIdentity` is called, I think the most robust solution is to move the `saveIdentity` out of the write lock. It does need a read lock, because it does read the internal state to store it in `UserDefaults`, but writing isn't needed. Calling `saveIdentity` is also done without a read lock in other places in the codebase.

I made the necessary adjustments in this PR and verified this solves the deadlock in my case.

## Note on reproduction

I can quite easily reproduce this in my own app by putting a breakpoint in the `unarchive` method on the line setting the `anonymousId`. Hitting the breakpoint makes my app resign focus (because Xcode takes focus) while still under the write lock.

However when I tried to make a reproduction sample I found it hard to make a simple demo. Since it only happens at first launch and I need the breakpoint to trigger it reliably.