### PR TITLE
Bump minimum iOS to 12 in Package and Pod

### DIFF
--- a/Mixpanel-swift.podspec
+++ b/Mixpanel-swift.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/mixpanel/mixpanel-swift.git',
                      :tag => "v#{s.version}" }
   s.resource_bundles = {'Mixpanel' => ['Sources/Mixpanel/PrivacyInfo.xcprivacy']}
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '12.0'
   s.ios.frameworks = 'UIKit', 'Foundation', 'CoreTelephony'
   s.ios.pod_target_xcconfig = {
     'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) IOS'

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Mixpanel",
     platforms: [
-      .iOS(.v11),
+      .iOS(.v12),
       .tvOS(.v11),
       .macOS(.v10_13),
       .watchOS(.v4)


### PR DESCRIPTION
The Xcode project build settings were actually already bumped to 12.0 a few weeks ago in https://github.com/mixpanel/mixpanel-swift/pull/653

This is needed now because Flutter supports iOS 12 and later and this SDK is wrapped by our Flutter SDK (see https://github.com/mixpanel/mixpanel-flutter/issues/186).

Since this is technically a breaking change for any app that still targets iOS 11, this will be released with a major version bump. 