### PR TITLE
Check opt out status inside tracking queue to avoid race condition

### DIFF
--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -1068,14 +1068,13 @@ extension MixpanelInstance {
      - parameter properties: properties dictionary
      */
     public func track(event: String?, properties: Properties? = nil) {
-        if hasOptedOutTracking() {
-            return
-        }
-        
         let epochInterval = Date().timeIntervalSince1970
         
         trackingQueue.async { [weak self, event, properties, epochInterval] in
-            guard let self = self else {
+            guard let self else {
+                return
+            }
+            if self.hasOptedOutTracking() {
                 return
             }
             var shadowTimedEvents = InternalProperties()


### PR DESCRIPTION
We set the opt out status from inside the tracking queue: https://github.com/mixpanel/mixpanel-swift/blob/master/Sources/MixpanelInstance.swift#L1507-L1534

But we were checking it outside of the queue, immediately upon calling `track()`, leading to cases where the check happens after opt out  is queued up but before it has been processed.

See: https://github.com/mixpanel/mixpanel-swift/issues/658#issuecomment-2551989138