### PR TITLE
Plumb additional flags properties through to exposure event

### DIFF
--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
@@ -1320,9 +1320,9 @@ class FeatureFlagManagerTests: XCTestCase {
     wait(for: [mockDelegate.trackExpectation!], timeout: 1.0)
 
     let props = mockDelegate.trackedEvents[0].properties!
-    XCTAssertEqual(props["experimentID"] as? String, "exp_123")
-    XCTAssertEqual(props["isExperimentActive"] as? Bool, true)
-    XCTAssertEqual(props["isQATester"] as? Bool, false)
+    XCTAssertEqual(props["$experiment_id"] as? String, "exp_123")
+    XCTAssertEqual(props["$is_experiment_active"] as? Bool, true)
+    XCTAssertEqual(props["$is_qa_tester"] as? Bool, false)
   }
 
   // MARK: - Timing Properties Sanity Tests

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -585,13 +585,13 @@ class FeatureFlagManager: Network, MixpanelFlags {
     }
 
     if let experimentID = variant.experimentID {
-      properties["experimentID"] = experimentID
+      properties["$experiment_id"] = experimentID
     }
     if let isExperimentActive = variant.isExperimentActive {
-      properties["isExperimentActive"] = isExperimentActive
+      properties["$is_experiment_active"] = isExperimentActive
     }
     if let isQATester = variant.isQATester {
-      properties["isQATester"] = isQATester
+      properties["$is_qa_tester"] = isQATester
     }
 
     // Dispatch delegate call asynchronously to main thread for safety


### PR DESCRIPTION
Plumbs ExperimentID, isExperimentActive, and isQATester, optional properties that may be present in the /flags API response, through to the tracked $experiment_started event.

## GitHub Copilot Summary

This pull request enhances feature flag support by adding optional experiment-related properties to the `MixpanelFlagVariant` model and ensuring these properties are correctly decoded, tracked, and tested. The changes improve the ability to track experiment metadata with feature flag usage, increasing flexibility for experimentation and analytics.

### Feature flag model enhancements

* Added optional fields `experimentID`, `isExperimentActive`, and `isQATester` to the `MixpanelFlagVariant` struct, allowing experiment metadata to be attached to flag variants.
* Updated decoding logic in `MixpanelFlagVariant` to properly parse these optional fields from API responses, and extended the helper initializer to accept them.

### Tracking and analytics improvements

* Modified `FeatureFlagManager` to include experiment-related properties (`$experiment_id`, `$is_experiment_active`, `$is_qa_tester`) when tracking `$experiment_started` events, if available.

### Testing improvements

* Added unit tests to verify that experiment properties are correctly parsed from JSON responses, including cases with missing or partial fields.
* Added a test to ensure that tracking events include the experiment properties when present.