### PR TITLE
use HTTP GET for feature flags

### DIFF
--- a/.github/workflows/iOS.yml
+++ b/.github/workflows/iOS.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        destination: ['name=iPhone 15 Pro,OS=latest']
+        destination: ['name=iPhone 16 Pro,OS=latest']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This is primarily so we can put feature flag evaluation behind a CDN