### PR TITLE
Sync first-time event checks; lazy property build

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(xcodebuild *)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(xcodebuild *)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ MixpanelDemo/build/
 
 # Claude.ai instructions
 CLAUDE.md
+.claude

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -872,22 +872,34 @@ class FeatureFlagManager: Network, MixpanelFlags {
 
   /// Checks if a tracked event matches any pending first-time events and activates the corresponding variant.
   ///
-  /// - Note:
-  ///   This method is **asynchronous** with respect to the caller. It dispatches its work onto
-  ///   the queue and returns immediately, without waiting for first-time event processing to
-  ///   complete. As a result, there is a short window during which a subsequent `getVariant` call
-  ///   may not yet observe the newly activated variant. Callers should not rely on immediate
-  ///   visibility of first-time event activations in the same synchronous call chain.
-  internal func checkFirstTimeEvents(eventName: String, properties: [String: Any]) {
-    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-      guard let self = self else { return }
+  /// This method executes synchronously to ensure proper ordering when track() and getVariant()/getVariantSync()
+  /// are called sequentially. The flag variant will be activated before returning, allowing
+  /// subsequent getVariantSync() calls to observe the newly activated variant.
+  ///
+  /// Uses lazy property evaluation to avoid overhead when there are no pending first-time events.
+  /// Properties are only built (via the buildProperties closure) if there's a pending event for this event name.
+  ///
+  /// - Parameters:
+  ///   - eventName: The name of the tracked event
+  ///   - buildProperties: A closure that builds event properties on-demand. Only called if needed.
+  ///
+  /// - Note: Only the backend recording API call is dispatched asynchronously (fire-and-forget).
+  ///         The actual flag activation happens synchronously on the calling thread.
+  internal func checkFirstTimeEvents(eventName: String, buildProperties: () -> [String: Any]) {
+    // Execute synchronously to preserve ordering with getVariant() calls
+    // This fixes the race condition where getVariant() could be called before
+    // the flag variant is activated when track() and getVariant() are called sequentially.
 
-      // O(1) check: skip iteration if no pending event matches this event name
-      var hasPendingEvent = false
-      self.flagsLock.read {
-        hasPendingEvent = self.pendingFirstTimeEventNames.contains(eventName)
-      }
-      guard hasPendingEvent else { return }
+    // O(1) check: skip iteration if no pending event matches this event name
+    // Properties are NOT built yet - this is the fast path for 99% of calls!
+    var hasPendingEvent = false
+    flagsLock.read {
+      hasPendingEvent = self.pendingFirstTimeEventNames.contains(eventName)
+    }
+    guard hasPendingEvent else { return }  // ← Exit immediately for non-matching events
+
+    // Only build properties when we actually need them (lazy evaluation)
+    let properties = buildProperties()
 
       // Snapshot pending events with lock
       // Note: We don't snapshot activatedFirstTimeEvents because we'll check it
@@ -935,15 +947,15 @@ class FeatureFlagManager: Network, MixpanelFlags {
         // Atomic check-and-set: Ensure only one thread activates this event.
         // This prevents duplicate recordFirstTimeEvent calls and flag variant changes
         // when multiple threads concurrently process the same event.
-        self.flagsLock.write {
-          if !self.activatedFirstTimeEvents.contains(eventKey) {
+        flagsLock.write {
+          if !activatedFirstTimeEvents.contains(eventKey) {
             // We won the race - activate this event
-            self.activatedFirstTimeEvents.insert(eventKey)
+            activatedFirstTimeEvents.insert(eventKey)
 
-            if self.flags == nil {
-              self.flags = [:]
+            if flags == nil {
+              flags = [:]
             }
-            self.flags![flagKey] = pendingEvent.pendingVariant
+            flags![flagKey] = pendingEvent.pendingVariant
             shouldActivate = true
           }
         }
@@ -953,10 +965,12 @@ class FeatureFlagManager: Network, MixpanelFlags {
           MixpanelLogger.info(message: "First-time event matched for flag '\(flagKey)': \(eventName)")
 
           // Track the feature flag check event with the new variant
-          self._trackFlagIfNeeded(flagName: flagKey, variant: pendingEvent.pendingVariant)
+          _trackFlagIfNeeded(flagName: flagKey, variant: pendingEvent.pendingVariant)
 
           // Record to backend (fire-and-forget)
-          self.recordFirstTimeEvent(
+          // Dispatch only the network call async to avoid blocking the caller
+          DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            self?.recordFirstTimeEvent(
             flagId: pendingEvent.flagId,
             projectId: pendingEvent.projectId,
             firstTimeEventHash: pendingEvent.firstTimeEventHash

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -298,6 +298,10 @@ class FeatureFlagManager: Network, MixpanelFlags {
   // Thread safety using ReadWriteLock (consistent with Track, People, MixpanelInstance)
   internal let flagsLock = ReadWriteLock(label: "com.mixpanel.featureflagmanager")
 
+  // Serial queue for feature flag operations (consistent with trackingQueue, networkQueue pattern)
+  private let flagsQueue = DispatchQueue(
+    label: "com.mixpanel.feature_flags", qos: .userInitiated, autoreleaseFrequency: .workItem)
+
   // Internal State - Protected by flagsLock
   var flags: [String: MixpanelFlagVariant]? = nil
   var isFetching: Bool = false
@@ -349,7 +353,7 @@ class FeatureFlagManager: Network, MixpanelFlags {
 
   func loadFlags(completion: ((Bool) -> Void)?) {
     // Dispatch fetch trigger to allow caller to continue
-    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+    flagsQueue.async { [weak self] in
       self?._fetchFlagsIfNeeded(completion: completion)
     }
   }
@@ -358,7 +362,7 @@ class FeatureFlagManager: Network, MixpanelFlags {
     flagsLock.write {
       self.flagContext = context
     }
-    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+    flagsQueue.async { [weak self] in
       self?._fetchFlagsIfNeeded { _ in
         completion()
       }
@@ -376,46 +380,50 @@ class FeatureFlagManager: Network, MixpanelFlags {
   // --- Sync Flag Retrieval ---
 
   func getVariantSync(_ flagName: String, fallback: MixpanelFlagVariant) -> MixpanelFlagVariant {
-    var flagVariant: MixpanelFlagVariant?
-    var tracked = false
-    var capturedTimeLastFetched: Date?
-    var capturedFetchLatencyMs: Int?
+    // Execute synchronously on flagQueue to respect serial ordering
+    // This ensures proper FIFO ordering with checkFirstTimeEvents calls
+    return flagsQueue.sync {
+      var flagVariant: MixpanelFlagVariant?
+      var tracked = false
+      var capturedTimeLastFetched: Date?
+      var capturedFetchLatencyMs: Int?
 
-    // Use write lock to perform atomic check-and-set for tracking
-    flagsLock.write {
-      guard let currentFlags = self.flags else { return }
+      // Use write lock to perform atomic check-and-set for tracking
+      flagsLock.write {
+        guard let currentFlags = self.flags else { return }
 
-      if let variant = currentFlags[flagName] {
-        flagVariant = variant
+        if let variant = currentFlags[flagName] {
+          flagVariant = variant
 
-        // Perform atomic check-and-set for tracking
-        if !self.trackedFeatures.contains(flagName) {
-          self.trackedFeatures.insert(flagName)
-          tracked = true
-          // Capture timing data while in lock
-          capturedTimeLastFetched = self.timeLastFetched
-          capturedFetchLatencyMs = self.fetchLatencyMs
+          // Perform atomic check-and-set for tracking
+          if !self.trackedFeatures.contains(flagName) {
+            self.trackedFeatures.insert(flagName)
+            tracked = true
+            // Capture timing data while in lock
+            capturedTimeLastFetched = self.timeLastFetched
+            capturedFetchLatencyMs = self.fetchLatencyMs
+          }
         }
+        // If flag wasn't found, flagVariant remains nil
       }
-      // If flag wasn't found, flagVariant remains nil
-    }
 
-    // Now, process the results outside the lock
+      // Now, process the results outside the lock
 
-    if let foundVariant = flagVariant {
-      // If tracking was done *in this call*, call the delegate with timing data
-      if tracked {
-        self._performTrackingDelegateCall(
-          flagName: flagName,
-          variant: foundVariant,
-          timeLastFetched: capturedTimeLastFetched,
-          fetchLatencyMs: capturedFetchLatencyMs
-        )
+      if let foundVariant = flagVariant {
+        // If tracking was done *in this call*, call the delegate with timing data
+        if tracked {
+          self._performTrackingDelegateCall(
+            flagName: flagName,
+            variant: foundVariant,
+            timeLastFetched: capturedTimeLastFetched,
+            fetchLatencyMs: capturedFetchLatencyMs
+          )
+        }
+        return foundVariant
+      } else {
+        MixpanelLogger.info(message: "Flag '\(flagName)' not found or flags not ready. Returning fallback.")
+        return fallback
       }
-      return foundVariant
-    } else {
-      MixpanelLogger.info(message: "Flag '\(flagName)' not found or flags not ready. Returning fallback.")
-      return fallback
     }
   }
 
@@ -425,7 +433,7 @@ class FeatureFlagManager: Network, MixpanelFlags {
     _ flagName: String, fallback: MixpanelFlagVariant,
     completion: @escaping (MixpanelFlagVariant) -> Void
   ) {
-    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+    flagsQueue.async { [weak self] in
       guard let self = self else { return }
 
       var flagVariant: MixpanelFlagVariant?
@@ -515,7 +523,7 @@ class FeatureFlagManager: Network, MixpanelFlags {
   }
 
   func getAllVariants(completion: @escaping ([String: MixpanelFlagVariant]) -> Void) {
-    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+    flagsQueue.async { [weak self] in
       guard let self = self else {
         DispatchQueue.main.async { completion([:]) }
         return
@@ -872,34 +880,29 @@ class FeatureFlagManager: Network, MixpanelFlags {
 
   /// Checks if a tracked event matches any pending first-time events and activates the corresponding variant.
   ///
-  /// This method executes synchronously to ensure proper ordering when track() and getVariant()/getVariantSync()
-  /// are called sequentially. The flag variant will be activated before returning, allowing
-  /// subsequent getVariantSync() calls to observe the newly activated variant.
-  ///
-  /// Uses lazy property evaluation to avoid overhead when there are no pending first-time events.
-  /// Properties are only built (via the buildProperties closure) if there's a pending event for this event name.
+  /// This method dispatches asynchronously to the serial flagQueue to ensure proper FIFO ordering
+  /// when track() and getVariant()/getVariantSync() are called sequentially. Because all flag operations
+  /// use the same serial queue, the flag variant will be activated before any subsequent getVariant() calls
+  /// execute, fixing the race condition.
   ///
   /// - Parameters:
   ///   - eventName: The name of the tracked event
-  ///   - buildProperties: A closure that builds event properties on-demand. Only called if needed.
+  ///   - properties: Event properties to match against property filters
   ///
-  /// - Note: Only the backend recording API call is dispatched asynchronously (fire-and-forget).
-  ///         The actual flag activation happens synchronously on the calling thread.
-  internal func checkFirstTimeEvents(eventName: String, buildProperties: () -> [String: Any]) {
-    // Execute synchronously to preserve ordering with getVariant() calls
-    // This fixes the race condition where getVariant() could be called before
-    // the flag variant is activated when track() and getVariant() are called sequentially.
+  /// - Note: Dispatches asynchronously to flagQueue. The backend recording API call is also dispatched asynchronously.
+  internal func checkFirstTimeEvents(eventName: String, properties: [String: Any]) {
+    // Dispatch to flagQueue to ensure serial execution with getVariant() calls
+    // This guarantees FIFO ordering: if track() is called before getVariant(),
+    // the flag will be activated before getVariant() reads it.
+    flagsQueue.async { [weak self] in
+      guard let self = self else { return }
 
-    // O(1) check: skip iteration if no pending event matches this event name
-    // Properties are NOT built yet - this is the fast path for 99% of calls!
-    var hasPendingEvent = false
-    flagsLock.read {
-      hasPendingEvent = self.pendingFirstTimeEventNames.contains(eventName)
-    }
-    guard hasPendingEvent else { return }  // ← Exit immediately for non-matching events
-
-    // Only build properties when we actually need them (lazy evaluation)
-    let properties = buildProperties()
+      // O(1) check: skip iteration if no pending event matches this event name
+      var hasPendingEvent = false
+      self.flagsLock.read {
+        hasPendingEvent = self.pendingFirstTimeEventNames.contains(eventName)
+      }
+      guard hasPendingEvent else { return }  // ← Exit immediately for non-matching events
 
       // Snapshot pending events with lock
       // Note: We don't snapshot activatedFirstTimeEvents because we'll check it
@@ -947,15 +950,15 @@ class FeatureFlagManager: Network, MixpanelFlags {
         // Atomic check-and-set: Ensure only one thread activates this event.
         // This prevents duplicate recordFirstTimeEvent calls and flag variant changes
         // when multiple threads concurrently process the same event.
-        flagsLock.write {
-          if !activatedFirstTimeEvents.contains(eventKey) {
+        self.flagsLock.write {
+          if !self.activatedFirstTimeEvents.contains(eventKey) {
             // We won the race - activate this event
-            activatedFirstTimeEvents.insert(eventKey)
+            self.activatedFirstTimeEvents.insert(eventKey)
 
-            if flags == nil {
-              flags = [:]
+            if self.flags == nil {
+              self.flags = [:]
             }
-            flags![flagKey] = pendingEvent.pendingVariant
+            self.flags![flagKey] = pendingEvent.pendingVariant
             shouldActivate = true
           }
         }
@@ -965,16 +968,17 @@ class FeatureFlagManager: Network, MixpanelFlags {
           MixpanelLogger.info(message: "First-time event matched for flag '\(flagKey)': \(eventName)")
 
           // Track the feature flag check event with the new variant
-          _trackFlagIfNeeded(flagName: flagKey, variant: pendingEvent.pendingVariant)
+          self._trackFlagIfNeeded(flagName: flagKey, variant: pendingEvent.pendingVariant)
 
           // Record to backend (fire-and-forget)
-          // Dispatch only the network call async to avoid blocking the caller
+          // Network call dispatched separately to avoid blocking the flag queue
           DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             self?.recordFirstTimeEvent(
-            flagId: pendingEvent.flagId,
-            projectId: pendingEvent.projectId,
-            firstTimeEventHash: pendingEvent.firstTimeEventHash
-          )
+              flagId: pendingEvent.flagId,
+              projectId: pendingEvent.projectId,
+              firstTimeEventHash: pendingEvent.firstTimeEventHash
+            )
+          }
         }
       }
     }

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -1202,81 +1202,90 @@ extension MixpanelInstance {
      - parameter event:      event name
      - parameter properties: properties dictionary
      */
-  public func track(event: String?, properties: Properties? = nil) {
-    let epochInterval = Date().timeIntervalSince1970
+    public func track(event: String?, properties: Properties? = nil) {
+        if self.hasOptedOutTracking() {
+            return
+        }
 
-    // Post first-time event check to the flagQueue (asynchronously)
-    // Because getVariant() also uses flagQueue, serial execution guarantees
-    // that if track() is called before getVariant(), the flag will be activated first.
-    // This matches the Android Handler pattern.
-    if let event = event, let flagManager = self.flags as? FeatureFlagManager {
-      // Build properties for first-time event check
-      var superProps = InternalProperties()
-      self.readWriteLock.read {
-        superProps = self.superProperties
-      }
+        // Return early if event is nil (consistent with Track.track() behavior)
+        var eventName: String = "mp_event"
+        if let event = event {
+            eventName = event
+        } else {
+            MixpanelLogger.info(
+                message: "mixpanel track called with empty event parameter. using 'mp_event'")
+        }
 
-      let mixpanelIdentity = MixpanelIdentity(
-        distinctID: self.distinctId,
-        peopleDistinctID: nil,
-        anonymousId: self.anonymousId,
-        userId: self.userId,
-        alias: nil,
-        hadPersistedDistinctId: self.hadPersistedDistinctId
-      )
+        // Check if this is an automatic event that should be ignored
+        if !self.trackAutomaticEventsEnabled && eventName.hasPrefix("$ae_") {
+            return
+        }
 
-      // Build event properties using shared builder
-      let eventProperties = self.trackInstance.buildEventProperties(
-        userProperties: properties,
-        superProperties: superProps,
-        mixpanelIdentity: mixpanelIdentity,
-        epochInterval: epochInterval
-      )
+        // Validate property types early before building
+        if let properties = properties {
+            assertPropertyTypes(properties)
+        }
 
-      // Post to flagQueue - will execute serially with getVariant() calls
-      flagManager.checkFirstTimeEvents(eventName: event, properties: eventProperties)
+        let epochInterval = Date().timeIntervalSince1970
+
+        // CRITICAL: Capture state snapshot atomically on calling thread to ensure consistency
+        // This guarantees that checkFirstTimeEvents and persistence use the SAME properties
+        var shadowTimedEvents = InternalProperties()
+        var shadowSuperProperties = InternalProperties()
+        self.readWriteLock.read {
+            shadowTimedEvents = self.timedEvents
+            shadowSuperProperties = self.superProperties
+        }
+
+        // Capture identity snapshot
+        let mixpanelIdentity = MixpanelIdentity(
+            distinctID: self.distinctId,
+            peopleDistinctID: nil,
+            anonymousId: self.anonymousId,
+            userId: self.userId,
+            alias: nil,
+            hadPersistedDistinctId: self.hadPersistedDistinctId
+        )
+
+        // Build event properties ONCE using the captured snapshot and shared helper function
+        // This ensures first-time event check and persistence use identical properties
+        let eventProperties: InternalProperties = self.trackInstance.buildTrackEventProperties(
+            eventName: eventName,
+            userProperties: properties,
+            timedEvents: shadowTimedEvents,
+            superProperties: shadowSuperProperties,
+            mixpanelIdentity: mixpanelIdentity,
+            epochInterval: epochInterval
+        )
+
+        // Dispatch to trackingQueue for persistence using the SAME captured state
+        trackingQueue.async { [weak self, eventName, eventProperties, shadowTimedEvents] in
+            guard let self = self else {
+                return
+            }
+
+            // Use the captured snapshot to ensure consistency with checkFirstTimeEvents
+            let timedEventsSnapshot: InternalProperties = self.trackInstance.track(
+                event: eventName,
+                properties: eventProperties,
+                timedEvents: shadowTimedEvents)
+
+            self.readWriteLock.write {
+                self.timedEvents = timedEventsSnapshot
+            }
+        }
+        
+        // Post first-time event check to flagQueue with the SAME properties
+        // Serial execution guarantees FIFO ordering with getVariant() calls
+        if let flagManager = self.flags as? FeatureFlagManager {
+            flagManager.checkFirstTimeEvents(eventName: eventName, properties: eventProperties)
+        }
+
+        if MixpanelInstance.isiOSAppExtension() {
+            flush()
+        }
     }
 
-    // Dispatch to trackingQueue for persistence (existing tracking logic)
-    trackingQueue.async { [weak self, event, properties, epochInterval] in
-      guard let self else {
-        return
-      }
-      if self.hasOptedOutTracking() {
-        return
-      }
-      var shadowTimedEvents = InternalProperties()
-      var shadowSuperProperties = InternalProperties()
-
-      self.readWriteLock.read {
-        shadowTimedEvents = self.timedEvents
-        shadowSuperProperties = self.superProperties
-      }
-
-      let mixpanelIdentity = MixpanelIdentity.init(
-        distinctID: self.distinctId,
-        peopleDistinctID: nil,
-        anonymousId: self.anonymousId,
-        userId: self.userId,
-        alias: nil,
-        hadPersistedDistinctId: self.hadPersistedDistinctId)
-      let timedEventsSnapshot = self.trackInstance.track(
-        event: event,
-        properties: properties,
-        timedEvents: shadowTimedEvents,
-        superProperties: shadowSuperProperties,
-        mixpanelIdentity: mixpanelIdentity,
-        epochInterval: epochInterval)
-
-      self.readWriteLock.write {
-        self.timedEvents = timedEventsSnapshot
-      }
-    }
-
-    if MixpanelInstance.isiOSAppExtension() {
-      flush()
-    }
-  }
 
   /**
      Tracks an event with properties and to specific groups.

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -1205,6 +1205,42 @@ extension MixpanelInstance {
   public func track(event: String?, properties: Properties? = nil) {
     let epochInterval = Date().timeIntervalSince1970
 
+    // Check first-time events synchronously on the calling thread before queuing
+    // This ensures proper ordering when track() and getVariantSync() are called sequentially
+    // Uses lazy property builder to avoid overhead when there are no pending first-time events
+    if let event = event, let flagManager = self.flags as? FeatureFlagManager {
+      // Pass a closure that builds properties only if there's a pending first-time event
+      // This avoids the cost of building properties for 99% of track() calls
+      flagManager.checkFirstTimeEvents(eventName: event) { [weak self] in
+        guard let self = self else { return [:] }
+
+        // Get super properties
+        var superProps = InternalProperties()
+        self.readWriteLock.read {
+          superProps = self.superProperties
+        }
+
+        // Build identity
+        let mixpanelIdentity = MixpanelIdentity(
+          distinctID: self.distinctId,
+          peopleDistinctID: nil,
+          anonymousId: self.anonymousId,
+          userId: self.userId,
+          alias: nil,
+          hadPersistedDistinctId: self.hadPersistedDistinctId
+        )
+
+        // Use shared property builder from Track for consistency
+        return self.trackInstance.buildEventProperties(
+          userProperties: properties,
+          superProperties: superProps,
+          mixpanelIdentity: mixpanelIdentity,
+          epochInterval: epochInterval
+        )
+      }
+    }
+
+    // Then dispatch to trackingQueue for persistence (existing tracking logic)
     trackingQueue.async { [weak self, event, properties, epochInterval] in
       guard let self else {
         return
@@ -1719,7 +1755,7 @@ extension MixpanelInstance {
 
   /**
      Returns if the current user has opted out tracking.
-  
+
      - returns: the current super opted out tracking status
      */
   public func hasOptedOutTracking() -> Bool {

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -1205,42 +1205,39 @@ extension MixpanelInstance {
   public func track(event: String?, properties: Properties? = nil) {
     let epochInterval = Date().timeIntervalSince1970
 
-    // Check first-time events synchronously on the calling thread before queuing
-    // This ensures proper ordering when track() and getVariantSync() are called sequentially
-    // Uses lazy property builder to avoid overhead when there are no pending first-time events
+    // Post first-time event check to the flagQueue (asynchronously)
+    // Because getVariant() also uses flagQueue, serial execution guarantees
+    // that if track() is called before getVariant(), the flag will be activated first.
+    // This matches the Android Handler pattern.
     if let event = event, let flagManager = self.flags as? FeatureFlagManager {
-      // Pass a closure that builds properties only if there's a pending first-time event
-      // This avoids the cost of building properties for 99% of track() calls
-      flagManager.checkFirstTimeEvents(eventName: event) { [weak self] in
-        guard let self = self else { return [:] }
-
-        // Get super properties
-        var superProps = InternalProperties()
-        self.readWriteLock.read {
-          superProps = self.superProperties
-        }
-
-        // Build identity
-        let mixpanelIdentity = MixpanelIdentity(
-          distinctID: self.distinctId,
-          peopleDistinctID: nil,
-          anonymousId: self.anonymousId,
-          userId: self.userId,
-          alias: nil,
-          hadPersistedDistinctId: self.hadPersistedDistinctId
-        )
-
-        // Use shared property builder from Track for consistency
-        return self.trackInstance.buildEventProperties(
-          userProperties: properties,
-          superProperties: superProps,
-          mixpanelIdentity: mixpanelIdentity,
-          epochInterval: epochInterval
-        )
+      // Build properties for first-time event check
+      var superProps = InternalProperties()
+      self.readWriteLock.read {
+        superProps = self.superProperties
       }
+
+      let mixpanelIdentity = MixpanelIdentity(
+        distinctID: self.distinctId,
+        peopleDistinctID: nil,
+        anonymousId: self.anonymousId,
+        userId: self.userId,
+        alias: nil,
+        hadPersistedDistinctId: self.hadPersistedDistinctId
+      )
+
+      // Build event properties using shared builder
+      let eventProperties = self.trackInstance.buildEventProperties(
+        userProperties: properties,
+        superProperties: superProps,
+        mixpanelIdentity: mixpanelIdentity,
+        epochInterval: epochInterval
+      )
+
+      // Post to flagQueue - will execute serially with getVariant() calls
+      flagManager.checkFirstTimeEvents(eventName: event, properties: eventProperties)
     }
 
-    // Then dispatch to trackingQueue for persistence (existing tracking logic)
+    // Dispatch to trackingQueue for persistence (existing tracking logic)
     trackingQueue.async { [weak self, event, properties, epochInterval] in
       guard let self else {
         return

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -1213,7 +1213,7 @@ extension MixpanelInstance {
             eventName = event
         } else {
             MixpanelLogger.info(
-                message: "mixpanel track called with empty event parameter. using 'mp_event'")
+                message: "mixpanel track called with empty event parameter.")
         }
 
         // Check if this is an automatic event that should be ignored

--- a/Sources/Track.swift
+++ b/Sources/Track.swift
@@ -34,26 +34,44 @@ class Track {
     self.mixpanelPersistence = mixpanelPersistence
   }
 
-  /// Builds event properties for tracking and first-time event checking.
-  /// This is the single source of truth for property building to ensure consistency.
+  /// Builds complete event properties for tracking.
+  /// This is the single source of truth for property building to ensure consistency
+  /// between persistence and first-time event checks.
   ///
   /// - Parameters:
+  ///   - eventName: The event name (after defaulting to "mp_event" if nil)
   ///   - userProperties: User-provided properties
+  ///   - timedEvents: Timed events dictionary for duration calculation
   ///   - superProperties: Super properties from MixpanelInstance
   ///   - mixpanelIdentity: Identity information
-  ///   - epochInterval: Epoch timestamp
-  /// - Returns: Complete event properties dictionary
-  func buildEventProperties(
+  ///   - epochInterval: Epoch timestamp in seconds
+  /// - Returns: Complete event properties dictionary with all standard fields
+  func buildTrackEventProperties(
+    eventName: String,
     userProperties: Properties?,
+    timedEvents: InternalProperties,
     superProperties: InternalProperties,
     mixpanelIdentity: MixpanelIdentity,
     epochInterval: Double
-  ) -> [String: Any] {
-    var p: [String: Any] = [:]
+  ) -> InternalProperties {
+    var p = InternalProperties()
+
+    // Add automatic properties first (lowest priority)
+    AutomaticProperties.automaticPropertiesLock.read {
+      p += AutomaticProperties.properties
+    }
+
+    // Add SDK-specific properties
+    p["token"] = apiToken
 
     // Add timestamp (milliseconds)
     let epochMilliseconds = round(epochInterval * 1000)
     p["time"] = epochMilliseconds
+
+    // Add duration if this is a timed event
+    if let eventStartTime = timedEvents[eventName] as? Double {
+      p["$duration"] = Double(String(format: "%.3f", epochInterval - eventStartTime))
+    }
 
     // Add identity properties
     p["distinct_id"] = mixpanelIdentity.distinctID
@@ -70,10 +88,10 @@ class Track {
       p["$had_persisted_distinct_id"] = hadPersistedDistinctId
     }
 
-    // Add super properties
+    // Add super properties (can override automatic properties)
     p += superProperties
 
-    // Add user properties (override super properties if keys conflict)
+    // Add user properties (highest priority - can override everything)
     if let userProperties = userProperties {
       p += userProperties
     }
@@ -81,68 +99,36 @@ class Track {
     return p
   }
 
-  func track(
-    event: String?,
-    properties: Properties? = nil,
-    timedEvents: InternalProperties,
-    superProperties: InternalProperties,
-    mixpanelIdentity: MixpanelIdentity,
-    epochInterval: Double
-  ) -> InternalProperties {
-    var ev = "mp_event"
-    if let event = event {
-      ev = event
-    } else {
-      MixpanelLogger.info(
-        message: "mixpanel track called with empty event parameter. using 'mp_event'")
+    func track(
+        event: String,
+        properties: InternalProperties,
+        timedEvents: InternalProperties,
+    ) -> InternalProperties {
+        // Update timed events (remove the event if it was timed)
+        var shadowTimedEvents = timedEvents
+        if timedEvents[event] != nil {
+            shadowTimedEvents.removeValue(forKey: event)
+        }
+
+        // Notify event bridge listeners (non-blocking)
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) {
+            MixpanelEventBridge.shared.notifyListeners(
+                eventName: event,
+                properties: properties
+            )
+        }
+
+        // Note: First-time event checking is now done in MixpanelInstance.track().
+        // This ensures proper ordering when
+        // track() and getVariantSync() are called sequentially.
+
+        var trackEvent: InternalProperties = ["event": event, "properties": properties]
+        metadata.toDict().forEach { (k, v) in trackEvent[k] = v }
+
+        self.mixpanelPersistence.saveEntity(trackEvent, type: .events)
+        MixpanelPersistence.saveTimedEvents(timedEvents: shadowTimedEvents, instanceName: instanceName)
+        return shadowTimedEvents
     }
-    if !(mixpanelInstance?.trackAutomaticEventsEnabled ?? false) && ev.hasPrefix("$ae_") {
-      return timedEvents
-    }
-    assertPropertyTypes(properties)
-
-    // Use shared property builder for consistency
-    var p = buildEventProperties(
-      userProperties: properties,
-      superProperties: superProperties,
-      mixpanelIdentity: mixpanelIdentity,
-      epochInterval: epochInterval
-    )
-
-    // Add SDK-specific properties for persistence
-    AutomaticProperties.automaticPropertiesLock.read {
-      p += AutomaticProperties.properties
-    }
-    p["token"] = apiToken
-
-    // Handle timed events
-    let eventStartTime = timedEvents[ev] as? Double
-    var shadowTimedEvents = timedEvents
-    if let eventStartTime = eventStartTime {
-      shadowTimedEvents.removeValue(forKey: ev)
-      p["$duration"] = Double(String(format: "%.3f", epochInterval - eventStartTime))
-    }
-
-    // Notify event bridge listeners (non-blocking)
-    if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) {
-      MixpanelEventBridge.shared.notifyListeners(
-        eventName: ev,
-        properties: p
-      )
-    }
-
-    // Note: First-time event checking is now done synchronously in MixpanelInstance.track()
-    // before dispatching to trackingQueue. This ensures proper ordering when track() and
-    // getVariantSync() are called sequentially. The check was removed from here to avoid
-    // duplicate work and matches the Android SDK fix in PR #936.
-
-    var trackEvent: InternalProperties = ["event": ev, "properties": p]
-    metadata.toDict().forEach { (k, v) in trackEvent[k] = v }
-
-    self.mixpanelPersistence.saveEntity(trackEvent, type: .events)
-    MixpanelPersistence.saveTimedEvents(timedEvents: shadowTimedEvents, instanceName: instanceName)
-    return shadowTimedEvents
-  }
 
   func registerSuperProperties(
     _ properties: Properties,

--- a/Sources/Track.swift
+++ b/Sources/Track.swift
@@ -34,6 +34,53 @@ class Track {
     self.mixpanelPersistence = mixpanelPersistence
   }
 
+  /// Builds event properties for tracking and first-time event checking.
+  /// This is the single source of truth for property building to ensure consistency.
+  ///
+  /// - Parameters:
+  ///   - userProperties: User-provided properties
+  ///   - superProperties: Super properties from MixpanelInstance
+  ///   - mixpanelIdentity: Identity information
+  ///   - epochInterval: Epoch timestamp
+  /// - Returns: Complete event properties dictionary
+  func buildEventProperties(
+    userProperties: Properties?,
+    superProperties: InternalProperties,
+    mixpanelIdentity: MixpanelIdentity,
+    epochInterval: Double
+  ) -> [String: Any] {
+    var p: [String: Any] = [:]
+
+    // Add timestamp (milliseconds)
+    let epochMilliseconds = round(epochInterval * 1000)
+    p["time"] = epochMilliseconds
+
+    // Add identity properties
+    p["distinct_id"] = mixpanelIdentity.distinctID
+
+    if let anonymousId = mixpanelIdentity.anonymousId {
+      p["$device_id"] = anonymousId
+    }
+
+    if let userId = mixpanelIdentity.userId {
+      p["$user_id"] = userId
+    }
+
+    if let hadPersistedDistinctId = mixpanelIdentity.hadPersistedDistinctId {
+      p["$had_persisted_distinct_id"] = hadPersistedDistinctId
+    }
+
+    // Add super properties
+    p += superProperties
+
+    // Add user properties (override super properties if keys conflict)
+    if let userProperties = userProperties {
+      p += userProperties
+    }
+
+    return p
+  }
+
   func track(
     event: String?,
     properties: Properties? = nil,
@@ -53,33 +100,27 @@ class Track {
       return timedEvents
     }
     assertPropertyTypes(properties)
-    let epochMilliseconds = round(epochInterval * 1000)
-    let eventStartTime = timedEvents[ev] as? Double
-    var p = InternalProperties()
+
+    // Use shared property builder for consistency
+    var p = buildEventProperties(
+      userProperties: properties,
+      superProperties: superProperties,
+      mixpanelIdentity: mixpanelIdentity,
+      epochInterval: epochInterval
+    )
+
+    // Add SDK-specific properties for persistence
     AutomaticProperties.automaticPropertiesLock.read {
       p += AutomaticProperties.properties
     }
     p["token"] = apiToken
-    p["time"] = epochMilliseconds
+
+    // Handle timed events
+    let eventStartTime = timedEvents[ev] as? Double
     var shadowTimedEvents = timedEvents
     if let eventStartTime = eventStartTime {
       shadowTimedEvents.removeValue(forKey: ev)
       p["$duration"] = Double(String(format: "%.3f", epochInterval - eventStartTime))
-    }
-    p["distinct_id"] = mixpanelIdentity.distinctID
-    if mixpanelIdentity.anonymousId != nil {
-      p["$device_id"] = mixpanelIdentity.anonymousId
-    }
-    if mixpanelIdentity.userId != nil {
-      p["$user_id"] = mixpanelIdentity.userId
-    }
-    if mixpanelIdentity.hadPersistedDistinctId != nil {
-      p["$had_persisted_distinct_id"] = mixpanelIdentity.hadPersistedDistinctId
-    }
-
-    p += superProperties
-    if let properties = properties {
-      p += properties
     }
 
     // Notify event bridge listeners (non-blocking)
@@ -90,11 +131,10 @@ class Track {
       )
     }
 
-    // Check for first-time event matches
-    if let mixpanelInstance = mixpanelInstance,
-       let flagManager = mixpanelInstance.flags as? FeatureFlagManager {
-      flagManager.checkFirstTimeEvents(eventName: ev, properties: p)
-    }
+    // Note: First-time event checking is now done synchronously in MixpanelInstance.track()
+    // before dispatching to trackingQueue. This ensures proper ordering when track() and
+    // getVariantSync() are called sequentially. The check was removed from here to avoid
+    // duplicate work and matches the Android SDK fix in PR #936.
 
     var trackEvent: InternalProperties = ["event": ev, "properties": p]
     metadata.toDict().forEach { (k, v) in trackEvent[k] = v }


### PR DESCRIPTION
Fix race between track() and getVariantSync() by making first-time event matching execute synchronously on the calling thread and activating variants before returning. The FeatureFlagManager.checkFirstTimeEvents API was changed to accept a lazy properties builder closure so properties are only constructed when a pending first-time event exists (fast O(1) exit for common cases). The backend recording call remains fire-and-forget (dispatched asynchronously).

Also introduced Track.buildEventProperties as a single source of truth for constructing event properties and updated Track.track to use it. MixpanelInstance.track now calls the new checkFirstTimeEvents synchronously (passing a closure that builds properties) before dispatching the existing async persistence logic, and removed the duplicate first-time check from Track.track. Minor locking/cleanup adjustments made around activatedFirstTimeEvents and flags mutation to ensure atomic activation.