### PR TITLE
Fix feature flags and track events race condition

### DIFF
--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
@@ -292,8 +292,7 @@ class FeatureFlagManagerTests: XCTestCase {
     mockDelegate = MockFeatureFlagDelegate()
 
     // Use MockFeatureFlagManager to prevent real network calls
-    let mockManager = MockFeatureFlagManager(serverURL: "https://test.com", delegate: mockDelegate)
-
+      let mockManager = MockFeatureFlagManager(serverURL: "https://test.com", delegate: mockDelegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
     // Configure default simulation - successful fetch with sample flags
     mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
     mockManager.shouldSimulateNetworkDelay = true
@@ -1318,7 +1317,7 @@ class FeatureFlagManagerTests: XCTestCase {
 
   func testFetchWithNoDelegate() {
     // Create manager with no delegate
-    let noDelegate = FeatureFlagManager(serverURL: "https://test.com", delegate: nil)
+    let noDelegate = FeatureFlagManager(serverURL: "https://test.com", delegate: nil, trackingQueue: DispatchQueue.global(qos: .userInitiated))
 
     // Try to load flags
     noDelegate.loadFlags()
@@ -1521,7 +1520,7 @@ class FeatureFlagManagerTests: XCTestCase {
       anonymousId: testAnonymousId
     )
 
-    let manager = FeatureFlagManager(serverURL: "https://test.com", delegate: mockDelegate)
+    let manager = FeatureFlagManager(serverURL: "https://test.com", delegate: mockDelegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
 
     // Verify the delegate methods return expected values
     XCTAssertEqual(mockDelegate.getDistinctId(), testDistinctId)
@@ -1542,7 +1541,7 @@ class FeatureFlagManagerTests: XCTestCase {
       anonymousId: nil
     )
 
-    let manager = FeatureFlagManager(serverURL: "https://test.com", delegate: mockDelegate)
+    let manager = FeatureFlagManager(serverURL: "https://test.com", delegate: mockDelegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
 
     // Verify the delegate methods return expected values
     XCTAssertEqual(mockDelegate.getDistinctId(), testDistinctId)
@@ -1917,7 +1916,7 @@ class FeatureFlagManagerTests: XCTestCase {
 
   func testGETRequestFormat() {
     // Use a fresh MockFeatureFlagManager with request validation enabled
-    let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", delegate: mockDelegate)
+    let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", delegate: mockDelegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
     mockManager.requestValidationEnabled = true
     mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
 
@@ -1982,7 +1981,7 @@ class FeatureFlagManagerTests: XCTestCase {
       anonymousId: "custom-device-id"
     )
 
-    let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", delegate: customDelegate)
+    let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", delegate: customDelegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
     mockManager.requestValidationEnabled = true
     mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
 
@@ -2025,7 +2024,7 @@ class FeatureFlagManagerTests: XCTestCase {
       anonymousId: nil
     )
 
-    let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", delegate: nilAnonymousDelegate)
+    let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", delegate: nilAnonymousDelegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
     mockManager.requestValidationEnabled = true
     mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
 
@@ -2535,7 +2534,7 @@ class FeatureFlagManagerTests: XCTestCase {
         featureFlagOptions: FeatureFlagOptions(enabled: true, prefetchFlags: true)
       )
     )
-    let mock = MockFeatureFlagManager(serverURL: "https://test.com", delegate: delegate)
+    let mock = MockFeatureFlagManager(serverURL: "https://test.com", delegate: delegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
     mock.simulatedFetchResult = (success: true, flags: sampleFlags)
 
     // Call loadFlags() (which prefetchFlags: true would trigger during init)
@@ -2561,7 +2560,7 @@ class FeatureFlagManagerTests: XCTestCase {
         featureFlagOptions: FeatureFlagOptions(enabled: true, prefetchFlags: false)
       )
     )
-    let mock = MockFeatureFlagManager(serverURL: "https://test.com", delegate: delegate)
+    let mock = MockFeatureFlagManager(serverURL: "https://test.com", delegate: delegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
     mock.simulatedFetchResult = (success: true, flags: sampleFlags)
 
     // Do NOT call loadFlags() - simulating prefetchFlags: false behavior
@@ -2585,7 +2584,7 @@ class FeatureFlagManagerTests: XCTestCase {
       )
     )
 
-    let mockManager = MockFeatureFlagManager(serverURL: "https://test.com", delegate: delegate)
+    let mockManager = MockFeatureFlagManager(serverURL: "https://test.com", delegate: delegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
     mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
 
     // Manually load flags (simulating what user would do after identify)

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
@@ -257,7 +257,7 @@ class MockFeatureFlagManager: FeatureFlagManager {
   }
 
   // Override recordFirstTimeEvent to prevent real network calls and track invocations
-  override func recordFirstTimeEvent(flagId: String, projectId: Int, firstTimeEventHash: String) {
+  override func recordFirstTimeEvent(flagId: String, projectId: Int, firstTimeEventHash: String, distinctId: String) {
     recordFirstTimeEventCallCount += 1
     lastRecordedFlagId = flagId
     lastRecordedProjectId = projectId

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
@@ -292,7 +292,7 @@ class FeatureFlagManagerTests: XCTestCase {
     mockDelegate = MockFeatureFlagDelegate()
 
     // Use MockFeatureFlagManager to prevent real network calls
-      let mockManager = MockFeatureFlagManager(serverURL: "https://test.com", delegate: mockDelegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
+      let mockManager = MockFeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: mockDelegate)
     // Configure default simulation - successful fetch with sample flags
     mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
     mockManager.shouldSimulateNetworkDelay = true
@@ -1317,7 +1317,7 @@ class FeatureFlagManagerTests: XCTestCase {
 
   func testFetchWithNoDelegate() {
     // Create manager with no delegate
-    let noDelegate = FeatureFlagManager(serverURL: "https://test.com", delegate: nil, trackingQueue: DispatchQueue.global(qos: .userInitiated))
+      let noDelegate = FeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: nil)
 
     // Try to load flags
     noDelegate.loadFlags()
@@ -1520,7 +1520,7 @@ class FeatureFlagManagerTests: XCTestCase {
       anonymousId: testAnonymousId
     )
 
-    let manager = FeatureFlagManager(serverURL: "https://test.com", delegate: mockDelegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
+      let manager = FeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: mockDelegate)
 
     // Verify the delegate methods return expected values
     XCTAssertEqual(mockDelegate.getDistinctId(), testDistinctId)
@@ -1541,7 +1541,7 @@ class FeatureFlagManagerTests: XCTestCase {
       anonymousId: nil
     )
 
-    let manager = FeatureFlagManager(serverURL: "https://test.com", delegate: mockDelegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
+      let manager = FeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: mockDelegate)
 
     // Verify the delegate methods return expected values
     XCTAssertEqual(mockDelegate.getDistinctId(), testDistinctId)
@@ -1916,7 +1916,7 @@ class FeatureFlagManagerTests: XCTestCase {
 
   func testGETRequestFormat() {
     // Use a fresh MockFeatureFlagManager with request validation enabled
-    let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", delegate: mockDelegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
+      let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: mockDelegate)
     mockManager.requestValidationEnabled = true
     mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
 
@@ -1981,7 +1981,7 @@ class FeatureFlagManagerTests: XCTestCase {
       anonymousId: "custom-device-id"
     )
 
-    let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", delegate: customDelegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
+      let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: customDelegate)
     mockManager.requestValidationEnabled = true
     mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
 
@@ -2024,7 +2024,7 @@ class FeatureFlagManagerTests: XCTestCase {
       anonymousId: nil
     )
 
-    let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", delegate: nilAnonymousDelegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
+      let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: nilAnonymousDelegate)
     mockManager.requestValidationEnabled = true
     mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
 
@@ -2534,7 +2534,7 @@ class FeatureFlagManagerTests: XCTestCase {
         featureFlagOptions: FeatureFlagOptions(enabled: true, prefetchFlags: true)
       )
     )
-    let mock = MockFeatureFlagManager(serverURL: "https://test.com", delegate: delegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
+      let mock = MockFeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: delegate)
     mock.simulatedFetchResult = (success: true, flags: sampleFlags)
 
     // Call loadFlags() (which prefetchFlags: true would trigger during init)
@@ -2560,7 +2560,7 @@ class FeatureFlagManagerTests: XCTestCase {
         featureFlagOptions: FeatureFlagOptions(enabled: true, prefetchFlags: false)
       )
     )
-    let mock = MockFeatureFlagManager(serverURL: "https://test.com", delegate: delegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
+      let mock = MockFeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: delegate)
     mock.simulatedFetchResult = (success: true, flags: sampleFlags)
 
     // Do NOT call loadFlags() - simulating prefetchFlags: false behavior
@@ -2584,7 +2584,7 @@ class FeatureFlagManagerTests: XCTestCase {
       )
     )
 
-    let mockManager = MockFeatureFlagManager(serverURL: "https://test.com", delegate: delegate, trackingQueue: DispatchQueue.global(qos: .userInitiated))
+      let mockManager = MockFeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: delegate)
     mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
 
     // Manually load flags (simulating what user would do after identify)

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -179,6 +179,8 @@ public protocol MixpanelFlags {
   ///   It is NOT recommended to call this from the main UI thread.
   ///   If flags are not ready (`areFlagsReady()` is false), this method returns the `fallback`
   ///   value, but it may still block while waiting for queued tracking or activation work to complete.
+  ///   If called immediately after track(), variants may not be activated yet due to a
+  ///   race condition as track is executed asynchronously. Use `getVariant` instead.
   ///
   /// - Parameters:
   ///   - flagName: The unique identifier for the feature flag.
@@ -212,6 +214,8 @@ public protocol MixpanelFlags {
   ///   It is NOT recommended to call this from the main UI thread.
   ///   If flags are not ready (`areFlagsReady()` is false), this method returns the `fallbackValue`,
   ///   but it may still block while waiting for queued tracking or activation work to complete.
+  ///   If called immediately after track(), variants may not be activated yet due to a
+  ///   race condition as track is executed asynchronously. Use `getVariantValue` instead.
   ///
   /// - Parameters:
   ///   - flagName: The unique identifier for the feature flag.
@@ -277,6 +281,8 @@ public protocol MixpanelFlags {
   ///   If flags are not ready (`areFlagsReady()` is false), it returns an empty dictionary
   ///   immediately without fetching, but it may still block while waiting for queued tracking
   ///   or activation work to complete.
+  ///   If called immediately after track(), variants may not be activated yet due to a
+  ///   race condition as track is executed asynchronously. Use `getAllVariants` instead.
   ///
   /// - Returns: A dictionary mapping flag names to their `MixpanelFlagVariant` values,
   ///            or an empty dictionary if flags are not ready.
@@ -355,11 +361,11 @@ class FeatureFlagManager: MixpanelFlags {
   private var trackingQueue: DispatchQueue
 
   // Initializers
-    internal init(serverURL: String, delegate: MixpanelFlagDelegate? = nil, trackingQueue: DispatchQueue) {
+    internal init(serverURL: String, trackingQueue: DispatchQueue, delegate: MixpanelFlagDelegate? = nil) {
         self.serverURL = serverURL
+        self.trackingQueue = trackingQueue
         self.delegate = delegate
         self.flagContext = delegate?.getOptions().featureFlagOptions.context ?? [:]
-        self.trackingQueue = trackingQueue
     }
 
   // --- Public Methods ---
@@ -397,17 +403,12 @@ class FeatureFlagManager: MixpanelFlags {
   // --- Sync Flag Retrieval ---
 
   func getVariantSync(_ flagName: String, fallback: MixpanelFlagVariant) -> MixpanelFlagVariant {
-    #if DEBUG
     if Thread.isMainThread {
       MixpanelLogger.warn(
         message: "It is NOT recommended to call this method from the main thread as it might block the calling thread until the value can be retrieved. Consider using async getVariant() instead."
       )
     }
-    #endif
-
-      return trackingQueue.sync {
-        return _getVariantSyncImpl(flagName, fallback: fallback)
-      }
+      return _getVariantSyncImpl(flagName, fallback: fallback)
   }
 
   private func _getVariantSyncImpl(_ flagName: String, fallback: MixpanelFlagVariant) -> MixpanelFlagVariant {
@@ -494,9 +495,7 @@ class FeatureFlagManager: MixpanelFlags {
           // This completion runs *after* fetch completes (or fails)
           let result: MixpanelFlagVariant
           if success {
-            // Fetch succeeded – call the private impl directly to avoid re-entering
-            // trackingQueue.sync (which would block the main thread unnecessarily
-            // and fire a false positive DEBUG warning).
+            // Fetch succeeded – call the private impl directly to avoid false positive DEBUG warning
             result = self._getVariantSyncImpl(flagName, fallback: fallback)
           } else {
             MixpanelLogger.warn(message: "Failed to fetch flags, returning fallback for \(flagName).")
@@ -544,17 +543,12 @@ class FeatureFlagManager: MixpanelFlags {
   // --- Bulk Flag Retrieval ---
 
     func getAllVariantsSync() -> [String: MixpanelFlagVariant] {
-        #if DEBUG
         if Thread.isMainThread {
             MixpanelLogger.warn(
                 message: "It is NOT recommended to call this method from the main thread as it might block the calling thread until the value can be retrieved. Consider using async getAllVariants() instead."
             )
         }
-        #endif
-        
-        return trackingQueue.sync {
-            return _getAllVariantsSyncImpl()
-        }
+        return _getAllVariantsSyncImpl()
     }
 
   private func _getAllVariantsSyncImpl() -> [String: MixpanelFlagVariant] {
@@ -582,9 +576,7 @@ class FeatureFlagManager: MixpanelFlags {
         self._fetchFlagsIfNeeded { success in
           let result: [String: MixpanelFlagVariant]
           if success {
-            // Fetch succeeded – call the private impl directly to avoid re-entering
-            // trackingQueue.sync (which would block the main thread unnecessarily
-            // and fire a false positive DEBUG warning).
+            // Fetch succeeded – call the private impl directly to avoid false positive DEBUG warning
             result = self._getAllVariantsSyncImpl()
           } else {
             MixpanelLogger.warn(message: "Failed to fetch flags, returning empty dictionary.")

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -175,9 +175,10 @@ public protocol MixpanelFlags {
   /// Otherwise, the provided `fallback` `MixpanelFlagVariant` is returned.
   /// This method will also trigger any necessary tracking logic for the accessed flag.
   ///
-  /// - Important:This method will block the calling thread until the value can be retrieved
+  /// - Important: This method may block the calling thread until the value can be retrieved.
   ///   It is NOT recommended to call this from the main UI thread.
-  ///   If flags are not ready (`areFlagsReady()` is false), it returns the fallback immediately without blocking or fetching.
+  ///   If flags are not ready (`areFlagsReady()` is false), this method returns the `fallback`
+  ///   value, but it may still block while waiting for queued tracking or activation work to complete.
   ///
   /// - Parameters:
   ///   - flagName: The unique identifier for the feature flag.

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -272,7 +272,7 @@ public protocol MixpanelFlags {
   /// Returns an empty dictionary if flags have not been loaded yet.
   /// This method does not trigger tracking for any flags.
   ///
-  /// - Important: This method will block the calling thread until the value can be retrieved.
+  /// - Important: This method may block the calling thread until the value can be retrieved.
   ///   It is NOT recommended to call this from the main UI thread.
   ///   If flags are not ready (`areFlagsReady()` is false), it returns an empty dictionary
   ///   immediately without fetching, but it may still block while waiting for queued tracking

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -175,6 +175,10 @@ public protocol MixpanelFlags {
   /// Otherwise, the provided `fallback` `MixpanelFlagVariant` is returned.
   /// This method will also trigger any necessary tracking logic for the accessed flag.
   ///
+  /// - Important:This method will block the calling thread until the value can be retrieved
+  ///   It is NOT recommended to call this from the main UI thread.
+  ///   If flags are not ready (`areFlagsReady()` is false), it returns the fallback immediately without blocking or fetching.
+  ///
   /// - Parameters:
   ///   - flagName: The unique identifier for the feature flag.
   ///   - fallback: The `MixpanelFlagVariant` to return if the specified flag is not found
@@ -203,6 +207,10 @@ public protocol MixpanelFlags {
   /// This is a convenience method that extracts the `value` property from the `MixpanelFlagVariant`
   /// obtained via `getVariantSync`.
   ///
+  /// - Important:This method will block the calling thread until the value can be retrieved
+  ///   It is NOT recommended to call this from the main UI thread.
+  ///   If flags are not ready (`areFlagsReady()` is false), it returns the fallback immediately without blocking or fetching.
+  ///
   /// - Parameters:
   ///   - flagName: The unique identifier for the feature flag.
   ///   - fallbackValue: The default value to return if the flag is not found,
@@ -230,6 +238,10 @@ public protocol MixpanelFlags {
   /// The exact logic for what constitutes "enabled" (e.g., `true`, non-nil, a specific string)
   /// should be defined by the implementing class.
   ///
+  /// - Important:This method will block the calling thread until the value can be retrieved
+  ///   It is NOT recommended to call this from the main UI thread.
+  ///   If flags are not ready (`areFlagsReady()` is false), it returns the fallback immediately without blocking or fetching.
+  ///
   /// - Parameters:
   ///   - flagName: The unique identifier for the feature flag.
   ///   - fallbackValue: The boolean value to return if the flag is not found,
@@ -256,6 +268,10 @@ public protocol MixpanelFlags {
   /// Synchronously retrieves all currently fetched feature flag variants.
   /// Returns an empty dictionary if flags have not been loaded yet.
   /// This method does not trigger tracking for any flags.
+  ///
+  /// - Important:This method will block the calling thread until the value can be retrieved
+  ///   It is NOT recommended to call this from the main UI thread.
+  ///   If flags are not ready (`areFlagsReady()` is false), it returns the fallback immediately without blocking or fetching.
   ///
   /// - Returns: A dictionary mapping flag names to their `MixpanelFlagVariant` values,
   ///            or an empty dictionary if flags are not ready.
@@ -329,6 +345,9 @@ class FeatureFlagManager: Network, MixpanelFlags {
   private var currentOptions: MixpanelOptions? { delegate?.getOptions() }
   private var flagsRoute = "/flags/"
 
+  // Queue for synchronizing flag operations with tracking
+  private var trackingQueue: DispatchQueue?
+
   // Initializers
   required init(serverURL: String) {
     self.flagContext = [:]
@@ -341,6 +360,17 @@ class FeatureFlagManager: Network, MixpanelFlags {
     super.init(serverURL: serverURL)
   }
 
+  convenience init(serverURL: String, trackingQueue: DispatchQueue?) {
+    self.init(serverURL: serverURL)
+    self.trackingQueue = trackingQueue
+  }
+
+  // --- Helper Methods ---
+
+  private func getTrackingQueue() -> DispatchQueue {
+    return trackingQueue ?? DispatchQueue.global(qos: .userInitiated)
+  }
+
   // --- Public Methods ---
 
   func loadFlags() {
@@ -349,7 +379,7 @@ class FeatureFlagManager: Network, MixpanelFlags {
 
   func loadFlags(completion: ((Bool) -> Void)?) {
     // Dispatch fetch trigger to allow caller to continue
-    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+    getTrackingQueue().async { [weak self] in
       self?._fetchFlagsIfNeeded(completion: completion)
     }
   }
@@ -358,7 +388,7 @@ class FeatureFlagManager: Network, MixpanelFlags {
     flagsLock.write {
       self.flagContext = context
     }
-    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+    getTrackingQueue().async { [weak self] in
       self?._fetchFlagsIfNeeded { _ in
         completion()
       }
@@ -376,6 +406,24 @@ class FeatureFlagManager: Network, MixpanelFlags {
   // --- Sync Flag Retrieval ---
 
   func getVariantSync(_ flagName: String, fallback: MixpanelFlagVariant) -> MixpanelFlagVariant {
+    #if DEBUG
+    if Thread.isMainThread, trackingQueue != nil {
+      MixpanelLogger.warn(
+        message: "It is NOT recommended to call this method from the main thread as it might block the calling thread until the value can be retrieved. Consider using async getVariant() instead."
+      )
+    }
+    #endif
+
+    if let trackingQueue = trackingQueue {
+      return trackingQueue.sync {
+        return _getVariantSyncImpl(flagName, fallback: fallback)
+      }
+    } else {
+      return _getVariantSyncImpl(flagName, fallback: fallback)
+    }
+  }
+
+  private func _getVariantSyncImpl(_ flagName: String, fallback: MixpanelFlagVariant) -> MixpanelFlagVariant {
     var flagVariant: MixpanelFlagVariant?
     var tracked = false
     var capturedTimeLastFetched: Date?
@@ -425,7 +473,7 @@ class FeatureFlagManager: Network, MixpanelFlags {
     _ flagName: String, fallback: MixpanelFlagVariant,
     completion: @escaping (MixpanelFlagVariant) -> Void
   ) {
-    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+    getTrackingQueue().async { [weak self] in
       guard let self = self else { return }
 
       var flagVariant: MixpanelFlagVariant?
@@ -507,6 +555,24 @@ class FeatureFlagManager: Network, MixpanelFlags {
   // --- Bulk Flag Retrieval ---
 
   func getAllVariantsSync() -> [String: MixpanelFlagVariant] {
+    #if DEBUG
+    if Thread.isMainThread, trackingQueue != nil {
+      MixpanelLogger.warn(
+        message: "It is NOT recommended to call this method from the main thread as it might block the calling thread until the value can be retrieved. Consider using async getAllVariants() instead."
+      )
+    }
+    #endif
+
+    if let trackingQueue = trackingQueue {
+      return trackingQueue.sync {
+        return _getAllVariantsSyncImpl()
+      }
+    } else {
+      return _getAllVariantsSyncImpl()
+    }
+  }
+
+  private func _getAllVariantsSyncImpl() -> [String: MixpanelFlagVariant] {
     var result: [String: MixpanelFlagVariant] = [:]
     flagsLock.read {
       result = self.flags ?? [:]
@@ -515,7 +581,7 @@ class FeatureFlagManager: Network, MixpanelFlags {
   }
 
   func getAllVariants(completion: @escaping ([String: MixpanelFlagVariant]) -> Void) {
-    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+    getTrackingQueue().async { [weak self] in
       guard let self = self else {
         DispatchQueue.main.async { completion([:]) }
         return
@@ -879,7 +945,7 @@ class FeatureFlagManager: Network, MixpanelFlags {
   ///   may not yet observe the newly activated variant. Callers should not rely on immediate
   ///   visibility of first-time event activations in the same synchronous call chain.
   internal func checkFirstTimeEvents(eventName: String, properties: [String: Any]) {
-    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+    getTrackingQueue().async { [weak self] in
       guard let self = self else { return }
 
       // O(1) check: skip iteration if no pending event matches this event name
@@ -955,12 +1021,14 @@ class FeatureFlagManager: Network, MixpanelFlags {
           // Track the feature flag check event with the new variant
           self._trackFlagIfNeeded(flagName: flagKey, variant: pendingEvent.pendingVariant)
 
-          // Record to backend (fire-and-forget)
-          self.recordFirstTimeEvent(
-            flagId: pendingEvent.flagId,
-            projectId: pendingEvent.projectId,
-            firstTimeEventHash: pendingEvent.firstTimeEventHash
-          )
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                // Record to backend (fire-and-forget)
+                self?.recordFirstTimeEvent(
+                    flagId: pendingEvent.flagId,
+                    projectId: pendingEvent.projectId,
+                    firstTimeEventHash: pendingEvent.firstTimeEventHash
+                )
+            }
         }
       }
     }

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -297,7 +297,7 @@ public protocol MixpanelFlags {
 
 // --- FeatureFlagManager Class ---
 
-class FeatureFlagManager: Network, MixpanelFlags {
+class FeatureFlagManager: MixpanelFlags {
 
   weak var delegate: MixpanelFlagDelegate? {
     didSet {
@@ -311,6 +311,7 @@ class FeatureFlagManager: Network, MixpanelFlags {
     }
   }
 
+    var serverURL: String!
   // Thread safety using ReadWriteLock (consistent with Track, People, MixpanelInstance)
   internal let flagsLock = ReadWriteLock(label: "com.mixpanel.featureflagmanager")
 
@@ -346,30 +347,15 @@ class FeatureFlagManager: Network, MixpanelFlags {
   private var flagsRoute = "/flags/"
 
   // Queue for synchronizing flag operations with tracking
-  private var trackingQueue: DispatchQueue?
+  private var trackingQueue: DispatchQueue
 
   // Initializers
-  required init(serverURL: String) {
-    self.flagContext = [:]
-    super.init(serverURL: serverURL)
-  }
-
-  public init(serverURL: String, delegate: MixpanelFlagDelegate?) {
-    self.delegate = delegate
-    self.flagContext = delegate?.getOptions().featureFlagOptions.context ?? [:]
-    super.init(serverURL: serverURL)
-  }
-
-  convenience init(serverURL: String, trackingQueue: DispatchQueue?) {
-    self.init(serverURL: serverURL)
-    self.trackingQueue = trackingQueue
-  }
-
-  // --- Helper Methods ---
-
-  private func getTrackingQueue() -> DispatchQueue {
-    return trackingQueue ?? DispatchQueue.global(qos: .userInitiated)
-  }
+    internal init(serverURL: String, delegate: MixpanelFlagDelegate? = nil, trackingQueue: DispatchQueue) {
+        self.serverURL = serverURL
+        self.delegate = delegate
+        self.flagContext = delegate?.getOptions().featureFlagOptions.context ?? [:]
+        self.trackingQueue = trackingQueue
+    }
 
   // --- Public Methods ---
 
@@ -379,7 +365,7 @@ class FeatureFlagManager: Network, MixpanelFlags {
 
   func loadFlags(completion: ((Bool) -> Void)?) {
     // Dispatch fetch trigger to allow caller to continue
-    getTrackingQueue().async { [weak self] in
+      trackingQueue.async { [weak self] in
       self?._fetchFlagsIfNeeded(completion: completion)
     }
   }
@@ -388,7 +374,7 @@ class FeatureFlagManager: Network, MixpanelFlags {
     flagsLock.write {
       self.flagContext = context
     }
-    getTrackingQueue().async { [weak self] in
+      trackingQueue.async { [weak self] in
       self?._fetchFlagsIfNeeded { _ in
         completion()
       }
@@ -407,20 +393,16 @@ class FeatureFlagManager: Network, MixpanelFlags {
 
   func getVariantSync(_ flagName: String, fallback: MixpanelFlagVariant) -> MixpanelFlagVariant {
     #if DEBUG
-    if Thread.isMainThread, trackingQueue != nil {
+    if Thread.isMainThread {
       MixpanelLogger.warn(
         message: "It is NOT recommended to call this method from the main thread as it might block the calling thread until the value can be retrieved. Consider using async getVariant() instead."
       )
     }
     #endif
 
-    if let trackingQueue = trackingQueue {
       return trackingQueue.sync {
         return _getVariantSyncImpl(flagName, fallback: fallback)
       }
-    } else {
-      return _getVariantSyncImpl(flagName, fallback: fallback)
-    }
   }
 
   private func _getVariantSyncImpl(_ flagName: String, fallback: MixpanelFlagVariant) -> MixpanelFlagVariant {
@@ -473,7 +455,7 @@ class FeatureFlagManager: Network, MixpanelFlags {
     _ flagName: String, fallback: MixpanelFlagVariant,
     completion: @escaping (MixpanelFlagVariant) -> Void
   ) {
-    getTrackingQueue().async { [weak self] in
+      trackingQueue.async { [weak self] in
       guard let self = self else { return }
 
       var flagVariant: MixpanelFlagVariant?
@@ -554,23 +536,19 @@ class FeatureFlagManager: Network, MixpanelFlags {
 
   // --- Bulk Flag Retrieval ---
 
-  func getAllVariantsSync() -> [String: MixpanelFlagVariant] {
-    #if DEBUG
-    if Thread.isMainThread, trackingQueue != nil {
-      MixpanelLogger.warn(
-        message: "It is NOT recommended to call this method from the main thread as it might block the calling thread until the value can be retrieved. Consider using async getAllVariants() instead."
-      )
+    func getAllVariantsSync() -> [String: MixpanelFlagVariant] {
+        #if DEBUG
+        if Thread.isMainThread {
+            MixpanelLogger.warn(
+                message: "It is NOT recommended to call this method from the main thread as it might block the calling thread until the value can be retrieved. Consider using async getAllVariants() instead."
+            )
+        }
+        #endif
+        
+        return trackingQueue.sync {
+            return _getAllVariantsSyncImpl()
+        }
     }
-    #endif
-
-    if let trackingQueue = trackingQueue {
-      return trackingQueue.sync {
-        return _getAllVariantsSyncImpl()
-      }
-    } else {
-      return _getAllVariantsSyncImpl()
-    }
-  }
 
   private func _getAllVariantsSyncImpl() -> [String: MixpanelFlagVariant] {
     var result: [String: MixpanelFlagVariant] = [:]
@@ -581,7 +559,7 @@ class FeatureFlagManager: Network, MixpanelFlags {
   }
 
   func getAllVariants(completion: @escaping ([String: MixpanelFlagVariant]) -> Void) {
-    getTrackingQueue().async { [weak self] in
+      trackingQueue.async { [weak self] in
       guard let self = self else {
         DispatchQueue.main.async { completion([:]) }
         return
@@ -945,7 +923,7 @@ class FeatureFlagManager: Network, MixpanelFlags {
   ///   may not yet observe the newly activated variant. Callers should not rely on immediate
   ///   visibility of first-time event activations in the same synchronous call chain.
   internal func checkFirstTimeEvents(eventName: String, properties: [String: Any]) {
-    getTrackingQueue().async { [weak self] in
+      trackingQueue.async { [weak self] in
       guard let self = self else { return }
 
       // O(1) check: skip iteration if no pending event matches this event name

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -270,9 +270,9 @@ public protocol MixpanelFlags {
   /// Returns an empty dictionary if flags have not been loaded yet.
   /// This method does not trigger tracking for any flags.
   ///
-  /// - Important:This method will block the calling thread until the value can be retrieved
+  /// - Important: This method will block the calling thread until the value can be retrieved.
   ///   It is NOT recommended to call this from the main UI thread.
-  ///   If flags are not ready (`areFlagsReady()` is false), it returns the fallback immediately without blocking or fetching.
+  ///   If flags are not ready (`areFlagsReady()` is false), it returns an empty dictionary immediately without fetching.
   ///
   /// - Returns: A dictionary mapping flag names to their `MixpanelFlagVariant` values,
   ///            or an empty dictionary if flags are not ready.

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -694,7 +694,7 @@ class FeatureFlagManager: MixpanelFlags {
         self?._completeFetch(success: false)
       },
       success: { [weak self] (flagsResponse, response) in
-        MixpanelLogger.info(message: "Successfully fetched flags.")
+        MixpanelLogger.info(message: "Successfully fetched flags.  \(flagsResponse)")
         guard let self = self else { return }
         let fetchEndTime = Date()
 
@@ -916,111 +916,107 @@ class FeatureFlagManager: MixpanelFlags {
 
   // MARK: - First-Time Event Checking
 
-  /// Checks if a tracked event matches any pending first-time events and activates the corresponding variant.
-  ///
-  /// - Note:
-  ///   This method is **asynchronous** with respect to the caller. It dispatches its work onto
-  ///   the queue and returns immediately, without waiting for first-time event processing to
-  ///   complete. As a result, there is a short window during which a subsequent `getVariant` call
-  ///   may not yet observe the newly activated variant. Callers should not rely on immediate
-  ///   visibility of first-time event activations in the same synchronous call chain.
-  internal func checkFirstTimeEvents(eventName: String, properties: [String: Any]) {
-      trackingQueue.async { [weak self] in
-      guard let self = self else { return }
-
-      // O(1) check: skip iteration if no pending event matches this event name
-      var hasPendingEvent = false
-      self.flagsLock.read {
-        hasPendingEvent = self.pendingFirstTimeEventNames.contains(eventName)
-      }
-      guard hasPendingEvent else { return }
-
-      // Snapshot pending events with lock
-      // Note: We don't snapshot activatedFirstTimeEvents because we'll check it
-      // atomically later under write lock to avoid TOCTOU race
-      var pendingEventsCopy: [String: PendingFirstTimeEvent] = [:]
-
-      self.flagsLock.read {
-        pendingEventsCopy = self.pendingFirstTimeEvents
-      }
-
-      // Iterate through all pending first-time events
-      for (eventKey, pendingEvent) in pendingEventsCopy {
-        // Check exact event name match (case-sensitive)
-        if eventName != pendingEvent.eventName {
-          continue
+    /// Checks if a tracked event matches any pending first-time events and activates the corresponding variant.
+    ///
+    ///- Note:
+    ///   This method **must** be called from the `trackingQueue`.
+    ///   Executing this sequentially on the background serial queue ensures that
+    ///   any subsequent `getVariant` calls (which also wait for or read from this state)
+    ///   will receive the newly activated variant, effectively eliminating the race
+    ///   condition between tracking and flag evaluation.
+    internal func checkFirstTimeEvents(eventName: String, properties: [String: Any]) {
+        // O(1) check: skip iteration if no pending event matches this event name
+        var hasPendingEvent = false
+        flagsLock.read {
+            hasPendingEvent = self.pendingFirstTimeEventNames.contains(eventName)
         }
-
-        // Evaluate property filters using json-logic-swift library
-        if let filters = pendingEvent.propertyFilters, !filters.isEmpty {
-          // Convert to JSON strings for json-logic-swift library
-          guard let rulesString = pendingEvent.propertyFiltersJSON,
-                let dataJSON = try? JSONSerialization.data(withJSONObject: properties),
-                let dataString = String(data: dataJSON, encoding: .utf8) else {
-            MixpanelLogger.warn(message: "Failed to serialize JsonLogic filters for event '\(eventKey)' matching '\(eventName)'")
-            continue
-          }
-
-          // Evaluate the filter
-          do {
-            let result: Bool = try applyRule(rulesString, to: dataString)
-            if !result {
-              MixpanelLogger.debug(message: "JsonLogic filter evaluated to false for event '\(eventKey)'")
-              continue
+        guard hasPendingEvent else { return }
+        
+        // Snapshot pending events with lock
+        // Note: We don't snapshot activatedFirstTimeEvents because we'll check it
+        // atomically later under write lock to avoid TOCTOU race
+        var pendingEventsCopy: [String: PendingFirstTimeEvent] = [:]
+        
+        flagsLock.read {
+            pendingEventsCopy = self.pendingFirstTimeEvents
+        }
+        
+        // Iterate through all pending first-time events
+        for (eventKey, pendingEvent) in pendingEventsCopy {
+            // Check exact event name match (case-sensitive)
+            if eventName != pendingEvent.eventName {
+                continue
             }
-          } catch {
-            MixpanelLogger.error(message: "JsonLogic evaluation error for event '\(eventKey)': \(error)")
-            continue
-          }
-        }
-
-        // Event matched! Try to activate the variant atomically
-        let flagKey = pendingEvent.flagKey
-        var shouldActivate = false
-
-        // Atomic check-and-set: Ensure only one thread activates this event.
-        // This prevents duplicate recordFirstTimeEvent calls and flag variant changes
-        // when multiple threads concurrently process the same event.
-        self.flagsLock.write {
-          if !self.activatedFirstTimeEvents.contains(eventKey) {
-            // We won the race - activate this event
-            self.activatedFirstTimeEvents.insert(eventKey)
-
-            if self.flags == nil {
-              self.flags = [:]
+            
+            // Evaluate property filters using json-logic-swift library
+            if let filters = pendingEvent.propertyFilters, !filters.isEmpty {
+                // Convert to JSON strings for json-logic-swift library
+                guard let rulesString = pendingEvent.propertyFiltersJSON,
+                      let dataJSON = try? JSONSerialization.data(withJSONObject: properties),
+                      let dataString = String(data: dataJSON, encoding: .utf8) else {
+                    MixpanelLogger.warn(message: "Failed to serialize JsonLogic filters for event '\(eventKey)' matching '\(eventName)'")
+                    continue
+                }
+                
+                // Evaluate the filter
+                do {
+                    let result: Bool = try applyRule(rulesString, to: dataString)
+                    if !result {
+                        MixpanelLogger.debug(message: "JsonLogic filter evaluated to false for event '\(eventKey)'")
+                        continue
+                    }
+                } catch {
+                    MixpanelLogger.error(message: "JsonLogic evaluation error for event '\(eventKey)': \(error)")
+                    continue
+                }
             }
-            self.flags![flagKey] = pendingEvent.pendingVariant
-            shouldActivate = true
-          }
+            
+            // Event matched! Try to activate the variant atomically
+            let flagKey = pendingEvent.flagKey
+            var shouldActivate = false
+            
+            // Atomic check-and-set: Ensure only one thread activates this event.
+            // This prevents duplicate recordFirstTimeEvent calls and flag variant changes
+            // when multiple threads concurrently process the same event.
+            flagsLock.write {
+                if !activatedFirstTimeEvents.contains(eventKey) {
+                    // We won the race - activate this event
+                    activatedFirstTimeEvents.insert(eventKey)
+                    
+                    if flags == nil {
+                        flags = [:]
+                    }
+                    flags![flagKey] = pendingEvent.pendingVariant
+                    shouldActivate = true
+                }
+            }
+            
+            // Only proceed with external calls if we successfully activated
+            if shouldActivate {
+                MixpanelLogger.info(message: "First-time event matched for flag '\(flagKey)': \(eventName)")
+                
+                // Track the feature flag check event with the new variant
+                self._trackFlagIfNeeded(flagName: flagKey, variant: pendingEvent.pendingVariant)
+                
+                guard let delegate = self.delegate else {
+                    MixpanelLogger.error(message: "Delegate missing for recording first-time event")
+                    return
+                }
+                
+                let distinctId = delegate.getDistinctId()
+                
+                DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                    // Record to backend (fire-and-forget)
+                    self?.recordFirstTimeEvent(
+                        flagId: pendingEvent.flagId,
+                        projectId: pendingEvent.projectId,
+                        firstTimeEventHash: pendingEvent.firstTimeEventHash,
+                        distinctId: distinctId
+                    )
+                }
+            }
         }
-
-        // Only proceed with external calls if we successfully activated
-        if shouldActivate {
-          MixpanelLogger.info(message: "First-time event matched for flag '\(flagKey)': \(eventName)")
-
-          // Track the feature flag check event with the new variant
-          self._trackFlagIfNeeded(flagName: flagKey, variant: pendingEvent.pendingVariant)
-
-           guard let delegate = self.delegate else {
-               MixpanelLogger.error(message: "Delegate missing for recording first-time event")
-               return
-           }
-           
-           let distinctId = delegate.getDistinctId()
-
-           DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-               // Record to backend (fire-and-forget)
-             self?.recordFirstTimeEvent(
-                 flagId: pendingEvent.flagId,
-                 projectId: pendingEvent.projectId,
-                 firstTimeEventHash: pendingEvent.firstTimeEventHash,
-                 distinctId: distinctId
-             )
-          }
-        }
-      }
     }
-  }
 
   /// Records a first-time event activation to the backend
   internal func recordFirstTimeEvent(flagId: String, projectId: Int, firstTimeEventHash: String, distinctId: String) {

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -999,27 +999,29 @@ class FeatureFlagManager: MixpanelFlags {
           // Track the feature flag check event with the new variant
           self._trackFlagIfNeeded(flagName: flagKey, variant: pendingEvent.pendingVariant)
 
-            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-                // Record to backend (fire-and-forget)
-                self?.recordFirstTimeEvent(
-                    flagId: pendingEvent.flagId,
-                    projectId: pendingEvent.projectId,
-                    firstTimeEventHash: pendingEvent.firstTimeEventHash
-                )
-            }
+           guard let delegate = self.delegate else {
+               MixpanelLogger.error(message: "Delegate missing for recording first-time event")
+               return
+           }
+           
+           let distinctId = delegate.getDistinctId()
+
+           DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+               // Record to backend (fire-and-forget)
+             self?.recordFirstTimeEvent(
+                 flagId: pendingEvent.flagId,
+                 projectId: pendingEvent.projectId,
+                 firstTimeEventHash: pendingEvent.firstTimeEventHash,
+                 distinctId: distinctId
+             )
+          }
         }
       }
     }
   }
 
   /// Records a first-time event activation to the backend
-  internal func recordFirstTimeEvent(flagId: String, projectId: Int, firstTimeEventHash: String) {
-    guard let delegate = self.delegate else {
-      MixpanelLogger.error(message: "Delegate missing for recording first-time event")
-      return
-    }
-
-    let distinctId = delegate.getDistinctId()
+  internal func recordFirstTimeEvent(flagId: String, projectId: Int, firstTimeEventHash: String, distinctId: String) {
     let url = "/flags/\(flagId)/first-time-events"
 
     let queryItems = [

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -208,9 +208,10 @@ public protocol MixpanelFlags {
   /// This is a convenience method that extracts the `value` property from the `MixpanelFlagVariant`
   /// obtained via `getVariantSync`.
   ///
-  /// - Important:This method will block the calling thread until the value can be retrieved
+  /// - Important: This method may block the calling thread until the value can be retrieved.
   ///   It is NOT recommended to call this from the main UI thread.
-  ///   If flags are not ready (`areFlagsReady()` is false), it returns the fallback immediately without blocking or fetching.
+  ///   If flags are not ready (`areFlagsReady()` is false), this method returns the `fallbackValue`,
+  ///   but it may still block while waiting for queued tracking or activation work to complete.
   ///
   /// - Parameters:
   ///   - flagName: The unique identifier for the feature flag.
@@ -239,9 +240,10 @@ public protocol MixpanelFlags {
   /// The exact logic for what constitutes "enabled" (e.g., `true`, non-nil, a specific string)
   /// should be defined by the implementing class.
   ///
-  /// - Important:This method will block the calling thread until the value can be retrieved
+  /// - Important: This method may block the calling thread until the value can be retrieved.
   ///   It is NOT recommended to call this from the main UI thread.
-  ///   If flags are not ready (`areFlagsReady()` is false), it returns the fallback immediately without blocking or fetching.
+  ///   If flags are not ready (`areFlagsReady()` is false), this method returns the `fallbackValue`,
+  ///   but it may still block while waiting for queued tracking or activation work to complete.
   ///
   /// - Parameters:
   ///   - flagName: The unique identifier for the feature flag.
@@ -272,7 +274,9 @@ public protocol MixpanelFlags {
   ///
   /// - Important: This method will block the calling thread until the value can be retrieved.
   ///   It is NOT recommended to call this from the main UI thread.
-  ///   If flags are not ready (`areFlagsReady()` is false), it returns an empty dictionary immediately without fetching.
+  ///   If flags are not ready (`areFlagsReady()` is false), it returns an empty dictionary
+  ///   immediately without fetching, but it may still block while waiting for queued tracking
+  ///   or activation work to complete.
   ///
   /// - Returns: A dictionary mapping flag names to their `MixpanelFlagVariant` values,
   ///            or an empty dictionary if flags are not ready.
@@ -490,8 +494,10 @@ class FeatureFlagManager: MixpanelFlags {
           // This completion runs *after* fetch completes (or fails)
           let result: MixpanelFlagVariant
           if success {
-            // Fetch succeeded, get the flag SYNCHRONOUSLY
-            result = self.getVariantSync(flagName, fallback: fallback)
+            // Fetch succeeded – call the private impl directly to avoid re-entering
+            // trackingQueue.sync (which would block the main thread unnecessarily
+            // and fire a false positive DEBUG warning).
+            result = self._getVariantSyncImpl(flagName, fallback: fallback)
           } else {
             MixpanelLogger.warn(message: "Failed to fetch flags, returning fallback for \(flagName).")
             result = fallback
@@ -576,7 +582,10 @@ class FeatureFlagManager: MixpanelFlags {
         self._fetchFlagsIfNeeded { success in
           let result: [String: MixpanelFlagVariant]
           if success {
-            result = self.getAllVariantsSync()
+            // Fetch succeeded – call the private impl directly to avoid re-entering
+            // trackingQueue.sync (which would block the main thread unnecessarily
+            // and fire a false positive DEBUG warning).
+            result = self._getAllVariantsSyncImpl()
           } else {
             MixpanelLogger.warn(message: "Failed to fetch flags, returning empty dictionary.")
             result = [:]

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -391,7 +391,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
       instanceName: self.name,
       lock: self.readWriteLock,
       metadata: sessionMetadata, mixpanelPersistence: mixpanelPersistence)
-    flags = FeatureFlagManager(serverURL: self.serverURL)
+    flags = FeatureFlagManager(serverURL: self.serverURL, trackingQueue: self.trackingQueue)
     trackInstance.mixpanelInstance = self
     flags.delegate = self
     #if os(iOS) && !targetEnvironment(macCatalyst)


### PR DESCRIPTION
This pull request improves the way feature flag operations are synchronized and documents important threading considerations for synchronous flag retrieval methods. The main changes are the introduction of a configurable `trackingQueue` for all flag operations, enhanced documentation and runtime warnings to discourage blocking calls on the main thread, and refactoring to ensure all relevant operations use the correct queue.

**Important**

- Main thread blocking - If user calls getVariantSync() or getVariantValueSync() from main thread after track(), it will block while waiting for variant activation. This is by design to fix the race, but could cause UI hiccups if the async work takes long. Our warnings/DEBUG checks address this.                                                                                                                                                                                                   


**Threading and Synchronization Improvements:**

* Introduced a `trackingQueue` property to `FeatureFlagManager`, allowing feature flag operations to be dispatched on a configurable queue, with a fallback to a global queue if not provided. Added a convenience initializer for dependency injection of the queue. (`Sources/FeatureFlags.swift`, [[1]](diffhunk://#diff-e13b1afbb6108893e0e3a7c5d9816b471e7352d4ea12e92740a8dd9c560b6fb4R348-R350) [[2]](diffhunk://#diff-e13b1afbb6108893e0e3a7c5d9816b471e7352d4ea12e92740a8dd9c560b6fb4R363-R373) [[3]](diffhunk://#diff-764368484691977ff02e15390a9fac71fa56690bb43a46b1d99ab3e5d6dd50c5L394-R394)
* Refactored all asynchronous flag operations (such as `loadFlags`, `getAllVariants`, and first-time event checks) to use `getTrackingQueue()` instead of hardcoding `DispatchQueue.global(qos: .userInitiated)`, ensuring consistent queue usage and easier testing. (`Sources/FeatureFlags.swift`, [[1]](diffhunk://#diff-e13b1afbb6108893e0e3a7c5d9816b471e7352d4ea12e92740a8dd9c560b6fb4L352-R382) [[2]](diffhunk://#diff-e13b1afbb6108893e0e3a7c5d9816b471e7352d4ea12e92740a8dd9c560b6fb4L361-R391) [[3]](diffhunk://#diff-e13b1afbb6108893e0e3a7c5d9816b471e7352d4ea12e92740a8dd9c560b6fb4L428-R476) [[4]](diffhunk://#diff-e13b1afbb6108893e0e3a7c5d9816b471e7352d4ea12e92740a8dd9c560b6fb4L518-R584) [[5]](diffhunk://#diff-e13b1afbb6108893e0e3a7c5d9816b471e7352d4ea12e92740a8dd9c560b6fb4L882-R948)

**Synchronous Method Safety and Documentation:**

* Updated documentation for all synchronous flag retrieval methods (e.g., `getVariantSync`, `getAllVariantsSync`, etc.) to clearly state that these methods may block the calling thread and should not be called from the main UI thread. Also clarified fallback behavior when flags are not ready. (`Sources/FeatureFlags.swift`, [[1]](diffhunk://#diff-e13b1afbb6108893e0e3a7c5d9816b471e7352d4ea12e92740a8dd9c560b6fb4R178-R181) [[2]](diffhunk://#diff-e13b1afbb6108893e0e3a7c5d9816b471e7352d4ea12e92740a8dd9c560b6fb4R210-R213) [[3]](diffhunk://#diff-e13b1afbb6108893e0e3a7c5d9816b471e7352d4ea12e92740a8dd9c560b6fb4R241-R244) [[4]](diffhunk://#diff-e13b1afbb6108893e0e3a7c5d9816b471e7352d4ea12e92740a8dd9c560b6fb4R272-R275)
* Added runtime warnings (in debug builds) when synchronous flag retrieval methods are called from the main thread and a tracking queue is set, to help developers avoid UI-blocking calls. (`Sources/FeatureFlags.swift`, [[1]](diffhunk://#diff-e13b1afbb6108893e0e3a7c5d9816b471e7352d4ea12e92740a8dd9c560b6fb4R409-R426) [[2]](diffhunk://#diff-e13b1afbb6108893e0e3a7c5d9816b471e7352d4ea12e92740a8dd9c560b6fb4R558-R575)

