### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,12 +15,10 @@ let package = Package(
   ],
   dependencies: [
     .package(
-      name: "jsonlogic",
       url: "https://github.com/advantagefse/json-logic-swift",
       from: "1.2.0"
     ),
     .package(
-      name: "MixpanelSwiftCommon",
       url: "https://github.com/mixpanel/mixpanel-swift-common.git",
       from: "1.0.0"
     )
@@ -29,8 +27,8 @@ let package = Package(
     .target(
       name: "Mixpanel",
       dependencies: [
-        "MixpanelSwiftCommon",
-        "jsonlogic",
+        .product(name: "MixpanelSwiftCommon", package: "mixpanel-swift-common"),
+        .product(name: "jsonlogic", package: "json-logic-swift"),
       ],
       path: "Sources",
       resources: [


### PR DESCRIPTION
This pull request updates the way dependencies are declared in the Swift package manifest (`Package.swift`). The changes improve clarity and compatibility by using explicit product references for dependencies instead of relying on implicit naming.

**Dependency declaration improvements:**

* Updated the dependencies section to remove the explicit `name` fields for the `jsonlogic` and `MixpanelSwiftCommon` packages, relying on the repository URLs and versions instead.
* Modified the `Mixpanel` target's dependencies to use `.product(name:..., package:...)` syntax for both `MixpanelSwiftCommon` and `jsonlogic`, specifying the exact products from each package for improved clarity and SPM compatibility.