### PR TITLE
Reset flags instance

### DIFF
--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -739,6 +739,24 @@ class FeatureFlagManager: MixpanelFlags {
     }
   }
 
+  /// Extracts and clears all pending fetch completion handlers before instance deallocation.
+  /// Called from MixpanelInstance.resetFeatureFlags() to retrieve handlers that need to be
+  /// notified before the instance is replaced.
+  ///
+  /// - Returns: Array of completion handlers that were pending. The caller is responsible
+  ///   for invoking them with the appropriate result.
+  func drainCompletionHandlers() -> [(Bool) -> Void] {
+    var handlers: [(Bool) -> Void] = []
+
+    flagsLock.write {
+      handlers = self.fetchCompletionHandlers
+      self.fetchCompletionHandlers.removeAll()
+      self.isFetching = false
+    }
+
+    return handlers
+  }
+
   // --- Flag Merging Helper ---
   func mergeFlags(
     responseFlags: [String: MixpanelFlagVariant]?,

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -331,6 +331,12 @@ class FeatureFlagManager: MixpanelFlags {
   var isFetching: Bool = false
   private var trackedFeatures: Set<String> = Set()
   private var fetchCompletionHandlers: [(Bool) -> Void] = []
+  /// Set to true by `markDiscarded()` when this manager has been replaced by a fresh
+  /// instance (see `MixpanelInstance.resetFeatureFlags()`). In-flight fetch closures check
+  /// this before mutating in-memory state — without the guard, a network response that
+  /// arrives after reset could write the prior identity's variants into a manager whose
+  /// callers have moved on.
+  private var isDiscarded: Bool = false
 
   // First-time event targeting state
   internal var pendingFirstTimeEvents: [String: PendingFirstTimeEvent] = [:]  // Keyed by "flagKey:firstTimeEventHash"
@@ -705,6 +711,11 @@ class FeatureFlagManager: MixpanelFlags {
         )
 
         self.flagsLock.write {
+          // If this manager has been replaced (resetFeatureFlags), drop the result rather
+          // than writing the prior identity's variants into a manager whose callers have
+          // moved on. The disk-cache write that lives below this block (when the variant
+          // persistence feature lands) gets gated by the same check.
+          guard !self.isDiscarded else { return }
           self.flags = mergedFlags
           self.pendingFirstTimeEvents = mergedPendingEvents
           self.pendingFirstTimeEventNames = mergedPendingEventNames
@@ -737,6 +748,16 @@ class FeatureFlagManager: MixpanelFlags {
     DispatchQueue.main.async {
       handlers.forEach { $0(success) }
     }
+  }
+
+  /// Marks this manager as discarded so any in-flight fetch closure that arrives after
+  /// `MixpanelInstance.resetFeatureFlags()` will drop its result rather than mutating
+  /// state that no longer reaches the user. Idempotent.
+  ///
+  /// Call this on the OLD manager instance immediately before replacing it on
+  /// `MixpanelInstance.flags`.
+  func markDiscarded() {
+    flagsLock.write { self.isDiscarded = true }
   }
 
   /// Extracts and clears all pending fetch completion handlers before instance deallocation.

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -1198,6 +1198,7 @@ extension MixpanelInstance {
 }
 
 extension MixpanelInstance {
+    // MARK: Feature Flags
     func resetFeatureFlags() {
         // Extract pending completion handlers from the old instance before replacing it.
         // We'll notify them after creating the new instance.

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -1200,17 +1200,19 @@ extension MixpanelInstance {
 extension MixpanelInstance {
     // MARK: Feature Flags
     func resetFeatureFlags() {
-        // Extract pending completion handlers from the old instance before replacing it.
-        // We'll notify them after creating the new instance.
+        // Extract pending completion handlers from the old instance and mark it as discarded
+        // before replacing it. The discarded flag prevents an in-flight fetch's success
+        // closure (which captured a reference to the old manager) from writing the prior
+        // identity's variants into a manager whose callers have moved on.
         var pendingHandlers: [(Bool) -> Void] = []
         if let flagManager = self.flags as? FeatureFlagManager {
             pendingHandlers = flagManager.drainCompletionHandlers()
+            flagManager.markDiscarded()
         }
 
         // Reset feature flags by creating a fresh FeatureFlagManager.
         // Re-initialization automatically clears all state (flags cache, tracked features,
-        // pending events, fetch timing) and eliminates race conditions with in-flight fetches
-        // without needing generation counters.
+        // pending events, fetch timing) and eliminates race conditions with in-flight fetches.
         let flagDelegate = self.flags.delegate
         self.flags = FeatureFlagManager(
             serverURL: self.serverURL,

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -1009,6 +1009,9 @@ extension MixpanelInstance {
 
       self.mixpanelPersistence.resetEntities()
       self.archive()
+
+      self.resetFeatureFlags()
+
       if let completion = completion {
         DispatchQueue.main.async(execute: completion)
       }
@@ -1192,6 +1195,40 @@ extension MixpanelInstance {
     }
   }
 
+}
+
+extension MixpanelInstance {
+    func resetFeatureFlags() {
+        // Extract pending completion handlers from the old instance before replacing it.
+        // We'll notify them after creating the new instance.
+        var pendingHandlers: [(Bool) -> Void] = []
+        if let flagManager = self.flags as? FeatureFlagManager {
+            pendingHandlers = flagManager.drainCompletionHandlers()
+        }
+
+        // Reset feature flags by creating a fresh FeatureFlagManager.
+        // Re-initialization automatically clears all state (flags cache, tracked features,
+        // pending events, fetch timing) and eliminates race conditions with in-flight fetches
+        // without needing generation counters.
+        let flagDelegate = self.flags.delegate
+        self.flags = FeatureFlagManager(
+            serverURL: self.serverURL,
+            trackingQueue: self.trackingQueue
+        )
+        self.flags.delegate = flagDelegate
+
+        // Notify pending handlers that their fetch will not complete (due to reset)
+        if !pendingHandlers.isEmpty {
+            DispatchQueue.main.async {
+                pendingHandlers.forEach { $0(false) }
+            }
+        }
+
+        // If prefetchFlags is enabled, load flags under the new identity
+        if self.options.featureFlagOptions.prefetchFlags {
+            self.flags.loadFlags()
+        }
+    }
 }
 
 extension MixpanelInstance {


### PR DESCRIPTION
This pull request improves the handling of feature flag state resets in the `MixpanelInstance` class to ensure pending fetch completion handlers are properly managed and notified when a reset occurs. The changes add a mechanism to drain and clear pending handlers before replacing the feature flag manager, preventing race conditions and ensuring correct notification.

Feature Flag Reset Improvements:

* Added a `drainCompletionHandlers()` method to `FeatureFlagManager` to extract and clear all pending fetch completion handlers before the instance is deallocated, allowing for proper notification of these handlers during a reset.
* Introduced a new `resetFeatureFlags()` method in `MixpanelInstance` that:
  * Drains pending completion handlers from the old flag manager,
  * Replaces the feature flag manager with a fresh instance (resetting all internal state and eliminating race conditions),
  * Notifies any pending handlers that their fetch will not complete due to the reset,
  * Triggers flag prefetching if configured.
* Updated the main reset logic in `MixpanelInstance` to call `resetFeatureFlags()` as part of the reset process, ensuring feature flag state and handlers are cleared and managed correctly.