### PR TITLE
Defer automatic events initialization - Fix SwiftUI global accent color override when initializing Mixpanel with automatic events

### DIFF
--- a/MixpanelDemo/MixpanelDemoTests/MixpanelAutomaticEventsTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelAutomaticEventsTests.swift
@@ -16,6 +16,7 @@ class MixpanelAutomaticEventsTests: MixpanelBaseTests {
   func testSession() {
     let testMixpanel = Mixpanel.initialize(
       token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+    waitForAsyncTasks()
     testMixpanel.minimumSessionDuration = 0
     testMixpanel.identify(distinctId: "d1")
     waitForTrackingQueue(testMixpanel)
@@ -42,6 +43,7 @@ class MixpanelAutomaticEventsTests: MixpanelBaseTests {
   func testKeepAutomaticEventsIfNetworkNotAvailable() {
     let testMixpanel = Mixpanel.initialize(
       token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+    waitForAsyncTasks()
     testMixpanel.minimumSessionDuration = 0
     testMixpanel.automaticEvents.perform(
       #selector(AutomaticEvents.appWillResignActive(_:)),
@@ -72,6 +74,7 @@ class MixpanelAutomaticEventsTests: MixpanelBaseTests {
   func testFlushAutomaticEventsIftrackAutomaticEventsEnabledIsTrue() {
     let testMixpanel = Mixpanel.initialize(
       token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+    waitForAsyncTasks()
     testMixpanel.minimumSessionDuration = 0
     testMixpanel.automaticEvents.perform(
       #selector(AutomaticEvents.appWillResignActive(_:)),
@@ -87,6 +90,7 @@ class MixpanelAutomaticEventsTests: MixpanelBaseTests {
   }
 
   func testUpdated() {
+    waitForAsyncTasks()
     let defaults = UserDefaults(suiteName: "Mixpanel")
     let infoDict = Bundle.main.infoDictionary
     let appVersionValue = infoDict?["CFBundleShortVersionString"]
@@ -99,6 +103,7 @@ class MixpanelAutomaticEventsTests: MixpanelBaseTests {
   func testFirstAppShouldOnlyBeTrackedOnce() {
     let testToken = randomId()
     let mp = Mixpanel.initialize(token: testToken, trackAutomaticEvents: true)
+    waitForAsyncTasks()
     mp.minimumSessionDuration = 0
     waitForTrackingQueue(mp)
     XCTAssertEqual(
@@ -106,6 +111,7 @@ class MixpanelAutomaticEventsTests: MixpanelBaseTests {
     flushAndWaitForTrackingQueue(mp)
 
     let mp2 = Mixpanel.initialize(token: testToken, trackAutomaticEvents: true)
+    waitForAsyncTasks()
     mp2.minimumSessionDuration = 0
     waitForTrackingQueue(mp2)
     XCTAssertEqual(
@@ -118,9 +124,11 @@ class MixpanelAutomaticEventsTests: MixpanelBaseTests {
     defaults?.removeObject(forKey: "MPFirstOpen")
 
     let mp = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: true)
+    waitForAsyncTasks()
     mp.minimumSessionDuration = 0
     waitForTrackingQueue(mp)
     let mp2 = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: true)
+    waitForAsyncTasks()
     mp2.minimumSessionDuration = 0
     waitForTrackingQueue(mp2)
 

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelBaseTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelBaseTests.swift
@@ -69,6 +69,9 @@ class MixpanelBaseTests: XCTestCase, MixpanelDelegate {
   }
 
   func waitForTrackingQueue(_ mixpanel: MixpanelInstance) {
+    // Drain the main run loop first to ensure any deferred initialization
+    // (e.g. automatic events) has been dispatched to the tracking queue.
+    waitForAsyncTasks()
     mixpanel.trackingQueue.sync {
       mixpanel.networkQueue.sync {
         return

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelBaseTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelBaseTests.swift
@@ -69,9 +69,6 @@ class MixpanelBaseTests: XCTestCase, MixpanelDelegate {
   }
 
   func waitForTrackingQueue(_ mixpanel: MixpanelInstance) {
-    // Drain the main run loop first to ensure any deferred initialization
-    // (e.g. automatic events) has been dispatched to the tracking queue.
-    waitForAsyncTasks()
     mixpanel.trackingQueue.sync {
       mixpanel.networkQueue.sync {
         return

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
@@ -17,6 +17,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
   func test5XXResponse() {
     let testMixpanel = Mixpanel.initialize(
       token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+    waitForAsyncTasks()
     testMixpanel.serverURL = kFakeServerUrl
     testMixpanel.track(event: "Fake Event")
     flushAndWaitForTrackingQueue(testMixpanel)
@@ -114,6 +115,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
   func testFlushNetworkFailure() {
     let testMixpanel = Mixpanel.initialize(
       token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+    waitForAsyncTasks()
     testMixpanel.serverURL = kFakeServerUrl
     for i in 0..<50 {
       testMixpanel.track(event: "event \(UInt(i))")
@@ -190,6 +192,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
   func testAddingEventsAfterFlush() {
     let testMixpanel = Mixpanel.initialize(
       token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+    waitForAsyncTasks()
     for i in 0..<10 {
       testMixpanel.track(event: "event \(UInt(i))")
     }
@@ -833,6 +836,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
   func testReset() {
     let testMixpanel = Mixpanel.initialize(
       token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+    waitForAsyncTasks()
     testMixpanel.identify(distinctId: "d1")
     testMixpanel.track(event: "e1")
     waitForTrackingQueue(testMixpanel)
@@ -857,6 +861,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
     XCTAssertTrue(peopleQueue(token: testMixpanel.apiToken).isEmpty, "people queue failed to reset")
     let testMixpanel2 = Mixpanel.initialize(
       token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+    waitForAsyncTasks()
     waitForTrackingQueue(testMixpanel2)
     #if MIXPANEL_UNIQUE_DISTINCT_ID
       XCTAssertEqual(
@@ -883,6 +888,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
     let testToken = randomId()
     let testMixpanel = Mixpanel.initialize(
       token: testToken, trackAutomaticEvents: true, flushInterval: 60)
+    waitForAsyncTasks()
     testMixpanel.serverURL = kFakeServerUrl
     let aBoolNumber: Bool = true
     let aBoolNSNumber = NSNumber(value: aBoolNumber)
@@ -896,6 +902,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
 
     let testMixpanel2 = Mixpanel.initialize(
       token: testToken, trackAutomaticEvents: true, flushInterval: 60)
+    waitForAsyncTasks()
     testMixpanel2.serverURL = kFakeServerUrl
     waitForTrackingQueue(testMixpanel2)
 
@@ -1023,6 +1030,7 @@ class MixpanelDemoTests: MixpanelBaseTests {
   func testMixpanelDelegate() {
     let testMixpanel = Mixpanel.initialize(
       token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+    waitForAsyncTasks()
     testMixpanel.delegate = self
     testMixpanel.identify(distinctId: "d1")
     testMixpanel.track(event: "e1")

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelOptOutTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelOptOutTests.swift
@@ -219,6 +219,7 @@ class MixpanelOptOutTests: MixpanelBaseTests {
 
   func testEventBeingTrackedBeforeOptOutShouldNotBeCleared() {
     let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: true)
+    waitForAsyncTasks()
     testMixpanel.track(event: "a normal event")
     waitForTrackingQueue(testMixpanel)
     XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).count == 2, "events should be queued")

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelPeopleTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelPeopleTests.swift
@@ -72,6 +72,7 @@ class MixpanelPeopleTests: MixpanelBaseTests {
   func testDropUnidentifiedPeopleRecords() {
     let testMixpanel = Mixpanel.initialize(
       token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+    waitForAsyncTasks()
     for i in 0..<505 {
       testMixpanel.people.set(property: "i", to: i)
     }

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -453,7 +453,14 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
     #if os(iOS) || os(tvOS) || os(visionOS) || os(macOS)
       if !MixpanelInstance.isiOSAppExtension() && trackAutomaticEvents {
         automaticEvents.delegate = self
-        automaticEvents.initializeEvents(instanceName: self.name)
+        // Defer automatic events initialization to the next run loop iteration
+        // to avoid interfering with SwiftUI's accent color setup when
+        // Mixpanel.initialize() is called from a SwiftUI App's init().
+        // See: https://github.com/mixpanel/mixpanel-swift/issues/522
+        DispatchQueue.main.async { [weak self] in
+          guard let self = self else { return }
+          self.automaticEvents.initializeEvents(instanceName: self.name)
+        }
       }
     #endif
     if self.options.featureFlagOptions.prefetchFlags {


### PR DESCRIPTION
Delay automaticEvents.initializeEvents by dispatching to DispatchQueue.main.async to run on the next run loop iteration. This avoids interfering with SwiftUI's accent color setup when Mixpanel.initialize() is called from a SwiftUI App's init (see #522). Uses a weak self capture to avoid retain cycles.

- Defers automaticEvents.initializeEvents() to the next main run loop iteration via DispatchQueue.main.async
- This prevents Mixpanel's automatic event setup (StoreKit observer, first-open tracking, notification observers) from interfering with SwiftUI's window and accent color configuration when Mixpanel.initialize() is called from a SwiftUI App's
  init()
- No behavioral change. The delay is a single run loop cycle, all automatic events are still tracked identically

Fixes: [#522](url)

Root cause: When **trackAutomaticEvents: true**, initializeEvents() ran synchronously during MixpanelInstance.init(), which blocked the main thread (via instanceQueue.sync) and triggered UIKit interactions (e.g., SKPaymentQueue.default()) before
  **SwiftUI** had finished setting up its window with the asset catalog's accent color. This caused the accent color to revert to system blue, particularly on first launch.
  
 The following project can be used to reproduce the issue: https://github.com/santigracia/mixpanel-swift-issue-522-repro 