### PR TITLE
Add loadFlags(completion:) callback variant

### DIFF
--- a/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
@@ -218,6 +218,11 @@ class MixpanelDemoTests: MixpanelBaseTests {
       loadFlagsCallCount += 1
     }
 
+    func loadFlags(completion: ((Bool) -> Void)?) {
+      loadFlagsCallCount += 1
+      completion?(true)
+    }
+
     func areFlagsReady() -> Bool {
       return true
     }

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -158,6 +158,10 @@ public protocol MixpanelFlags {
   /// Initiates the loading or refreshing of flags
   func loadFlags()
 
+  /// Initiates the loading or refreshing of flags with a completion callback.
+  /// The completion handler is called with `true` on success and `false` on failure.
+  func loadFlags(completion: ((Bool) -> Void)?)
+
   /// Synchronously checks if the flags  have been successfully loaded
   /// and are available for querying.
   ///
@@ -318,9 +322,13 @@ class FeatureFlagManager: Network, MixpanelFlags {
   // --- Public Methods ---
 
   func loadFlags() {
+    loadFlags(completion: nil)
+  }
+
+  func loadFlags(completion: ((Bool) -> Void)?) {
     // Dispatch fetch trigger to allow caller to continue
     DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-      self?._fetchFlagsIfNeeded(completion: nil)
+      self?._fetchFlagsIfNeeded(completion: completion)
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds `loadFlags(completion: ((Bool) -> Void)?)` to the `MixpanelFlags` protocol, allowing callers to receive a success/failure callback when flags finish loading.
- Implements the new method in `FeatureFlagManager`, delegating to `_fetchFlagsIfNeeded(completion:)`.
- Refactors the existing no-arg `loadFlags()` to delegate to `loadFlags(completion: nil)`.

## Test plan
- [ ] Verify `loadFlags()` (no-arg) still works as before
- [ ] Verify `loadFlags(completion:)` calls back with `true` on successful flag fetch
- [ ] Verify `loadFlags(completion:)` calls back with `false` on failure (e.g., network error)
- [ ] Confirm protocol conformance compiles for any existing adopters of `MixpanelFlags`

🤖 Generated with [Claude Code](https://claude.com/claude-code)