### PR TITLE
feat: Feature Flag persistence

### DIFF
--- a/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
+++ b/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
@@ -8,8 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		171E4C1C2DB055BC00B7CB11 /* MixpanelFeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171E4C1B2DB055A900B7CB11 /* MixpanelFeatureFlagTests.swift */; };
-		1A1B2C3D4E5F60718293A4B0 /* MixpanelFeatureFlagCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1B2C3D4E5F60718293A4B1 /* MixpanelFeatureFlagCacheTests.swift */; };
-		1A1B2C3D4E5F60718293A4B2 /* MixpanelFeatureFlagCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1B2C3D4E5F60718293A4B1 /* MixpanelFeatureFlagCacheTests.swift */; };
+		1A1B2C3D4E5F60718293A4B0 /* MixpanelFeatureFlagPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1B2C3D4E5F60718293A4B1 /* MixpanelFeatureFlagPersistenceTests.swift */; };
+		1A1B2C3D4E5F60718293A4B2 /* MixpanelFeatureFlagPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1B2C3D4E5F60718293A4B1 /* MixpanelFeatureFlagPersistenceTests.swift */; };
 		174205522F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174205512F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift */; };
 		4A856A22C3D44379A5471460 /* MixpanelEventBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C72DDD552B64791AD52E1DC /* MixpanelEventBridgeTests.swift */; };
 		B1AB7B0E940444B7A9B0876A /* MixpanelEventBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DA802B4623D45938280B06A /* MixpanelEventBridgeTests.swift */; };
@@ -258,7 +258,7 @@
 
 /* Begin PBXFileReference section */
 		171E4C1B2DB055A900B7CB11 /* MixpanelFeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelFeatureFlagTests.swift; sourceTree = "<group>"; };
-		1A1B2C3D4E5F60718293A4B1 /* MixpanelFeatureFlagCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelFeatureFlagCacheTests.swift; sourceTree = "<group>"; };
+		1A1B2C3D4E5F60718293A4B1 /* MixpanelFeatureFlagPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelFeatureFlagPersistenceTests.swift; sourceTree = "<group>"; };
 		174205512F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelDeviceIdProviderTests.swift; sourceTree = "<group>"; };
 		7DA802B4623D45938280B06A /* MixpanelEventBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelEventBridgeTests.swift; sourceTree = "<group>"; };
 		8C72DDD552B64791AD52E1DC /* MixpanelEventBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelEventBridgeTests.swift; sourceTree = "<group>"; };
@@ -610,7 +610,7 @@
 			children = (
 				174205512F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift */,
 				171E4C1B2DB055A900B7CB11 /* MixpanelFeatureFlagTests.swift */,
-				1A1B2C3D4E5F60718293A4B1 /* MixpanelFeatureFlagCacheTests.swift */,
+				1A1B2C3D4E5F60718293A4B1 /* MixpanelFeatureFlagPersistenceTests.swift */,
 				E124061F1D249B2500383635 /* MixpanelBaseTests.swift */,
 				E15FF7EB1D0461130076CDE3 /* MixpanelDemoTests.swift */,
 				E1C61EB91D22F6470056C56C /* MixpanelPeopleTests.swift */,
@@ -1066,7 +1066,7 @@
 				8654F3012671636B00ACEED5 /* MixpanelOptOutTests.swift in Sources */,
 				47BE9AE5B837EEAA088FB3FD /* MixpanelAutomaticEventsTests.swift in Sources */,
 				4A856A22C3D44379A5471460 /* MixpanelEventBridgeTests.swift in Sources */,
-				1A1B2C3D4E5F60718293A4B2 /* MixpanelFeatureFlagCacheTests.swift in Sources */,
+				1A1B2C3D4E5F60718293A4B2 /* MixpanelFeatureFlagPersistenceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1141,7 +1141,7 @@
 				E17AA05E1EC6234E0066EFE8 /* MixpanelAutomaticEventsTests.swift in Sources */,
 				E15FF7EC1D0461130076CDE3 /* MixpanelDemoTests.swift in Sources */,
 				171E4C1C2DB055BC00B7CB11 /* MixpanelFeatureFlagTests.swift in Sources */,
-				1A1B2C3D4E5F60718293A4B0 /* MixpanelFeatureFlagCacheTests.swift in Sources */,
+				1A1B2C3D4E5F60718293A4B0 /* MixpanelFeatureFlagPersistenceTests.swift in Sources */,
 				174205522F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift in Sources */,
 				B1AB7B0E940444B7A9B0876A /* MixpanelEventBridgeTests.swift in Sources */,
 			);

--- a/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
+++ b/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		171E4C1C2DB055BC00B7CB11 /* MixpanelFeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171E4C1B2DB055A900B7CB11 /* MixpanelFeatureFlagTests.swift */; };
+		1A1B2C3D4E5F60718293A4B0 /* MixpanelFeatureFlagCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1B2C3D4E5F60718293A4B1 /* MixpanelFeatureFlagCacheTests.swift */; };
+		1A1B2C3D4E5F60718293A4B2 /* MixpanelFeatureFlagCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1B2C3D4E5F60718293A4B1 /* MixpanelFeatureFlagCacheTests.swift */; };
 		174205522F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174205512F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift */; };
 		4A856A22C3D44379A5471460 /* MixpanelEventBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C72DDD552B64791AD52E1DC /* MixpanelEventBridgeTests.swift */; };
 		B1AB7B0E940444B7A9B0876A /* MixpanelEventBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DA802B4623D45938280B06A /* MixpanelEventBridgeTests.swift */; };
@@ -256,6 +258,7 @@
 
 /* Begin PBXFileReference section */
 		171E4C1B2DB055A900B7CB11 /* MixpanelFeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelFeatureFlagTests.swift; sourceTree = "<group>"; };
+		1A1B2C3D4E5F60718293A4B1 /* MixpanelFeatureFlagCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelFeatureFlagCacheTests.swift; sourceTree = "<group>"; };
 		174205512F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelDeviceIdProviderTests.swift; sourceTree = "<group>"; };
 		7DA802B4623D45938280B06A /* MixpanelEventBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelEventBridgeTests.swift; sourceTree = "<group>"; };
 		8C72DDD552B64791AD52E1DC /* MixpanelEventBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelEventBridgeTests.swift; sourceTree = "<group>"; };
@@ -607,6 +610,7 @@
 			children = (
 				174205512F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift */,
 				171E4C1B2DB055A900B7CB11 /* MixpanelFeatureFlagTests.swift */,
+				1A1B2C3D4E5F60718293A4B1 /* MixpanelFeatureFlagCacheTests.swift */,
 				E124061F1D249B2500383635 /* MixpanelBaseTests.swift */,
 				E15FF7EB1D0461130076CDE3 /* MixpanelDemoTests.swift */,
 				E1C61EB91D22F6470056C56C /* MixpanelPeopleTests.swift */,
@@ -1062,6 +1066,7 @@
 				8654F3012671636B00ACEED5 /* MixpanelOptOutTests.swift in Sources */,
 				47BE9AE5B837EEAA088FB3FD /* MixpanelAutomaticEventsTests.swift in Sources */,
 				4A856A22C3D44379A5471460 /* MixpanelEventBridgeTests.swift in Sources */,
+				1A1B2C3D4E5F60718293A4B2 /* MixpanelFeatureFlagCacheTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1136,6 +1141,7 @@
 				E17AA05E1EC6234E0066EFE8 /* MixpanelAutomaticEventsTests.swift in Sources */,
 				E15FF7EC1D0461130076CDE3 /* MixpanelDemoTests.swift in Sources */,
 				171E4C1C2DB055BC00B7CB11 /* MixpanelFeatureFlagTests.swift in Sources */,
+				1A1B2C3D4E5F60718293A4B0 /* MixpanelFeatureFlagCacheTests.swift in Sources */,
 				174205522F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift in Sources */,
 				B1AB7B0E940444B7A9B0876A /* MixpanelEventBridgeTests.swift in Sources */,
 			);

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagCacheTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagCacheTests.swift
@@ -5,7 +5,7 @@
 //  Tests for the feature-flag variant persistence layer:
 //   - Persistence round-trip + self-healing on malformed blobs
 //   - distinctId and TTL validation
-//   - Init loads cache and stamps variants with .cache(at:)
+//   - Init loads cache and stamps variants with .cache(cachedAt:)
 //   - CacheFirst serves cached values immediately
 //   - NetworkFirst awaits the initial network response, falls back on failure
 //   - reset() wipes both in-memory state and the on-disk blob
@@ -183,7 +183,7 @@ class FeatureFlagCacheTests: XCTestCase {
     if case .network = stamped.source {} else { XCTFail("expected .network source") }
 
     let cachedAt = Date(timeIntervalSince1970: 1_700_000_000)
-    let cacheStamped = original.withSource(.cache(at: cachedAt))
+    let cacheStamped = original.withSource(.cache(cachedAt: cachedAt))
     if case .cache(let at) = cacheStamped.source {
       XCTAssertEqual(at.timeIntervalSince1970, cachedAt.timeIntervalSince1970, accuracy: 0.001)
     } else {
@@ -426,11 +426,11 @@ class FeatureFlagCacheTests: XCTestCase {
   // MARK: - TTL re-check on get
   //
   // The TTL is re-checked on every `getVariant`/`getAllVariants` call (not only at init load
-  // time). Once a `.cache(at:)`-stamped variant ages past TTL while sitting in memory, lookups
+  // time). Once a `.cache(cachedAt:)`-stamped variant ages past TTL while sitting in memory, lookups
   // return the developer fallback rather than the stale value. The on-disk blob is NOT
   // deleted — the next successful fetch will overwrite it.
 
-  /// A `.cache(at:)`-stamped variant that's older than the configured TTL is treated as
+  /// A `.cache(cachedAt:)`-stamped variant that's older than the configured TTL is treated as
   /// not-present by `getVariantSync` — the developer fallback is returned instead.
   func testGetVariantSyncReturnsFallbackForExpiredCachedVariant() throws {
     let manager = makeManager(
@@ -441,7 +441,7 @@ class FeatureFlagCacheTests: XCTestCase {
     // load path so we can test the get-time TTL check in isolation. cachedAt is 1 hour ago,
     // well past the 60s TTL configured above.
     let expired = MixpanelFlagVariant(key: "v1", value: "stale_value")
-      .withSource(.cache(at: Date(timeIntervalSinceNow: -3600)))
+      .withSource(.cache(cachedAt: Date(timeIntervalSinceNow: -3600)))
     manager.flagsLock.write {
       manager.flags = ["flag_a": expired]
     }
@@ -453,14 +453,14 @@ class FeatureFlagCacheTests: XCTestCase {
     XCTAssertNil(result.source, "fallback variant has nil source")
   }
 
-  /// A `.cache(at:)`-stamped variant within TTL is served as-is (with `.cache` source preserved).
+  /// A `.cache(cachedAt:)`-stamped variant within TTL is served as-is (with `.cache` source preserved).
   func testGetVariantSyncReturnsFreshCachedVariant() throws {
     let manager = makeManager(
       distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
     waitForTrackingQueue(manager: manager)
 
     let fresh = MixpanelFlagVariant(key: "v1", value: "fresh_value")
-      .withSource(.cache(at: Date(timeIntervalSinceNow: -60)))
+      .withSource(.cache(cachedAt: Date(timeIntervalSinceNow: -60)))
     manager.flagsLock.write {
       manager.flags = ["flag_a": fresh]
     }
@@ -473,7 +473,7 @@ class FeatureFlagCacheTests: XCTestCase {
   }
 
   /// `.network`-stamped variants are never expired regardless of how old they are — TTL only
-  /// applies to `.cache(at:)` variants.
+  /// applies to `.cache(cachedAt:)` variants.
   func testGetVariantSyncReturnsNetworkVariantRegardlessOfAge() throws {
     let manager = makeManager(
       distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 60))
@@ -492,16 +492,16 @@ class FeatureFlagCacheTests: XCTestCase {
   }
 
   /// `getAllVariantsSync` filters out expired cached variants but keeps `.network` variants
-  /// and unexpired `.cache(at:)` variants.
+  /// and unexpired `.cache(cachedAt:)` variants.
   func testGetAllVariantsSyncFiltersExpiredCachedVariants() throws {
     let manager = makeManager(
       distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 60))
     waitForTrackingQueue(manager: manager)
 
     let expired = MixpanelFlagVariant(key: "v1", value: "stale")
-      .withSource(.cache(at: Date(timeIntervalSinceNow: -3600)))
+      .withSource(.cache(cachedAt: Date(timeIntervalSinceNow: -3600)))
     let fresh = MixpanelFlagVariant(key: "v2", value: "ok")
-      .withSource(.cache(at: Date(timeIntervalSinceNow: -10)))
+      .withSource(.cache(cachedAt: Date(timeIntervalSinceNow: -10)))
     let networkSourced = MixpanelFlagVariant(key: "v3", value: "from_network")
       .withSource(.network)
 
@@ -534,7 +534,7 @@ class FeatureFlagCacheTests: XCTestCase {
 
     // Force the in-memory variant to be expired without wiping the disk blob.
     let expired = MixpanelFlagVariant(key: "v1", value: "stale")
-      .withSource(.cache(at: Date(timeIntervalSinceNow: -90_000)))  // > 86_400s TTL
+      .withSource(.cache(cachedAt: Date(timeIntervalSinceNow: -90_000)))  // > 86_400s TTL
     manager.flagsLock.write {
       manager.flags = ["flag_a": expired]
     }

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagCacheTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagCacheTests.swift
@@ -1,0 +1,650 @@
+//
+//  MixpanelFeatureFlagCacheTests.swift
+//  MixpanelDemo
+//
+//  Tests for the feature-flag variant persistence layer:
+//   - Persistence round-trip + self-healing on malformed blobs
+//   - distinctId and TTL validation
+//   - Init loads cache and stamps variants with .cache(at:)
+//   - CacheFirst serves cached values immediately
+//   - NetworkFirst awaits the initial network response, falls back on failure
+//   - reset() wipes both in-memory state and the on-disk blob
+//   - cacheVariants=true causes successful fetches to write the blob
+//
+
+import XCTest
+
+@testable import Mixpanel
+
+// MARK: - Test-local mocks
+//
+// Defined here (rather than reusing the mocks in MixpanelFeatureFlagTests.swift) so this
+// file can be compiled into both the iOS and macOS test targets without dragging in the
+// rest of that file's iOS-specific dependencies. Keep the surface minimal — just what these
+// cache tests actually exercise.
+
+private final class CacheTestMockDelegate: MixpanelFlagDelegate {
+  var options: MixpanelOptions
+  var distinctId: String
+  var anonymousId: String?
+  var trackedEvents: [(event: String?, properties: Properties?)] = []
+  private let trackQueue = DispatchQueue(label: "cache.test.mock.track")
+
+  init(options: MixpanelOptions, distinctId: String, anonymousId: String? = nil) {
+    self.options = options
+    self.distinctId = distinctId
+    self.anonymousId = anonymousId
+  }
+
+  func getOptions() -> MixpanelOptions { return options }
+  func getDistinctId() -> String { return distinctId }
+  func getAnonymousId() -> String? { return anonymousId }
+  func track(event: String?, properties: Properties?) {
+    trackQueue.sync { trackedEvents.append((event: event, properties: properties)) }
+  }
+}
+
+/// Minimal mock of FeatureFlagManager that intercepts the network call. Deliberately
+/// reproduces the parts of the real fetch path we care about (source stamping,
+/// awaitingInitialNetworkResponse handling, completion fan-out) so async-lookup tests
+/// can verify behavior end-to-end.
+private final class CacheTestMockManager: FeatureFlagManager {
+  var simulatedFetchResult: (success: Bool, flags: [String: MixpanelFlagVariant]?)?
+  var simulatedNetworkDelay: TimeInterval = 0.1
+
+  override func _performFetchRequest() {
+    let work: () -> Void = { [weak self] in
+      guard let self = self else { return }
+      guard let result = self.simulatedFetchResult else {
+        self.flagsLock.write { self.awaitingInitialNetworkResponse = false }
+        self._completeFetch(success: false)
+        return
+      }
+      if result.success, let flags = result.flags {
+        let stamped = flags.mapValues { $0.withSource(.network) }
+        self.flagsLock.write {
+          self.flags = stamped
+          self.awaitingInitialNetworkResponse = false
+          self.timeLastFetched = Date()
+        }
+        self._completeFetch(success: true)
+      } else {
+        // Failure: leave flags in place (NetworkFirst fallback semantics) but clear awaiting.
+        self.flagsLock.write { self.awaitingInitialNetworkResponse = false }
+        self._completeFetch(success: false)
+      }
+    }
+    if simulatedNetworkDelay > 0 {
+      DispatchQueue.global().asyncAfter(deadline: .now() + simulatedNetworkDelay, execute: work)
+    } else {
+      work()
+    }
+  }
+
+  // No-op so we don't fire real first-time-event recording requests.
+  override func recordFirstTimeEvent(
+    flagId: String, projectId: Int, firstTimeEventHash: String, distinctId: String
+  ) {}
+}
+
+class FeatureFlagCacheTests: XCTestCase {
+
+  // Each test uses a unique instance name so UserDefaults state from one test can't bleed
+  // into another. Writes go to the shared "Mixpanel" suite, but the per-instance prefix
+  // keys keep them isolated.
+  private var instanceName: String!
+
+  // FeatureFlagManager.delegate is `weak`. Tests build delegates inside helper methods, so
+  // unless the test instance holds a strong ref the delegate gets deallocated as soon as the
+  // helper returns and `delegate?.getOptions()` returns nil. Stash all created delegates
+  // here for the test's lifetime.
+  private var retainedDelegates: [MixpanelFlagDelegate] = []
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    instanceName = "fftest-\(UUID().uuidString)"
+  }
+
+  override func tearDownWithError() throws {
+    MixpanelPersistence.deleteFlagsCache(instanceName: instanceName)
+    instanceName = nil
+    retainedDelegates.removeAll()
+    try super.tearDownWithError()
+  }
+
+  // MARK: - Persistence layer
+
+  func testSaveAndLoadRoundTrip() throws {
+    let blob = FlagsCacheBlob(
+      cachedAt: Date(timeIntervalSince1970: 1_700_000_000),
+      distinctId: "user_a",
+      response: #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+    )
+
+    MixpanelPersistence.saveFlagsCache(blob, instanceName: instanceName)
+    let loaded = MixpanelPersistence.loadFlagsCache(instanceName: instanceName)
+
+    let loadedBlob = try XCTUnwrap(loaded)
+    XCTAssertEqual(loadedBlob.distinctId, blob.distinctId)
+    XCTAssertEqual(loadedBlob.response, blob.response)
+    XCTAssertEqual(
+      loadedBlob.cachedAt.timeIntervalSince1970,
+      blob.cachedAt.timeIntervalSince1970, accuracy: 0.001)
+  }
+
+  func testLoadReturnsNilWhenNothingPersisted() {
+    XCTAssertNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+  }
+
+  func testDeleteRemovesBlob() {
+    let blob = FlagsCacheBlob(
+      cachedAt: Date(), distinctId: "user_x", response: "{}")
+    MixpanelPersistence.saveFlagsCache(blob, instanceName: instanceName)
+    XCTAssertNotNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+
+    MixpanelPersistence.deleteFlagsCache(instanceName: instanceName)
+    XCTAssertNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+  }
+
+  func testMalformedBlobIsSelfHealed() {
+    // Write a non-JSON byte sequence directly to the same key the persistence layer uses.
+    let defaults = UserDefaults(suiteName: "Mixpanel")!
+    let key = "mixpanel-\(instanceName!)-MPFlagsCache"
+    defaults.set(Data([0xFF, 0xFE, 0xFD]), forKey: key)
+
+    // Read should return nil AND clear the blob so we don't keep failing on every load.
+    XCTAssertNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+    XCTAssertNil(defaults.data(forKey: key))
+  }
+
+  func testWellFormedJSONWithUnexpectedShapeIsSelfHealed() {
+    // Valid JSON but wrong shape (missing required keys) should also self-heal.
+    let defaults = UserDefaults(suiteName: "Mixpanel")!
+    let key = "mixpanel-\(instanceName!)-MPFlagsCache"
+    let bogus = #"{"unexpected":"shape"}"#.data(using: .utf8)!
+    defaults.set(bogus, forKey: key)
+
+    XCTAssertNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+    XCTAssertNil(defaults.data(forKey: key))
+  }
+
+  // MARK: - Source stamping
+
+  func testWithSourceStampsAndPreservesOtherFields() {
+    let original = MixpanelFlagVariant(
+      key: "k", value: "v", isExperimentActive: true, isQATester: false, experimentID: "exp_1")
+    let stamped = original.withSource(.network)
+
+    XCTAssertEqual(stamped.key, "k")
+    XCTAssertEqual(stamped.value as? String, "v")
+    XCTAssertEqual(stamped.experimentID, "exp_1")
+    XCTAssertEqual(stamped.isExperimentActive, true)
+    XCTAssertEqual(stamped.isQATester, false)
+    if case .network = stamped.source {} else { XCTFail("expected .network source") }
+
+    let cachedAt = Date(timeIntervalSince1970: 1_700_000_000)
+    let cacheStamped = original.withSource(.cache(at: cachedAt))
+    if case .cache(let at) = cacheStamped.source {
+      XCTAssertEqual(at.timeIntervalSince1970, cachedAt.timeIntervalSince1970, accuracy: 0.001)
+    } else {
+      XCTFail("expected .cache source")
+    }
+  }
+
+  func testFallbackVariantsHaveNilSource() {
+    let fallback = MixpanelFlagVariant(value: "default")
+    XCTAssertNil(fallback.source)
+  }
+
+  // MARK: - Init loads cache and stamps variants
+
+  func testInitLoadsCachedVariantsAndStampsCacheSource() throws {
+    // `Date()` (rather than a fixed-far-past timestamp) so the 86_400s TTL check passes.
+    let cachedAt = Date()
+    let context = ["plan": "enterprise"]
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":42},"flag_b":{"variant_key":"v2","variant_value":"hello"}}}"#
+
+    MixpanelPersistence.saveFlagsCache(
+      FlagsCacheBlob(cachedAt: cachedAt, distinctId: "user_a", response: response),
+      instanceName: instanceName)
+
+    let manager = makeManager(
+      distinctId: "user_a", context: context, policy: .cacheFirst(ttl: 86_400))
+
+    waitForTrackingQueue(manager: manager)
+
+    XCTAssertTrue(manager.areFlagsReady())
+    let variants = manager.getAllVariantsSync()
+    XCTAssertEqual(variants.count, 2)
+
+    if case .cache(let at) = variants["flag_a"]?.source {
+      XCTAssertEqual(at.timeIntervalSince1970, cachedAt.timeIntervalSince1970, accuracy: 0.001)
+    } else {
+      XCTFail("flag_a should have .cache source")
+    }
+    XCTAssertEqual(variants["flag_a"]?.value as? Int, 42)
+    XCTAssertEqual(variants["flag_b"]?.value as? String, "hello")
+  }
+
+  func testInitIgnoresCacheOnDistinctIdMismatch() throws {
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+    MixpanelPersistence.saveFlagsCache(
+      FlagsCacheBlob(
+        cachedAt: Date(),
+        distinctId: "different_user",
+        response: response),
+      instanceName: instanceName)
+
+    let manager = makeManager(
+      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
+    waitForTrackingQueue(manager: manager)
+
+    XCTAssertFalse(manager.areFlagsReady(), "distinctId mismatch should leave flags empty")
+    XCTAssertTrue(manager.getAllVariantsSync().isEmpty)
+  }
+
+  /// Documents the deliberate decision to key the cache on distinctId only — context changes
+  /// do NOT invalidate the cached blob. A cache written under one context will load under a
+  /// different context for the same user (in-memory variants will then be stale with respect
+  /// to the new context until the next successful fetch overwrites them).
+  ///
+  /// Customers signaled this tradeoff is acceptable: context rarely flips mid-session in
+  /// practice, and the gain is keeping the cache useful when customers do flip between
+  /// contexts they've used before.
+  func testInitLoadsCacheRegardlessOfContextDifference() throws {
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+    MixpanelPersistence.saveFlagsCache(
+      FlagsCacheBlob(
+        cachedAt: Date(),
+        // Blob originally cached under no context.
+        distinctId: "user_a",
+        response: response),
+      instanceName: instanceName)
+
+    // Manager comes up under a different context for the same user.
+    let manager = makeManager(
+      distinctId: "user_a",
+      context: ["plan": "enterprise"],
+      policy: .cacheFirst(ttl: 86_400))
+    waitForTrackingQueue(manager: manager)
+
+    XCTAssertTrue(
+      manager.areFlagsReady(),
+      "context mismatch must NOT invalidate cache when keyed on distinctId only")
+    XCTAssertEqual(manager.getAllVariantsSync().count, 1)
+  }
+
+  func testInitIgnoresCacheWhenExpired() throws {
+    let oldDate = Date(timeIntervalSinceNow: -86_400 * 7) // 7 days ago
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+    MixpanelPersistence.saveFlagsCache(
+      FlagsCacheBlob(
+        cachedAt: oldDate,
+        distinctId: "user_a",
+        response: response),
+      instanceName: instanceName)
+
+    let manager = makeManager(
+      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 60))  // 60s TTL
+    waitForTrackingQueue(manager: manager)
+
+    XCTAssertFalse(manager.areFlagsReady(), "expired entry should be ignored")
+  }
+
+  func testInitClearsCacheBlobWhenResponseStringIsUnparseable() throws {
+    // Structurally-valid envelope but the `response` string is garbage. Without self-heal
+    // the blob would stick on disk and fail every cold-start. The init-time cache load
+    // should both ignore it AND wipe it.
+    let blob = FlagsCacheBlob(
+      cachedAt: Date(),
+      distinctId: "user_a",
+      response: "this is not json"
+    )
+    MixpanelPersistence.saveFlagsCache(blob, instanceName: instanceName)
+    XCTAssertNotNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+
+    let manager = makeManager(
+      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
+    waitForTrackingQueue(manager: manager)
+
+    XCTAssertFalse(manager.areFlagsReady(), "unparseable response should leave flags empty")
+    XCTAssertNil(
+      MixpanelPersistence.loadFlagsCache(instanceName: instanceName),
+      "blob should be wiped so the next successful fetch gets a clean slate")
+  }
+
+  func testInitDoesNotLoadCacheWhenPolicyIsNetworkOnly() throws {
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+    MixpanelPersistence.saveFlagsCache(
+      FlagsCacheBlob(
+        cachedAt: Date(),
+        distinctId: "user_a",
+        response: response),
+      instanceName: instanceName)
+
+    let manager = makeManager(distinctId: "user_a", context: [:], policy: .networkOnly)
+    waitForTrackingQueue(manager: manager)
+
+    XCTAssertFalse(manager.areFlagsReady(), ".networkOnly must not load from cache")
+  }
+
+  /// Regression test for the init-time race that motivated moving FeatureFlagManager
+  /// construction below `unarchive()` in MixpanelInstance.init.
+  ///
+  /// The async cache-load block reads `delegate.getDistinctId()` at the moment GCD picks it
+  /// up — NOT at the moment FeatureFlagManager.init dispatched it. This test simulates the
+  /// race by:
+  ///   1. Persisting a cache blob keyed to "real_user".
+  ///   2. Constructing the manager with a delegate whose distinctId is "wrong_user" — the
+  ///      cache-load block is queued on a SUSPENDED tracking queue, so it can't run yet.
+  ///   3. Mutating delegate.distinctId to "real_user" (simulating unarchive() loading the
+  ///      persisted identity AFTER FeatureFlagManager init returned).
+  ///   4. Resuming the queue and waiting.
+  /// If the cache load read distinctId at the right time (block-execution, not dispatch),
+  /// flags load successfully. If we'd snapshotted at dispatch time, this would fail.
+  func testCacheLoadReadsDistinctIdAtBlockExecutionNotDispatch() throws {
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+    MixpanelPersistence.saveFlagsCache(
+      FlagsCacheBlob(
+        cachedAt: Date(),
+        distinctId: "real_user",
+        response: response),
+      instanceName: instanceName)
+
+    let delegate = CacheTestMockDelegate(
+      options: MixpanelOptions(
+        token: "test_token",
+        featureFlagOptions: FeatureFlagOptions(
+          enabled: true,
+          variantLookupPolicy: .cacheFirst(ttl: 86_400),
+          cacheVariants: true)),
+      distinctId: "wrong_user")
+    retainedDelegates.append(delegate)
+
+    // Suspend the queue BEFORE the manager init so the cache-load dispatch sits in the queue
+    // without running. Models the worst-case race: GCD couldn't schedule the worker thread
+    // before init's caller continued past the dispatch point.
+    let queue = DispatchQueue(label: "ff.cache.race.test.\(UUID().uuidString)")
+    queue.suspend()
+    let manager = FeatureFlagManager(
+      serverURL: "https://example.test",
+      trackingQueue: queue,
+      instanceName: instanceName,
+      delegate: delegate)
+
+    // "unarchive() finishes" — the persisted identity is now visible via the delegate.
+    delegate.distinctId = "real_user"
+
+    // Let the cache load proceed. The waitForTrackingQueue helper posts a barrier task;
+    // because the queue is serial, the cache-load runs first.
+    queue.resume()
+    waitForTrackingQueue(manager: manager)
+
+    XCTAssertTrue(
+      manager.areFlagsReady(),
+      "cache load should have used the post-mutation distinctId, not the construction-time one")
+    XCTAssertEqual(manager.getAllVariantsSync().count, 1)
+  }
+
+  // MARK: - NetworkFirst gating
+
+  func testNetworkFirstSetsAwaitingFlagWhenCacheLoaded() throws {
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"cached_val"}}}"#
+    MixpanelPersistence.saveFlagsCache(
+      FlagsCacheBlob(
+        cachedAt: Date(),
+        distinctId: "user_a",
+        response: response),
+      instanceName: instanceName)
+
+    let manager = makeManager(
+      distinctId: "user_a", context: [:], policy: .networkFirst(ttl: 86_400))
+    waitForTrackingQueue(manager: manager)
+
+    // Sync lookups + areFlagsReady reflect the cache regardless of policy.
+    XCTAssertTrue(manager.areFlagsReady())
+    var awaitingValue = false
+    manager.flagsLock.read { awaitingValue = manager.awaitingInitialNetworkResponse }
+    XCTAssertTrue(awaitingValue, ".networkFirst must await initial network response")
+  }
+
+  func testCacheFirstDoesNotSetAwaitingFlagWhenCacheLoaded() throws {
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"cached_val"}}}"#
+    MixpanelPersistence.saveFlagsCache(
+      FlagsCacheBlob(
+        cachedAt: Date(),
+        distinctId: "user_a",
+        response: response),
+      instanceName: instanceName)
+
+    let manager = makeManager(
+      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
+    waitForTrackingQueue(manager: manager)
+
+    var awaitingValue = false
+    manager.flagsLock.read { awaitingValue = manager.awaitingInitialNetworkResponse }
+    XCTAssertFalse(awaitingValue, ".cacheFirst must not await initial network response")
+  }
+
+  func testNetworkFirstAsyncLookupAwaitsFetchEvenWithCache() throws {
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"cached_val"}}}"#
+    MixpanelPersistence.saveFlagsCache(
+      FlagsCacheBlob(
+        cachedAt: Date(),
+        distinctId: "user_a",
+        response: response),
+      instanceName: instanceName)
+
+    let mock = makeMockManager(
+      distinctId: "user_a", context: [:], policy: .networkFirst(ttl: 86_400))
+
+    // Configure the mock to "succeed" with new flags, but with a delay that lets us assert
+    // the async lookup waited for the network rather than serving cached values immediately.
+    mock.simulatedFetchResult = (
+      success: true,
+      flags: [
+        "flag_a": MixpanelFlagVariant(key: "v_fresh", value: "network_val")
+      ]
+    )
+    mock.simulatedNetworkDelay = 0.1  // 100ms delay
+
+    waitForTrackingQueue(manager: mock)
+    // Cache should have populated `flags` with .cache stamping. Now async lookup must NOT
+    // serve those cached values — it has to await the network response.
+    let asyncDone = expectation(description: "async lookup completes after network")
+    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+      // The variant served must be the network value, not the cached one.
+      XCTAssertEqual(variant.value as? String, "network_val")
+      if case .network = variant.source {} else {
+        XCTFail("variant served by NetworkFirst should be from .network after fetch")
+      }
+      asyncDone.fulfill()
+    }
+    wait(for: [asyncDone], timeout: 2.0)
+  }
+
+  func testNetworkFirstFallsBackToCacheOnFetchFailure() throws {
+    let cachedAt = Date(timeIntervalSinceNow: -60)  // 60s old, well within TTL
+    let response = #"{"flags":{"flag_a":{"variant_key":"v_cached","variant_value":"cached_val"}}}"#
+    MixpanelPersistence.saveFlagsCache(
+      FlagsCacheBlob(
+        cachedAt: cachedAt,
+        distinctId: "user_a",
+        response: response),
+      instanceName: instanceName)
+
+    let mock = makeMockManager(
+      distinctId: "user_a", context: [:], policy: .networkFirst(ttl: 86_400))
+    mock.simulatedFetchResult = (success: false, flags: nil)
+
+    waitForTrackingQueue(manager: mock)
+
+    let asyncDone = expectation(description: "async lookup completes after fetch failure")
+    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+      // Fetch failed → cached values stay → async lookup serves the cached variant.
+      XCTAssertEqual(variant.value as? String, "cached_val")
+      if case .cache = variant.source {} else {
+        XCTFail("variant served on NetworkFirst failure should keep .cache source")
+      }
+      asyncDone.fulfill()
+    }
+    wait(for: [asyncDone], timeout: 2.0)
+  }
+
+  func testCacheFirstAsyncLookupServesCachedImmediately() throws {
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"cached_val"}}}"#
+    MixpanelPersistence.saveFlagsCache(
+      FlagsCacheBlob(
+        cachedAt: Date(),
+        distinctId: "user_a",
+        response: response),
+      instanceName: instanceName)
+
+    let mock = makeMockManager(
+      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
+    // Configure a slow network so we'd notice if the lookup was waiting on it.
+    mock.simulatedFetchResult = (
+      success: true, flags: ["flag_a": MixpanelFlagVariant(key: "v2", value: "network_val")])
+    mock.simulatedNetworkDelay = 0.1
+
+    waitForTrackingQueue(manager: mock)
+
+    let asyncDone = expectation(description: "async lookup completes")
+    let start = Date()
+    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+      let elapsed = Date().timeIntervalSince(start)
+      XCTAssertEqual(variant.value as? String, "cached_val", "cacheFirst should serve cached")
+      if case .cache = variant.source {} else { XCTFail("expected .cache source") }
+      // Generous bound — just want to confirm we didn't wait on the 100ms simulated network.
+      XCTAssertLessThan(elapsed, 0.08, "cacheFirst should not wait for network")
+      asyncDone.fulfill()
+    }
+    wait(for: [asyncDone], timeout: 1.0)
+  }
+
+  // MARK: - Reset wipes cache
+
+  func testResetWipesDiskCache() throws {
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+    MixpanelPersistence.saveFlagsCache(
+      FlagsCacheBlob(
+        cachedAt: Date(),
+        distinctId: "user_a",
+        response: response),
+      instanceName: instanceName)
+
+    let manager = makeManager(
+      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
+    waitForTrackingQueue(manager: manager)
+
+    XCTAssertNotNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+
+    manager.reset()
+    waitForTrackingQueue(manager: manager)
+
+    XCTAssertNil(
+      MixpanelPersistence.loadFlagsCache(instanceName: instanceName),
+      "reset() should wipe the on-disk cache")
+    XCTAssertFalse(manager.areFlagsReady())
+  }
+
+  /// `setContext` deliberately does NOT clear in-memory variants OR the on-disk cache. The
+  /// cache is keyed on distinctId only, so it remains valid across context changes for the
+  /// same user. The next successful fetch under the new context overwrites the cache.
+  func testSetContextDoesNotWipeCacheOrInMemoryState() throws {
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+    MixpanelPersistence.saveFlagsCache(
+      FlagsCacheBlob(
+        cachedAt: Date(),
+        distinctId: "user_a",
+        response: response),
+      instanceName: instanceName)
+
+    let mock = makeMockManager(
+      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
+    // Make the post-setContext fetch fail so we can isolate setContext's effect — without
+    // a successful overwrite, the blob's survival is solely attributable to setContext
+    // NOT wiping it. The same goes for in-memory state.
+    mock.simulatedFetchResult = (success: false, flags: nil)
+    mock.simulatedNetworkDelay = 0
+    waitForTrackingQueue(manager: mock)
+
+    XCTAssertNotNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+    XCTAssertTrue(mock.areFlagsReady(), "cache load on init should populate flags")
+
+    let setContextDone = expectation(description: "setContext fetch completes")
+    mock.setContext(["plan": "enterprise"]) { setContextDone.fulfill() }
+    wait(for: [setContextDone], timeout: 2.0)
+    waitForTrackingQueue(manager: mock)
+
+    XCTAssertNotNil(
+      MixpanelPersistence.loadFlagsCache(instanceName: instanceName),
+      "setContext must NOT wipe the on-disk cache")
+    XCTAssertTrue(
+      mock.areFlagsReady(),
+      "setContext must NOT clear in-memory variants")
+  }
+
+  // MARK: - Helpers
+
+  private func makeManager(
+    distinctId: String,
+    context: [String: Any],
+    policy: VariantLookupPolicy,
+    cacheVariants: Bool = true
+  ) -> FeatureFlagManager {
+    let delegate = CacheTestMockDelegate(
+      options: MixpanelOptions(
+        token: "test_token",
+        featureFlagOptions: FeatureFlagOptions(
+          enabled: true,
+          context: context,
+          variantLookupPolicy: policy,
+          cacheVariants: cacheVariants)),
+      distinctId: distinctId)
+    retainedDelegates.append(delegate)
+    let queue = DispatchQueue(label: "ff.cache.test.\(UUID().uuidString)")
+    return FeatureFlagManager(
+      serverURL: "https://example.test",
+      trackingQueue: queue,
+      instanceName: instanceName,
+      delegate: delegate)
+  }
+
+  private func makeMockManager(
+    distinctId: String,
+    context: [String: Any],
+    policy: VariantLookupPolicy,
+    cacheVariants: Bool = true
+  ) -> CacheTestMockManager {
+    let delegate = CacheTestMockDelegate(
+      options: MixpanelOptions(
+        token: "test_token",
+        featureFlagOptions: FeatureFlagOptions(
+          enabled: true,
+          context: context,
+          variantLookupPolicy: policy,
+          cacheVariants: cacheVariants)),
+      distinctId: distinctId)
+    retainedDelegates.append(delegate)
+    let queue = DispatchQueue(label: "ff.cache.mock.test.\(UUID().uuidString)")
+    return CacheTestMockManager(
+      serverURL: "https://example.test",
+      trackingQueue: queue,
+      instanceName: instanceName,
+      delegate: delegate)
+  }
+
+  /// Wait for any pending work on the manager's tracking queue (notably the async cache
+  /// load posted from init) to complete by posting a barrier task and blocking on it.
+  private func waitForTrackingQueue(
+    manager: FeatureFlagManager,
+    timeout: TimeInterval = 1.0,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    let done = expectation(description: "tracking queue drained")
+    manager.trackingQueue.async { done.fulfill() }
+    wait(for: [done], timeout: timeout)
+  }
+}

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagCacheTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagCacheTests.swift
@@ -196,6 +196,30 @@ class FeatureFlagCacheTests: XCTestCase {
     XCTAssertNil(fallback.source)
   }
 
+  // MARK: - Default TTL
+
+  /// `VariantLookupPolicy.defaultTTL` is 1 hour, and the zero-arg static factories
+  /// `cacheFirst()` / `networkFirst()` produce cases keyed to that default. This also
+  /// exercises the case-plus-static-func overload pattern (different parameter lists, so
+  /// `.cacheFirst()` and `.cacheFirst(ttl:)` resolve to different members).
+  func testDefaultTTLConvenienceConstructors() throws {
+    XCTAssertEqual(VariantLookupPolicy.defaultTTL, 60 * 60, "default TTL should be 1 hour")
+
+    let convenientCacheFirst = VariantLookupPolicy.cacheFirst()
+    if case .cacheFirst(let ttl) = convenientCacheFirst {
+      XCTAssertEqual(ttl, VariantLookupPolicy.defaultTTL)
+    } else {
+      XCTFail("convenience cacheFirst() should produce .cacheFirst case")
+    }
+
+    let convenientNetworkFirst = VariantLookupPolicy.networkFirst()
+    if case .networkFirst(let ttl) = convenientNetworkFirst {
+      XCTAssertEqual(ttl, VariantLookupPolicy.defaultTTL)
+    } else {
+      XCTFail("convenience networkFirst() should produce .networkFirst case")
+    }
+  }
+
   // MARK: - Init loads cache and stamps variants
 
   func testInitLoadsCachedVariantsAndStampsCacheSource() throws {

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagCacheTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagCacheTests.swift
@@ -9,7 +9,7 @@
 //   - CacheFirst serves cached values immediately
 //   - NetworkFirst awaits the initial network response, falls back on failure
 //   - reset() wipes both in-memory state and the on-disk blob
-//   - cacheVariants=true causes successful fetches to write the blob
+//   - successful fetches write the blob (when policy is .cacheFirst or .networkFirst)
 //
 
 import XCTest
@@ -226,7 +226,10 @@ class FeatureFlagCacheTests: XCTestCase {
     XCTAssertEqual(variants["flag_b"]?.value as? String, "hello")
   }
 
-  func testInitIgnoresCacheOnDistinctIdMismatch() throws {
+  /// distinctId mismatch on init is the cross-session form of "distinctId changed":
+  /// it leaves flags empty AND wipes the stale blob from disk, so the prior identity's
+  /// variants don't sit on this device after the user has moved on.
+  func testInitWipesCacheOnDistinctIdMismatch() throws {
     let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
     MixpanelPersistence.saveFlagsCache(
       FlagsCacheBlob(
@@ -234,6 +237,7 @@ class FeatureFlagCacheTests: XCTestCase {
         distinctId: "different_user",
         response: response),
       instanceName: instanceName)
+    XCTAssertNotNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
 
     let manager = makeManager(
       distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
@@ -241,6 +245,9 @@ class FeatureFlagCacheTests: XCTestCase {
 
     XCTAssertFalse(manager.areFlagsReady(), "distinctId mismatch should leave flags empty")
     XCTAssertTrue(manager.getAllVariantsSync().isEmpty)
+    XCTAssertNil(
+      MixpanelPersistence.loadFlagsCache(instanceName: instanceName),
+      "distinctId mismatch on init should wipe the stale blob")
   }
 
   /// Documents the deliberate decision to key the cache on distinctId only — context changes
@@ -313,7 +320,10 @@ class FeatureFlagCacheTests: XCTestCase {
       "blob should be wiped so the next successful fetch gets a clean slate")
   }
 
-  func testInitDoesNotLoadCacheWhenPolicyIsNetworkOnly() throws {
+  /// `.networkOnly` does two things on init when a stale blob is on disk: (a) doesn't load
+  /// it into memory, and (b) actively wipes it. This way, toggling from a caching policy
+  /// back to `.networkOnly` cleans up the orphaned blob rather than leaving it stranded.
+  func testInitWipesAndDoesNotLoadCacheWhenPolicyIsNetworkOnly() throws {
     let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
     MixpanelPersistence.saveFlagsCache(
       FlagsCacheBlob(
@@ -321,11 +331,15 @@ class FeatureFlagCacheTests: XCTestCase {
         distinctId: "user_a",
         response: response),
       instanceName: instanceName)
+    XCTAssertNotNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
 
     let manager = makeManager(distinctId: "user_a", context: [:], policy: .networkOnly)
     waitForTrackingQueue(manager: manager)
 
     XCTAssertFalse(manager.areFlagsReady(), ".networkOnly must not load from cache")
+    XCTAssertNil(
+      MixpanelPersistence.loadFlagsCache(instanceName: instanceName),
+      ".networkOnly init should wipe a stale blob from a previous caching-policy session")
   }
 
   /// Regression test for the init-time race that motivated moving FeatureFlagManager
@@ -356,8 +370,7 @@ class FeatureFlagCacheTests: XCTestCase {
         token: "test_token",
         featureFlagOptions: FeatureFlagOptions(
           enabled: true,
-          variantLookupPolicy: .cacheFirst(ttl: 86_400),
-          cacheVariants: true)),
+          variantLookupPolicy: .cacheFirst(ttl: 86_400))),
       distinctId: "wrong_user")
     retainedDelegates.append(delegate)
 
@@ -384,6 +397,133 @@ class FeatureFlagCacheTests: XCTestCase {
       manager.areFlagsReady(),
       "cache load should have used the post-mutation distinctId, not the construction-time one")
     XCTAssertEqual(manager.getAllVariantsSync().count, 1)
+  }
+
+  // MARK: - TTL re-check on get
+  //
+  // The TTL is re-checked on every `getVariant`/`getAllVariants` call (not only at init load
+  // time). Once a `.cache(at:)`-stamped variant ages past TTL while sitting in memory, lookups
+  // return the developer fallback rather than the stale value. The on-disk blob is NOT
+  // deleted — the next successful fetch will overwrite it.
+
+  /// A `.cache(at:)`-stamped variant that's older than the configured TTL is treated as
+  /// not-present by `getVariantSync` — the developer fallback is returned instead.
+  func testGetVariantSyncReturnsFallbackForExpiredCachedVariant() throws {
+    let manager = makeManager(
+      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 60))
+    waitForTrackingQueue(manager: manager)
+
+    // Inject an expired cached variant directly into in-memory state. Bypasses the disk
+    // load path so we can test the get-time TTL check in isolation. cachedAt is 1 hour ago,
+    // well past the 60s TTL configured above.
+    let expired = MixpanelFlagVariant(key: "v1", value: "stale_value")
+      .withSource(.cache(at: Date(timeIntervalSinceNow: -3600)))
+    manager.flagsLock.write {
+      manager.flags = ["flag_a": expired]
+    }
+
+    let fallback = MixpanelFlagVariant(key: "fb", value: "fallback_value")
+    let result = manager.getVariantSync("flag_a", fallback: fallback)
+
+    XCTAssertEqual(result.value as? String, "fallback_value")
+    XCTAssertNil(result.source, "fallback variant has nil source")
+  }
+
+  /// A `.cache(at:)`-stamped variant within TTL is served as-is (with `.cache` source preserved).
+  func testGetVariantSyncReturnsFreshCachedVariant() throws {
+    let manager = makeManager(
+      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
+    waitForTrackingQueue(manager: manager)
+
+    let fresh = MixpanelFlagVariant(key: "v1", value: "fresh_value")
+      .withSource(.cache(at: Date(timeIntervalSinceNow: -60)))
+    manager.flagsLock.write {
+      manager.flags = ["flag_a": fresh]
+    }
+
+    let fallback = MixpanelFlagVariant(key: "fb", value: "fallback_value")
+    let result = manager.getVariantSync("flag_a", fallback: fallback)
+
+    XCTAssertEqual(result.value as? String, "fresh_value")
+    if case .cache = result.source {} else { XCTFail("expected .cache source preserved") }
+  }
+
+  /// `.network`-stamped variants are never expired regardless of how old they are — TTL only
+  /// applies to `.cache(at:)` variants.
+  func testGetVariantSyncReturnsNetworkVariantRegardlessOfAge() throws {
+    let manager = makeManager(
+      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 60))
+    waitForTrackingQueue(manager: manager)
+
+    // .network variants don't carry a timestamp, so the TTL check should always return false.
+    let networkVariant = MixpanelFlagVariant(key: "v1", value: "from_network")
+      .withSource(.network)
+    manager.flagsLock.write {
+      manager.flags = ["flag_a": networkVariant]
+    }
+
+    let fallback = MixpanelFlagVariant(key: "fb", value: "fallback_value")
+    let result = manager.getVariantSync("flag_a", fallback: fallback)
+    XCTAssertEqual(result.value as? String, "from_network")
+  }
+
+  /// `getAllVariantsSync` filters out expired cached variants but keeps `.network` variants
+  /// and unexpired `.cache(at:)` variants.
+  func testGetAllVariantsSyncFiltersExpiredCachedVariants() throws {
+    let manager = makeManager(
+      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 60))
+    waitForTrackingQueue(manager: manager)
+
+    let expired = MixpanelFlagVariant(key: "v1", value: "stale")
+      .withSource(.cache(at: Date(timeIntervalSinceNow: -3600)))
+    let fresh = MixpanelFlagVariant(key: "v2", value: "ok")
+      .withSource(.cache(at: Date(timeIntervalSinceNow: -10)))
+    let networkSourced = MixpanelFlagVariant(key: "v3", value: "from_network")
+      .withSource(.network)
+
+    manager.flagsLock.write {
+      manager.flags = [
+        "expired_flag": expired,
+        "fresh_flag": fresh,
+        "network_flag": networkSourced,
+      ]
+    }
+
+    let result = manager.getAllVariantsSync()
+    XCTAssertEqual(result.count, 2)
+    XCTAssertNil(result["expired_flag"], "expired flag should be filtered out")
+    XCTAssertNotNil(result["fresh_flag"])
+    XCTAssertNotNil(result["network_flag"])
+  }
+
+  /// The on-disk blob is NOT deleted when an in-memory variant expires at get-time.
+  /// Per the rule: "no harm in keeping. Will likely be overwritten shortly after."
+  func testExpiredVariantOnGetVariantDoesNotWipeDiskCache() throws {
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"v"}}}"#
+    let blob = FlagsCacheBlob(cachedAt: Date(), distinctId: "user_a", response: response)
+    MixpanelPersistence.saveFlagsCache(blob, instanceName: instanceName)
+
+    let manager = makeManager(
+      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
+    waitForTrackingQueue(manager: manager)
+    XCTAssertNotNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+
+    // Force the in-memory variant to be expired without wiping the disk blob.
+    let expired = MixpanelFlagVariant(key: "v1", value: "stale")
+      .withSource(.cache(at: Date(timeIntervalSinceNow: -90_000)))  // > 86_400s TTL
+    manager.flagsLock.write {
+      manager.flags = ["flag_a": expired]
+    }
+
+    let fallback = MixpanelFlagVariant(key: "fb", value: "fb")
+    let result = manager.getVariantSync("flag_a", fallback: fallback)
+    XCTAssertEqual(result.value as? String, "fb")
+
+    // Critical: blob persists. The next successful fetch overwrites it; this lookup didn't
+    // delete it.
+    XCTAssertNotNil(
+      MixpanelPersistence.loadFlagsCache(instanceName: instanceName),
+      "expired-on-get must NOT wipe the on-disk blob")
   }
 
   // MARK: - NetworkFirst gating
@@ -590,8 +730,7 @@ class FeatureFlagCacheTests: XCTestCase {
   private func makeManager(
     distinctId: String,
     context: [String: Any],
-    policy: VariantLookupPolicy,
-    cacheVariants: Bool = true
+    policy: VariantLookupPolicy
   ) -> FeatureFlagManager {
     let delegate = CacheTestMockDelegate(
       options: MixpanelOptions(
@@ -599,8 +738,7 @@ class FeatureFlagCacheTests: XCTestCase {
         featureFlagOptions: FeatureFlagOptions(
           enabled: true,
           context: context,
-          variantLookupPolicy: policy,
-          cacheVariants: cacheVariants)),
+          variantLookupPolicy: policy)),
       distinctId: distinctId)
     retainedDelegates.append(delegate)
     let queue = DispatchQueue(label: "ff.cache.test.\(UUID().uuidString)")
@@ -614,8 +752,7 @@ class FeatureFlagCacheTests: XCTestCase {
   private func makeMockManager(
     distinctId: String,
     context: [String: Any],
-    policy: VariantLookupPolicy,
-    cacheVariants: Bool = true
+    policy: VariantLookupPolicy
   ) -> CacheTestMockManager {
     let delegate = CacheTestMockDelegate(
       options: MixpanelOptions(
@@ -623,8 +760,7 @@ class FeatureFlagCacheTests: XCTestCase {
         featureFlagOptions: FeatureFlagOptions(
           enabled: true,
           context: context,
-          variantLookupPolicy: policy,
-          cacheVariants: cacheVariants)),
+          variantLookupPolicy: policy)),
       distinctId: distinctId)
     retainedDelegates.append(delegate)
     let queue = DispatchQueue(label: "ff.cache.mock.test.\(UUID().uuidString)")

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
@@ -197,9 +197,11 @@ class FeatureFlagPersistenceTests: XCTestCase {
     }
   }
 
-  func testFallbackVariantsHaveNilSource() {
+  func testFallbackVariantsHaveFallbackSource() {
     let fallback = MixpanelFlagVariant(value: "default")
-    XCTAssertNil(fallback.source)
+    if case .fallback = fallback.source {} else {
+      XCTFail("developer-supplied variants should carry .fallback source")
+    }
   }
 
   // MARK: - Default TTL
@@ -459,7 +461,9 @@ class FeatureFlagPersistenceTests: XCTestCase {
     let result = manager.getVariantSync("flag_a", fallback: fallback)
 
     XCTAssertEqual(result.value as? String, "fallback_value")
-    XCTAssertNil(result.source, "fallback variant has nil source")
+    if case .fallback = result.source {} else {
+      XCTFail("served fallback should carry .fallback source")
+    }
   }
 
   /// A `.persistence(persistedAt:)`-stamped variant within TTL is served as-is (with

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
@@ -70,6 +70,11 @@ private final class PersistenceTestMockManager: FeatureFlagManager {
         let stamped = flags.mapValues { $0.withSource(.network) }
         self.flagsLock.write {
           self.flags = stamped
+          self.loadedBlobPersistedAt = nil
+          // Mirror production: clear the per-flag $experiment_started dedup window on every
+          // successful fetch so a flag whose variant changed between fetches re-fires
+          // tracking on the next lookup.
+          self.trackedFeatures.removeAll()
           self.awaitingInitialNetworkResponse = false
           self.timeLastFetched = Date()
         }
@@ -1172,6 +1177,88 @@ class FeatureFlagPersistenceTests: XCTestCase {
     XCTAssertEqual(props["$variant_source"] as? String, "network")
     XCTAssertNil(props["$persisted_at_in_ms"], "network variants don't carry persistedAt")
     XCTAssertNil(props["$ttl_in_ms"], "network variants don't carry TTL")
+  }
+
+  // MARK: - Tracking dedup window resets after every successful fetch
+
+  /// Regression test mirroring mixpanel-android's
+  /// `testTracking_getVariantSync_refireAfterSuccessfulRefetch`.
+  ///
+  /// The per-flag `trackedFeatures` set deduplicates `$experiment_started` within a fetch
+  /// round, but must clear on every successful refetch so a second fetch round gets a fresh
+  /// shot at firing tracking — even when the variant value didn't change. Without the clear,
+  /// a flag whose value flipped between fetches (persisted "control" → network "treatment")
+  /// would serve the new value but skip tracking, leaving Mixpanel analytics permanently
+  /// tied to the prior exposure.
+  func testTrackingRefiresAfterSuccessfulRefetch() throws {
+    let delegate = PersistenceTestMockDelegate(
+      options: MixpanelOptions(
+        token: "test_token",
+        featureFlagOptions: FeatureFlagOptions(
+          enabled: true,
+          variantLookupPolicy: .networkOnly)),
+      distinctId: "user_a")
+    retainedDelegates.append(delegate)
+    let queue = DispatchQueue(label: "ff.refire.test.\(UUID().uuidString)")
+    let mock = PersistenceTestMockManager(
+      serverURL: "https://example.test",
+      trackingQueue: queue,
+      instanceName: instanceName,
+      delegate: delegate)
+    waitForTrackingQueue(manager: mock)
+
+    // ── Fetch round 1: server returns flag_X = variant_A. ──
+    mock.simulatedFetchResult = (
+      success: true,
+      flags: ["flag_x": MixpanelFlagVariant(key: "variant_a", value: "value_a")]
+    )
+    mock.simulatedNetworkDelay = 0
+    let firstFetchDone = expectation(description: "first fetch completes")
+    mock.loadFlags(completion: { _ in firstFetchDone.fulfill() })
+    wait(for: [firstFetchDone], timeout: 2.0)
+
+    let fallback = MixpanelFlagVariant(key: "fb", value: "fb_value")
+
+    // First lookup → tracks once.
+    _ = mock.getVariantSync("flag_x", fallback: fallback)
+    waitForMainAndTracking(manager: mock)
+    XCTAssertEqual(
+      delegate.snapshotTrackedEvents().filter { $0.event == "$experiment_started" }.count, 1,
+      "first lookup should fire $experiment_started exactly once")
+
+    // Second lookup in the same fetch round → still 1 (dedup intact).
+    _ = mock.getVariantSync("flag_x", fallback: fallback)
+    waitForMainAndTracking(manager: mock)
+    XCTAssertEqual(
+      delegate.snapshotTrackedEvents().filter { $0.event == "$experiment_started" }.count, 1,
+      "repeat lookup in the same fetch round must not re-fire (dedup window)")
+
+    // ── Fetch round 2: server returns the SAME variant — proves we're testing the
+    //    dedup-clearing behavior, not a value-change-detection behavior. ──
+    mock.simulatedFetchResult = (
+      success: true,
+      flags: ["flag_x": MixpanelFlagVariant(key: "variant_a", value: "value_a")]
+    )
+    let secondFetchDone = expectation(description: "second fetch completes")
+    mock.loadFlags(completion: { _ in secondFetchDone.fulfill() })
+    wait(for: [secondFetchDone], timeout: 2.0)
+
+    // Lookup after refetch → fires again (dedup window reset).
+    _ = mock.getVariantSync("flag_x", fallback: fallback)
+    waitForMainAndTracking(manager: mock)
+    XCTAssertEqual(
+      delegate.snapshotTrackedEvents().filter { $0.event == "$experiment_started" }.count, 2,
+      "successful refetch should clear the dedup window so the next lookup re-fires")
+  }
+
+  /// `waitForTrackingQueue` only drains the tracking queue. Tracking-event recording goes
+  /// through `DispatchQueue.main.async` after the tracking queue, so we need to drain main
+  /// too to observe the recorded events.
+  private func waitForMainAndTracking(manager: FeatureFlagManager) {
+    waitForTrackingQueue(manager: manager)
+    let mainDrained = expectation(description: "main queue drained")
+    DispatchQueue.main.async { mainDrained.fulfill() }
+    wait(for: [mainDrained], timeout: 1.0)
   }
 
   // MARK: - Helpers

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
@@ -6,10 +6,10 @@
 //   - Persistence round-trip + self-healing on malformed blobs
 //   - distinctId and TTL validation
 //   - Init loads persisted blob and stamps variants with .persistence(persistedAt:)
-//   - PersistenceFirst serves persisted values immediately
+//   - PersistenceUntilNetworkSuccess serves persisted values immediately
 //   - NetworkFirst awaits the initial network response, falls back on failure
 //   - reset() wipes both in-memory state and the on-disk blob
-//   - successful fetches write the blob (when policy is .persistenceFirst or .networkFirst)
+//   - successful fetches write the blob (when policy is .persistenceUntilNetworkSuccess or .networkFirst)
 //   - $experiment_started includes $variant_source / $persisted_at_in_ms / $ttl_in_ms when
 //     the served variant came from the persistence layer
 //
@@ -207,17 +207,17 @@ class FeatureFlagPersistenceTests: XCTestCase {
   // MARK: - Default TTL
 
   /// `VariantLookupPolicy.defaultTTL` is 24 hours, and the zero-arg static factories
-  /// `persistenceFirst()` / `networkFirst()` produce cases keyed to that default. This also
+  /// `persistenceUntilNetworkSuccess()` / `networkFirst()` produce cases keyed to that default. This also
   /// exercises the case-plus-static-func overload pattern (different parameter lists, so
-  /// `.persistenceFirst()` and `.persistenceFirst(ttl:)` resolve to different members).
+  /// `.persistenceUntilNetworkSuccess()` and `.persistenceUntilNetworkSuccess(ttl:)` resolve to different members).
   func testDefaultTTLConvenienceConstructors() throws {
     XCTAssertEqual(VariantLookupPolicy.defaultTTL, 24 * 60 * 60, "default TTL should be 24 hours")
 
-    let convenientPersistenceFirst = VariantLookupPolicy.persistenceFirst()
-    if case .persistenceFirst(let ttl) = convenientPersistenceFirst {
+    let convenientPersistenceUntilNetworkSuccess = VariantLookupPolicy.persistenceUntilNetworkSuccess()
+    if case .persistenceUntilNetworkSuccess(let ttl) = convenientPersistenceUntilNetworkSuccess {
       XCTAssertEqual(ttl, VariantLookupPolicy.defaultTTL)
     } else {
-      XCTFail("convenience persistenceFirst() should produce .persistenceFirst case")
+      XCTFail("convenience persistenceUntilNetworkSuccess() should produce .persistenceUntilNetworkSuccess case")
     }
 
     let convenientNetworkFirst = VariantLookupPolicy.networkFirst()
@@ -241,7 +241,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
       instanceName: instanceName)
 
     let manager = makeManager(
-      distinctId: "user_a", context: context, policy: .persistenceFirst(ttl: 86_400))
+      distinctId: "user_a", context: context, policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
 
     waitForTrackingQueue(manager: manager)
 
@@ -272,7 +272,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
     XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
     waitForTrackingQueue(manager: manager)
 
     XCTAssertFalse(manager.areFlagsReady(), "distinctId mismatch should leave flags empty")
@@ -304,7 +304,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
     let manager = makeManager(
       distinctId: "user_a",
       context: ["plan": "enterprise"],
-      policy: .persistenceFirst(ttl: 86_400))
+      policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
     waitForTrackingQueue(manager: manager)
 
     XCTAssertTrue(
@@ -324,7 +324,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
       instanceName: instanceName)
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 60))  // 60s TTL
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 60))  // 60s TTL
     waitForTrackingQueue(manager: manager)
 
     XCTAssertFalse(manager.areFlagsReady(), "expired entry should be ignored")
@@ -343,7 +343,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
     XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
     waitForTrackingQueue(manager: manager)
 
     XCTAssertFalse(manager.areFlagsReady(), "unparseable response should leave flags empty")
@@ -403,7 +403,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
         token: "test_token",
         featureFlagOptions: FeatureFlagOptions(
           enabled: true,
-          variantLookupPolicy: .persistenceFirst(ttl: 86_400))),
+          variantLookupPolicy: .persistenceUntilNetworkSuccess(ttl: 86_400))),
       distinctId: "wrong_user")
     retainedDelegates.append(delegate)
 
@@ -443,7 +443,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// treated as not-present by `getVariantSync` — the developer fallback is returned instead.
   func testGetVariantSyncReturnsFallbackForExpiredPersistedVariant() throws {
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 60))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 60))
     waitForTrackingQueue(manager: manager)
 
     // Inject an expired persisted variant directly into in-memory state. Bypasses the disk
@@ -470,7 +470,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// `.persistence` source preserved).
   func testGetVariantSyncReturnsFreshPersistedVariant() throws {
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
     waitForTrackingQueue(manager: manager)
 
     let persistedAt = Date(timeIntervalSinceNow: -60)
@@ -494,7 +494,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// applies to `.persistence(persistedAt:)` variants.
   func testGetVariantSyncReturnsNetworkVariantRegardlessOfAge() throws {
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 60))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 60))
     waitForTrackingQueue(manager: manager)
 
     // .network variants don't carry a timestamp, so the TTL check should always return false.
@@ -516,7 +516,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// the TTL check together.
   func testGetAllVariantsSyncFiltersPersistedVariantsWhenBlobIsStale() throws {
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 60))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 60))
     waitForTrackingQueue(manager: manager)
 
     let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
@@ -552,7 +552,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
     MixpanelPersistence.saveFlagsPersistence(blob, instanceName: instanceName)
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
     waitForTrackingQueue(manager: manager)
     XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
@@ -598,7 +598,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
     XCTAssertTrue(awaitingValue, ".networkFirst must await initial network response")
   }
 
-  func testPersistenceFirstDoesNotSetAwaitingFlagWhenPersistenceLoaded() throws {
+  func testPersistenceUntilNetworkSuccessDoesNotSetAwaitingFlagWhenPersistenceLoaded() throws {
     let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"persisted_val"}}}"#
     MixpanelPersistence.saveFlagsPersistence(
       FlagsPersistenceBlob(
@@ -608,12 +608,12 @@ class FeatureFlagPersistenceTests: XCTestCase {
       instanceName: instanceName)
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
     waitForTrackingQueue(manager: manager)
 
     var awaitingValue = false
     manager.flagsLock.read { awaitingValue = manager.awaitingInitialNetworkResponse }
-    XCTAssertFalse(awaitingValue, ".persistenceFirst must not await initial network response")
+    XCTAssertFalse(awaitingValue, ".persistenceUntilNetworkSuccess must not await initial network response")
   }
 
   func testNetworkFirstAsyncLookupAwaitsFetchEvenWithPersistence() throws {
@@ -682,7 +682,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
     wait(for: [asyncDone], timeout: 2.0)
   }
 
-  func testPersistenceFirstAsyncLookupServesPersistedImmediately() throws {
+  func testPersistenceUntilNetworkSuccessAsyncLookupServesPersistedImmediately() throws {
     let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"persisted_val"}}}"#
     MixpanelPersistence.saveFlagsPersistence(
       FlagsPersistenceBlob(
@@ -692,7 +692,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
       instanceName: instanceName)
 
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
     // Configure a slow network so we'd notice if the lookup was waiting on it.
     mock.simulatedFetchResult = (
       success: true, flags: ["flag_a": MixpanelFlagVariant(key: "v2", value: "network_val")])
@@ -705,10 +705,10 @@ class FeatureFlagPersistenceTests: XCTestCase {
     mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
       let elapsed = Date().timeIntervalSince(start)
       XCTAssertEqual(
-        variant.value as? String, "persisted_val", "persistenceFirst should serve persisted")
+        variant.value as? String, "persisted_val", "persistenceUntilNetworkSuccess should serve persisted")
       if case .persistence = variant.source {} else { XCTFail("expected .persistence source") }
       // Generous bound — just want to confirm we didn't wait on the 100ms simulated network.
-      XCTAssertLessThan(elapsed, 0.08, "persistenceFirst should not wait for network")
+      XCTAssertLessThan(elapsed, 0.08, "persistenceUntilNetworkSuccess should not wait for network")
       asyncDone.fulfill()
     }
     wait(for: [asyncDone], timeout: 1.0)
@@ -726,7 +726,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
       instanceName: instanceName)
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
     waitForTrackingQueue(manager: manager)
 
     XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
@@ -753,7 +753,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
       instanceName: instanceName)
 
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
     // Make the post-setContext fetch fail so we can isolate setContext's effect — without
     // a successful overwrite, the blob's survival is solely attributable to setContext
     // NOT wiping it. The same goes for in-memory state.
@@ -789,7 +789,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// the developer fallback.
   func testGetVariantAsyncTriggersFetchWhenLoadedBlobIsStale() throws {
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 60))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 60))
     waitForTrackingQueue(manager: mock)
 
     // Inject an expired persisted variant directly. Bypasses the disk-load path so we can
@@ -828,7 +828,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// resurrect stale values just because the network was unavailable.
   func testGetVariantAsyncReturnsFallbackWhenStaleBlobAndFetchFails() throws {
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 60))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 60))
     waitForTrackingQueue(manager: mock)
 
     let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
@@ -854,7 +854,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// than returning an empty (post-filter) dictionary without attempting refresh.
   func testGetAllVariantsAsyncTriggersFetchWhenLoadedBlobIsStale() throws {
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 60))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 60))
     waitForTrackingQueue(manager: mock)
 
     let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
@@ -892,7 +892,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// we trust that.
   func testGetVariantAsyncServesFallbackOnEmptyFreshBlobWithoutRefresh() throws {
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
     waitForTrackingQueue(manager: mock)
 
     let freshPersistedAt = Date(timeIntervalSinceNow: -60)  // well within TTL
@@ -925,7 +925,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// variants to check, but its persistedAt still tells us when to give up on the cache.
   func testGetVariantAsyncTriggersFetchWhenEmptyBlobIsStale() throws {
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 60))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 60))
     waitForTrackingQueue(manager: mock)
 
     let stalePersistedAt = Date(timeIntervalSinceNow: -3600)  // well past 60s TTL
@@ -955,7 +955,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// network round-trip.
   func testGetVariantAsyncServesFreshPersistedImmediatelyWithoutFetch() throws {
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
     waitForTrackingQueue(manager: mock)
 
     let freshPersistedAt = Date(timeIntervalSinceNow: -60)
@@ -1001,7 +1001,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
     let persistedAt = Date(timeIntervalSinceNow: -60)  // 60s ago
     let ttlSeconds: TimeInterval = 86_400  // 24 hours
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: ttlSeconds))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: ttlSeconds))
     waitForTrackingQueue(manager: manager)
     let delegate = retainedDelegates.last as! PersistenceTestMockDelegate
 

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
@@ -447,10 +447,12 @@ class FeatureFlagPersistenceTests: XCTestCase {
     // Inject an expired persisted variant directly into in-memory state. Bypasses the disk
     // load path so we can test the get-time TTL check in isolation. persistedAt is 1 hour
     // ago, well past the 60s TTL configured above.
+    let persistedAt = Date(timeIntervalSinceNow: -3600)
     let expired = MixpanelFlagVariant(key: "v1", value: "stale_value")
-      .withSource(.persistence(persistedAt: Date(timeIntervalSinceNow: -3600)))
+      .withSource(.persistence(persistedAt: persistedAt))
     manager.flagsLock.write {
       manager.flags = ["flag_a": expired]
+      manager.loadedBlobPersistedAt = persistedAt
     }
 
     let fallback = MixpanelFlagVariant(key: "fb", value: "fallback_value")
@@ -467,10 +469,12 @@ class FeatureFlagPersistenceTests: XCTestCase {
       distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
     waitForTrackingQueue(manager: manager)
 
+    let persistedAt = Date(timeIntervalSinceNow: -60)
     let fresh = MixpanelFlagVariant(key: "v1", value: "fresh_value")
-      .withSource(.persistence(persistedAt: Date(timeIntervalSinceNow: -60)))
+      .withSource(.persistence(persistedAt: persistedAt))
     manager.flagsLock.write {
       manager.flags = ["flag_a": fresh]
+      manager.loadedBlobPersistedAt = persistedAt
     }
 
     let fallback = MixpanelFlagVariant(key: "fb", value: "fallback_value")
@@ -501,33 +505,39 @@ class FeatureFlagPersistenceTests: XCTestCase {
     XCTAssertEqual(result.value as? String, "from_network")
   }
 
-  /// `getAllVariantsSync` filters out expired persisted variants but keeps `.network`
-  /// variants and unexpired `.persistence(persistedAt:)` variants.
-  func testGetAllVariantsSyncFiltersExpiredPersistedVariants() throws {
+  /// When the loaded persisted blob is past TTL, `getAllVariantsSync` filters out all
+  /// `.persistence` variants but keeps `.network` variants (e.g., activated first-time
+  /// events that were promoted to network source mid-session). Documents the blob-level
+  /// expiry rule: all `.persistence` variants share `persistedAt`, so they pass-or-fail
+  /// the TTL check together.
+  func testGetAllVariantsSyncFiltersPersistedVariantsWhenBlobIsStale() throws {
     let manager = makeManager(
       distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 60))
     waitForTrackingQueue(manager: manager)
 
-    let expired = MixpanelFlagVariant(key: "v1", value: "stale")
-      .withSource(.persistence(persistedAt: Date(timeIntervalSinceNow: -3600)))
-    let fresh = MixpanelFlagVariant(key: "v2", value: "ok")
-      .withSource(.persistence(persistedAt: Date(timeIntervalSinceNow: -10)))
+    let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
+    let stalePersistedA = MixpanelFlagVariant(key: "v1", value: "stale_a")
+      .withSource(.persistence(persistedAt: stalePersistedAt))
+    let stalePersistedB = MixpanelFlagVariant(key: "v2", value: "stale_b")
+      .withSource(.persistence(persistedAt: stalePersistedAt))
     let networkSourced = MixpanelFlagVariant(key: "v3", value: "from_network")
       .withSource(.network)
 
     manager.flagsLock.write {
       manager.flags = [
-        "expired_flag": expired,
-        "fresh_flag": fresh,
+        "stale_flag_a": stalePersistedA,
+        "stale_flag_b": stalePersistedB,
         "network_flag": networkSourced,
       ]
+      manager.loadedBlobPersistedAt = stalePersistedAt
     }
 
     let result = manager.getAllVariantsSync()
-    XCTAssertEqual(result.count, 2)
-    XCTAssertNil(result["expired_flag"], "expired flag should be filtered out")
-    XCTAssertNotNil(result["fresh_flag"])
-    XCTAssertNotNil(result["network_flag"])
+    XCTAssertEqual(result.count, 1)
+    XCTAssertNil(result["stale_flag_a"], "stale persisted variant should be filtered out")
+    XCTAssertNil(result["stale_flag_b"], "stale persisted variant should be filtered out")
+    XCTAssertNotNil(
+      result["network_flag"], ".network variants survive blob expiration (e.g., activated FTEs)")
   }
 
   /// The on-disk blob is NOT deleted when an in-memory variant expires at get-time.
@@ -543,10 +553,12 @@ class FeatureFlagPersistenceTests: XCTestCase {
     XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
     // Force the in-memory variant to be expired without wiping the disk blob.
+    let stalePersistedAt = Date(timeIntervalSinceNow: -90_000)  // > 86_400s TTL
     let expired = MixpanelFlagVariant(key: "v1", value: "stale")
-      .withSource(.persistence(persistedAt: Date(timeIntervalSinceNow: -90_000)))  // > 86_400s TTL
+      .withSource(.persistence(persistedAt: stalePersistedAt))
     manager.flagsLock.write {
       manager.flags = ["flag_a": expired]
+      manager.loadedBlobPersistedAt = stalePersistedAt
     }
 
     let fallback = MixpanelFlagVariant(key: "fb", value: "fb")
@@ -761,6 +773,218 @@ class FeatureFlagPersistenceTests: XCTestCase {
       "setContext must NOT clear in-memory variants")
   }
 
+  // MARK: - Async lookups refresh when loaded blob is stale
+  //
+  // When a persisting policy is in effect and the loaded persisted blob has aged past TTL
+  // mid-session, the async getVariant / getAllVariants paths must fall through to a network
+  // fetch rather than silently serving the developer fallback or an empty dict. The blob
+  // shares a single `persistedAt`, so any one expired entry decides for the whole set.
+
+  /// `getVariant(completion:)` triggers a fetch when the in-memory persisted variant for the
+  /// requested flag has aged past TTL, and serves the post-fetch (network) value rather than
+  /// the developer fallback.
+  func testGetVariantAsyncTriggersFetchWhenLoadedBlobIsStale() throws {
+    let mock = makeMockManager(
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 60))
+    waitForTrackingQueue(manager: mock)
+
+    // Inject an expired persisted variant directly. Bypasses the disk-load path so we can
+    // pin the staleness without depending on init timing.
+    let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
+    let expired = MixpanelFlagVariant(key: "v_old", value: "stale_val")
+      .withSource(.persistence(persistedAt: stalePersistedAt))
+    mock.flagsLock.write {
+      mock.flags = ["flag_a": expired]
+      mock.loadedBlobPersistedAt = stalePersistedAt
+    }
+
+    // Mock the refresh response so we can confirm the served value came from the network.
+    mock.simulatedFetchResult = (
+      success: true,
+      flags: ["flag_a": MixpanelFlagVariant(key: "v_fresh", value: "network_val")]
+    )
+    mock.simulatedNetworkDelay = 0
+
+    let asyncDone = expectation(description: "async lookup completes after refresh")
+    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+      XCTAssertEqual(
+        variant.value as? String, "network_val",
+        "stale persisted blob should trigger fetch and serve the network value")
+      if case .network = variant.source {} else {
+        XCTFail("post-fetch variant should carry .network source")
+      }
+      asyncDone.fulfill()
+    }
+    wait(for: [asyncDone], timeout: 2.0)
+  }
+
+  /// When the loaded blob is stale and the refresh fails, async getVariant serves the
+  /// developer fallback (the stale persisted value is filtered by `_getVariantSyncImpl`'s
+  /// per-variant TTL check). This documents the post-fix tolerance: we fetch, but we don't
+  /// resurrect stale values just because the network was unavailable.
+  func testGetVariantAsyncReturnsFallbackWhenStaleBlobAndFetchFails() throws {
+    let mock = makeMockManager(
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 60))
+    waitForTrackingQueue(manager: mock)
+
+    let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
+    let expired = MixpanelFlagVariant(key: "v_old", value: "stale_val")
+      .withSource(.persistence(persistedAt: stalePersistedAt))
+    mock.flagsLock.write {
+      mock.flags = ["flag_a": expired]
+      mock.loadedBlobPersistedAt = stalePersistedAt
+    }
+
+    mock.simulatedFetchResult = (success: false, flags: nil)
+    mock.simulatedNetworkDelay = 0
+
+    let asyncDone = expectation(description: "async lookup completes after failed refresh")
+    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback_val")) { variant in
+      XCTAssertEqual(variant.value as? String, "fallback_val")
+      asyncDone.fulfill()
+    }
+    wait(for: [asyncDone], timeout: 2.0)
+  }
+
+  /// `getAllVariants(completion:)` triggers a fetch when the loaded blob is stale rather
+  /// than returning an empty (post-filter) dictionary without attempting refresh.
+  func testGetAllVariantsAsyncTriggersFetchWhenLoadedBlobIsStale() throws {
+    let mock = makeMockManager(
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 60))
+    waitForTrackingQueue(manager: mock)
+
+    let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
+    let expiredA = MixpanelFlagVariant(key: "v1", value: "stale_a")
+      .withSource(.persistence(persistedAt: stalePersistedAt))
+    let expiredB = MixpanelFlagVariant(key: "v2", value: "stale_b")
+      .withSource(.persistence(persistedAt: stalePersistedAt))
+    mock.flagsLock.write {
+      mock.flags = ["flag_a": expiredA, "flag_b": expiredB]
+      mock.loadedBlobPersistedAt = stalePersistedAt
+    }
+
+    mock.simulatedFetchResult = (
+      success: true,
+      flags: [
+        "flag_a": MixpanelFlagVariant(key: "v1f", value: "fresh_a"),
+        "flag_b": MixpanelFlagVariant(key: "v2f", value: "fresh_b"),
+      ]
+    )
+    mock.simulatedNetworkDelay = 0
+
+    let asyncDone = expectation(description: "async getAll completes after refresh")
+    mock.getAllVariants { variants in
+      XCTAssertEqual(variants.count, 2)
+      XCTAssertEqual(variants["flag_a"]?.value as? String, "fresh_a")
+      XCTAssertEqual(variants["flag_b"]?.value as? String, "fresh_b")
+      asyncDone.fulfill()
+    }
+    wait(for: [asyncDone], timeout: 2.0)
+  }
+
+  /// An empty persisted blob within TTL is treated as a valid state: serve the developer
+  /// fallback, no network refresh. The customer is opting into "use cached flags," and
+  /// the cache says "no flags configured at the time it was written" — until TTL elapses,
+  /// we trust that.
+  func testGetVariantAsyncServesFallbackOnEmptyFreshBlobWithoutRefresh() throws {
+    let mock = makeMockManager(
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
+    waitForTrackingQueue(manager: mock)
+
+    let freshPersistedAt = Date(timeIntervalSinceNow: -60)  // well within TTL
+    mock.flagsLock.write {
+      mock.flags = [:]
+      mock.loadedBlobPersistedAt = freshPersistedAt
+    }
+
+    // Configure a recognizable network response. If the staleness check wrongly triggers
+    // a fetch, the served value would be "should_not_be_served".
+    mock.simulatedFetchResult = (
+      success: true,
+      flags: ["flag_a": MixpanelFlagVariant(key: "v1", value: "should_not_be_served")]
+    )
+    mock.simulatedNetworkDelay = 0
+
+    let asyncDone = expectation(description: "async lookup completes without refresh")
+    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+      XCTAssertEqual(
+        variant.value as? String, "fallback",
+        "empty fresh blob should serve fallback without auto-refreshing")
+      asyncDone.fulfill()
+    }
+    wait(for: [asyncDone], timeout: 2.0)
+  }
+
+  /// An empty persisted blob PAST TTL still triggers a fetch — the TTL governs when to
+  /// refresh regardless of whether the blob has flags in it. This is exactly why we keep
+  /// `loadedBlobPersistedAt` separate from variant inspection: an empty blob has no
+  /// variants to check, but its persistedAt still tells us when to give up on the cache.
+  func testGetVariantAsyncTriggersFetchWhenEmptyBlobIsStale() throws {
+    let mock = makeMockManager(
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 60))
+    waitForTrackingQueue(manager: mock)
+
+    let stalePersistedAt = Date(timeIntervalSinceNow: -3600)  // well past 60s TTL
+    mock.flagsLock.write {
+      mock.flags = [:]
+      mock.loadedBlobPersistedAt = stalePersistedAt
+    }
+
+    mock.simulatedFetchResult = (
+      success: true,
+      flags: ["flag_a": MixpanelFlagVariant(key: "v1", value: "fresh_val")]
+    )
+    mock.simulatedNetworkDelay = 0
+
+    let asyncDone = expectation(description: "async lookup refreshes stale empty blob")
+    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+      XCTAssertEqual(
+        variant.value as? String, "fresh_val",
+        "stale empty blob should trigger fetch and serve newly-discovered flag")
+      asyncDone.fulfill()
+    }
+    wait(for: [asyncDone], timeout: 2.0)
+  }
+
+  /// Sanity check the existing serve-immediately path still wins when the loaded blob is
+  /// fresh — the staleness check shouldn't push fresh persisted variants through a needless
+  /// network round-trip.
+  func testGetVariantAsyncServesFreshPersistedImmediatelyWithoutFetch() throws {
+    let mock = makeMockManager(
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
+    waitForTrackingQueue(manager: mock)
+
+    let freshPersistedAt = Date(timeIntervalSinceNow: -60)
+    let fresh = MixpanelFlagVariant(key: "v1", value: "persisted_val")
+      .withSource(.persistence(persistedAt: freshPersistedAt))
+    mock.flagsLock.write {
+      mock.flags = ["flag_a": fresh]
+      mock.loadedBlobPersistedAt = freshPersistedAt
+    }
+
+    // Configure a slow + clearly-different network response. If the staleness check
+    // wrongly triggers a fetch, the test will catch the wrong value (and the slow delay
+    // would add noticeable latency).
+    mock.simulatedFetchResult = (
+      success: true,
+      flags: ["flag_a": MixpanelFlagVariant(key: "v2", value: "network_val")]
+    )
+    mock.simulatedNetworkDelay = 0.1
+
+    let asyncDone = expectation(description: "async getVariant completes")
+    let start = Date()
+    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fb")) { variant in
+      let elapsed = Date().timeIntervalSince(start)
+      XCTAssertEqual(variant.value as? String, "persisted_val")
+      if case .persistence = variant.source {} else {
+        XCTFail("fresh persisted variant should be served as-is, not refreshed")
+      }
+      XCTAssertLessThan(elapsed, 0.08, "fresh blob must not wait on the network")
+      asyncDone.fulfill()
+    }
+    wait(for: [asyncDone], timeout: 1.0)
+  }
+
   // MARK: - Tracking properties for persisted variants
 
   /// When a served variant came from the persistence layer, `$experiment_started` carries
@@ -782,7 +1006,10 @@ class FeatureFlagPersistenceTests: XCTestCase {
     // on the blob serializer's millisecond rounding.
     let persistedVariant = MixpanelFlagVariant(key: "v1", value: "persisted_val")
       .withSource(.persistence(persistedAt: persistedAt))
-    manager.flagsLock.write { manager.flags = ["flag_a": persistedVariant] }
+    manager.flagsLock.write {
+      manager.flags = ["flag_a": persistedVariant]
+      manager.loadedBlobPersistedAt = persistedAt
+    }
 
     // Trigger tracking by reading the persisted variant (first read records the tracking
     // event; subsequent reads are deduped via `trackedFeatures`).

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
@@ -1,15 +1,17 @@
 //
-//  MixpanelFeatureFlagCacheTests.swift
+//  MixpanelFeatureFlagPersistenceTests.swift
 //  MixpanelDemo
 //
 //  Tests for the feature-flag variant persistence layer:
 //   - Persistence round-trip + self-healing on malformed blobs
 //   - distinctId and TTL validation
-//   - Init loads cache and stamps variants with .cache(cachedAt:)
-//   - CacheFirst serves cached values immediately
+//   - Init loads persisted blob and stamps variants with .persistence(persistedAt:)
+//   - PersistenceFirst serves persisted values immediately
 //   - NetworkFirst awaits the initial network response, falls back on failure
 //   - reset() wipes both in-memory state and the on-disk blob
-//   - successful fetches write the blob (when policy is .cacheFirst or .networkFirst)
+//   - successful fetches write the blob (when policy is .persistenceFirst or .networkFirst)
+//   - $experiment_started includes $variant_source / $persisted_at_in_ms / $ttl_in_ms when
+//     the served variant came from the persistence layer
 //
 
 import XCTest
@@ -20,15 +22,15 @@ import XCTest
 //
 // Defined here (rather than reusing the mocks in MixpanelFeatureFlagTests.swift) so this
 // file can be compiled into both the iOS and macOS test targets without dragging in the
-// rest of that file's iOS-specific dependencies. Keep the surface minimal — just what these
-// cache tests actually exercise.
+// rest of that file's iOS-specific dependencies. Keep the surface minimal — just what
+// these persistence tests actually exercise.
 
-private final class CacheTestMockDelegate: MixpanelFlagDelegate {
+private final class PersistenceTestMockDelegate: MixpanelFlagDelegate {
   var options: MixpanelOptions
   var distinctId: String
   var anonymousId: String?
   var trackedEvents: [(event: String?, properties: Properties?)] = []
-  private let trackQueue = DispatchQueue(label: "cache.test.mock.track")
+  private let trackQueue = DispatchQueue(label: "persistence.test.mock.track")
 
   init(options: MixpanelOptions, distinctId: String, anonymousId: String? = nil) {
     self.options = options
@@ -42,13 +44,17 @@ private final class CacheTestMockDelegate: MixpanelFlagDelegate {
   func track(event: String?, properties: Properties?) {
     trackQueue.sync { trackedEvents.append((event: event, properties: properties)) }
   }
+
+  func snapshotTrackedEvents() -> [(event: String?, properties: Properties?)] {
+    return trackQueue.sync { trackedEvents }
+  }
 }
 
 /// Minimal mock of FeatureFlagManager that intercepts the network call. Deliberately
 /// reproduces the parts of the real fetch path we care about (source stamping,
 /// awaitingInitialNetworkResponse handling, completion fan-out) so async-lookup tests
 /// can verify behavior end-to-end.
-private final class CacheTestMockManager: FeatureFlagManager {
+private final class PersistenceTestMockManager: FeatureFlagManager {
   var simulatedFetchResult: (success: Bool, flags: [String: MixpanelFlagVariant]?)?
   var simulatedNetworkDelay: TimeInterval = 0.1
 
@@ -87,7 +93,7 @@ private final class CacheTestMockManager: FeatureFlagManager {
   ) {}
 }
 
-class FeatureFlagCacheTests: XCTestCase {
+class FeatureFlagPersistenceTests: XCTestCase {
 
   // Each test uses a unique instance name so UserDefaults state from one test can't bleed
   // into another. Writes go to the shared "Mixpanel" suite, but the per-instance prefix
@@ -106,7 +112,7 @@ class FeatureFlagCacheTests: XCTestCase {
   }
 
   override func tearDownWithError() throws {
-    MixpanelPersistence.deleteFlagsCache(instanceName: instanceName)
+    MixpanelPersistence.deleteFlagsPersistence(instanceName: instanceName)
     instanceName = nil
     retainedDelegates.removeAll()
     try super.tearDownWithError()
@@ -115,56 +121,56 @@ class FeatureFlagCacheTests: XCTestCase {
   // MARK: - Persistence layer
 
   func testSaveAndLoadRoundTrip() throws {
-    let blob = FlagsCacheBlob(
-      cachedAt: Date(timeIntervalSince1970: 1_700_000_000),
+    let blob = FlagsPersistenceBlob(
+      persistedAt: Date(timeIntervalSince1970: 1_700_000_000),
       distinctId: "user_a",
       response: #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
     )
 
-    MixpanelPersistence.saveFlagsCache(blob, instanceName: instanceName)
-    let loaded = MixpanelPersistence.loadFlagsCache(instanceName: instanceName)
+    MixpanelPersistence.saveFlagsPersistence(blob, instanceName: instanceName)
+    let loaded = MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName)
 
     let loadedBlob = try XCTUnwrap(loaded)
     XCTAssertEqual(loadedBlob.distinctId, blob.distinctId)
     XCTAssertEqual(loadedBlob.response, blob.response)
     XCTAssertEqual(
-      loadedBlob.cachedAt.timeIntervalSince1970,
-      blob.cachedAt.timeIntervalSince1970, accuracy: 0.001)
+      loadedBlob.persistedAt.timeIntervalSince1970,
+      blob.persistedAt.timeIntervalSince1970, accuracy: 0.001)
   }
 
   func testLoadReturnsNilWhenNothingPersisted() {
-    XCTAssertNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+    XCTAssertNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
   }
 
   func testDeleteRemovesBlob() {
-    let blob = FlagsCacheBlob(
-      cachedAt: Date(), distinctId: "user_x", response: "{}")
-    MixpanelPersistence.saveFlagsCache(blob, instanceName: instanceName)
-    XCTAssertNotNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+    let blob = FlagsPersistenceBlob(
+      persistedAt: Date(), distinctId: "user_x", response: "{}")
+    MixpanelPersistence.saveFlagsPersistence(blob, instanceName: instanceName)
+    XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
-    MixpanelPersistence.deleteFlagsCache(instanceName: instanceName)
-    XCTAssertNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+    MixpanelPersistence.deleteFlagsPersistence(instanceName: instanceName)
+    XCTAssertNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
   }
 
   func testMalformedBlobIsSelfHealed() {
     // Write a non-JSON byte sequence directly to the same key the persistence layer uses.
     let defaults = UserDefaults(suiteName: "Mixpanel")!
-    let key = "mixpanel-\(instanceName!)-MPFlagsCache"
+    let key = "mixpanel-\(instanceName!)-MPFlagsPersistence"
     defaults.set(Data([0xFF, 0xFE, 0xFD]), forKey: key)
 
     // Read should return nil AND clear the blob so we don't keep failing on every load.
-    XCTAssertNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+    XCTAssertNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
     XCTAssertNil(defaults.data(forKey: key))
   }
 
   func testWellFormedJSONWithUnexpectedShapeIsSelfHealed() {
     // Valid JSON but wrong shape (missing required keys) should also self-heal.
     let defaults = UserDefaults(suiteName: "Mixpanel")!
-    let key = "mixpanel-\(instanceName!)-MPFlagsCache"
+    let key = "mixpanel-\(instanceName!)-MPFlagsPersistence"
     let bogus = #"{"unexpected":"shape"}"#.data(using: .utf8)!
     defaults.set(bogus, forKey: key)
 
-    XCTAssertNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+    XCTAssertNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
     XCTAssertNil(defaults.data(forKey: key))
   }
 
@@ -182,12 +188,12 @@ class FeatureFlagCacheTests: XCTestCase {
     XCTAssertEqual(stamped.isQATester, false)
     if case .network = stamped.source {} else { XCTFail("expected .network source") }
 
-    let cachedAt = Date(timeIntervalSince1970: 1_700_000_000)
-    let cacheStamped = original.withSource(.cache(cachedAt: cachedAt))
-    if case .cache(let at) = cacheStamped.source {
-      XCTAssertEqual(at.timeIntervalSince1970, cachedAt.timeIntervalSince1970, accuracy: 0.001)
+    let persistedAt = Date(timeIntervalSince1970: 1_700_000_000)
+    let persistenceStamped = original.withSource(.persistence(persistedAt: persistedAt))
+    if case .persistence(let at) = persistenceStamped.source {
+      XCTAssertEqual(at.timeIntervalSince1970, persistedAt.timeIntervalSince1970, accuracy: 0.001)
     } else {
-      XCTFail("expected .cache source")
+      XCTFail("expected .persistence source")
     }
   }
 
@@ -198,18 +204,18 @@ class FeatureFlagCacheTests: XCTestCase {
 
   // MARK: - Default TTL
 
-  /// `VariantLookupPolicy.defaultTTL` is 1 hour, and the zero-arg static factories
-  /// `cacheFirst()` / `networkFirst()` produce cases keyed to that default. This also
+  /// `VariantLookupPolicy.defaultTTL` is 24 hours, and the zero-arg static factories
+  /// `persistenceFirst()` / `networkFirst()` produce cases keyed to that default. This also
   /// exercises the case-plus-static-func overload pattern (different parameter lists, so
-  /// `.cacheFirst()` and `.cacheFirst(ttl:)` resolve to different members).
+  /// `.persistenceFirst()` and `.persistenceFirst(ttl:)` resolve to different members).
   func testDefaultTTLConvenienceConstructors() throws {
-    XCTAssertEqual(VariantLookupPolicy.defaultTTL, 60 * 60, "default TTL should be 1 hour")
+    XCTAssertEqual(VariantLookupPolicy.defaultTTL, 24 * 60 * 60, "default TTL should be 24 hours")
 
-    let convenientCacheFirst = VariantLookupPolicy.cacheFirst()
-    if case .cacheFirst(let ttl) = convenientCacheFirst {
+    let convenientPersistenceFirst = VariantLookupPolicy.persistenceFirst()
+    if case .persistenceFirst(let ttl) = convenientPersistenceFirst {
       XCTAssertEqual(ttl, VariantLookupPolicy.defaultTTL)
     } else {
-      XCTFail("convenience cacheFirst() should produce .cacheFirst case")
+      XCTFail("convenience persistenceFirst() should produce .persistenceFirst case")
     }
 
     let convenientNetworkFirst = VariantLookupPolicy.networkFirst()
@@ -220,20 +226,20 @@ class FeatureFlagCacheTests: XCTestCase {
     }
   }
 
-  // MARK: - Init loads cache and stamps variants
+  // MARK: - Init loads persisted variants and stamps them
 
-  func testInitLoadsCachedVariantsAndStampsCacheSource() throws {
+  func testInitLoadsPersistedVariantsAndStampsPersistenceSource() throws {
     // `Date()` (rather than a fixed-far-past timestamp) so the 86_400s TTL check passes.
-    let cachedAt = Date()
+    let persistedAt = Date()
     let context = ["plan": "enterprise"]
     let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":42},"flag_b":{"variant_key":"v2","variant_value":"hello"}}}"#
 
-    MixpanelPersistence.saveFlagsCache(
-      FlagsCacheBlob(cachedAt: cachedAt, distinctId: "user_a", response: response),
+    MixpanelPersistence.saveFlagsPersistence(
+      FlagsPersistenceBlob(persistedAt: persistedAt, distinctId: "user_a", response: response),
       instanceName: instanceName)
 
     let manager = makeManager(
-      distinctId: "user_a", context: context, policy: .cacheFirst(ttl: 86_400))
+      distinctId: "user_a", context: context, policy: .persistenceFirst(ttl: 86_400))
 
     waitForTrackingQueue(manager: manager)
 
@@ -241,10 +247,10 @@ class FeatureFlagCacheTests: XCTestCase {
     let variants = manager.getAllVariantsSync()
     XCTAssertEqual(variants.count, 2)
 
-    if case .cache(let at) = variants["flag_a"]?.source {
-      XCTAssertEqual(at.timeIntervalSince1970, cachedAt.timeIntervalSince1970, accuracy: 0.001)
+    if case .persistence(let at) = variants["flag_a"]?.source {
+      XCTAssertEqual(at.timeIntervalSince1970, persistedAt.timeIntervalSince1970, accuracy: 0.001)
     } else {
-      XCTFail("flag_a should have .cache source")
+      XCTFail("flag_a should have .persistence source")
     }
     XCTAssertEqual(variants["flag_a"]?.value as? Int, 42)
     XCTAssertEqual(variants["flag_b"]?.value as? String, "hello")
@@ -253,41 +259,41 @@ class FeatureFlagCacheTests: XCTestCase {
   /// distinctId mismatch on init is the cross-session form of "distinctId changed":
   /// it leaves flags empty AND wipes the stale blob from disk, so the prior identity's
   /// variants don't sit on this device after the user has moved on.
-  func testInitWipesCacheOnDistinctIdMismatch() throws {
+  func testInitWipesPersistenceOnDistinctIdMismatch() throws {
     let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
-    MixpanelPersistence.saveFlagsCache(
-      FlagsCacheBlob(
-        cachedAt: Date(),
+    MixpanelPersistence.saveFlagsPersistence(
+      FlagsPersistenceBlob(
+        persistedAt: Date(),
         distinctId: "different_user",
         response: response),
       instanceName: instanceName)
-    XCTAssertNotNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+    XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
     waitForTrackingQueue(manager: manager)
 
     XCTAssertFalse(manager.areFlagsReady(), "distinctId mismatch should leave flags empty")
     XCTAssertTrue(manager.getAllVariantsSync().isEmpty)
     XCTAssertNil(
-      MixpanelPersistence.loadFlagsCache(instanceName: instanceName),
+      MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
       "distinctId mismatch on init should wipe the stale blob")
   }
 
-  /// Documents the deliberate decision to key the cache on distinctId only — context changes
-  /// do NOT invalidate the cached blob. A cache written under one context will load under a
-  /// different context for the same user (in-memory variants will then be stale with respect
+  /// Documents the deliberate decision to key persistence on distinctId only — context changes
+  /// do NOT invalidate the persisted blob. A blob written under one context will load under
+  /// a different context for the same user (in-memory variants will then be stale with respect
   /// to the new context until the next successful fetch overwrites them).
   ///
   /// Customers signaled this tradeoff is acceptable: context rarely flips mid-session in
-  /// practice, and the gain is keeping the cache useful when customers do flip between
-  /// contexts they've used before.
-  func testInitLoadsCacheRegardlessOfContextDifference() throws {
+  /// practice, and the gain is keeping the persistence layer useful when customers do flip
+  /// between contexts they've used before.
+  func testInitLoadsPersistenceRegardlessOfContextDifference() throws {
     let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
-    MixpanelPersistence.saveFlagsCache(
-      FlagsCacheBlob(
-        cachedAt: Date(),
-        // Blob originally cached under no context.
+    MixpanelPersistence.saveFlagsPersistence(
+      FlagsPersistenceBlob(
+        persistedAt: Date(),
+        // Blob originally persisted under no context.
         distinctId: "user_a",
         response: response),
       instanceName: instanceName)
@@ -296,112 +302,113 @@ class FeatureFlagCacheTests: XCTestCase {
     let manager = makeManager(
       distinctId: "user_a",
       context: ["plan": "enterprise"],
-      policy: .cacheFirst(ttl: 86_400))
+      policy: .persistenceFirst(ttl: 86_400))
     waitForTrackingQueue(manager: manager)
 
     XCTAssertTrue(
       manager.areFlagsReady(),
-      "context mismatch must NOT invalidate cache when keyed on distinctId only")
+      "context mismatch must NOT invalidate persisted blob when keyed on distinctId only")
     XCTAssertEqual(manager.getAllVariantsSync().count, 1)
   }
 
-  func testInitIgnoresCacheWhenExpired() throws {
+  func testInitIgnoresPersistenceWhenExpired() throws {
     let oldDate = Date(timeIntervalSinceNow: -86_400 * 7) // 7 days ago
     let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
-    MixpanelPersistence.saveFlagsCache(
-      FlagsCacheBlob(
-        cachedAt: oldDate,
+    MixpanelPersistence.saveFlagsPersistence(
+      FlagsPersistenceBlob(
+        persistedAt: oldDate,
         distinctId: "user_a",
         response: response),
       instanceName: instanceName)
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 60))  // 60s TTL
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 60))  // 60s TTL
     waitForTrackingQueue(manager: manager)
 
     XCTAssertFalse(manager.areFlagsReady(), "expired entry should be ignored")
   }
 
-  func testInitClearsCacheBlobWhenResponseStringIsUnparseable() throws {
+  func testInitClearsPersistedBlobWhenResponseStringIsUnparseable() throws {
     // Structurally-valid envelope but the `response` string is garbage. Without self-heal
-    // the blob would stick on disk and fail every cold-start. The init-time cache load
+    // the blob would stick on disk and fail every cold-start. The init-time persistence load
     // should both ignore it AND wipe it.
-    let blob = FlagsCacheBlob(
-      cachedAt: Date(),
+    let blob = FlagsPersistenceBlob(
+      persistedAt: Date(),
       distinctId: "user_a",
       response: "this is not json"
     )
-    MixpanelPersistence.saveFlagsCache(blob, instanceName: instanceName)
-    XCTAssertNotNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+    MixpanelPersistence.saveFlagsPersistence(blob, instanceName: instanceName)
+    XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
     waitForTrackingQueue(manager: manager)
 
     XCTAssertFalse(manager.areFlagsReady(), "unparseable response should leave flags empty")
     XCTAssertNil(
-      MixpanelPersistence.loadFlagsCache(instanceName: instanceName),
+      MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
       "blob should be wiped so the next successful fetch gets a clean slate")
   }
 
   /// `.networkOnly` does two things on init when a stale blob is on disk: (a) doesn't load
-  /// it into memory, and (b) actively wipes it. This way, toggling from a caching policy
+  /// it into memory, and (b) actively wipes it. This way, toggling from a persisting policy
   /// back to `.networkOnly` cleans up the orphaned blob rather than leaving it stranded.
-  func testInitWipesAndDoesNotLoadCacheWhenPolicyIsNetworkOnly() throws {
+  func testInitWipesAndDoesNotLoadPersistenceWhenPolicyIsNetworkOnly() throws {
     let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
-    MixpanelPersistence.saveFlagsCache(
-      FlagsCacheBlob(
-        cachedAt: Date(),
+    MixpanelPersistence.saveFlagsPersistence(
+      FlagsPersistenceBlob(
+        persistedAt: Date(),
         distinctId: "user_a",
         response: response),
       instanceName: instanceName)
-    XCTAssertNotNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+    XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
     let manager = makeManager(distinctId: "user_a", context: [:], policy: .networkOnly)
     waitForTrackingQueue(manager: manager)
 
-    XCTAssertFalse(manager.areFlagsReady(), ".networkOnly must not load from cache")
+    XCTAssertFalse(manager.areFlagsReady(), ".networkOnly must not load from persistence")
     XCTAssertNil(
-      MixpanelPersistence.loadFlagsCache(instanceName: instanceName),
-      ".networkOnly init should wipe a stale blob from a previous caching-policy session")
+      MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
+      ".networkOnly init should wipe a stale blob from a previous persisting-policy session")
   }
 
   /// Regression test for the init-time race that motivated moving FeatureFlagManager
   /// construction below `unarchive()` in MixpanelInstance.init.
   ///
-  /// The async cache-load block reads `delegate.getDistinctId()` at the moment GCD picks it
-  /// up — NOT at the moment FeatureFlagManager.init dispatched it. This test simulates the
-  /// race by:
-  ///   1. Persisting a cache blob keyed to "real_user".
+  /// The async persistence-load block reads `delegate.getDistinctId()` at the moment GCD
+  /// picks it up — NOT at the moment FeatureFlagManager.init dispatched it. This test
+  /// simulates the race by:
+  ///   1. Persisting a blob keyed to "real_user".
   ///   2. Constructing the manager with a delegate whose distinctId is "wrong_user" — the
-  ///      cache-load block is queued on a SUSPENDED tracking queue, so it can't run yet.
+  ///      persistence-load block is queued on a SUSPENDED tracking queue, so it can't run yet.
   ///   3. Mutating delegate.distinctId to "real_user" (simulating unarchive() loading the
   ///      persisted identity AFTER FeatureFlagManager init returned).
   ///   4. Resuming the queue and waiting.
-  /// If the cache load read distinctId at the right time (block-execution, not dispatch),
-  /// flags load successfully. If we'd snapshotted at dispatch time, this would fail.
-  func testCacheLoadReadsDistinctIdAtBlockExecutionNotDispatch() throws {
+  /// If the persistence load read distinctId at the right time (block-execution, not
+  /// dispatch), flags load successfully. If we'd snapshotted at dispatch time, this would
+  /// fail.
+  func testPersistenceLoadReadsDistinctIdAtBlockExecutionNotDispatch() throws {
     let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
-    MixpanelPersistence.saveFlagsCache(
-      FlagsCacheBlob(
-        cachedAt: Date(),
+    MixpanelPersistence.saveFlagsPersistence(
+      FlagsPersistenceBlob(
+        persistedAt: Date(),
         distinctId: "real_user",
         response: response),
       instanceName: instanceName)
 
-    let delegate = CacheTestMockDelegate(
+    let delegate = PersistenceTestMockDelegate(
       options: MixpanelOptions(
         token: "test_token",
         featureFlagOptions: FeatureFlagOptions(
           enabled: true,
-          variantLookupPolicy: .cacheFirst(ttl: 86_400))),
+          variantLookupPolicy: .persistenceFirst(ttl: 86_400))),
       distinctId: "wrong_user")
     retainedDelegates.append(delegate)
 
-    // Suspend the queue BEFORE the manager init so the cache-load dispatch sits in the queue
-    // without running. Models the worst-case race: GCD couldn't schedule the worker thread
-    // before init's caller continued past the dispatch point.
-    let queue = DispatchQueue(label: "ff.cache.race.test.\(UUID().uuidString)")
+    // Suspend the queue BEFORE the manager init so the persistence-load dispatch sits in
+    // the queue without running. Models the worst-case race: GCD couldn't schedule the
+    // worker thread before init's caller continued past the dispatch point.
+    let queue = DispatchQueue(label: "ff.persistence.race.test.\(UUID().uuidString)")
     queue.suspend()
     let manager = FeatureFlagManager(
       serverURL: "https://example.test",
@@ -412,36 +419,36 @@ class FeatureFlagCacheTests: XCTestCase {
     // "unarchive() finishes" — the persisted identity is now visible via the delegate.
     delegate.distinctId = "real_user"
 
-    // Let the cache load proceed. The waitForTrackingQueue helper posts a barrier task;
-    // because the queue is serial, the cache-load runs first.
+    // Let the persistence load proceed. The waitForTrackingQueue helper posts a barrier
+    // task; because the queue is serial, the persistence load runs first.
     queue.resume()
     waitForTrackingQueue(manager: manager)
 
     XCTAssertTrue(
       manager.areFlagsReady(),
-      "cache load should have used the post-mutation distinctId, not the construction-time one")
+      "persistence load should have used the post-mutation distinctId, not the construction-time one")
     XCTAssertEqual(manager.getAllVariantsSync().count, 1)
   }
 
   // MARK: - TTL re-check on get
   //
   // The TTL is re-checked on every `getVariant`/`getAllVariants` call (not only at init load
-  // time). Once a `.cache(cachedAt:)`-stamped variant ages past TTL while sitting in memory, lookups
-  // return the developer fallback rather than the stale value. The on-disk blob is NOT
-  // deleted — the next successful fetch will overwrite it.
+  // time). Once a `.persistence(persistedAt:)`-stamped variant ages past TTL while sitting in
+  // memory, lookups return the developer fallback rather than the stale value. The on-disk
+  // blob is NOT deleted — the next successful fetch will overwrite it.
 
-  /// A `.cache(cachedAt:)`-stamped variant that's older than the configured TTL is treated as
-  /// not-present by `getVariantSync` — the developer fallback is returned instead.
-  func testGetVariantSyncReturnsFallbackForExpiredCachedVariant() throws {
+  /// A `.persistence(persistedAt:)`-stamped variant that's older than the configured TTL is
+  /// treated as not-present by `getVariantSync` — the developer fallback is returned instead.
+  func testGetVariantSyncReturnsFallbackForExpiredPersistedVariant() throws {
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 60))
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 60))
     waitForTrackingQueue(manager: manager)
 
-    // Inject an expired cached variant directly into in-memory state. Bypasses the disk
-    // load path so we can test the get-time TTL check in isolation. cachedAt is 1 hour ago,
-    // well past the 60s TTL configured above.
+    // Inject an expired persisted variant directly into in-memory state. Bypasses the disk
+    // load path so we can test the get-time TTL check in isolation. persistedAt is 1 hour
+    // ago, well past the 60s TTL configured above.
     let expired = MixpanelFlagVariant(key: "v1", value: "stale_value")
-      .withSource(.cache(cachedAt: Date(timeIntervalSinceNow: -3600)))
+      .withSource(.persistence(persistedAt: Date(timeIntervalSinceNow: -3600)))
     manager.flagsLock.write {
       manager.flags = ["flag_a": expired]
     }
@@ -453,14 +460,15 @@ class FeatureFlagCacheTests: XCTestCase {
     XCTAssertNil(result.source, "fallback variant has nil source")
   }
 
-  /// A `.cache(cachedAt:)`-stamped variant within TTL is served as-is (with `.cache` source preserved).
-  func testGetVariantSyncReturnsFreshCachedVariant() throws {
+  /// A `.persistence(persistedAt:)`-stamped variant within TTL is served as-is (with
+  /// `.persistence` source preserved).
+  func testGetVariantSyncReturnsFreshPersistedVariant() throws {
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
     waitForTrackingQueue(manager: manager)
 
     let fresh = MixpanelFlagVariant(key: "v1", value: "fresh_value")
-      .withSource(.cache(cachedAt: Date(timeIntervalSinceNow: -60)))
+      .withSource(.persistence(persistedAt: Date(timeIntervalSinceNow: -60)))
     manager.flagsLock.write {
       manager.flags = ["flag_a": fresh]
     }
@@ -469,14 +477,16 @@ class FeatureFlagCacheTests: XCTestCase {
     let result = manager.getVariantSync("flag_a", fallback: fallback)
 
     XCTAssertEqual(result.value as? String, "fresh_value")
-    if case .cache = result.source {} else { XCTFail("expected .cache source preserved") }
+    if case .persistence = result.source {} else {
+      XCTFail("expected .persistence source preserved")
+    }
   }
 
   /// `.network`-stamped variants are never expired regardless of how old they are — TTL only
-  /// applies to `.cache(cachedAt:)` variants.
+  /// applies to `.persistence(persistedAt:)` variants.
   func testGetVariantSyncReturnsNetworkVariantRegardlessOfAge() throws {
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 60))
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 60))
     waitForTrackingQueue(manager: manager)
 
     // .network variants don't carry a timestamp, so the TTL check should always return false.
@@ -491,17 +501,17 @@ class FeatureFlagCacheTests: XCTestCase {
     XCTAssertEqual(result.value as? String, "from_network")
   }
 
-  /// `getAllVariantsSync` filters out expired cached variants but keeps `.network` variants
-  /// and unexpired `.cache(cachedAt:)` variants.
-  func testGetAllVariantsSyncFiltersExpiredCachedVariants() throws {
+  /// `getAllVariantsSync` filters out expired persisted variants but keeps `.network`
+  /// variants and unexpired `.persistence(persistedAt:)` variants.
+  func testGetAllVariantsSyncFiltersExpiredPersistedVariants() throws {
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 60))
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 60))
     waitForTrackingQueue(manager: manager)
 
     let expired = MixpanelFlagVariant(key: "v1", value: "stale")
-      .withSource(.cache(cachedAt: Date(timeIntervalSinceNow: -3600)))
+      .withSource(.persistence(persistedAt: Date(timeIntervalSinceNow: -3600)))
     let fresh = MixpanelFlagVariant(key: "v2", value: "ok")
-      .withSource(.cache(cachedAt: Date(timeIntervalSinceNow: -10)))
+      .withSource(.persistence(persistedAt: Date(timeIntervalSinceNow: -10)))
     let networkSourced = MixpanelFlagVariant(key: "v3", value: "from_network")
       .withSource(.network)
 
@@ -522,19 +532,19 @@ class FeatureFlagCacheTests: XCTestCase {
 
   /// The on-disk blob is NOT deleted when an in-memory variant expires at get-time.
   /// Per the rule: "no harm in keeping. Will likely be overwritten shortly after."
-  func testExpiredVariantOnGetVariantDoesNotWipeDiskCache() throws {
+  func testExpiredVariantOnGetVariantDoesNotWipeDiskPersistence() throws {
     let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"v"}}}"#
-    let blob = FlagsCacheBlob(cachedAt: Date(), distinctId: "user_a", response: response)
-    MixpanelPersistence.saveFlagsCache(blob, instanceName: instanceName)
+    let blob = FlagsPersistenceBlob(persistedAt: Date(), distinctId: "user_a", response: response)
+    MixpanelPersistence.saveFlagsPersistence(blob, instanceName: instanceName)
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
     waitForTrackingQueue(manager: manager)
-    XCTAssertNotNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+    XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
     // Force the in-memory variant to be expired without wiping the disk blob.
     let expired = MixpanelFlagVariant(key: "v1", value: "stale")
-      .withSource(.cache(cachedAt: Date(timeIntervalSinceNow: -90_000)))  // > 86_400s TTL
+      .withSource(.persistence(persistedAt: Date(timeIntervalSinceNow: -90_000)))  // > 86_400s TTL
     manager.flagsLock.write {
       manager.flags = ["flag_a": expired]
     }
@@ -546,17 +556,17 @@ class FeatureFlagCacheTests: XCTestCase {
     // Critical: blob persists. The next successful fetch overwrites it; this lookup didn't
     // delete it.
     XCTAssertNotNil(
-      MixpanelPersistence.loadFlagsCache(instanceName: instanceName),
+      MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
       "expired-on-get must NOT wipe the on-disk blob")
   }
 
   // MARK: - NetworkFirst gating
 
-  func testNetworkFirstSetsAwaitingFlagWhenCacheLoaded() throws {
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"cached_val"}}}"#
-    MixpanelPersistence.saveFlagsCache(
-      FlagsCacheBlob(
-        cachedAt: Date(),
+  func testNetworkFirstSetsAwaitingFlagWhenPersistenceLoaded() throws {
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"persisted_val"}}}"#
+    MixpanelPersistence.saveFlagsPersistence(
+      FlagsPersistenceBlob(
+        persistedAt: Date(),
         distinctId: "user_a",
         response: response),
       instanceName: instanceName)
@@ -565,36 +575,36 @@ class FeatureFlagCacheTests: XCTestCase {
       distinctId: "user_a", context: [:], policy: .networkFirst(ttl: 86_400))
     waitForTrackingQueue(manager: manager)
 
-    // Sync lookups + areFlagsReady reflect the cache regardless of policy.
+    // Sync lookups + areFlagsReady reflect the persistence layer regardless of policy.
     XCTAssertTrue(manager.areFlagsReady())
     var awaitingValue = false
     manager.flagsLock.read { awaitingValue = manager.awaitingInitialNetworkResponse }
     XCTAssertTrue(awaitingValue, ".networkFirst must await initial network response")
   }
 
-  func testCacheFirstDoesNotSetAwaitingFlagWhenCacheLoaded() throws {
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"cached_val"}}}"#
-    MixpanelPersistence.saveFlagsCache(
-      FlagsCacheBlob(
-        cachedAt: Date(),
+  func testPersistenceFirstDoesNotSetAwaitingFlagWhenPersistenceLoaded() throws {
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"persisted_val"}}}"#
+    MixpanelPersistence.saveFlagsPersistence(
+      FlagsPersistenceBlob(
+        persistedAt: Date(),
         distinctId: "user_a",
         response: response),
       instanceName: instanceName)
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
     waitForTrackingQueue(manager: manager)
 
     var awaitingValue = false
     manager.flagsLock.read { awaitingValue = manager.awaitingInitialNetworkResponse }
-    XCTAssertFalse(awaitingValue, ".cacheFirst must not await initial network response")
+    XCTAssertFalse(awaitingValue, ".persistenceFirst must not await initial network response")
   }
 
-  func testNetworkFirstAsyncLookupAwaitsFetchEvenWithCache() throws {
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"cached_val"}}}"#
-    MixpanelPersistence.saveFlagsCache(
-      FlagsCacheBlob(
-        cachedAt: Date(),
+  func testNetworkFirstAsyncLookupAwaitsFetchEvenWithPersistence() throws {
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"persisted_val"}}}"#
+    MixpanelPersistence.saveFlagsPersistence(
+      FlagsPersistenceBlob(
+        persistedAt: Date(),
         distinctId: "user_a",
         response: response),
       instanceName: instanceName)
@@ -603,7 +613,8 @@ class FeatureFlagCacheTests: XCTestCase {
       distinctId: "user_a", context: [:], policy: .networkFirst(ttl: 86_400))
 
     // Configure the mock to "succeed" with new flags, but with a delay that lets us assert
-    // the async lookup waited for the network rather than serving cached values immediately.
+    // the async lookup waited for the network rather than serving persisted values
+    // immediately.
     mock.simulatedFetchResult = (
       success: true,
       flags: [
@@ -613,11 +624,11 @@ class FeatureFlagCacheTests: XCTestCase {
     mock.simulatedNetworkDelay = 0.1  // 100ms delay
 
     waitForTrackingQueue(manager: mock)
-    // Cache should have populated `flags` with .cache stamping. Now async lookup must NOT
-    // serve those cached values — it has to await the network response.
+    // Persistence load should have populated `flags` with .persistence stamping. Now async
+    // lookup must NOT serve those persisted values — it has to await the network response.
     let asyncDone = expectation(description: "async lookup completes after network")
     mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
-      // The variant served must be the network value, not the cached one.
+      // The variant served must be the network value, not the persisted one.
       XCTAssertEqual(variant.value as? String, "network_val")
       if case .network = variant.source {} else {
         XCTFail("variant served by NetworkFirst should be from .network after fetch")
@@ -627,12 +638,12 @@ class FeatureFlagCacheTests: XCTestCase {
     wait(for: [asyncDone], timeout: 2.0)
   }
 
-  func testNetworkFirstFallsBackToCacheOnFetchFailure() throws {
-    let cachedAt = Date(timeIntervalSinceNow: -60)  // 60s old, well within TTL
-    let response = #"{"flags":{"flag_a":{"variant_key":"v_cached","variant_value":"cached_val"}}}"#
-    MixpanelPersistence.saveFlagsCache(
-      FlagsCacheBlob(
-        cachedAt: cachedAt,
+  func testNetworkFirstFallsBackToPersistenceOnFetchFailure() throws {
+    let persistedAt = Date(timeIntervalSinceNow: -60)  // 60s old, well within TTL
+    let response = #"{"flags":{"flag_a":{"variant_key":"v_persisted","variant_value":"persisted_val"}}}"#
+    MixpanelPersistence.saveFlagsPersistence(
+      FlagsPersistenceBlob(
+        persistedAt: persistedAt,
         distinctId: "user_a",
         response: response),
       instanceName: instanceName)
@@ -645,27 +656,27 @@ class FeatureFlagCacheTests: XCTestCase {
 
     let asyncDone = expectation(description: "async lookup completes after fetch failure")
     mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
-      // Fetch failed → cached values stay → async lookup serves the cached variant.
-      XCTAssertEqual(variant.value as? String, "cached_val")
-      if case .cache = variant.source {} else {
-        XCTFail("variant served on NetworkFirst failure should keep .cache source")
+      // Fetch failed → persisted values stay → async lookup serves the persisted variant.
+      XCTAssertEqual(variant.value as? String, "persisted_val")
+      if case .persistence = variant.source {} else {
+        XCTFail("variant served on NetworkFirst failure should keep .persistence source")
       }
       asyncDone.fulfill()
     }
     wait(for: [asyncDone], timeout: 2.0)
   }
 
-  func testCacheFirstAsyncLookupServesCachedImmediately() throws {
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"cached_val"}}}"#
-    MixpanelPersistence.saveFlagsCache(
-      FlagsCacheBlob(
-        cachedAt: Date(),
+  func testPersistenceFirstAsyncLookupServesPersistedImmediately() throws {
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"persisted_val"}}}"#
+    MixpanelPersistence.saveFlagsPersistence(
+      FlagsPersistenceBlob(
+        persistedAt: Date(),
         distinctId: "user_a",
         response: response),
       instanceName: instanceName)
 
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
     // Configure a slow network so we'd notice if the lookup was waiting on it.
     mock.simulatedFetchResult = (
       success: true, flags: ["flag_a": MixpanelFlagVariant(key: "v2", value: "network_val")])
@@ -677,55 +688,56 @@ class FeatureFlagCacheTests: XCTestCase {
     let start = Date()
     mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
       let elapsed = Date().timeIntervalSince(start)
-      XCTAssertEqual(variant.value as? String, "cached_val", "cacheFirst should serve cached")
-      if case .cache = variant.source {} else { XCTFail("expected .cache source") }
+      XCTAssertEqual(
+        variant.value as? String, "persisted_val", "persistenceFirst should serve persisted")
+      if case .persistence = variant.source {} else { XCTFail("expected .persistence source") }
       // Generous bound — just want to confirm we didn't wait on the 100ms simulated network.
-      XCTAssertLessThan(elapsed, 0.08, "cacheFirst should not wait for network")
+      XCTAssertLessThan(elapsed, 0.08, "persistenceFirst should not wait for network")
       asyncDone.fulfill()
     }
     wait(for: [asyncDone], timeout: 1.0)
   }
 
-  // MARK: - Reset wipes cache
+  // MARK: - Reset wipes persistence
 
-  func testResetWipesDiskCache() throws {
+  func testResetWipesDiskPersistence() throws {
     let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
-    MixpanelPersistence.saveFlagsCache(
-      FlagsCacheBlob(
-        cachedAt: Date(),
+    MixpanelPersistence.saveFlagsPersistence(
+      FlagsPersistenceBlob(
+        persistedAt: Date(),
         distinctId: "user_a",
         response: response),
       instanceName: instanceName)
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
     waitForTrackingQueue(manager: manager)
 
-    XCTAssertNotNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
+    XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
     manager.reset()
     waitForTrackingQueue(manager: manager)
 
     XCTAssertNil(
-      MixpanelPersistence.loadFlagsCache(instanceName: instanceName),
-      "reset() should wipe the on-disk cache")
+      MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
+      "reset() should wipe the on-disk persistence blob")
     XCTAssertFalse(manager.areFlagsReady())
   }
 
-  /// `setContext` deliberately does NOT clear in-memory variants OR the on-disk cache. The
-  /// cache is keyed on distinctId only, so it remains valid across context changes for the
-  /// same user. The next successful fetch under the new context overwrites the cache.
-  func testSetContextDoesNotWipeCacheOrInMemoryState() throws {
+  /// `setContext` deliberately does NOT clear in-memory variants OR the on-disk blob. The
+  /// blob is keyed on distinctId only, so it remains valid across context changes for the
+  /// same user. The next successful fetch under the new context overwrites the blob.
+  func testSetContextDoesNotWipePersistenceOrInMemoryState() throws {
     let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
-    MixpanelPersistence.saveFlagsCache(
-      FlagsCacheBlob(
-        cachedAt: Date(),
+    MixpanelPersistence.saveFlagsPersistence(
+      FlagsPersistenceBlob(
+        persistedAt: Date(),
         distinctId: "user_a",
         response: response),
       instanceName: instanceName)
 
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .cacheFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: 86_400))
     // Make the post-setContext fetch fail so we can isolate setContext's effect — without
     // a successful overwrite, the blob's survival is solely attributable to setContext
     // NOT wiping it. The same goes for in-memory state.
@@ -733,8 +745,8 @@ class FeatureFlagCacheTests: XCTestCase {
     mock.simulatedNetworkDelay = 0
     waitForTrackingQueue(manager: mock)
 
-    XCTAssertNotNil(MixpanelPersistence.loadFlagsCache(instanceName: instanceName))
-    XCTAssertTrue(mock.areFlagsReady(), "cache load on init should populate flags")
+    XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
+    XCTAssertTrue(mock.areFlagsReady(), "persistence load on init should populate flags")
 
     let setContextDone = expectation(description: "setContext fetch completes")
     mock.setContext(["plan": "enterprise"]) { setContextDone.fulfill() }
@@ -742,11 +754,105 @@ class FeatureFlagCacheTests: XCTestCase {
     waitForTrackingQueue(manager: mock)
 
     XCTAssertNotNil(
-      MixpanelPersistence.loadFlagsCache(instanceName: instanceName),
-      "setContext must NOT wipe the on-disk cache")
+      MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
+      "setContext must NOT wipe the on-disk persistence blob")
     XCTAssertTrue(
       mock.areFlagsReady(),
       "setContext must NOT clear in-memory variants")
+  }
+
+  // MARK: - Tracking properties for persisted variants
+
+  /// When a served variant came from the persistence layer, `$experiment_started` carries
+  /// `$variant_source` = "persistence", `$persisted_at_in_ms` (raw epoch ms — no offsets,
+  /// no deltas), and `$ttl_in_ms` (the customer-configured TTL in ms). Verifies the values
+  /// against the same `persistedAt` and `ttl` we configured.
+  func testTrackingIncludesPersistencePropertiesForPersistedVariant() throws {
+    // Use a recent fixed timestamp (offset from "now") so we can assert the exact
+    // $persisted_at_in_ms while still passing the TTL check.
+    let persistedAt = Date(timeIntervalSinceNow: -60)  // 60s ago
+    let ttlSeconds: TimeInterval = 86_400  // 24 hours
+    let manager = makeManager(
+      distinctId: "user_a", context: [:], policy: .persistenceFirst(ttl: ttlSeconds))
+    waitForTrackingQueue(manager: manager)
+    let delegate = retainedDelegates.last as! PersistenceTestMockDelegate
+
+    // Inject a .persistence-stamped variant directly. Bypasses the disk-load round-trip so
+    // we can pin `persistedAt` to an exact value for the assertion below without depending
+    // on the blob serializer's millisecond rounding.
+    let persistedVariant = MixpanelFlagVariant(key: "v1", value: "persisted_val")
+      .withSource(.persistence(persistedAt: persistedAt))
+    manager.flagsLock.write { manager.flags = ["flag_a": persistedVariant] }
+
+    // Trigger tracking by reading the persisted variant (first read records the tracking
+    // event; subsequent reads are deduped via `trackedFeatures`).
+    let fallback = MixpanelFlagVariant(key: "fb", value: "fb")
+    _ = manager.getVariantSync("flag_a", fallback: fallback)
+
+    // The delegate.track call is dispatched async to main; spin briefly until it lands.
+    let trackedExpectation = expectation(description: "tracking event recorded")
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+      let events = delegate.snapshotTrackedEvents()
+      if events.contains(where: { $0.event == "$experiment_started" }) {
+        trackedExpectation.fulfill()
+      }
+    }
+    wait(for: [trackedExpectation], timeout: 2.0)
+
+    let events = delegate.snapshotTrackedEvents()
+    let experiment = try XCTUnwrap(events.first(where: { $0.event == "$experiment_started" }))
+    let props = try XCTUnwrap(experiment.properties)
+
+    XCTAssertEqual(props["$variant_source"] as? String, "persistence")
+    let expectedPersistedAtMs = Int(persistedAt.timeIntervalSince1970 * 1000)
+    XCTAssertEqual(props["$persisted_at_in_ms"] as? Int, expectedPersistedAtMs)
+    XCTAssertEqual(props["$ttl_in_ms"] as? Int, Int(ttlSeconds * 1000))
+  }
+
+  /// `.network`-sourced variants must NOT include any of the persistence-layer tracking
+  /// properties. This protects against accidentally leaking persistence-stamped variants
+  /// through the `.network` path or vice versa.
+  func testTrackingOmitsPersistencePropertiesForNetworkVariant() throws {
+    let delegate = PersistenceTestMockDelegate(
+      options: MixpanelOptions(
+        token: "test_token",
+        featureFlagOptions: FeatureFlagOptions(
+          enabled: true,
+          variantLookupPolicy: .networkOnly)),
+      distinctId: "user_a")
+    retainedDelegates.append(delegate)
+    let queue = DispatchQueue(label: "ff.network.tracking.test.\(UUID().uuidString)")
+    let manager = FeatureFlagManager(
+      serverURL: "https://example.test",
+      trackingQueue: queue,
+      instanceName: instanceName,
+      delegate: delegate)
+    waitForTrackingQueue(manager: manager)
+
+    // Inject a .network-sourced variant directly — bypasses the fetch path.
+    let networkVariant = MixpanelFlagVariant(key: "v1", value: "network_val")
+      .withSource(.network)
+    manager.flagsLock.write { manager.flags = ["flag_a": networkVariant] }
+
+    let fallback = MixpanelFlagVariant(key: "fb", value: "fb")
+    _ = manager.getVariantSync("flag_a", fallback: fallback)
+
+    let trackedExpectation = expectation(description: "tracking event recorded")
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+      let events = delegate.snapshotTrackedEvents()
+      if events.contains(where: { $0.event == "$experiment_started" }) {
+        trackedExpectation.fulfill()
+      }
+    }
+    wait(for: [trackedExpectation], timeout: 2.0)
+
+    let events = delegate.snapshotTrackedEvents()
+    let experiment = try XCTUnwrap(events.first(where: { $0.event == "$experiment_started" }))
+    let props = try XCTUnwrap(experiment.properties)
+
+    XCTAssertNil(props["$variant_source"], "network variants must not carry $variant_source")
+    XCTAssertNil(props["$persisted_at_in_ms"])
+    XCTAssertNil(props["$ttl_in_ms"])
   }
 
   // MARK: - Helpers
@@ -756,7 +862,7 @@ class FeatureFlagCacheTests: XCTestCase {
     context: [String: Any],
     policy: VariantLookupPolicy
   ) -> FeatureFlagManager {
-    let delegate = CacheTestMockDelegate(
+    let delegate = PersistenceTestMockDelegate(
       options: MixpanelOptions(
         token: "test_token",
         featureFlagOptions: FeatureFlagOptions(
@@ -765,7 +871,7 @@ class FeatureFlagCacheTests: XCTestCase {
           variantLookupPolicy: policy)),
       distinctId: distinctId)
     retainedDelegates.append(delegate)
-    let queue = DispatchQueue(label: "ff.cache.test.\(UUID().uuidString)")
+    let queue = DispatchQueue(label: "ff.persistence.test.\(UUID().uuidString)")
     return FeatureFlagManager(
       serverURL: "https://example.test",
       trackingQueue: queue,
@@ -777,8 +883,8 @@ class FeatureFlagCacheTests: XCTestCase {
     distinctId: String,
     context: [String: Any],
     policy: VariantLookupPolicy
-  ) -> CacheTestMockManager {
-    let delegate = CacheTestMockDelegate(
+  ) -> PersistenceTestMockManager {
+    let delegate = PersistenceTestMockDelegate(
       options: MixpanelOptions(
         token: "test_token",
         featureFlagOptions: FeatureFlagOptions(
@@ -787,16 +893,17 @@ class FeatureFlagCacheTests: XCTestCase {
           variantLookupPolicy: policy)),
       distinctId: distinctId)
     retainedDelegates.append(delegate)
-    let queue = DispatchQueue(label: "ff.cache.mock.test.\(UUID().uuidString)")
-    return CacheTestMockManager(
+    let queue = DispatchQueue(label: "ff.persistence.mock.test.\(UUID().uuidString)")
+    return PersistenceTestMockManager(
       serverURL: "https://example.test",
       trackingQueue: queue,
       instanceName: instanceName,
       delegate: delegate)
   }
 
-  /// Wait for any pending work on the manager's tracking queue (notably the async cache
-  /// load posted from init) to complete by posting a barrier task and blocking on it.
+  /// Wait for any pending work on the manager's tracking queue (notably the async
+  /// persistence load posted from init) to complete by posting a barrier task and blocking
+  /// on it.
   private func waitForTrackingQueue(
     manager: FeatureFlagManager,
     timeout: TimeInterval = 1.0,

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
@@ -228,49 +228,91 @@ class FeatureFlagPersistenceTests: XCTestCase {
     }
   }
 
-  /// Matches the JS SDK's TTL contract: a negative TTL is invalid and silently coerced to
-  /// `defaultTTL`. Verified end-to-end via the staleness behavior — a fresh persisted
-  /// variant must NOT be treated as expired under negative TTL (because we coerce to 24h,
-  /// not "always expired").
-  func testNegativeTTLIsCoercedToDefault() throws {
-    let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: -1))
-    waitForTrackingQueue(manager: manager)
-
-    let recentlyPersistedAt = Date(timeIntervalSinceNow: -60)  // 60s ago, well within 24h
-    let fresh = MixpanelFlagVariant(key: "v1", value: "fresh_value")
-      .withSource(.persistence(persistedAt: recentlyPersistedAt))
-    manager.flagsLock.write {
-      manager.flags = ["flag_a": fresh]
-      manager.loadedBlobPersistedAt = recentlyPersistedAt
+  /// Factories preserve exactly what was asked — they don't sanitize. The "non-positive TTL
+  /// becomes networkOnly" rule is enforced at SDK init via `VariantLookupPolicy.effective(_:)`,
+  /// not at construction time, so callers can introspect what they configured.
+  func testFactoriesPreserveExactTtl() throws {
+    if case .persistenceUntilNetworkSuccess(let t) = VariantLookupPolicy.persistenceUntilNetworkSuccess(ttl: -1) {
+      XCTAssertEqual(t, -1)
+    } else {
+      XCTFail("expected .persistenceUntilNetworkSuccess case")
     }
-
-    let result = manager.getVariantSync("flag_a", fallback: MixpanelFlagVariant(value: "fb"))
-    XCTAssertEqual(
-      result.value as? String, "fresh_value",
-      "negative TTL should fall back to defaultTTL, leaving recent variants servable")
+    if case .persistenceUntilNetworkSuccess(let t) = VariantLookupPolicy.persistenceUntilNetworkSuccess(ttl: 0) {
+      XCTAssertEqual(t, 0)
+    } else {
+      XCTFail("expected .persistenceUntilNetworkSuccess case")
+    }
+    if case .networkFirst(let t) = VariantLookupPolicy.networkFirst(ttl: -100) {
+      XCTAssertEqual(t, -100)
+    } else {
+      XCTFail("expected .networkFirst case")
+    }
   }
 
-  /// TTL of `0` means "always expired" (matches JS). Even a variant persisted just now is
-  /// past TTL on the next check.
-  func testZeroTTLTreatsAllPersistedVariantsAsExpired() throws {
+  /// Persisting policies with TTL <= 0 do no useful work (we'd write to disk on every fetch
+  /// but never serve anything from persistence) so the SDK substitutes `.networkOnly` at init.
+  func testEffectivePolicyNonPositiveTtlBecomesNetworkOnly() throws {
+    let resolvedNegativePersistence = VariantLookupPolicy.effective(.persistenceUntilNetworkSuccess(ttl: -1))
+    if case .networkOnly = resolvedNegativePersistence {} else {
+      XCTFail("negative TTL on persistenceUntilNetworkSuccess should resolve to .networkOnly")
+    }
+
+    let resolvedZeroPersistence = VariantLookupPolicy.effective(.persistenceUntilNetworkSuccess(ttl: 0))
+    if case .networkOnly = resolvedZeroPersistence {} else {
+      XCTFail("zero TTL on persistenceUntilNetworkSuccess should resolve to .networkOnly")
+    }
+
+    let resolvedNegativeNetworkFirst = VariantLookupPolicy.effective(.networkFirst(ttl: -100))
+    if case .networkOnly = resolvedNegativeNetworkFirst {} else {
+      XCTFail("negative TTL on networkFirst should resolve to .networkOnly")
+    }
+
+    let resolvedZeroNetworkFirst = VariantLookupPolicy.effective(.networkFirst(ttl: 0))
+    if case .networkOnly = resolvedZeroNetworkFirst {} else {
+      XCTFail("zero TTL on networkFirst should resolve to .networkOnly")
+    }
+  }
+
+  /// Sanity: non-degenerate configurations pass through `effective(_:)` unchanged.
+  func testEffectivePolicyPositiveTtlPreserved() throws {
+    let persistence = VariantLookupPolicy.persistenceUntilNetworkSuccess(ttl: 3600)
+    if case .persistenceUntilNetworkSuccess(let t) = VariantLookupPolicy.effective(persistence) {
+      XCTAssertEqual(t, 3600)
+    } else {
+      XCTFail("positive TTL should pass through unchanged")
+    }
+
+    let networkOnly = VariantLookupPolicy.networkOnly
+    if case .networkOnly = VariantLookupPolicy.effective(networkOnly) {} else {
+      XCTFail(".networkOnly should pass through unchanged")
+    }
+  }
+
+  /// End-to-end check: configuring the SDK with a persisting policy + non-positive TTL means
+  /// no persistence happens at runtime — the SDK behaves as if `.networkOnly` was configured.
+  func testNonPositiveTtlPersistingPolicyBehavesAsNetworkOnly() throws {
+    // Pre-stage a persisted blob on disk. Under .networkOnly init, the manager should wipe
+    // it (proves the resolved policy is .networkOnly, not the persisting policy the customer
+    // requested).
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+    MixpanelPersistence.saveFlagsPersistence(
+      FlagsPersistenceBlob(
+        persistedAt: Date(),
+        distinctId: "user_a",
+        response: response),
+      instanceName: instanceName)
+    XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
+
     let manager = makeManager(
       distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 0))
     waitForTrackingQueue(manager: manager)
 
-    let justNow = Date(timeIntervalSinceNow: -0.001)
-    let variant = MixpanelFlagVariant(key: "v1", value: "stale")
-      .withSource(.persistence(persistedAt: justNow))
-    manager.flagsLock.write {
-      manager.flags = ["flag_a": variant]
-      manager.loadedBlobPersistedAt = justNow
-    }
-
-    let fallback = MixpanelFlagVariant(key: "fb", value: "fallback_val")
-    let result = manager.getVariantSync("flag_a", fallback: fallback)
-    XCTAssertEqual(
-      result.value as? String, "fallback_val",
-      "TTL of 0 should treat any persisted variant as expired")
+    XCTAssertFalse(
+      manager.areFlagsReady(),
+      "non-positive TTL should resolve to .networkOnly; nothing loaded from persistence")
+    XCTAssertNil(
+      MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
+      "resolved .networkOnly init should wipe the existing blob")
   }
 
   // MARK: - Init loads persisted variants and stamps them

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
@@ -216,7 +216,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// `VariantLookupPolicy.defaultTTL` is 24 hours, and the zero-arg static factories
   /// `persistenceUntilNetworkSuccess()` / `networkFirst()` produce cases keyed to that default. This also
   /// exercises the case-plus-static-func overload pattern (different parameter lists, so
-  /// `.persistenceUntilNetworkSuccess()` and `.persistenceUntilNetworkSuccess(ttl:)` resolve to different members).
+  /// `.persistenceUntilNetworkSuccess()` and `.persistenceUntilNetworkSuccess(persistenceTtl:)` resolve to different members).
   func testDefaultTTLConvenienceConstructors() throws {
     XCTAssertEqual(VariantLookupPolicy.defaultTTL, 24 * 60 * 60, "default TTL should be 24 hours")
 
@@ -239,17 +239,17 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// becomes networkOnly" rule is enforced at SDK init via `VariantLookupPolicy.effective(_:)`,
   /// not at construction time, so callers can introspect what they configured.
   func testFactoriesPreserveExactTtl() throws {
-    if case .persistenceUntilNetworkSuccess(let t) = VariantLookupPolicy.persistenceUntilNetworkSuccess(ttl: -1) {
+    if case .persistenceUntilNetworkSuccess(let t) = VariantLookupPolicy.persistenceUntilNetworkSuccess(persistenceTtl: -1) {
       XCTAssertEqual(t, -1)
     } else {
       XCTFail("expected .persistenceUntilNetworkSuccess case")
     }
-    if case .persistenceUntilNetworkSuccess(let t) = VariantLookupPolicy.persistenceUntilNetworkSuccess(ttl: 0) {
+    if case .persistenceUntilNetworkSuccess(let t) = VariantLookupPolicy.persistenceUntilNetworkSuccess(persistenceTtl: 0) {
       XCTAssertEqual(t, 0)
     } else {
       XCTFail("expected .persistenceUntilNetworkSuccess case")
     }
-    if case .networkFirst(let t) = VariantLookupPolicy.networkFirst(ttl: -100) {
+    if case .networkFirst(let t) = VariantLookupPolicy.networkFirst(persistenceTtl: -100) {
       XCTAssertEqual(t, -100)
     } else {
       XCTFail("expected .networkFirst case")
@@ -259,22 +259,22 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// Persisting policies with TTL <= 0 do no useful work (we'd write to disk on every fetch
   /// but never serve anything from persistence) so the SDK substitutes `.networkOnly` at init.
   func testEffectivePolicyNonPositiveTtlBecomesNetworkOnly() throws {
-    let resolvedNegativePersistence = VariantLookupPolicy.effective(.persistenceUntilNetworkSuccess(ttl: -1))
+    let resolvedNegativePersistence = VariantLookupPolicy.effective(.persistenceUntilNetworkSuccess(persistenceTtl: -1))
     if case .networkOnly = resolvedNegativePersistence {} else {
       XCTFail("negative TTL on persistenceUntilNetworkSuccess should resolve to .networkOnly")
     }
 
-    let resolvedZeroPersistence = VariantLookupPolicy.effective(.persistenceUntilNetworkSuccess(ttl: 0))
+    let resolvedZeroPersistence = VariantLookupPolicy.effective(.persistenceUntilNetworkSuccess(persistenceTtl: 0))
     if case .networkOnly = resolvedZeroPersistence {} else {
       XCTFail("zero TTL on persistenceUntilNetworkSuccess should resolve to .networkOnly")
     }
 
-    let resolvedNegativeNetworkFirst = VariantLookupPolicy.effective(.networkFirst(ttl: -100))
+    let resolvedNegativeNetworkFirst = VariantLookupPolicy.effective(.networkFirst(persistenceTtl: -100))
     if case .networkOnly = resolvedNegativeNetworkFirst {} else {
       XCTFail("negative TTL on networkFirst should resolve to .networkOnly")
     }
 
-    let resolvedZeroNetworkFirst = VariantLookupPolicy.effective(.networkFirst(ttl: 0))
+    let resolvedZeroNetworkFirst = VariantLookupPolicy.effective(.networkFirst(persistenceTtl: 0))
     if case .networkOnly = resolvedZeroNetworkFirst {} else {
       XCTFail("zero TTL on networkFirst should resolve to .networkOnly")
     }
@@ -282,7 +282,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
 
   /// Sanity: non-degenerate configurations pass through `effective(_:)` unchanged.
   func testEffectivePolicyPositiveTtlPreserved() throws {
-    let persistence = VariantLookupPolicy.persistenceUntilNetworkSuccess(ttl: 3600)
+    let persistence = VariantLookupPolicy.persistenceUntilNetworkSuccess(persistenceTtl: 3600)
     if case .persistenceUntilNetworkSuccess(let t) = VariantLookupPolicy.effective(persistence) {
       XCTAssertEqual(t, 3600)
     } else {
@@ -311,7 +311,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
     XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 0))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 0))
     waitForTrackingQueue(manager: manager)
 
     XCTAssertFalse(
@@ -335,7 +335,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
       instanceName: instanceName)
 
     let manager = makeManager(
-      distinctId: "user_a", context: context, policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
+      distinctId: "user_a", context: context, policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
 
     waitForTrackingQueue(manager: manager)
 
@@ -366,7 +366,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
     XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
     waitForTrackingQueue(manager: manager)
 
     XCTAssertFalse(manager.areFlagsReady(), "distinctId mismatch should leave flags empty")
@@ -398,7 +398,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
     let manager = makeManager(
       distinctId: "user_a",
       context: ["plan": "enterprise"],
-      policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
+      policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
     waitForTrackingQueue(manager: manager)
 
     XCTAssertTrue(
@@ -418,7 +418,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
       instanceName: instanceName)
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 60))  // 60s TTL
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))  // 60s TTL
     waitForTrackingQueue(manager: manager)
 
     XCTAssertFalse(manager.areFlagsReady(), "expired entry should be ignored")
@@ -437,7 +437,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
     XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
     waitForTrackingQueue(manager: manager)
 
     XCTAssertFalse(manager.areFlagsReady(), "unparseable response should leave flags empty")
@@ -497,7 +497,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
         token: "test_token",
         featureFlagOptions: FeatureFlagOptions(
           enabled: true,
-          variantLookupPolicy: .persistenceUntilNetworkSuccess(ttl: 86_400))),
+          variantLookupPolicy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))),
       distinctId: "wrong_user")
     retainedDelegates.append(delegate)
 
@@ -537,7 +537,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// treated as not-present by `getVariantSync` — the developer fallback is returned instead.
   func testGetVariantSyncReturnsFallbackForExpiredPersistedVariant() throws {
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 60))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
     waitForTrackingQueue(manager: manager)
 
     // Inject an expired persisted variant directly into in-memory state. Bypasses the disk
@@ -564,7 +564,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// `.persistence` source preserved).
   func testGetVariantSyncReturnsFreshPersistedVariant() throws {
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
     waitForTrackingQueue(manager: manager)
 
     let persistedAt = Date(timeIntervalSinceNow: -60)
@@ -588,7 +588,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// applies to `.persistence(persistedAt:)` variants.
   func testGetVariantSyncReturnsNetworkVariantRegardlessOfAge() throws {
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 60))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
     waitForTrackingQueue(manager: manager)
 
     // .network variants don't carry a timestamp, so the TTL check should always return false.
@@ -610,7 +610,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// the TTL check together.
   func testGetAllVariantsSyncFiltersPersistedVariantsWhenBlobIsStale() throws {
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 60))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
     waitForTrackingQueue(manager: manager)
 
     let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
@@ -646,7 +646,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
     MixpanelPersistence.saveFlagsPersistence(blob, instanceName: instanceName)
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
     waitForTrackingQueue(manager: manager)
     XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
@@ -682,7 +682,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
       instanceName: instanceName)
 
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .networkFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .networkFirst(persistenceTtl: 86_400))
 
     // Configure the mock to "succeed" with new flags, but with a delay that lets us assert
     // the async lookup waited for the network rather than serving persisted values
@@ -721,7 +721,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
       instanceName: instanceName)
 
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .networkFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .networkFirst(persistenceTtl: 86_400))
     mock.simulatedFetchResult = (success: false, flags: nil)
 
     waitForTrackingQueue(manager: mock)
@@ -748,7 +748,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
       instanceName: instanceName)
 
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
     // Configure a slow network so we'd notice if the lookup was waiting on it.
     mock.simulatedFetchResult = (
       success: true, flags: ["flag_a": MixpanelFlagVariant(key: "v2", value: "network_val")])
@@ -782,7 +782,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
       instanceName: instanceName)
 
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
     waitForTrackingQueue(manager: manager)
 
     XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
@@ -809,7 +809,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
       instanceName: instanceName)
 
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
     // Make the post-setContext fetch fail so we can isolate setContext's effect — without
     // a successful overwrite, the blob's survival is solely attributable to setContext
     // NOT wiping it. The same goes for in-memory state.
@@ -845,7 +845,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// the developer fallback.
   func testGetVariantAsyncTriggersFetchWhenLoadedBlobIsStale() throws {
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 60))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
     waitForTrackingQueue(manager: mock)
 
     // Inject an expired persisted variant directly. Bypasses the disk-load path so we can
@@ -884,7 +884,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// resurrect stale values just because the network was unavailable.
   func testGetVariantAsyncReturnsFallbackWhenStaleBlobAndFetchFails() throws {
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 60))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
     waitForTrackingQueue(manager: mock)
 
     let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
@@ -910,7 +910,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// than returning an empty (post-filter) dictionary without attempting refresh.
   func testGetAllVariantsAsyncTriggersFetchWhenLoadedBlobIsStale() throws {
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 60))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
     waitForTrackingQueue(manager: mock)
 
     let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
@@ -948,7 +948,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// we trust that.
   func testGetVariantAsyncServesFallbackOnEmptyFreshBlobWithoutRefresh() throws {
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
     waitForTrackingQueue(manager: mock)
 
     let freshPersistedAt = Date(timeIntervalSinceNow: -60)  // well within TTL
@@ -981,7 +981,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// variants to check, but its persistedAt still tells us when to give up on the cache.
   func testGetVariantAsyncTriggersFetchWhenEmptyBlobIsStale() throws {
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 60))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
     waitForTrackingQueue(manager: mock)
 
     let stalePersistedAt = Date(timeIntervalSinceNow: -3600)  // well past 60s TTL
@@ -1011,7 +1011,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// network round-trip.
   func testGetVariantAsyncServesFreshPersistedImmediatelyWithoutFetch() throws {
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
     waitForTrackingQueue(manager: mock)
 
     let freshPersistedAt = Date(timeIntervalSinceNow: -60)
@@ -1057,7 +1057,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
     let persistedAt = Date(timeIntervalSinceNow: -60)  // 60s ago
     let ttlSeconds: TimeInterval = 86_400  // 24 hours
     let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: ttlSeconds))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: ttlSeconds))
     waitForTrackingQueue(manager: manager)
     let delegate = retainedDelegates.last as! PersistenceTestMockDelegate
 
@@ -1164,7 +1164,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
       instanceName: instanceName)
 
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .networkFirst(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .networkFirst(persistenceTtl: 86_400))
     waitForTrackingQueue(manager: mock)
 
     // Round 1: fetch fails. Lookup falls back to persisted value.
@@ -1226,7 +1226,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// background-refresh trigger.
   func testPersistenceUntilNetworkSuccessLookupKicksOffBackgroundRefresh() throws {
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
     waitForTrackingQueue(manager: mock)
 
     let freshPersistedAt = Date(timeIntervalSinceNow: -60)
@@ -1273,7 +1273,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
   /// fetch on every single lookup forever.
   func testPersistenceUntilNetworkSuccessBackgroundRefreshSelfStopsAfterSuccess() throws {
     let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
     waitForTrackingQueue(manager: mock)
 
     let freshPersistedAt = Date(timeIntervalSinceNow: -60)

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
@@ -57,8 +57,12 @@ private final class PersistenceTestMockDelegate: MixpanelFlagDelegate {
 private final class PersistenceTestMockManager: FeatureFlagManager {
   var simulatedFetchResult: (success: Bool, flags: [String: MixpanelFlagVariant]?)?
   var simulatedNetworkDelay: TimeInterval = 0.1
+  private let fetchCountQueue = DispatchQueue(label: "ff.mock.fetchcount.\(UUID().uuidString)")
+  private var _fetchCallCount = 0
+  var fetchCallCount: Int { fetchCountQueue.sync { _fetchCallCount } }
 
   override func _performFetchRequest() {
+    fetchCountQueue.sync { _fetchCallCount += 1 }
     let work: () -> Void = { [weak self] in
       guard let self = self else { return }
       guard let result = self.simulatedFetchResult else {
@@ -1177,6 +1181,101 @@ class FeatureFlagPersistenceTests: XCTestCase {
     XCTAssertEqual(props["$variant_source"] as? String, "network")
     XCTAssertNil(props["$persisted_at_in_ms"], "network variants don't carry persistedAt")
     XCTAssertNil(props["$ttl_in_ms"], "network variants don't carry TTL")
+  }
+
+  // MARK: - PersistenceUntilNetworkSuccess background refresh
+
+  /// PUN's contract is "serve persisted now, refresh in background." The first lookup that
+  /// finds the immediate-serve path satisfied by a persisted blob (not yet overwritten by a
+  /// successful network fetch) must kick off a background fetch — without blocking the
+  /// lookup itself — so subsequent lookups eventually see fresh values. The fetch self-stops
+  /// because a successful fetch clears `loadedBlobPersistedAt`, taking us off the
+  /// background-refresh trigger.
+  func testPersistenceUntilNetworkSuccessLookupKicksOffBackgroundRefresh() throws {
+    let mock = makeMockManager(
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
+    waitForTrackingQueue(manager: mock)
+
+    let freshPersistedAt = Date(timeIntervalSinceNow: -60)
+    let persisted = MixpanelFlagVariant(key: "v_old", value: "persisted_val")
+      .withSource(.persistence(persistedAt: freshPersistedAt))
+    mock.flagsLock.write {
+      mock.flags = ["flag_a": persisted]
+      mock.loadedBlobPersistedAt = freshPersistedAt
+    }
+
+    // Hang the simulated fetch so it counts as kicked-off but doesn't complete and replace
+    // `flags` mid-test. Counter increments synchronously inside `_performFetchRequest`.
+    mock.simulatedFetchResult = (success: true, flags: ["flag_a": MixpanelFlagVariant(key: "v_new", value: "network_val")])
+    mock.simulatedNetworkDelay = 60  // effectively never completes within the test
+
+    XCTAssertEqual(mock.fetchCallCount, 0, "no fetch before lookup")
+
+    let asyncDone = expectation(description: "async lookup completes immediately")
+    let start = Date()
+    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+      let elapsed = Date().timeIntervalSince(start)
+      XCTAssertEqual(
+        variant.value as? String, "persisted_val",
+        "lookup must serve the persisted value, not wait on the background fetch")
+      if case .persistence = variant.source {} else {
+        XCTFail("expected .persistence source")
+      }
+      XCTAssertLessThan(elapsed, 0.5, "lookup must not block on the background fetch")
+      asyncDone.fulfill()
+    }
+    wait(for: [asyncDone], timeout: 2.0)
+
+    // Drain the tracking queue to make sure the background _fetchFlagsIfNeeded has been
+    // invoked (it's posted to the same serial queue from inside the lookup block).
+    waitForTrackingQueue(manager: mock)
+    XCTAssertEqual(
+      mock.fetchCallCount, 1,
+      "PUN's first lookup serving persistence should kick off exactly one background fetch")
+  }
+
+  /// After the background fetch completes successfully, `loadedBlobPersistedAt` is cleared
+  /// (in production, by the fetch-success handler) so subsequent lookups stop triggering
+  /// the background-refresh path. Verifies the self-stopping property: PUN doesn't fire a
+  /// fetch on every single lookup forever.
+  func testPersistenceUntilNetworkSuccessBackgroundRefreshSelfStopsAfterSuccess() throws {
+    let mock = makeMockManager(
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
+    waitForTrackingQueue(manager: mock)
+
+    let freshPersistedAt = Date(timeIntervalSinceNow: -60)
+    let persisted = MixpanelFlagVariant(key: "v1", value: "persisted_val")
+      .withSource(.persistence(persistedAt: freshPersistedAt))
+    mock.flagsLock.write {
+      mock.flags = ["flag_a": persisted]
+      mock.loadedBlobPersistedAt = freshPersistedAt
+    }
+
+    mock.simulatedFetchResult = (
+      success: true, flags: ["flag_a": MixpanelFlagVariant(key: "v2", value: "network_val")])
+    mock.simulatedNetworkDelay = 0  // complete immediately so flags get replaced post-fetch
+
+    // First lookup: kicks off the background refresh.
+    let firstDone = expectation(description: "first lookup")
+    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fb")) { _ in firstDone.fulfill() }
+    wait(for: [firstDone], timeout: 2.0)
+    waitForTrackingQueue(manager: mock)
+    XCTAssertEqual(mock.fetchCallCount, 1, "first lookup kicks off the background refresh")
+
+    // Second lookup: now `loadedBlobPersistedAt` should be nil (cleared by the successful
+    // fetch), so this lookup serves the network value without triggering another fetch.
+    let secondDone = expectation(description: "second lookup")
+    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fb")) { variant in
+      XCTAssertEqual(
+        variant.value as? String, "network_val",
+        "second lookup should serve the freshly-fetched network value")
+      secondDone.fulfill()
+    }
+    wait(for: [secondDone], timeout: 2.0)
+    waitForTrackingQueue(manager: mock)
+    XCTAssertEqual(
+      mock.fetchCallCount, 1,
+      "no additional fetch — successful refresh cleared loadedBlobPersistedAt")
   }
 
   // MARK: - Tracking dedup window resets after every successful fetch

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
@@ -228,6 +228,51 @@ class FeatureFlagPersistenceTests: XCTestCase {
     }
   }
 
+  /// Matches the JS SDK's TTL contract: a negative TTL is invalid and silently coerced to
+  /// `defaultTTL`. Verified end-to-end via the staleness behavior — a fresh persisted
+  /// variant must NOT be treated as expired under negative TTL (because we coerce to 24h,
+  /// not "always expired").
+  func testNegativeTTLIsCoercedToDefault() throws {
+    let manager = makeManager(
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: -1))
+    waitForTrackingQueue(manager: manager)
+
+    let recentlyPersistedAt = Date(timeIntervalSinceNow: -60)  // 60s ago, well within 24h
+    let fresh = MixpanelFlagVariant(key: "v1", value: "fresh_value")
+      .withSource(.persistence(persistedAt: recentlyPersistedAt))
+    manager.flagsLock.write {
+      manager.flags = ["flag_a": fresh]
+      manager.loadedBlobPersistedAt = recentlyPersistedAt
+    }
+
+    let result = manager.getVariantSync("flag_a", fallback: MixpanelFlagVariant(value: "fb"))
+    XCTAssertEqual(
+      result.value as? String, "fresh_value",
+      "negative TTL should fall back to defaultTTL, leaving recent variants servable")
+  }
+
+  /// TTL of `0` means "always expired" (matches JS). Even a variant persisted just now is
+  /// past TTL on the next check.
+  func testZeroTTLTreatsAllPersistedVariantsAsExpired() throws {
+    let manager = makeManager(
+      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 0))
+    waitForTrackingQueue(manager: manager)
+
+    let justNow = Date(timeIntervalSinceNow: -0.001)
+    let variant = MixpanelFlagVariant(key: "v1", value: "stale")
+      .withSource(.persistence(persistedAt: justNow))
+    manager.flagsLock.write {
+      manager.flags = ["flag_a": variant]
+      manager.loadedBlobPersistedAt = justNow
+    }
+
+    let fallback = MixpanelFlagVariant(key: "fb", value: "fallback_val")
+    let result = manager.getVariantSync("flag_a", fallback: fallback)
+    XCTAssertEqual(
+      result.value as? String, "fallback_val",
+      "TTL of 0 should treat any persisted variant as expired")
+  }
+
   // MARK: - Init loads persisted variants and stamps them
 
   func testInitLoadsPersistedVariantsAndStampsPersistenceSource() throws {
@@ -1040,10 +1085,11 @@ class FeatureFlagPersistenceTests: XCTestCase {
     XCTAssertEqual(props["$ttl_in_ms"] as? Int, Int(ttlSeconds * 1000))
   }
 
-  /// `.network`-sourced variants must NOT include any of the persistence-layer tracking
-  /// properties. This protects against accidentally leaking persistence-stamped variants
-  /// through the `.network` path or vice versa.
-  func testTrackingOmitsPersistencePropertiesForNetworkVariant() throws {
+  /// `.network`-sourced variants carry `$variant_source = "network"` (matching the JS SDK)
+  /// but NOT the persistence-layer-only properties (`$persisted_at_in_ms`, `$ttl_in_ms`).
+  /// This protects against accidentally leaking persistence properties through the
+  /// `.network` path.
+  func testTrackingIncludesVariantSourceForNetworkVariant() throws {
     let delegate = PersistenceTestMockDelegate(
       options: MixpanelOptions(
         token: "test_token",
@@ -1081,9 +1127,9 @@ class FeatureFlagPersistenceTests: XCTestCase {
     let experiment = try XCTUnwrap(events.first(where: { $0.event == "$experiment_started" }))
     let props = try XCTUnwrap(experiment.properties)
 
-    XCTAssertNil(props["$variant_source"], "network variants must not carry $variant_source")
-    XCTAssertNil(props["$persisted_at_in_ms"])
-    XCTAssertNil(props["$ttl_in_ms"])
+    XCTAssertEqual(props["$variant_source"] as? String, "network")
+    XCTAssertNil(props["$persisted_at_in_ms"], "network variants don't carry persistedAt")
+    XCTAssertNil(props["$ttl_in_ms"], "network variants don't carry TTL")
   }
 
   // MARK: - Helpers

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
@@ -52,8 +52,8 @@ private final class PersistenceTestMockDelegate: MixpanelFlagDelegate {
 
 /// Minimal mock of FeatureFlagManager that intercepts the network call. Deliberately
 /// reproduces the parts of the real fetch path we care about (source stamping,
-/// awaitingInitialNetworkResponse handling, completion fan-out) so async-lookup tests
-/// can verify behavior end-to-end.
+/// `loadedBlobPersistedAt` lifecycle, completion fan-out) so async-lookup tests can
+/// verify behavior end-to-end.
 private final class PersistenceTestMockManager: FeatureFlagManager {
   var simulatedFetchResult: (success: Bool, flags: [String: MixpanelFlagVariant]?)?
   var simulatedNetworkDelay: TimeInterval = 0.1
@@ -66,7 +66,6 @@ private final class PersistenceTestMockManager: FeatureFlagManager {
     let work: () -> Void = { [weak self] in
       guard let self = self else { return }
       guard let result = self.simulatedFetchResult else {
-        self.flagsLock.write { self.awaitingInitialNetworkResponse = false }
         self._completeFetch(success: false)
         return
       }
@@ -74,18 +73,17 @@ private final class PersistenceTestMockManager: FeatureFlagManager {
         let stamped = flags.mapValues { $0.withSource(.network) }
         self.flagsLock.write {
           self.flags = stamped
+          // Mirror production: a successful fetch overwrites the persisted blob (so the
+          // marker clears) and resets the per-flag $experiment_started dedup window.
           self.loadedBlobPersistedAt = nil
-          // Mirror production: clear the per-flag $experiment_started dedup window on every
-          // successful fetch so a flag whose variant changed between fetches re-fires
-          // tracking on the next lookup.
           self.trackedFeatures.removeAll()
-          self.awaitingInitialNetworkResponse = false
           self.timeLastFetched = Date()
         }
         self._completeFetch(success: true)
       } else {
-        // Failure: leave flags in place (NetworkFirst fallback semantics) but clear awaiting.
-        self.flagsLock.write { self.awaitingInitialNetworkResponse = false }
+        // Failure: leave `flags` AND `loadedBlobPersistedAt` in place. NetworkFirst's
+        // `isNetworkFirstAwaitingFetch()` derives from the persisted-blob marker, so the
+        // gate stays true after a failure and the next async lookup retries the network.
         self._completeFetch(success: false)
       }
     }
@@ -674,44 +672,6 @@ class FeatureFlagPersistenceTests: XCTestCase {
 
   // MARK: - NetworkFirst gating
 
-  func testNetworkFirstSetsAwaitingFlagWhenPersistenceLoaded() throws {
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"persisted_val"}}}"#
-    MixpanelPersistence.saveFlagsPersistence(
-      FlagsPersistenceBlob(
-        persistedAt: Date(),
-        distinctId: "user_a",
-        response: response),
-      instanceName: instanceName)
-
-    let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .networkFirst(ttl: 86_400))
-    waitForTrackingQueue(manager: manager)
-
-    // Sync lookups + areFlagsReady reflect the persistence layer regardless of policy.
-    XCTAssertTrue(manager.areFlagsReady())
-    var awaitingValue = false
-    manager.flagsLock.read { awaitingValue = manager.awaitingInitialNetworkResponse }
-    XCTAssertTrue(awaitingValue, ".networkFirst must await initial network response")
-  }
-
-  func testPersistenceUntilNetworkSuccessDoesNotSetAwaitingFlagWhenPersistenceLoaded() throws {
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"persisted_val"}}}"#
-    MixpanelPersistence.saveFlagsPersistence(
-      FlagsPersistenceBlob(
-        persistedAt: Date(),
-        distinctId: "user_a",
-        response: response),
-      instanceName: instanceName)
-
-    let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(ttl: 86_400))
-    waitForTrackingQueue(manager: manager)
-
-    var awaitingValue = false
-    manager.flagsLock.read { awaitingValue = manager.awaitingInitialNetworkResponse }
-    XCTAssertFalse(awaitingValue, ".persistenceUntilNetworkSuccess must not await initial network response")
-  }
-
   func testNetworkFirstAsyncLookupAwaitsFetchEvenWithPersistence() throws {
     let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"persisted_val"}}}"#
     MixpanelPersistence.saveFlagsPersistence(
@@ -1181,6 +1141,79 @@ class FeatureFlagPersistenceTests: XCTestCase {
     XCTAssertEqual(props["$variant_source"] as? String, "network")
     XCTAssertNil(props["$persisted_at_in_ms"], "network variants don't carry persistedAt")
     XCTAssertNil(props["$ttl_in_ms"], "network variants don't carry TTL")
+  }
+
+  // MARK: - NetworkFirst retries until a fetch succeeds
+
+  /// Regression test for the bug where NetworkFirst would stop attempting the network after
+  /// the first failure: `awaitingInitialNetworkResponse` was being cleared on fetch failure,
+  /// so subsequent async lookups would silently serve persistence forever even though no
+  /// successful network response had ever come back.
+  ///
+  /// Spec: NetworkFirst lookups await a successful network response. After a failed fetch,
+  /// the next async lookup must retry the network — only a successful fetch satisfies the
+  /// "we got the network value" gate. Verified end-to-end: two failed fetches in a row → two
+  /// fetch attempts (not one).
+  func testNetworkFirstRetriesNetworkAfterFailureUntilSuccess() throws {
+    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"persisted_val"}}}"#
+    MixpanelPersistence.saveFlagsPersistence(
+      FlagsPersistenceBlob(
+        persistedAt: Date(),
+        distinctId: "user_a",
+        response: response),
+      instanceName: instanceName)
+
+    let mock = makeMockManager(
+      distinctId: "user_a", context: [:], policy: .networkFirst(ttl: 86_400))
+    waitForTrackingQueue(manager: mock)
+
+    // Round 1: fetch fails. Lookup falls back to persisted value.
+    mock.simulatedFetchResult = (success: false, flags: nil)
+    mock.simulatedNetworkDelay = 0
+    let firstDone = expectation(description: "first lookup")
+    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+      XCTAssertEqual(variant.value as? String, "persisted_val",
+                     "first lookup should fall back to persisted value after failed fetch")
+      firstDone.fulfill()
+    }
+    wait(for: [firstDone], timeout: 2.0)
+    XCTAssertEqual(mock.fetchCallCount, 1, "first lookup should trigger one fetch attempt")
+
+    // Round 2: fetch fails again. Pre-fix, the lookup would skip the network entirely
+    // (`awaiting` had been cleared by round 1's failure) and serve persisted directly,
+    // leaving the count at 1. Post-fix, NetworkFirst retries until success.
+    let secondDone = expectation(description: "second lookup")
+    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+      XCTAssertEqual(variant.value as? String, "persisted_val")
+      secondDone.fulfill()
+    }
+    wait(for: [secondDone], timeout: 2.0)
+    XCTAssertEqual(
+      mock.fetchCallCount, 2,
+      "NetworkFirst must retry the network on subsequent lookups after a failure")
+
+    // Round 3: fetch succeeds. Network value served, blob marker cleared.
+    mock.simulatedFetchResult = (
+      success: true, flags: ["flag_a": MixpanelFlagVariant(key: "v_fresh", value: "network_val")])
+    let thirdDone = expectation(description: "third lookup")
+    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+      XCTAssertEqual(variant.value as? String, "network_val",
+                     "successful fetch should serve the network value")
+      thirdDone.fulfill()
+    }
+    wait(for: [thirdDone], timeout: 2.0)
+    XCTAssertEqual(mock.fetchCallCount, 3, "third lookup triggers the successful fetch")
+
+    // Round 4: subsequent lookup should NOT retry — the gate flipped off after success.
+    let fourthDone = expectation(description: "fourth lookup")
+    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+      XCTAssertEqual(variant.value as? String, "network_val")
+      fourthDone.fulfill()
+    }
+    wait(for: [fourthDone], timeout: 2.0)
+    XCTAssertEqual(
+      mock.fetchCallCount, 3,
+      "after a successful fetch, NetworkFirst stops retrying — gate is satisfied")
   }
 
   // MARK: - PersistenceUntilNetworkSuccess background refresh

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
@@ -2602,4 +2602,155 @@ class FeatureFlagManagerTests: XCTestCase {
     _ = delegate
   }
 
+  // MARK: - Reset Tests
+
+  private func waitForResetToComplete(_ mockMgr: MockFeatureFlagManager, timeout: TimeInterval = 10.0) {
+    // reset() dispatches its work onto trackingQueue. Wait for `flags` to be cleared
+    // as a proxy for the reset block having executed.
+    let cleared = NSPredicate { _, _ in
+      var done = false
+      mockMgr.flagsLock.read { done = mockMgr.flags == nil }
+      return done
+    }
+    wait(for: [XCTNSPredicateExpectation(predicate: cleared, object: nil)], timeout: timeout)
+  }
+
+  func testReset_ClearsFlagsAndFetchTiming() {
+    setupReadyFlagsAndVerify()
+
+    guard let mockMgr = mockManager else {
+      XCTFail("Manager is not a MockFeatureFlagManager")
+      return
+    }
+
+    // Sanity check pre-reset state
+    mockMgr.flagsLock.read {
+      XCTAssertNotNil(mockMgr.flags, "Flags should be set before reset")
+      XCTAssertNotNil(mockMgr.timeLastFetched, "timeLastFetched should be set before reset")
+      XCTAssertNotNil(mockMgr.fetchLatencyMs, "fetchLatencyMs should be set before reset")
+    }
+
+    mockMgr.reset()
+    waitForResetToComplete(mockMgr)
+
+    XCTAssertFalse(manager.areFlagsReady(), "Flags should not be ready after reset")
+    mockMgr.flagsLock.read {
+      XCTAssertNil(mockMgr.flags, "flags should be cleared")
+      XCTAssertNil(mockMgr.timeLastFetched, "timeLastFetched should be cleared")
+      XCTAssertNil(mockMgr.fetchLatencyMs, "fetchLatencyMs should be cleared")
+      XCTAssertFalse(mockMgr.isFetching, "isFetching should be false after reset")
+    }
+  }
+
+  func testReset_ClearsTrackedFeaturesSoTrackingFiresAgain() {
+    setupReadyFlagsAndVerify()
+
+    guard let mockMgr = mockManager else {
+      XCTFail("Manager is not a MockFeatureFlagManager")
+      return
+    }
+
+    // First read tracks the variant exactly once.
+    expectTracking(expectedCount: 1, description: "Initial tracking") {
+      _ = manager.getVariantSync("feature_string", fallback: defaultFallback)
+    }
+
+    // A second read with the same flag should NOT track again pre-reset.
+    _ = manager.getVariantSync("feature_string", fallback: defaultFallback)
+    waitBriefly()
+    XCTAssertEqual(mockDelegate.trackedEvents.count, 1, "Second read pre-reset should not re-track")
+
+    mockMgr.reset()
+    waitForResetToComplete(mockMgr)
+
+    // Re-populate flags after the reset (mirrors a refetch under a new identity).
+    setupReadyFlags()
+
+    // After reset, reading the same flag should track again because the
+    // trackedFeatures set was cleared.
+    expectTracking(expectedCount: 1, description: "Tracking after reset") {
+      _ = manager.getVariantSync("feature_string", fallback: defaultFallback)
+    }
+  }
+
+  func testReset_ClearsFirstTimeEventState() {
+    guard let mockMgr = mockManager else {
+      XCTFail("Manager is not a MockFeatureFlagManager")
+      return
+    }
+
+    let pendingVariant = MixpanelFlagVariant(key: "activated", value: true)
+    let pendingEvent = createPendingEvent(
+      flagKey: "reset-flag",
+      eventName: "Reset Event",
+      filters: nil,
+      pendingVariant: pendingVariant
+    )
+
+    mockMgr.flagsLock.write {
+      mockMgr.flags = ["reset-flag": createControlVariant()]
+      mockMgr.pendingFirstTimeEvents = ["reset-flag:hash123": pendingEvent]
+      mockMgr.pendingFirstTimeEventNames = [pendingEvent.eventName]
+      mockMgr.activatedFirstTimeEvents.insert("reset-flag:hash123")
+    }
+
+    mockMgr.flagsLock.read {
+      XCTAssertEqual(mockMgr.pendingFirstTimeEvents.count, 1)
+      XCTAssertEqual(mockMgr.pendingFirstTimeEventNames.count, 1)
+      XCTAssertEqual(mockMgr.activatedFirstTimeEvents.count, 1)
+    }
+
+    mockMgr.reset()
+    waitForResetToComplete(mockMgr)
+
+    mockMgr.flagsLock.read {
+      XCTAssertTrue(mockMgr.pendingFirstTimeEvents.isEmpty,
+                    "pendingFirstTimeEvents should be cleared by reset")
+      XCTAssertTrue(mockMgr.pendingFirstTimeEventNames.isEmpty,
+                    "pendingFirstTimeEventNames should be cleared by reset")
+      XCTAssertTrue(mockMgr.activatedFirstTimeEvents.isEmpty,
+                    "activatedFirstTimeEvents should be cleared by reset")
+    }
+  }
+
+  func testReset_PreservesContextSetViaSetContext() {
+    guard let mockMgr = mockManager else {
+      XCTFail("Manager is not a MockFeatureFlagManager")
+      return
+    }
+
+    // Default options carry an empty context.
+    mockMgr.flagsLock.read {
+      XCTAssertTrue(mockMgr.flagContext.isEmpty, "Initial flagContext should be empty")
+    }
+
+    let customContext: [String: Any] = [
+      "user_id": "ctx-user",
+      "group_id": "ctx-group",
+    ]
+
+    let setContextExpectation = XCTestExpectation(description: "setContext completes")
+    mockMgr.setContext(customContext) {
+      setContextExpectation.fulfill()
+    }
+    wait(for: [setContextExpectation], timeout: 5.0)
+
+    mockMgr.flagsLock.read {
+      XCTAssertEqual(mockMgr.flagContext["user_id"] as? String, "ctx-user")
+      XCTAssertEqual(mockMgr.flagContext["group_id"] as? String, "ctx-group")
+    }
+
+    mockMgr.reset()
+    waitForResetToComplete(mockMgr)
+
+    // setContext-supplied context should survive reset() — only identity-tied
+    // state (flags, tracking, first-time events, fetch timing) is cleared.
+    mockMgr.flagsLock.read {
+      XCTAssertEqual(mockMgr.flagContext["user_id"] as? String, "ctx-user",
+                     "setContext value should survive reset()")
+      XCTAssertEqual(mockMgr.flagContext["group_id"] as? String, "ctx-group",
+                     "setContext value should survive reset()")
+    }
+  }
+
 }  // End Test Class

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
@@ -2604,15 +2604,16 @@ class FeatureFlagManagerTests: XCTestCase {
 
   // MARK: - Reset Tests
 
-  private func waitForResetToComplete(_ mockMgr: MockFeatureFlagManager, timeout: TimeInterval = 10.0) {
-    // reset() dispatches its work onto trackingQueue. Wait for `flags` to be cleared
-    // as a proxy for the reset block having executed.
-    let cleared = NSPredicate { _, _ in
-      var done = false
-      mockMgr.flagsLock.read { done = mockMgr.flags == nil }
-      return done
+  /// Calls `reset()` and blocks until its completion fires. We use the completion (rather
+  /// than polling for `flags == nil`) because the polling approach is vacuous in tests where
+  /// `flags` was already nil before the reset — the predicate would match immediately
+  /// without observing the reset block actually running, masking real bugs.
+  private func resetAndWait(_ mockMgr: MockFeatureFlagManager, timeout: TimeInterval = 10.0) {
+    let done = expectation(description: "FeatureFlagManager.reset completes")
+    mockMgr.reset {
+      done.fulfill()
     }
-    wait(for: [XCTNSPredicateExpectation(predicate: cleared, object: nil)], timeout: timeout)
+    wait(for: [done], timeout: timeout)
   }
 
   func testReset_ClearsFlagsAndFetchTiming() {
@@ -2630,8 +2631,7 @@ class FeatureFlagManagerTests: XCTestCase {
       XCTAssertNotNil(mockMgr.fetchLatencyMs, "fetchLatencyMs should be set before reset")
     }
 
-    mockMgr.reset()
-    waitForResetToComplete(mockMgr)
+    resetAndWait(mockMgr)
 
     XCTAssertFalse(manager.areFlagsReady(), "Flags should not be ready after reset")
     mockMgr.flagsLock.read {
@@ -2660,8 +2660,7 @@ class FeatureFlagManagerTests: XCTestCase {
     waitBriefly()
     XCTAssertEqual(mockDelegate.trackedEvents.count, 1, "Second read pre-reset should not re-track")
 
-    mockMgr.reset()
-    waitForResetToComplete(mockMgr)
+    resetAndWait(mockMgr)
 
     // Re-populate flags after the reset (mirrors a refetch under a new identity).
     setupReadyFlags()
@@ -2700,8 +2699,7 @@ class FeatureFlagManagerTests: XCTestCase {
       XCTAssertEqual(mockMgr.activatedFirstTimeEvents.count, 1)
     }
 
-    mockMgr.reset()
-    waitForResetToComplete(mockMgr)
+    resetAndWait(mockMgr)
 
     mockMgr.flagsLock.read {
       XCTAssertTrue(mockMgr.pendingFirstTimeEvents.isEmpty,
@@ -2740,8 +2738,7 @@ class FeatureFlagManagerTests: XCTestCase {
       XCTAssertEqual(mockMgr.flagContext["group_id"] as? String, "ctx-group")
     }
 
-    mockMgr.reset()
-    waitForResetToComplete(mockMgr)
+    resetAndWait(mockMgr)
 
     // setContext-supplied context should survive reset() — only identity-tied
     // state (flags, tracking, first-time events, fetch timing) is cleared.

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
@@ -941,7 +941,7 @@ class FeatureFlagManagerTests: XCTestCase {
     }
 
     // MockFeatureFlagManager will automatically handle the fetch simulation
-    wait(for: [expectation], timeout: 3.0)
+    wait(for: [expectation], timeout: 10.0)
 
     XCTAssertNotNil(receivedVariants, "Should receive variants after fetch")
     XCTAssertEqual(receivedVariants?.count, sampleFlags.count, "Should return all flags after fetch")
@@ -964,7 +964,7 @@ class FeatureFlagManagerTests: XCTestCase {
       expectation.fulfill()
     }
 
-    wait(for: [expectation], timeout: 3.0)
+    wait(for: [expectation], timeout: 10.0)
 
     XCTAssertNotNil(receivedVariants, "Should receive result even on failure")
     XCTAssertTrue(receivedVariants?.isEmpty ?? false, "Should return empty dictionary on fetch failure")
@@ -1716,10 +1716,16 @@ class FeatureFlagManagerTests: XCTestCase {
         XCTAssertGreaterThan(latencyMs, 0, "fetchLatencyMs should be positive")
         XCTAssertLessThan(latencyMs, 30000, "fetchLatencyMs should be less than 30 seconds")
 
-        // Verify latency is in reasonable range for our simulated delay
-        // Allow generous tolerance for CI/slow systems with async dispatch overhead
+        // Sanity check that the SDK's reported latency is in the same ballpark as the
+        // wall-clock duration of the call. We don't assert tight bounds: `fetchStartTime`
+        // is captured before `getVariant` returns control to the trackingQueue, so on a
+        // contested CI runner the dispatch delay before the mock fetch even starts can
+        // dwarf the simulated 100ms delay. The SDK timer (latencyMs) measures only the
+        // fetch itself, so it can legitimately be much smaller than actualElapsedMs.
+        // Using a 30s tolerance — same as the upper bound on latencyMs above — keeps
+        // this an order-of-magnitude check rather than a tight equivalence one.
         let actualElapsedMs = Int(Date().timeIntervalSince(fetchStartTime) * 1000)
-        let tolerance = 5000  // 5s tolerance for slow CI runners
+        let tolerance = 30000
         XCTAssertLessThanOrEqual(
           abs(latencyMs - actualElapsedMs), tolerance,
           "fetchLatencyMs (\(latencyMs)ms) should be close to actual elapsed time (\(actualElapsedMs)ms)"

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
@@ -292,7 +292,7 @@ class FeatureFlagManagerTests: XCTestCase {
     mockDelegate = MockFeatureFlagDelegate()
 
     // Use MockFeatureFlagManager to prevent real network calls
-      let mockManager = MockFeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: mockDelegate)
+      let mockManager = MockFeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: mockDelegate)
     // Configure default simulation - successful fetch with sample flags
     mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
     mockManager.shouldSimulateNetworkDelay = true
@@ -1317,7 +1317,7 @@ class FeatureFlagManagerTests: XCTestCase {
 
   func testFetchWithNoDelegate() {
     // Create manager with no delegate
-      let noDelegate = FeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: nil)
+      let noDelegate = FeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: nil)
 
     // Try to load flags
     noDelegate.loadFlags()
@@ -1520,7 +1520,7 @@ class FeatureFlagManagerTests: XCTestCase {
       anonymousId: testAnonymousId
     )
 
-      let manager = FeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: mockDelegate)
+      let manager = FeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: mockDelegate)
 
     // Verify the delegate methods return expected values
     XCTAssertEqual(mockDelegate.getDistinctId(), testDistinctId)
@@ -1541,7 +1541,7 @@ class FeatureFlagManagerTests: XCTestCase {
       anonymousId: nil
     )
 
-      let manager = FeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: mockDelegate)
+      let manager = FeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: mockDelegate)
 
     // Verify the delegate methods return expected values
     XCTAssertEqual(mockDelegate.getDistinctId(), testDistinctId)
@@ -1916,7 +1916,7 @@ class FeatureFlagManagerTests: XCTestCase {
 
   func testGETRequestFormat() {
     // Use a fresh MockFeatureFlagManager with request validation enabled
-      let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: mockDelegate)
+      let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: mockDelegate)
     mockManager.requestValidationEnabled = true
     mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
 
@@ -1981,7 +1981,7 @@ class FeatureFlagManagerTests: XCTestCase {
       anonymousId: "custom-device-id"
     )
 
-      let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: customDelegate)
+      let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: customDelegate)
     mockManager.requestValidationEnabled = true
     mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
 
@@ -2024,7 +2024,7 @@ class FeatureFlagManagerTests: XCTestCase {
       anonymousId: nil
     )
 
-      let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: nilAnonymousDelegate)
+      let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: nilAnonymousDelegate)
     mockManager.requestValidationEnabled = true
     mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
 
@@ -2534,7 +2534,7 @@ class FeatureFlagManagerTests: XCTestCase {
         featureFlagOptions: FeatureFlagOptions(enabled: true, prefetchFlags: true)
       )
     )
-      let mock = MockFeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: delegate)
+      let mock = MockFeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: delegate)
     mock.simulatedFetchResult = (success: true, flags: sampleFlags)
 
     // Call loadFlags() (which prefetchFlags: true would trigger during init)
@@ -2560,7 +2560,7 @@ class FeatureFlagManagerTests: XCTestCase {
         featureFlagOptions: FeatureFlagOptions(enabled: true, prefetchFlags: false)
       )
     )
-      let mock = MockFeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: delegate)
+      let mock = MockFeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: delegate)
     mock.simulatedFetchResult = (success: true, flags: sampleFlags)
 
     // Do NOT call loadFlags() - simulating prefetchFlags: false behavior
@@ -2584,7 +2584,7 @@ class FeatureFlagManagerTests: XCTestCase {
       )
     )
 
-      let mockManager = MockFeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), delegate: delegate)
+      let mockManager = MockFeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: delegate)
     mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
 
     // Manually load flags (simulating what user would do after identify)

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -40,6 +40,21 @@ public struct MixpanelFlagVariant: Decodable {
   public let isExperimentActive: Bool? // Corresponds to 'is_experiment_active' from API
   public let isQATester: Bool? // Corresponds to 'is_qa_tester' from API
 
+  /// Where this variant was sourced from. `nil` on developer-supplied fallback instances;
+  /// `.network` or `.cache(at:)` when the SDK serves a variant. For cached variants, the
+  /// timestamp lives on the `.cache` case so invalid combinations like "network with a
+  /// timestamp" are unrepresentable.
+  public let source: Source?
+
+  /// Identifies where a served variant came from.
+  public enum Source {
+    /// Variant assigned by the most recent successful `/flags/` network call.
+    case network
+    /// Variant loaded from the on-disk cache. `at` is the time the variant set was
+    /// originally written to the cache.
+    case cache(at: Date)
+  }
+
   enum CodingKeys: String, CodingKey {
     case key = "variant_key"
     case value = "variant_value"
@@ -63,6 +78,7 @@ public struct MixpanelFlagVariant: Decodable {
     experimentID = try container.decodeIfPresent(String.self, forKey: .experimentID)
     isExperimentActive = try container.decodeIfPresent(Bool.self, forKey: .isExperimentActive)
     isQATester = try container.decodeIfPresent(Bool.self, forKey: .isQATester)
+    source = nil
   }
 
   // Helper initializer with fallbacks, value defaults to key if nil
@@ -76,6 +92,36 @@ public struct MixpanelFlagVariant: Decodable {
     self.experimentID = experimentID
     self.isExperimentActive = isExperimentActive
     self.isQATester = isQATester
+    self.source = nil
+  }
+
+  /// Internal initializer used when stamping a served variant with its origin.
+  internal init(
+    key: String,
+    value: Any?,
+    experimentID: String?,
+    isExperimentActive: Bool?,
+    isQATester: Bool?,
+    source: Source?
+  ) {
+    self.key = key
+    self.value = value
+    self.experimentID = experimentID
+    self.isExperimentActive = isExperimentActive
+    self.isQATester = isQATester
+    self.source = source
+  }
+
+  /// Returns a copy of this variant stamped with the given source. Other fields are preserved.
+  internal func withSource(_ source: Source) -> MixpanelFlagVariant {
+    return MixpanelFlagVariant(
+      key: self.key,
+      value: self.value,
+      experimentID: self.experimentID,
+      isExperimentActive: self.isExperimentActive,
+      isQATester: self.isQATester,
+      source: source
+    )
   }
 }
 
@@ -162,10 +208,16 @@ public protocol MixpanelFlags {
   /// The completion handler is called with `true` on success and `false` on failure.
   func loadFlags(completion: ((Bool) -> Void)?)
 
-  /// Synchronously checks if the flags  have been successfully loaded
-  /// and are available for querying.
+  /// Synchronously checks if flag variants are in memory and available for synchronous access.
   ///
-  /// - Returns: `true` if the flags are loaded and ready for use, `false` otherwise.
+  /// - Note: When a caching `variantLookupPolicy` is configured (`.cacheFirst` or
+  ///   `.networkFirst`), this can return `true` before the SDK has spoken to the network this
+  ///   session — the returned variants may be stale data from a previous session. Use the
+  ///   `source` field on the served `MixpanelFlagVariant` to distinguish: `.network` for
+  ///   fresh values, `.cache(at:)` for on-disk-cache values (with the cache timestamp).
+  ///
+  /// - Returns: `true` if flag variants are available in memory (from network or cache),
+  ///            `false` otherwise.
   func areFlagsReady() -> Bool
 
   // --- Sync Flag Retrieval ---
@@ -300,9 +352,14 @@ public protocol MixpanelFlags {
 
   /// Replaces the current custom flag evaluation context entirely and triggers a flag re-fetch.
   ///
+  /// In-memory variants and the on-disk cache are intentionally NOT cleared — the cache is
+  /// keyed on distinctId only, so it remains valid for this user across context changes. The
+  /// next successful fetch under the new context will overwrite the cache with fresh values.
+  ///
   /// - Parameters:
   ///   - context: The new context dictionary to use for flag evaluation.
-  ///   - completion: A closure called when the fetch completes (success or failure).
+  ///   - completion: A closure called when the fetch under the new context completes (success
+  ///     or failure). Always invoked exactly once.
   func setContext(_ context: [String: Any], completion: @escaping () -> Void)
 }
 
@@ -331,6 +388,18 @@ class FeatureFlagManager: MixpanelFlags {
   var isFetching: Bool = false
   private var trackedFeatures: Set<String> = Set()
   private var fetchCompletionHandlers: [(Bool) -> Void] = []
+
+  /// True when `flags` was populated from the on-disk cache and we have not yet seen the
+  /// initial network response for the current user/context. Only set for `.networkFirst` —
+  /// `.cacheFirst` serves cached values immediately. Async lookups gate on this to honor the
+  /// NetworkFirst spec ("await on network call, only serve persisted values if it fails")
+  /// while still letting sync lookups + areFlagsReady() see the cached values.
+  internal var awaitingInitialNetworkResponse: Bool = false
+
+  /// Per-instance name used as the UserDefaults key prefix for the on-disk cache. Captured
+  /// from the delegate at init so we can persist/clear without holding a delegate reference
+  /// during async work.
+  private let instanceName: String
 
   // First-time event targeting state
   internal var pendingFirstTimeEvents: [String: PendingFirstTimeEvent] = [:]  // Keyed by "flagKey:firstTimeEventHash"
@@ -361,15 +430,37 @@ class FeatureFlagManager: MixpanelFlags {
   private var currentOptions: MixpanelOptions? { delegate?.getOptions() }
   private var flagsRoute = "/flags/"
 
-  // Queue for synchronizing flag operations with tracking
-  private var trackingQueue: DispatchQueue
+  // Queue for synchronizing flag operations with tracking. `internal` rather than `private`
+  // so tests can post barrier tasks to wait for queued work (cache load on init, etc.).
+  internal var trackingQueue: DispatchQueue
 
   // Initializers
-    internal init(serverURL: String, trackingQueue: DispatchQueue, delegate: MixpanelFlagDelegate? = nil) {
+    internal init(
+      serverURL: String,
+      trackingQueue: DispatchQueue,
+      instanceName: String,
+      delegate: MixpanelFlagDelegate? = nil
+    ) {
         self.serverURL = serverURL
         self.trackingQueue = trackingQueue
+        self.instanceName = instanceName
         self.delegate = delegate
         self.flagContext = delegate?.getOptions().featureFlagOptions.context ?? [:]
+
+        // Load cached variants on the tracking queue so UserDefaults I/O doesn't block the
+        // caller (typically the main thread during MixpanelInstance construction). Only do
+        // this when the configuration actually reads from cache — NetworkOnly + cacheVariants
+        // means writes-only and shouldn't load.
+        if let options = delegate?.getOptions(), options.featureFlagOptions.enabled {
+            switch options.featureFlagOptions.variantLookupPolicy {
+            case .cacheFirst, .networkFirst:
+                trackingQueue.async { [weak self] in
+                    self?._loadCachedVariants()
+                }
+            case .networkOnly:
+                break
+            }
+        }
     }
 
   // --- Public Methods ---
@@ -385,8 +476,11 @@ class FeatureFlagManager: MixpanelFlags {
     }
   }
 
-  /// Clears all in-memory feature flag state: cached flags, tracked-flag set, fetch timing,
-  /// and first-time event state. Intended to be called from `MixpanelInstance.reset()`.
+  /// Clears all in-memory feature flag state (cached flags, tracked-flag set, fetch timing,
+  /// first-time event state) AND wipes the on-disk cache blob. Intended for identity-change
+  /// paths: `MixpanelInstance.reset()`, `identify` when distinctId actually changes, and
+  /// `optOutTracking`. `setContext` deliberately does NOT call this — context changes don't
+  /// invalidate the cache (the blob is keyed on distinctId only).
   ///
   /// Posts to the tracking queue so the mutation is serialized with reads and fetches. Any
   /// in-flight fetch dispatched before this call is discarded when it completes (via the
@@ -407,10 +501,16 @@ class FeatureFlagManager: MixpanelFlags {
         self.fetchStartTime = nil
         self.timeLastFetched = nil
         self.fetchLatencyMs = nil
+        self.awaitingInitialNetworkResponse = false
         orphanedHandlers = self.fetchCompletionHandlers
         self.fetchCompletionHandlers.removeAll()
         self.isFetching = false
       }
+
+      // Wipe the on-disk cache so a freshly-identified user can't be served the prior
+      // user's variants. `MixpanelInstance.reset()` also wipes via deleteMPUserDefaultsData,
+      // so this is defensive (idempotent) but keeps the manager self-contained.
+      MixpanelPersistence.deleteFlagsCache(instanceName: self.instanceName)
 
       DispatchQueue.main.async {
         orphanedHandlers.forEach { $0(false) }
@@ -422,7 +522,7 @@ class FeatureFlagManager: MixpanelFlags {
     flagsLock.write {
       self.flagContext = context
     }
-      trackingQueue.async { [weak self] in
+    trackingQueue.async { [weak self] in
       self?._fetchFlagsIfNeeded { _ in
         completion()
       }
@@ -503,12 +603,15 @@ class FeatureFlagManager: MixpanelFlags {
 
       var flagVariant: MixpanelFlagVariant?
       var needsTrackingCheck = false
-      var flagsAreCurrentlyReady = false
+      var canServeImmediately = false
 
-      // Read state with lock
+      // Read state with lock. Serve immediately when flags are populated AND we're not in
+      // the NetworkFirst-init window (waiting for the first network response after a cache
+      // hit). For CacheFirst, awaitingInitialNetworkResponse is never set so cached values
+      // are served right away.
       self.flagsLock.read {
-        flagsAreCurrentlyReady = (self.flags != nil)
-        if flagsAreCurrentlyReady, let currentFlags = self.flags {
+        canServeImmediately = (self.flags != nil) && !self.awaitingInitialNetworkResponse
+        if canServeImmediately, let currentFlags = self.flags {
           if let variant = currentFlags[flagName] {
             flagVariant = variant
             needsTrackingCheck = !self.trackedFeatures.contains(flagName)
@@ -516,7 +619,7 @@ class FeatureFlagManager: MixpanelFlags {
         }
       }
 
-      if flagsAreCurrentlyReady {
+      if canServeImmediately {
         let result = flagVariant ?? fallback
         if flagVariant != nil, needsTrackingCheck {
           // Perform atomic check-and-track
@@ -525,21 +628,19 @@ class FeatureFlagManager: MixpanelFlags {
         DispatchQueue.main.async { completion(result) }
 
       } else {
-        // --- Flags were NOT ready ---
-        // Trigger fetch; fetch completion will handle calling the original completion handler
-        MixpanelLogger.debug(message: "Flags not ready, attempting fetch for getFeature call...")
-        self._fetchFlagsIfNeeded { success in
-          // This completion runs *after* fetch completes (or fails)
-          let result: MixpanelFlagVariant
-          if success {
-            // Fetch succeeded – call the private impl directly to avoid false positive DEBUG warning
-            result = self._getVariantSyncImpl(flagName, fallback: fallback)
-          } else {
-            MixpanelLogger.warn(message: "Failed to fetch flags, returning fallback for \(flagName).")
-            result = fallback
+        // Flags not yet servable. Either nothing in memory, or NetworkFirst awaiting the
+        // initial network response. Trigger a fetch and serve from `flags` afterward.
+        // On failure, `flags` is left untouched: NetworkFirst with a cache hit still has
+        // cached values (Source.cache); everything else stays nil and we serve the fallback.
+        MixpanelLogger.debug(message: "Flags not yet servable, attempting fetch for getVariant '\(flagName)'...")
+        self._fetchFlagsIfNeeded { _ in
+          // Hop back to the tracking queue so we can read flags + run the tracking check
+          // atomically. Whether the fetch succeeded or not, _getVariantSyncImpl returns the
+          // variant from `flags` if present (cached or network) else the fallback.
+          self.trackingQueue.async {
+            let result = self._getVariantSyncImpl(flagName, fallback: fallback)
+            DispatchQueue.main.async { completion(result) }
           }
-          // Call original completion (on main thread)
-          DispatchQueue.main.async { completion(result) }
         }
       }
     }
@@ -604,22 +705,20 @@ class FeatureFlagManager: MixpanelFlags {
       }
 
       var currentFlags: [String: MixpanelFlagVariant]?
-      self.flagsLock.read { currentFlags = self.flags }
+      var canServeImmediately = false
+      self.flagsLock.read {
+        canServeImmediately = (self.flags != nil) && !self.awaitingInitialNetworkResponse
+        if canServeImmediately { currentFlags = self.flags }
+      }
       if let currentFlags = currentFlags {
         DispatchQueue.main.async { completion(currentFlags) }
       } else {
-        // Flags not ready, trigger fetch
-        MixpanelLogger.debug(message: "Flags not ready, attempting fetch for getAllVariants call...")
-        self._fetchFlagsIfNeeded { success in
-          let result: [String: MixpanelFlagVariant]
-          if success {
-            // Fetch succeeded – call the private impl directly to avoid false positive DEBUG warning
-            result = self._getAllVariantsSyncImpl()
-          } else {
-            MixpanelLogger.warn(message: "Failed to fetch flags, returning empty dictionary.")
-            result = [:]
-          }
-          DispatchQueue.main.async { completion(result) }
+        // Either nothing in memory yet, or NetworkFirst awaiting the initial network
+        // response. Trigger a fetch and serve from `flags` afterward — on success it has
+        // the fresh values, on NetworkFirst failure the cached values stayed in place.
+        MixpanelLogger.debug(message: "Flags not yet servable, attempting fetch for getAllVariants...")
+        self._fetchFlagsIfNeeded { _ in
+          DispatchQueue.main.async { completion(self._getAllVariantsSyncImpl()) }
         }
       }
     }
@@ -716,7 +815,13 @@ class FeatureFlagManager: MixpanelFlags {
       URLQueryItem(name: "$lib_version", value: AutomaticProperties.libVersion())
     ]
 
+    // Capture the raw response bytes via a reference holder so we can persist the wire
+    // format unchanged. Storing raw JSON (rather than re-encoding the parsed variants)
+    // keeps the parser as the single source of truth and carries `pending_first_time_events`
+    // through to subsequent loads for free.
+    let rawHolder = RawDataHolder()
     let responseParser: (Data) -> FlagsResponse? = { data in
+      rawHolder.data = data
       do { return try JSONDecoder().decode(FlagsResponse.self, from: data) } catch {
         MixpanelLogger.error(message: "Error parsing flags JSON: \(error)")
         return nil
@@ -725,6 +830,11 @@ class FeatureFlagManager: MixpanelFlags {
     let resource = Network.buildResource(
       path: flagsRoute, method: .get, queryItems: queryItems, headers: headers,
       parse: responseParser)
+
+    // Capture the distinctId at dispatch time. Using this (rather than re-reading delegate
+    // state at write time) ensures the persisted blob is keyed to the user we actually
+    // fetched for, even if identify() raced ahead.
+    let distinctIdAtDispatch = distinctId
 
     // Make the API request
     Network.apiRequest(
@@ -737,6 +847,12 @@ class FeatureFlagManager: MixpanelFlags {
           MixpanelLogger.debug(
             message: "Discarding flag fetch failure from stale generation \(generation).")
           return
+        }
+        // Whether or not we have cached values, we've definitively failed to get a network
+        // response. NetworkFirst async lookups can stop awaiting and serve from `flags`
+        // (cached values stay in place since we don't touch them on failure).
+        self.flagsLock.write {
+          self.awaitingInitialNetworkResponse = false
         }
         self._completeFetch(success: false)
       },
@@ -756,13 +872,33 @@ class FeatureFlagManager: MixpanelFlags {
           responsePendingEvents: flagsResponse.pendingFirstTimeEvents
         )
 
+        // Stamp every variant with .network before publishing. mergeFlags may have preserved
+        // some prior-flag entries (activated first-time events) — those came from a prior
+        // network response too, so .network is correct for them as well.
+        let stampedFlags = mergedFlags.mapValues { $0.withSource(.network) }
+
+        // Snapshot the cache-policy decision OUTSIDE the lock to avoid calling into the
+        // delegate (`getOptions()`) while holding the write lock — keeps the lock surface
+        // narrow and avoids potential deadlocks if a future delegate impl ever takes a lock
+        // of its own.
+        let shouldCache = self.shouldCacheVariants()
+
+        // Single critical section: gate the in-memory write AND the on-disk cache write on
+        // the same generation check. Without this, a reset() between the lock release and
+        // the disk write could leak prior-user variants onto disk under the prior-user
+        // distinctId (the next session's distinctId check would catch it, but the disk
+        // write is wasted I/O and confusing in logs).
+        var didApplyResults = false
         self.flagsLock.write {
           // Re-check generation under the lock in case reset() raced between the check above
           // and the write. If stale, drop the result without touching state or completing.
           guard generation == self.fetchGeneration else { return }
-          self.flags = mergedFlags
+          self.flags = stampedFlags
           self.pendingFirstTimeEvents = mergedPendingEvents
           self.pendingFirstTimeEventNames = mergedPendingEventNames
+          // Network response received — async lookups can stop awaiting (NetworkFirst) and
+          // serve from the freshly-populated `flags`.
+          self.awaitingInitialNetworkResponse = false
 
           // Calculate timing metrics
           if let startTime = self.fetchStartTime {
@@ -772,11 +908,136 @@ class FeatureFlagManager: MixpanelFlags {
           self.timeLastFetched = fetchEndTime
 
           MixpanelLogger.debug(message: "Flags updated: \(self.flags ?? [:]), Pending events: \(self.pendingFirstTimeEvents.count)")
+          didApplyResults = true
+        }
+
+        // Persist the raw response so future sessions / failed fetches can fall back. Writes
+        // are independent of the lookup policy — a customer may opt into caching just to warm
+        // up for a future migration to a caching policy. Skipped when `didApplyResults` is
+        // false because that means the generation check failed (reset raced ahead) and we
+        // shouldn't overwrite the cache with prior-user data. UserDefaults I/O is kept
+        // outside the lock since it can block.
+        if didApplyResults,
+           shouldCache,
+           let rawData = rawHolder.data,
+           let rawString = String(data: rawData, encoding: .utf8) {
+          let blob = FlagsCacheBlob(
+            cachedAt: fetchEndTime,
+            distinctId: distinctIdAtDispatch,
+            response: rawString
+          )
+          MixpanelPersistence.saveFlagsCache(blob, instanceName: self.instanceName)
         }
 
         self._completeFetch(success: true)
       }
     )
+  }
+
+  /// Internal reference-type holder so the response-parser closure can hand the raw response
+  /// bytes back to the success closure for caching. Class (not struct) so the captured
+  /// reference shares state across closure invocations.
+  private final class RawDataHolder {
+    var data: Data?
+  }
+
+  // MARK: - Cache Helpers
+
+  /// Loads the on-disk cache, validates distinctId + TTL, parses, stamps every variant with
+  /// `.cache(at:)`, and writes into `flags`. Both `.cacheFirst` and `.networkFirst` populate
+  /// `flags` directly so sync lookups and `areFlagsReady()` reflect the cache. The difference
+  /// between policies is enforced at async-lookup time via `awaitingInitialNetworkResponse`:
+  /// `.networkFirst` sets it true so async lookups await the network call before serving.
+  ///
+  /// Runs on the tracking queue (called from init).
+  internal func _loadCachedVariants() {
+    guard let blob = MixpanelPersistence.loadFlagsCache(instanceName: self.instanceName) else {
+      return
+    }
+
+    // distinctId check — refuse to serve another user's variants under this user's identity.
+    let delegate = self.delegate
+    let currentDistinctId = delegate?.getDistinctId() ?? ""
+    if blob.distinctId != currentDistinctId {
+      MixpanelLogger.debug(message: "Cached flags belong to a different distinct_id; ignoring cache.")
+      return
+    }
+
+    // TTL check — discard expired entries.
+    if let ttl = self.cacheTtlSeconds(), ttl > 0,
+       Date().timeIntervalSince(blob.cachedAt) > ttl {
+      MixpanelLogger.debug(message: "Cached flags expired; ignoring cache.")
+      return
+    }
+
+    // Parse the raw response. The persistence layer self-heals structural failures (bad
+    // JSON envelope) on read, but a structurally-valid blob with an unparseable `response`
+    // string would stick on disk and fail every cold-start. Wipe it here too so the next
+    // successful fetch gets a clean slate.
+    guard let responseData = blob.response.data(using: .utf8),
+          let parsed = try? JSONDecoder().decode(FlagsResponse.self, from: responseData) else {
+      MixpanelLogger.warn(message: "Failed to parse cached flags response; clearing.")
+      MixpanelPersistence.deleteFlagsCache(instanceName: self.instanceName)
+      return
+    }
+
+    let parsedFlags = parsed.flags ?? [:]
+    let stamped = parsedFlags.mapValues { $0.withSource(.cache(at: blob.cachedAt)) }
+
+    // Build pending-event lookups so first-time event matching keeps working from cache.
+    var pendingEvents: [String: PendingFirstTimeEvent] = [:]
+    var pendingEventNames: Set<String> = []
+    if let events = parsed.pendingFirstTimeEvents {
+      for event in events {
+        let key = self.getPendingEventKey(event.flagKey, event.firstTimeEventHash)
+        pendingEvents[key] = event
+        pendingEventNames.insert(event.eventName)
+      }
+    }
+
+    // Snapshot the policy OUTSIDE the lock — `currentLookupPolicy()` calls into the delegate,
+    // and we don't want to hold a delegate call inside our write lock (a future delegate impl
+    // taking its own lock could deadlock). Compute here, branch on it inside the lock.
+    let isNetworkFirst: Bool
+    if case .networkFirst = self.currentLookupPolicy() {
+      isNetworkFirst = true
+    } else {
+      isNetworkFirst = false
+    }
+
+    flagsLock.write {
+      // Defer to network values if a fetch already raced ahead of us between init and now.
+      guard self.flags == nil else { return }
+      self.flags = stamped
+      self.pendingFirstTimeEvents = pendingEvents
+      self.pendingFirstTimeEventNames = pendingEventNames
+      // For .networkFirst, async lookups must wait for the initial network response. The
+      // fetch success/failure path will clear this flag.
+      if isNetworkFirst {
+        self.awaitingInitialNetworkResponse = true
+      }
+      MixpanelLogger.debug(message: "Loaded \(stamped.count) cached variants into memory.")
+    }
+  }
+
+  /// Returns the configured TTL in seconds, or `nil` for `.networkOnly` (no expiry check).
+  /// `.cacheFirst(0)` / `.networkFirst(0)` (or negative) effectively disable expiry — the
+  /// _loadCachedVariants caller treats `<= 0` as "no expiry".
+  private func cacheTtlSeconds() -> TimeInterval? {
+    switch self.currentLookupPolicy() {
+    case .networkOnly:
+      return nil
+    case .cacheFirst(let ttl), .networkFirst(let ttl):
+      return ttl
+    }
+  }
+
+  private func currentLookupPolicy() -> VariantLookupPolicy {
+    return self.delegate?.getOptions().featureFlagOptions.variantLookupPolicy ?? .networkOnly
+  }
+
+  private func shouldCacheVariants() -> Bool {
+    return self.delegate?.getOptions().featureFlagOptions.cacheVariants ?? false
   }
 
   /// Returns true if the captured `generation` no longer matches the current generation,
@@ -1047,11 +1308,14 @@ class FeatureFlagManager: MixpanelFlags {
                 if !activatedFirstTimeEvents.contains(eventKey) {
                     // We won the race - activate this event
                     activatedFirstTimeEvents.insert(eventKey)
-                    
+
                     if flags == nil {
                         flags = [:]
                     }
-                    flags![flagKey] = pendingEvent.pendingVariant
+                    // Stamp NETWORK source — the activated variant came from the prior /flags/
+                    // response. Activations are deliberately not persisted; the cache stays a
+                    // passive snapshot of the wire response so it can be re-loaded verbatim.
+                    flags![flagKey] = pendingEvent.pendingVariant.withSource(.network)
                     shouldActivate = true
                 }
             }

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -40,11 +40,12 @@ public struct MixpanelFlagVariant: Decodable {
   public let isExperimentActive: Bool? // Corresponds to 'is_experiment_active' from API
   public let isQATester: Bool? // Corresponds to 'is_qa_tester' from API
 
-  /// Where this variant was sourced from. `nil` on developer-supplied fallback instances;
-  /// `.network` or `.persistence(persistedAt:)` when the SDK serves a variant. For persisted
-  /// variants, the timestamp lives on the `.persistence` case so invalid combinations like
-  /// "network with a timestamp" are unrepresentable.
-  public let source: Source?
+  /// Where this variant was sourced from. Always non-nil — every `MixpanelFlagVariant`
+  /// carries a definite source. `.fallback` for developer-supplied fallback instances;
+  /// `.network` or `.persistence(persistedAt:)` when the SDK serves a variant. For
+  /// persisted variants, the timestamp lives on the `.persistence` case so invalid
+  /// combinations like "network with a timestamp" are unrepresentable.
+  public let source: Source
 
   /// Identifies where a served variant came from.
   public enum Source {
@@ -53,6 +54,9 @@ public struct MixpanelFlagVariant: Decodable {
     /// Variant loaded from the on-disk persistence layer. `persistedAt` is the time the
     /// variant set was originally written to disk.
     case persistence(persistedAt: Date)
+    /// Developer-supplied fallback returned because the SDK had no value to serve (flag
+    /// not in the loaded set, flags never loaded, fetch failed under NetworkFirst, etc.).
+    case fallback
   }
 
   enum CodingKeys: String, CodingKey {
@@ -78,7 +82,10 @@ public struct MixpanelFlagVariant: Decodable {
     experimentID = try container.decodeIfPresent(String.self, forKey: .experimentID)
     isExperimentActive = try container.decodeIfPresent(Bool.self, forKey: .isExperimentActive)
     isQATester = try container.decodeIfPresent(Bool.self, forKey: .isQATester)
-    source = nil
+    // Decoded variants are immediately re-stamped via `withSource` before being placed in
+    // `flags`, so the customer never observes `.fallback` here. Defaulting to `.fallback`
+    // keeps `source` non-optional without needing a sentinel "unstamped" case.
+    source = .fallback
   }
 
   // Helper initializer with fallbacks, value defaults to key if nil
@@ -92,7 +99,7 @@ public struct MixpanelFlagVariant: Decodable {
     self.experimentID = experimentID
     self.isExperimentActive = isExperimentActive
     self.isQATester = isQATester
-    self.source = nil
+    self.source = .fallback
   }
 
   /// Internal initializer used when stamping a served variant with its origin.
@@ -102,7 +109,7 @@ public struct MixpanelFlagVariant: Decodable {
     experimentID: String?,
     isExperimentActive: Bool?,
     isQATester: Bool?,
-    source: Source?
+    source: Source
   ) {
     self.key = key
     self.value = value

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -399,6 +399,21 @@ class FeatureFlagManager: MixpanelFlags {
   /// values.
   internal var awaitingInitialNetworkResponse: Bool = false
 
+  /// `persistedAt` from the persisted blob currently sitting in `flags`. Lifetime matches
+  /// the persistence-derived state (`flags` + `pendingFirstTimeEvents`):
+  ///   - Set in `_loadPersistedVariants` when we read the blob from disk
+  ///   - Cleared in the network-fetch success closure (the in-memory blob is fully
+  ///     `.network`-stamped after a refresh, so the persisted timestamp no longer applies)
+  ///   - Cleared in `reset()` along with the rest of the per-user state
+  ///
+  /// Stored separately from the `.persistence(persistedAt:)` variant case so we can answer
+  /// "is the loaded blob past TTL?" even when `flags` is empty (the previous session may
+  /// have persisted an empty response).
+  ///
+  /// `internal` so tests that inject `.persistence` variants directly can match the
+  /// production invariant.
+  internal var loadedBlobPersistedAt: Date?
+
   /// Per-instance name used as the UserDefaults key prefix for the on-disk persistence layer.
   /// Captured from the delegate at init so we can persist/clear without holding a delegate
   /// reference during async work.
@@ -500,6 +515,7 @@ class FeatureFlagManager: MixpanelFlags {
       self.flagsLock.write {
         self.fetchGeneration &+= 1
         self.flags = nil
+        self.loadedBlobPersistedAt = nil
         self.trackedFeatures.removeAll()
         self.pendingFirstTimeEvents.removeAll()
         self.pendingFirstTimeEventNames.removeAll()
@@ -615,18 +631,20 @@ class FeatureFlagManager: MixpanelFlags {
       var needsTrackingCheck = false
       var canServeImmediately = false
 
-      // Read state with lock. Serve immediately when flags are populated AND we're not in
-      // the NetworkFirst-init window (waiting for the first network response after a
-      // persistence hit). For PersistenceFirst, awaitingInitialNetworkResponse is never set
-      // so persisted values are served right away. Expired persisted variants are treated as
-      // not-present so the caller falls through to the fetch path below.
+      // Read state with lock. Serve immediately when flags are populated, we're not in the
+      // NetworkFirst-init window (waiting for the first network response after a persistence
+      // hit), AND the loaded blob isn't past TTL. The blob-staleness check is what makes the
+      // async path fall through to a fetch when persisted values have aged out mid-session —
+      // the inline TTL check below would otherwise silently serve the developer fallback
+      // without refreshing.
       self.flagsLock.read {
-        canServeImmediately = (self.flags != nil) && !self.awaitingInitialNetworkResponse
-        if canServeImmediately, let currentFlags = self.flags {
-          if let variant = currentFlags[flagName], !self.isVariantExpired(variant) {
-            flagVariant = variant
-            needsTrackingCheck = !self.trackedFeatures.contains(flagName)
-          }
+        guard let currentFlags = self.flags,
+              !self.awaitingInitialNetworkResponse,
+              !self.loadedFlagsAreStale() else { return }
+        canServeImmediately = true
+        if let variant = currentFlags[flagName], !self.isVariantExpired(variant) {
+          flagVariant = variant
+          needsTrackingCheck = !self.trackedFeatures.contains(flagName)
         }
       }
 
@@ -722,16 +740,20 @@ class FeatureFlagManager: MixpanelFlags {
 
       var canServeImmediately = false
       self.flagsLock.read {
-        canServeImmediately = (self.flags != nil) && !self.awaitingInitialNetworkResponse
+        canServeImmediately = (self.flags != nil)
+          && !self.awaitingInitialNetworkResponse
+          && !self.loadedFlagsAreStale()
       }
       if canServeImmediately {
         // Use the sync impl so the expired-filter is applied consistently.
         let result = self._getAllVariantsSyncImpl()
         DispatchQueue.main.async { completion(result) }
       } else {
-        // Either nothing in memory yet, or NetworkFirst awaiting the initial network
-        // response. Trigger a fetch and serve from `flags` afterward — on success it has
-        // the fresh values, on NetworkFirst failure the persisted values stayed in place.
+        // Either nothing in memory yet, NetworkFirst awaiting the initial network response,
+        // or the loaded persisted blob is past TTL. Trigger a fetch and serve from `flags`
+        // afterward — on success it has the fresh values, on NetworkFirst failure the
+        // persisted values stayed in place (still served, _getAllVariantsSyncImpl filters
+        // any expired entries).
         MixpanelLogger.debug(message: "Flags not yet servable, attempting fetch for getAllVariants...")
         self._fetchFlagsIfNeeded { _ in
           DispatchQueue.main.async { completion(self._getAllVariantsSyncImpl()) }
@@ -910,6 +932,7 @@ class FeatureFlagManager: MixpanelFlags {
           // and the write. If stale, drop the result without touching state or completing.
           guard generation == self.fetchGeneration else { return }
           self.flags = stampedFlags
+          self.loadedBlobPersistedAt = nil
           self.pendingFirstTimeEvents = mergedPendingEvents
           self.pendingFirstTimeEventNames = mergedPendingEventNames
           // Network response received — async lookups can stop awaiting (NetworkFirst) and
@@ -1031,6 +1054,7 @@ class FeatureFlagManager: MixpanelFlags {
       // Defer to network values if a fetch already raced ahead of us between init and now.
       guard self.flags == nil else { return }
       self.flags = stamped
+      self.loadedBlobPersistedAt = blob.persistedAt
       self.pendingFirstTimeEvents = pendingEvents
       self.pendingFirstTimeEventNames = pendingEventNames
       // For .networkFirst, async lookups must wait for the initial network response. The
@@ -1069,19 +1093,31 @@ class FeatureFlagManager: MixpanelFlags {
     }
   }
 
-  /// Returns true if the variant came from the on-disk persistence layer and has aged past
-  /// the configured TTL. Variants stamped `.network` (or `nil` developer fallbacks) are never
-  /// expired.
+  /// Returns true if the loaded persisted blob is past TTL. Uses `loadedBlobPersistedAt`
+  /// rather than inspecting variant sources so the check works uniformly whether the blob
+  /// has flags in it or is empty (a previous session may have persisted a no-flags
+  /// response — we still want TTL to govern when to refresh).
   ///
-  /// Get-paths use this to skip stale persisted values mid-session — once a persisted blob's
-  /// TTL elapses while it's loaded in memory, subsequent `getVariant` calls return the
-  /// developer fallback instead of the stale value. The blob itself is intentionally NOT
-  /// deleted (per the "don't clear if TTL has expired on getVariant" rule); the next
-  /// successful network fetch overwrites it.
+  /// Returns false when no persisted blob is in memory, under `.networkOnly`, or with
+  /// TTL `<= 0`.
   ///
-  /// `.networkOnly` policy returns `nil` from `persistenceTtlSeconds()` so this returns false;
-  /// in practice no `.persistence(persistedAt:)` variants exist under `.networkOnly` anyway.
-  /// TTL `<= 0` disables expiry entirely (matches the init-time semantics).
+  /// Caller must hold `flagsLock`.
+  private func loadedFlagsAreStale() -> Bool {
+    guard let persistedAt = self.loadedBlobPersistedAt,
+          let ttl = self.persistenceTtlSeconds(), ttl > 0 else { return false }
+    return Date().timeIntervalSince(persistedAt) > ttl
+  }
+
+  /// Returns true if the variant was loaded from the persistence layer and has aged past
+  /// the configured TTL. `.network` variants (and `nil`-source developer fallbacks) are
+  /// never expired — including activated first-time-event variants, which are deliberately
+  /// stamped `.network` to survive blob expiration.
+  ///
+  /// Get-paths use this to skip stale persisted values mid-session — once a variant's TTL
+  /// elapses while loaded in memory, subsequent `getVariant` calls return the developer
+  /// fallback instead of the stale value. The on-disk blob is intentionally NOT deleted
+  /// (per the "don't clear if TTL has expired on getVariant" rule); the next successful
+  /// network fetch overwrites it.
   private func isVariantExpired(_ variant: MixpanelFlagVariant) -> Bool {
     guard case .persistence(let persistedAt) = variant.source else { return false }
     guard let ttl = self.persistenceTtlSeconds(), ttl > 0 else { return false }

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -1014,8 +1014,9 @@ class FeatureFlagManager: MixpanelFlags {
       return
     }
 
-    // TTL check — discard expired entries.
-    if let ttl = self.persistenceTtlSeconds(), ttl > 0,
+    // TTL check — discard expired entries. TTL of 0 means "always expired"; negative TTLs
+    // are coerced to default by `persistenceTtlSeconds()`.
+    if let ttl = self.persistenceTtlSeconds(),
        Date().timeIntervalSince(blob.persistedAt) > ttl {
       MixpanelLogger.debug(message: "Persisted flags expired; ignoring.")
       return
@@ -1074,13 +1075,18 @@ class FeatureFlagManager: MixpanelFlags {
   }
 
   /// Returns the configured TTL in seconds, or `nil` for `.networkOnly` (no expiry check).
-  /// `.persistenceUntilNetworkSuccess(0)` / `.networkFirst(0)` (or negative) effectively disable expiry —
-  /// the `_loadPersistedVariants` caller treats `<= 0` as "no expiry".
+  /// Negative TTLs are invalid and coerced to `VariantLookupPolicy.defaultTTL` with a warning
+  /// (matches the JS SDK). TTL of `0` is valid and means "always expired."
   private func persistenceTtlSeconds() -> TimeInterval? {
     switch self.currentLookupPolicy() {
     case .networkOnly:
       return nil
     case .persistenceUntilNetworkSuccess(let ttl), .networkFirst(let ttl):
+      if ttl < 0 {
+        MixpanelLogger.warn(
+          message: "Negative TTL (\(ttl)) is invalid; using default \(VariantLookupPolicy.defaultTTL)s")
+        return VariantLookupPolicy.defaultTTL
+      }
       return ttl
     }
   }
@@ -1105,20 +1111,19 @@ class FeatureFlagManager: MixpanelFlags {
   /// has flags in it or is empty (a previous session may have persisted a no-flags
   /// response — we still want TTL to govern when to refresh).
   ///
-  /// Returns false when no persisted blob is in memory, under `.networkOnly`, or with
-  /// TTL `<= 0`.
+  /// Returns false when no persisted blob is in memory or under `.networkOnly`.
   ///
   /// Caller must hold `flagsLock`.
   private func loadedFlagsAreStale() -> Bool {
     guard let persistedAt = self.loadedBlobPersistedAt,
-          let ttl = self.persistenceTtlSeconds(), ttl > 0 else { return false }
+          let ttl = self.persistenceTtlSeconds() else { return false }
     return Date().timeIntervalSince(persistedAt) > ttl
   }
 
   /// Returns true if the variant was loaded from the persistence layer and has aged past
-  /// the configured TTL. `.network` variants (and `nil`-source developer fallbacks) are
-  /// never expired — including activated first-time-event variants, which are deliberately
-  /// stamped `.network` to survive blob expiration.
+  /// the configured TTL. `.network` and `.fallback` variants are never expired — including
+  /// activated first-time-event variants, which are deliberately stamped `.network` to
+  /// survive blob expiration.
   ///
   /// Get-paths use this to skip stale persisted values mid-session — once a variant's TTL
   /// elapses while loaded in memory, subsequent `getVariant` calls return the developer
@@ -1127,7 +1132,7 @@ class FeatureFlagManager: MixpanelFlags {
   /// network fetch overwrites it.
   private func isVariantExpired(_ variant: MixpanelFlagVariant) -> Bool {
     guard case .persistence(let persistedAt) = variant.source else { return false }
-    guard let ttl = self.persistenceTtlSeconds(), ttl > 0 else { return false }
+    guard let ttl = self.persistenceTtlSeconds() else { return false }
     return Date().timeIntervalSince(persistedAt) > ttl
   }
 
@@ -1284,16 +1289,22 @@ class FeatureFlagManager: MixpanelFlags {
       properties["$is_qa_tester"] = isQATester
     }
 
-    // Persistence-source tracking properties. Only stamped when the served variant came from
-    // the on-disk persistence layer; network-sourced and unstamped variants don't get them.
-    // `$persisted_at_in_ms` is the raw epoch millis the blob was written — sent without any
-    // delta calculation so the server can derive whatever it needs.
-    if case .persistence(let persistedAt) = variant.source {
+    // Source tracking properties. `$variant_source` is sent for every served variant
+    // (`.network` or `.persistence`) to match the JS SDK. `$persisted_at_in_ms` and
+    // `$ttl_in_ms` are persistence-only — the timestamp is the raw epoch millis the blob
+    // was written, sent without any delta calculation so the server can derive what it
+    // needs. Tracking only fires for served variants, so `.fallback` won't appear here.
+    switch variant.source {
+    case .network:
+      properties["$variant_source"] = "network"
+    case .persistence(let persistedAt):
       properties["$variant_source"] = "persistence"
       properties["$persisted_at_in_ms"] = Int(persistedAt.timeIntervalSince1970 * 1000)
       if let ttl = self.persistenceTtlSeconds() {
         properties["$ttl_in_ms"] = Int(ttl * 1000)
       }
+    case .fallback:
+      break
     }
 
     // Dispatch delegate call asynchronously to main thread for safety

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -455,6 +455,12 @@ class FeatureFlagManager: MixpanelFlags {
   private var currentOptions: MixpanelOptions? { delegate?.getOptions() }
   private var flagsRoute = "/flags/"
 
+  /// Resolved variant lookup policy snapshot. Computed once at init via
+  /// `VariantLookupPolicy.effective(_:)`, which collapses any persisting policy with
+  /// non-positive TTL down to `.networkOnly` (with a warning logged). Treat this as the
+  /// canonical policy — downstream code should never re-read from `delegate?.getOptions()`.
+  private let resolvedLookupPolicy: VariantLookupPolicy
+
   // Queue for synchronizing flag operations with tracking. `internal` rather than `private`
   // so tests can post barrier tasks to wait for queued work (persistence load on init, etc.).
   internal var trackingQueue: DispatchQueue
@@ -471,13 +477,19 @@ class FeatureFlagManager: MixpanelFlags {
         self.instanceName = instanceName
         self.delegate = delegate
         self.flagContext = delegate?.getOptions().featureFlagOptions.context ?? [:]
+        // Resolve the policy once at init: persisting policies with non-positive TTL collapse
+        // to `.networkOnly` (since "persist on every fetch but TTL makes nothing serve" does
+        // no useful work). Logs a warning when the substitution happens.
+        let requestedPolicy =
+          delegate?.getOptions().featureFlagOptions.variantLookupPolicy ?? .networkOnly
+        self.resolvedLookupPolicy = VariantLookupPolicy.effective(requestedPolicy)
 
         // Dispatch the init-time persistence work on the tracking queue so UserDefaults I/O
         // doesn't block the caller (typically the main thread during MixpanelInstance
         // construction). Persisting policies load the persistence layer; `.networkOnly` wipes
         // any stale blob left over from a previous session that used a persisting policy.
         if let options = delegate?.getOptions(), options.featureFlagOptions.enabled {
-            switch options.featureFlagOptions.variantLookupPolicy {
+            switch self.resolvedLookupPolicy {
             case .persistenceUntilNetworkSuccess, .networkFirst:
                 trackingQueue.async { [weak self] in
                     self?._loadPersistedVariants()
@@ -1014,8 +1026,9 @@ class FeatureFlagManager: MixpanelFlags {
       return
     }
 
-    // TTL check — discard expired entries. TTL of 0 means "always expired"; negative TTLs
-    // are coerced to default by `persistenceTtlSeconds()`.
+    // TTL check — discard expired entries. `persistenceTtlSeconds()` returns nil under
+    // `.networkOnly` (we wouldn't be here in that case) and otherwise a positive TTL
+    // (non-positive values are filtered out at policy resolution).
     if let ttl = self.persistenceTtlSeconds(),
        Date().timeIntervalSince(blob.persistedAt) > ttl {
       MixpanelLogger.debug(message: "Persisted flags expired; ignoring.")
@@ -1048,11 +1061,8 @@ class FeatureFlagManager: MixpanelFlags {
       }
     }
 
-    // Snapshot the policy OUTSIDE the lock — `currentLookupPolicy()` calls into the delegate,
-    // and we don't want to hold a delegate call inside our write lock (a future delegate impl
-    // taking its own lock could deadlock). Compute here, branch on it inside the lock.
     let isNetworkFirst: Bool
-    if case .networkFirst = self.currentLookupPolicy() {
+    if case .networkFirst = self.resolvedLookupPolicy {
       isNetworkFirst = true
     } else {
       isNetworkFirst = false
@@ -1075,30 +1085,22 @@ class FeatureFlagManager: MixpanelFlags {
   }
 
   /// Returns the configured TTL in seconds, or `nil` for `.networkOnly` (no expiry check).
-  /// Negative TTLs are invalid and coerced to `VariantLookupPolicy.defaultTTL` with a warning
-  /// (matches the JS SDK). TTL of `0` is valid and means "always expired."
+  /// Reads from `resolvedLookupPolicy`, so non-positive TTLs have already been collapsed to
+  /// `.networkOnly` at init — anything returned here is `> 0`.
   private func persistenceTtlSeconds() -> TimeInterval? {
-    switch self.currentLookupPolicy() {
+    switch self.resolvedLookupPolicy {
     case .networkOnly:
       return nil
     case .persistenceUntilNetworkSuccess(let ttl), .networkFirst(let ttl):
-      if ttl < 0 {
-        MixpanelLogger.warn(
-          message: "Negative TTL (\(ttl)) is invalid; using default \(VariantLookupPolicy.defaultTTL)s")
-        return VariantLookupPolicy.defaultTTL
-      }
       return ttl
     }
   }
 
-  private func currentLookupPolicy() -> VariantLookupPolicy {
-    return self.delegate?.getOptions().featureFlagOptions.variantLookupPolicy ?? .networkOnly
-  }
-
-  /// Whether successful fetches should be persisted to disk. Derived from the lookup policy:
-  /// `.persistenceUntilNetworkSuccess` and `.networkFirst` write to disk; `.networkOnly` doesn't.
+  /// Whether successful fetches should be persisted to disk. Derived from the resolved
+  /// policy: `.persistenceUntilNetworkSuccess` and `.networkFirst` write to disk;
+  /// `.networkOnly` doesn't.
   private func shouldPersistVariants() -> Bool {
-    switch self.currentLookupPolicy() {
+    switch self.resolvedLookupPolicy {
     case .networkOnly:
       return false
     case .persistenceUntilNetworkSuccess, .networkFirst:

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -217,7 +217,7 @@ public protocol MixpanelFlags {
 
   /// Synchronously checks if flag variants are in memory and available for synchronous access.
   ///
-  /// - Note: When a persisting `variantLookupPolicy` is configured (`.persistenceFirst` or
+  /// - Note: When a persisting `variantLookupPolicy` is configured (`.persistenceUntilNetworkSuccess` or
   ///   `.networkFirst`), this can return `true` before the SDK has spoken to the network this
   ///   session — the returned variants may be stale data from a previous session. Use the
   ///   `source` field on the served `MixpanelFlagVariant` to distinguish: `.network` for
@@ -400,7 +400,7 @@ class FeatureFlagManager: MixpanelFlags {
 
   /// True when `flags` was populated from the on-disk persistence layer and we have not yet
   /// seen the initial network response for the current user/context. Only set for
-  /// `.networkFirst` — `.persistenceFirst` serves persisted values immediately. Async lookups
+  /// `.networkFirst` — `.persistenceUntilNetworkSuccess` serves persisted values immediately. Async lookups
   /// gate on this to honor the NetworkFirst spec ("await on network call, only serve persisted
   /// values if it fails") while still letting sync lookups + areFlagsReady() see the persisted
   /// values.
@@ -478,7 +478,7 @@ class FeatureFlagManager: MixpanelFlags {
         // any stale blob left over from a previous session that used a persisting policy.
         if let options = delegate?.getOptions(), options.featureFlagOptions.enabled {
             switch options.featureFlagOptions.variantLookupPolicy {
-            case .persistenceFirst, .networkFirst:
+            case .persistenceUntilNetworkSuccess, .networkFirst:
                 trackingQueue.async { [weak self] in
                     self?._loadPersistedVariants()
                 }
@@ -958,7 +958,7 @@ class FeatureFlagManager: MixpanelFlags {
         }
 
         // Persist the raw response so future sessions / failed fetches can fall back. Writes
-        // are gated by the lookup policy via `shouldPersist` (true for `.persistenceFirst`
+        // are gated by the lookup policy via `shouldPersist` (true for `.persistenceUntilNetworkSuccess`
         // and `.networkFirst`, false for `.networkOnly`). Skipped when `didApplyResults` is
         // false because that means the generation check failed (reset raced ahead) and we
         // shouldn't overwrite the persisted blob with prior-user data. UserDefaults I/O is
@@ -991,7 +991,7 @@ class FeatureFlagManager: MixpanelFlags {
 
   /// Loads the on-disk persistence blob, validates distinctId + TTL, parses, stamps every
   /// variant with `.persistence(persistedAt:)`, and writes into `flags`. Both
-  /// `.persistenceFirst` and `.networkFirst` populate `flags` directly so sync lookups and
+  /// `.persistenceUntilNetworkSuccess` and `.networkFirst` populate `flags` directly so sync lookups and
   /// `areFlagsReady()` reflect persisted values. The difference between policies is enforced
   /// at async-lookup time via `awaitingInitialNetworkResponse`: `.networkFirst` sets it true
   /// so async lookups await the network call before serving.
@@ -1074,13 +1074,13 @@ class FeatureFlagManager: MixpanelFlags {
   }
 
   /// Returns the configured TTL in seconds, or `nil` for `.networkOnly` (no expiry check).
-  /// `.persistenceFirst(0)` / `.networkFirst(0)` (or negative) effectively disable expiry —
+  /// `.persistenceUntilNetworkSuccess(0)` / `.networkFirst(0)` (or negative) effectively disable expiry —
   /// the `_loadPersistedVariants` caller treats `<= 0` as "no expiry".
   private func persistenceTtlSeconds() -> TimeInterval? {
     switch self.currentLookupPolicy() {
     case .networkOnly:
       return nil
-    case .persistenceFirst(let ttl), .networkFirst(let ttl):
+    case .persistenceUntilNetworkSuccess(let ttl), .networkFirst(let ttl):
       return ttl
     }
   }
@@ -1090,12 +1090,12 @@ class FeatureFlagManager: MixpanelFlags {
   }
 
   /// Whether successful fetches should be persisted to disk. Derived from the lookup policy:
-  /// `.persistenceFirst` and `.networkFirst` write to disk; `.networkOnly` doesn't.
+  /// `.persistenceUntilNetworkSuccess` and `.networkFirst` write to disk; `.networkOnly` doesn't.
   private func shouldPersistVariants() -> Bool {
     switch self.currentLookupPolicy() {
     case .networkOnly:
       return false
-    case .persistenceFirst, .networkFirst:
+    case .persistenceUntilNetworkSuccess, .networkFirst:
       return true
     }
   }

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -392,9 +392,17 @@ class FeatureFlagManager: MixpanelFlags {
   /// in-flight fetch dispatched before this call is discarded when it completes (via the
   /// generation check in `_performFetchRequest`'s success/failure closures). Pending
   /// fetch-completion handlers are invoked with `false` so callers don't hang.
-  func reset() {
+  ///
+  /// `completion` (optional) fires on the tracking queue once the in-memory state has been
+  /// cleared, so callers (notably `MixpanelInstance.reset(completion:)`) can defer their own
+  /// completion until after the wipe — without it, a customer calling a sync flag API from
+  /// the outer reset completion handler could observe pre-reset variants.
+  func reset(completion: (() -> Void)? = nil) {
     trackingQueue.async { [weak self] in
-      guard let self = self else { return }
+      guard let self = self else {
+        completion?()
+        return
+      }
 
       var orphanedHandlers: [(Bool) -> Void] = []
       self.flagsLock.write {
@@ -415,6 +423,8 @@ class FeatureFlagManager: MixpanelFlags {
       DispatchQueue.main.async {
         orphanedHandlers.forEach { $0(false) }
       }
+
+      completion?()
     }
   }
 

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -41,18 +41,18 @@ public struct MixpanelFlagVariant: Decodable {
   public let isQATester: Bool? // Corresponds to 'is_qa_tester' from API
 
   /// Where this variant was sourced from. `nil` on developer-supplied fallback instances;
-  /// `.network` or `.cache(cachedAt:)` when the SDK serves a variant. For cached variants,
-  /// the timestamp lives on the `.cache` case so invalid combinations like "network with a
-  /// timestamp" are unrepresentable.
+  /// `.network` or `.persistence(persistedAt:)` when the SDK serves a variant. For persisted
+  /// variants, the timestamp lives on the `.persistence` case so invalid combinations like
+  /// "network with a timestamp" are unrepresentable.
   public let source: Source?
 
   /// Identifies where a served variant came from.
   public enum Source {
     /// Variant assigned by the most recent successful `/flags/` network call.
     case network
-    /// Variant loaded from the on-disk cache. `cachedAt` is the time the variant set was
-    /// originally written to the cache.
-    case cache(cachedAt: Date)
+    /// Variant loaded from the on-disk persistence layer. `persistedAt` is the time the
+    /// variant set was originally written to disk.
+    case persistence(persistedAt: Date)
   }
 
   enum CodingKeys: String, CodingKey {
@@ -210,13 +210,14 @@ public protocol MixpanelFlags {
 
   /// Synchronously checks if flag variants are in memory and available for synchronous access.
   ///
-  /// - Note: When a caching `variantLookupPolicy` is configured (`.cacheFirst` or
+  /// - Note: When a persisting `variantLookupPolicy` is configured (`.persistenceFirst` or
   ///   `.networkFirst`), this can return `true` before the SDK has spoken to the network this
   ///   session — the returned variants may be stale data from a previous session. Use the
   ///   `source` field on the served `MixpanelFlagVariant` to distinguish: `.network` for
-  ///   fresh values, `.cache(cachedAt:)` for on-disk-cache values (with the cache timestamp).
+  ///   fresh values, `.persistence(persistedAt:)` for on-disk persisted values (with the
+  ///   persistence timestamp).
   ///
-  /// - Returns: `true` if flag variants are available in memory (from network or cache),
+  /// - Returns: `true` if flag variants are available in memory (from network or persistence),
   ///            `false` otherwise.
   func areFlagsReady() -> Bool
 
@@ -352,9 +353,10 @@ public protocol MixpanelFlags {
 
   /// Replaces the current custom flag evaluation context entirely and triggers a flag re-fetch.
   ///
-  /// In-memory variants and the on-disk cache are intentionally NOT cleared — the cache is
-  /// keyed on distinctId only, so it remains valid for this user across context changes. The
-  /// next successful fetch under the new context will overwrite the cache with fresh values.
+  /// In-memory variants and the on-disk persistence layer are intentionally NOT cleared — the
+  /// persistence layer is keyed on distinctId only, so it remains valid for this user across
+  /// context changes. The next successful fetch under the new context will overwrite the
+  /// persistence layer with fresh values.
   ///
   /// - Parameters:
   ///   - context: The new context dictionary to use for flag evaluation.
@@ -389,16 +391,17 @@ class FeatureFlagManager: MixpanelFlags {
   private var trackedFeatures: Set<String> = Set()
   private var fetchCompletionHandlers: [(Bool) -> Void] = []
 
-  /// True when `flags` was populated from the on-disk cache and we have not yet seen the
-  /// initial network response for the current user/context. Only set for `.networkFirst` —
-  /// `.cacheFirst` serves cached values immediately. Async lookups gate on this to honor the
-  /// NetworkFirst spec ("await on network call, only serve persisted values if it fails")
-  /// while still letting sync lookups + areFlagsReady() see the cached values.
+  /// True when `flags` was populated from the on-disk persistence layer and we have not yet
+  /// seen the initial network response for the current user/context. Only set for
+  /// `.networkFirst` — `.persistenceFirst` serves persisted values immediately. Async lookups
+  /// gate on this to honor the NetworkFirst spec ("await on network call, only serve persisted
+  /// values if it fails") while still letting sync lookups + areFlagsReady() see the persisted
+  /// values.
   internal var awaitingInitialNetworkResponse: Bool = false
 
-  /// Per-instance name used as the UserDefaults key prefix for the on-disk cache. Captured
-  /// from the delegate at init so we can persist/clear without holding a delegate reference
-  /// during async work.
+  /// Per-instance name used as the UserDefaults key prefix for the on-disk persistence layer.
+  /// Captured from the delegate at init so we can persist/clear without holding a delegate
+  /// reference during async work.
   private let instanceName: String
 
   // First-time event targeting state
@@ -431,7 +434,7 @@ class FeatureFlagManager: MixpanelFlags {
   private var flagsRoute = "/flags/"
 
   // Queue for synchronizing flag operations with tracking. `internal` rather than `private`
-  // so tests can post barrier tasks to wait for queued work (cache load on init, etc.).
+  // so tests can post barrier tasks to wait for queued work (persistence load on init, etc.).
   internal var trackingQueue: DispatchQueue
 
   // Initializers
@@ -447,20 +450,20 @@ class FeatureFlagManager: MixpanelFlags {
         self.delegate = delegate
         self.flagContext = delegate?.getOptions().featureFlagOptions.context ?? [:]
 
-        // Dispatch the init-time cache work on the tracking queue so UserDefaults I/O doesn't
-        // block the caller (typically the main thread during MixpanelInstance construction).
-        // Caching policies load the cache; `.networkOnly` wipes any stale blob left over from
-        // a previous session that used a caching policy.
+        // Dispatch the init-time persistence work on the tracking queue so UserDefaults I/O
+        // doesn't block the caller (typically the main thread during MixpanelInstance
+        // construction). Persisting policies load the persistence layer; `.networkOnly` wipes
+        // any stale blob left over from a previous session that used a persisting policy.
         if let options = delegate?.getOptions(), options.featureFlagOptions.enabled {
             switch options.featureFlagOptions.variantLookupPolicy {
-            case .cacheFirst, .networkFirst:
+            case .persistenceFirst, .networkFirst:
                 trackingQueue.async { [weak self] in
-                    self?._loadCachedVariants()
+                    self?._loadPersistedVariants()
                 }
             case .networkOnly:
                 trackingQueue.async { [weak self] in
                     guard let self = self else { return }
-                    MixpanelPersistence.deleteFlagsCache(instanceName: self.instanceName)
+                    MixpanelPersistence.deleteFlagsPersistence(instanceName: self.instanceName)
                 }
             }
         }
@@ -479,11 +482,11 @@ class FeatureFlagManager: MixpanelFlags {
     }
   }
 
-  /// Clears all in-memory feature flag state (cached flags, tracked-flag set, fetch timing,
-  /// first-time event state) AND wipes the on-disk cache blob. Intended for identity-change
-  /// paths: `MixpanelInstance.reset()`, `identify` when distinctId actually changes, and
-  /// `optOutTracking`. `setContext` deliberately does NOT call this — context changes don't
-  /// invalidate the cache (the blob is keyed on distinctId only).
+  /// Clears all in-memory feature flag state (in-memory variants, tracked-flag set, fetch
+  /// timing, first-time event state) AND wipes the on-disk persistence blob. Intended for
+  /// identity-change paths: `MixpanelInstance.reset()`, `identify` when distinctId actually
+  /// changes, and `optOutTracking`. `setContext` deliberately does NOT call this — context
+  /// changes don't invalidate the persisted blob (it is keyed on distinctId only).
   ///
   /// Posts to the tracking queue so the mutation is serialized with reads and fetches. Any
   /// in-flight fetch dispatched before this call is discarded when it completes (via the
@@ -510,10 +513,11 @@ class FeatureFlagManager: MixpanelFlags {
         self.isFetching = false
       }
 
-      // Wipe the on-disk cache so a freshly-identified user can't be served the prior
-      // user's variants. `MixpanelInstance.reset()` also wipes via deleteMPUserDefaultsData,
-      // so this is defensive (idempotent) but keeps the manager self-contained.
-      MixpanelPersistence.deleteFlagsCache(instanceName: self.instanceName)
+      // Wipe the on-disk persistence blob so a freshly-identified user can't be served the
+      // prior user's variants. `MixpanelInstance.reset()` also wipes via
+      // deleteMPUserDefaultsData, so this is defensive (idempotent) but keeps the manager
+      // self-contained.
+      MixpanelPersistence.deleteFlagsPersistence(instanceName: self.instanceName)
 
       DispatchQueue.main.async {
         orphanedHandlers.forEach { $0(false) }
@@ -561,7 +565,7 @@ class FeatureFlagManager: MixpanelFlags {
     flagsLock.write {
       guard let currentFlags = self.flags else { return }
 
-      // Treat expired cached variants as not-present — return the developer fallback and
+      // Treat expired persisted variants as not-present — return the developer fallback and
       // skip tracking, since the customer effectively didn't receive a value. The blob
       // stays on disk; the next successful fetch overwrites it.
       if let variant = currentFlags[flagName], !self.isVariantExpired(variant) {
@@ -612,10 +616,10 @@ class FeatureFlagManager: MixpanelFlags {
       var canServeImmediately = false
 
       // Read state with lock. Serve immediately when flags are populated AND we're not in
-      // the NetworkFirst-init window (waiting for the first network response after a cache
-      // hit). For CacheFirst, awaitingInitialNetworkResponse is never set so cached values
-      // are served right away. Expired cached variants are treated as not-present so the
-      // caller falls through to the fetch path below.
+      // the NetworkFirst-init window (waiting for the first network response after a
+      // persistence hit). For PersistenceFirst, awaitingInitialNetworkResponse is never set
+      // so persisted values are served right away. Expired persisted variants are treated as
+      // not-present so the caller falls through to the fetch path below.
       self.flagsLock.read {
         canServeImmediately = (self.flags != nil) && !self.awaitingInitialNetworkResponse
         if canServeImmediately, let currentFlags = self.flags {
@@ -637,13 +641,14 @@ class FeatureFlagManager: MixpanelFlags {
       } else {
         // Flags not yet servable. Either nothing in memory, or NetworkFirst awaiting the
         // initial network response. Trigger a fetch and serve from `flags` afterward.
-        // On failure, `flags` is left untouched: NetworkFirst with a cache hit still has
-        // cached values (Source.cache); everything else stays nil and we serve the fallback.
+        // On failure, `flags` is left untouched: NetworkFirst with a persistence hit still
+        // has persisted values (Source.persistence); everything else stays nil and we serve
+        // the fallback.
         MixpanelLogger.debug(message: "Flags not yet servable, attempting fetch for getVariant '\(flagName)'...")
         self._fetchFlagsIfNeeded { _ in
           // Hop back to the tracking queue so we can read flags + run the tracking check
           // atomically. Whether the fetch succeeded or not, _getVariantSyncImpl returns the
-          // variant from `flags` if present (cached or network) else the fallback.
+          // variant from `flags` if present (persisted or network) else the fallback.
           self.trackingQueue.async {
             let result = self._getVariantSyncImpl(flagName, fallback: fallback)
             DispatchQueue.main.async { completion(result) }
@@ -699,8 +704,8 @@ class FeatureFlagManager: MixpanelFlags {
   private func _getAllVariantsSyncImpl() -> [String: MixpanelFlagVariant] {
     var result: [String: MixpanelFlagVariant] = [:]
     flagsLock.read {
-      // Filter out expired cached variants — same rule as getVariantSync. Keep `.network`
-      // and unexpired `.cache(cachedAt:)` entries.
+      // Filter out expired persisted variants — same rule as getVariantSync. Keep `.network`
+      // and unexpired `.persistence(persistedAt:)` entries.
       if let currentFlags = self.flags {
         result = currentFlags.filter { _, variant in !self.isVariantExpired(variant) }
       }
@@ -726,7 +731,7 @@ class FeatureFlagManager: MixpanelFlags {
       } else {
         // Either nothing in memory yet, or NetworkFirst awaiting the initial network
         // response. Trigger a fetch and serve from `flags` afterward — on success it has
-        // the fresh values, on NetworkFirst failure the cached values stayed in place.
+        // the fresh values, on NetworkFirst failure the persisted values stayed in place.
         MixpanelLogger.debug(message: "Flags not yet servable, attempting fetch for getAllVariants...")
         self._fetchFlagsIfNeeded { _ in
           DispatchQueue.main.async { completion(self._getAllVariantsSyncImpl()) }
@@ -859,9 +864,9 @@ class FeatureFlagManager: MixpanelFlags {
             message: "Discarding flag fetch failure from stale generation \(generation).")
           return
         }
-        // Whether or not we have cached values, we've definitively failed to get a network
-        // response. NetworkFirst async lookups can stop awaiting and serve from `flags`
-        // (cached values stay in place since we don't touch them on failure).
+        // Whether or not we have persisted values, we've definitively failed to get a
+        // network response. NetworkFirst async lookups can stop awaiting and serve from
+        // `flags` (persisted values stay in place since we don't touch them on failure).
         self.flagsLock.write {
           self.awaitingInitialNetworkResponse = false
         }
@@ -888,17 +893,17 @@ class FeatureFlagManager: MixpanelFlags {
         // network response too, so .network is correct for them as well.
         let stampedFlags = mergedFlags.mapValues { $0.withSource(.network) }
 
-        // Snapshot the cache-policy decision OUTSIDE the lock to avoid calling into the
-        // delegate (`getOptions()`) while holding the write lock — keeps the lock surface
-        // narrow and avoids potential deadlocks if a future delegate impl ever takes a lock
-        // of its own.
-        let shouldCache = self.shouldCacheVariants()
+        // Snapshot the persistence-policy decision OUTSIDE the lock to avoid calling into
+        // the delegate (`getOptions()`) while holding the write lock — keeps the lock
+        // surface narrow and avoids potential deadlocks if a future delegate impl ever takes
+        // a lock of its own.
+        let shouldPersist = self.shouldPersistVariants()
 
-        // Single critical section: gate the in-memory write AND the on-disk cache write on
-        // the same generation check. Without this, a reset() between the lock release and
-        // the disk write could leak prior-user variants onto disk under the prior-user
-        // distinctId (the next session's distinctId check would catch it, but the disk
-        // write is wasted I/O and confusing in logs).
+        // Single critical section: gate the in-memory write AND the on-disk persistence
+        // write on the same generation check. Without this, a reset() between the lock
+        // release and the disk write could leak prior-user variants onto disk under the
+        // prior-user distinctId (the next session's distinctId check would catch it, but
+        // the disk write is wasted I/O and confusing in logs).
         var didApplyResults = false
         self.flagsLock.write {
           // Re-check generation under the lock in case reset() raced between the check above
@@ -923,21 +928,21 @@ class FeatureFlagManager: MixpanelFlags {
         }
 
         // Persist the raw response so future sessions / failed fetches can fall back. Writes
-        // are independent of the lookup policy — a customer may opt into caching just to warm
-        // up for a future migration to a caching policy. Skipped when `didApplyResults` is
+        // are gated by the lookup policy via `shouldPersist` (true for `.persistenceFirst`
+        // and `.networkFirst`, false for `.networkOnly`). Skipped when `didApplyResults` is
         // false because that means the generation check failed (reset raced ahead) and we
-        // shouldn't overwrite the cache with prior-user data. UserDefaults I/O is kept
-        // outside the lock since it can block.
+        // shouldn't overwrite the persisted blob with prior-user data. UserDefaults I/O is
+        // kept outside the lock since it can block.
         if didApplyResults,
-           shouldCache,
+           shouldPersist,
            let rawData = rawHolder.data,
            let rawString = String(data: rawData, encoding: .utf8) {
-          let blob = FlagsCacheBlob(
-            cachedAt: fetchEndTime,
+          let blob = FlagsPersistenceBlob(
+            persistedAt: fetchEndTime,
             distinctId: distinctIdAtDispatch,
             response: rawString
           )
-          MixpanelPersistence.saveFlagsCache(blob, instanceName: self.instanceName)
+          MixpanelPersistence.saveFlagsPersistence(blob, instanceName: self.instanceName)
         }
 
         self._completeFetch(success: true)
@@ -946,23 +951,24 @@ class FeatureFlagManager: MixpanelFlags {
   }
 
   /// Internal reference-type holder so the response-parser closure can hand the raw response
-  /// bytes back to the success closure for caching. Class (not struct) so the captured
+  /// bytes back to the success closure for persistence. Class (not struct) so the captured
   /// reference shares state across closure invocations.
   private final class RawDataHolder {
     var data: Data?
   }
 
-  // MARK: - Cache Helpers
+  // MARK: - Persistence Helpers
 
-  /// Loads the on-disk cache, validates distinctId + TTL, parses, stamps every variant with
-  /// `.cache(cachedAt:)`, and writes into `flags`. Both `.cacheFirst` and `.networkFirst` populate
-  /// `flags` directly so sync lookups and `areFlagsReady()` reflect the cache. The difference
-  /// between policies is enforced at async-lookup time via `awaitingInitialNetworkResponse`:
-  /// `.networkFirst` sets it true so async lookups await the network call before serving.
+  /// Loads the on-disk persistence blob, validates distinctId + TTL, parses, stamps every
+  /// variant with `.persistence(persistedAt:)`, and writes into `flags`. Both
+  /// `.persistenceFirst` and `.networkFirst` populate `flags` directly so sync lookups and
+  /// `areFlagsReady()` reflect persisted values. The difference between policies is enforced
+  /// at async-lookup time via `awaitingInitialNetworkResponse`: `.networkFirst` sets it true
+  /// so async lookups await the network call before serving.
   ///
   /// Runs on the tracking queue (called from init).
-  internal func _loadCachedVariants() {
-    guard let blob = MixpanelPersistence.loadFlagsCache(instanceName: self.instanceName) else {
+  internal func _loadPersistedVariants() {
+    guard let blob = MixpanelPersistence.loadFlagsPersistence(instanceName: self.instanceName) else {
       return
     }
 
@@ -973,15 +979,15 @@ class FeatureFlagManager: MixpanelFlags {
     let delegate = self.delegate
     let currentDistinctId = delegate?.getDistinctId() ?? ""
     if blob.distinctId != currentDistinctId {
-      MixpanelLogger.debug(message: "Cached flags belong to a different distinct_id; clearing.")
-      MixpanelPersistence.deleteFlagsCache(instanceName: self.instanceName)
+      MixpanelLogger.debug(message: "Persisted flags belong to a different distinct_id; clearing.")
+      MixpanelPersistence.deleteFlagsPersistence(instanceName: self.instanceName)
       return
     }
 
     // TTL check — discard expired entries.
-    if let ttl = self.cacheTtlSeconds(), ttl > 0,
-       Date().timeIntervalSince(blob.cachedAt) > ttl {
-      MixpanelLogger.debug(message: "Cached flags expired; ignoring cache.")
+    if let ttl = self.persistenceTtlSeconds(), ttl > 0,
+       Date().timeIntervalSince(blob.persistedAt) > ttl {
+      MixpanelLogger.debug(message: "Persisted flags expired; ignoring.")
       return
     }
 
@@ -991,15 +997,16 @@ class FeatureFlagManager: MixpanelFlags {
     // successful fetch gets a clean slate.
     guard let responseData = blob.response.data(using: .utf8),
           let parsed = try? JSONDecoder().decode(FlagsResponse.self, from: responseData) else {
-      MixpanelLogger.warn(message: "Failed to parse cached flags response; clearing.")
-      MixpanelPersistence.deleteFlagsCache(instanceName: self.instanceName)
+      MixpanelLogger.warn(message: "Failed to parse persisted flags response; clearing.")
+      MixpanelPersistence.deleteFlagsPersistence(instanceName: self.instanceName)
       return
     }
 
     let parsedFlags = parsed.flags ?? [:]
-    let stamped = parsedFlags.mapValues { $0.withSource(.cache(cachedAt: blob.cachedAt)) }
+    let stamped = parsedFlags.mapValues { $0.withSource(.persistence(persistedAt: blob.persistedAt)) }
 
-    // Build pending-event lookups so first-time event matching keeps working from cache.
+    // Build pending-event lookups so first-time event matching keeps working from
+    // persistence.
     var pendingEvents: [String: PendingFirstTimeEvent] = [:]
     var pendingEventNames: Set<String> = []
     if let events = parsed.pendingFirstTimeEvents {
@@ -1031,18 +1038,18 @@ class FeatureFlagManager: MixpanelFlags {
       if isNetworkFirst {
         self.awaitingInitialNetworkResponse = true
       }
-      MixpanelLogger.debug(message: "Loaded \(stamped.count) cached variants into memory.")
+      MixpanelLogger.debug(message: "Loaded \(stamped.count) persisted variants into memory.")
     }
   }
 
   /// Returns the configured TTL in seconds, or `nil` for `.networkOnly` (no expiry check).
-  /// `.cacheFirst(0)` / `.networkFirst(0)` (or negative) effectively disable expiry — the
-  /// _loadCachedVariants caller treats `<= 0` as "no expiry".
-  private func cacheTtlSeconds() -> TimeInterval? {
+  /// `.persistenceFirst(0)` / `.networkFirst(0)` (or negative) effectively disable expiry —
+  /// the `_loadPersistedVariants` caller treats `<= 0` as "no expiry".
+  private func persistenceTtlSeconds() -> TimeInterval? {
     switch self.currentLookupPolicy() {
     case .networkOnly:
       return nil
-    case .cacheFirst(let ttl), .networkFirst(let ttl):
+    case .persistenceFirst(let ttl), .networkFirst(let ttl):
       return ttl
     }
   }
@@ -1052,32 +1059,33 @@ class FeatureFlagManager: MixpanelFlags {
   }
 
   /// Whether successful fetches should be persisted to disk. Derived from the lookup policy:
-  /// `.cacheFirst` and `.networkFirst` write to disk; `.networkOnly` doesn't.
-  private func shouldCacheVariants() -> Bool {
+  /// `.persistenceFirst` and `.networkFirst` write to disk; `.networkOnly` doesn't.
+  private func shouldPersistVariants() -> Bool {
     switch self.currentLookupPolicy() {
     case .networkOnly:
       return false
-    case .cacheFirst, .networkFirst:
+    case .persistenceFirst, .networkFirst:
       return true
     }
   }
 
-  /// Returns true if the variant came from the on-disk cache and has aged past the configured
-  /// TTL. Variants stamped `.network` (or `nil` developer fallbacks) are never expired.
+  /// Returns true if the variant came from the on-disk persistence layer and has aged past
+  /// the configured TTL. Variants stamped `.network` (or `nil` developer fallbacks) are never
+  /// expired.
   ///
-  /// Get-paths use this to skip stale cached values mid-session — once a cached blob's TTL
-  /// elapses while it's loaded in memory, subsequent `getVariant` calls return the developer
-  /// fallback instead of the stale value. The blob itself is intentionally NOT deleted (per
-  /// the "don't clear if TTL has expired on getVariant" rule); the next successful network
-  /// fetch overwrites it.
+  /// Get-paths use this to skip stale persisted values mid-session — once a persisted blob's
+  /// TTL elapses while it's loaded in memory, subsequent `getVariant` calls return the
+  /// developer fallback instead of the stale value. The blob itself is intentionally NOT
+  /// deleted (per the "don't clear if TTL has expired on getVariant" rule); the next
+  /// successful network fetch overwrites it.
   ///
-  /// `.networkOnly` policy returns `nil` from `cacheTtlSeconds()` so this returns false; in
-  /// practice no `.cache(cachedAt:)` variants exist under `.networkOnly` anyway.
+  /// `.networkOnly` policy returns `nil` from `persistenceTtlSeconds()` so this returns false;
+  /// in practice no `.persistence(persistedAt:)` variants exist under `.networkOnly` anyway.
   /// TTL `<= 0` disables expiry entirely (matches the init-time semantics).
   private func isVariantExpired(_ variant: MixpanelFlagVariant) -> Bool {
-    guard case .cache(let cachedAt) = variant.source else { return false }
-    guard let ttl = self.cacheTtlSeconds(), ttl > 0 else { return false }
-    return Date().timeIntervalSince(cachedAt) > ttl
+    guard case .persistence(let persistedAt) = variant.source else { return false }
+    guard let ttl = self.persistenceTtlSeconds(), ttl > 0 else { return false }
+    return Date().timeIntervalSince(persistedAt) > ttl
   }
 
   /// Returns true if the captured `generation` no longer matches the current generation,
@@ -1233,6 +1241,18 @@ class FeatureFlagManager: MixpanelFlags {
       properties["$is_qa_tester"] = isQATester
     }
 
+    // Persistence-source tracking properties. Only stamped when the served variant came from
+    // the on-disk persistence layer; network-sourced and unstamped variants don't get them.
+    // `$persisted_at_in_ms` is the raw epoch millis the blob was written — sent without any
+    // delta calculation so the server can derive whatever it needs.
+    if case .persistence(let persistedAt) = variant.source {
+      properties["$variant_source"] = "persistence"
+      properties["$persisted_at_in_ms"] = Int(persistedAt.timeIntervalSince1970 * 1000)
+      if let ttl = self.persistenceTtlSeconds() {
+        properties["$ttl_in_ms"] = Int(ttl * 1000)
+      }
+    }
+
     // Dispatch delegate call asynchronously to main thread for safety
     DispatchQueue.main.async {
       delegate.track(event: "$experiment_started", properties: properties)
@@ -1353,8 +1373,9 @@ class FeatureFlagManager: MixpanelFlags {
                         flags = [:]
                     }
                     // Stamp NETWORK source — the activated variant came from the prior /flags/
-                    // response. Activations are deliberately not persisted; the cache stays a
-                    // passive snapshot of the wire response so it can be re-loaded verbatim.
+                    // response. Activations are deliberately not written to disk; the
+                    // persistence layer stays a passive snapshot of the wire response so it
+                    // can be re-loaded verbatim.
                     flags![flagKey] = pendingEvent.pendingVariant.withSource(.network)
                     shouldActivate = true
                 }

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -395,7 +395,9 @@ class FeatureFlagManager: MixpanelFlags {
   // Internal State - Protected by flagsLock
   var flags: [String: MixpanelFlagVariant]? = nil
   var isFetching: Bool = false
-  private var trackedFeatures: Set<String> = Set()
+  // `internal` so tests that override `_performFetchRequest` can mirror production's
+  // post-success state mutation (clearing the dedup window after a successful fetch).
+  internal var trackedFeatures: Set<String> = Set()
   private var fetchCompletionHandlers: [(Bool) -> Void] = []
 
   /// True when `flags` was populated from the on-disk persistence layer and we have not yet
@@ -954,6 +956,15 @@ class FeatureFlagManager: MixpanelFlags {
           self.loadedBlobPersistedAt = nil
           self.pendingFirstTimeEvents = mergedPendingEvents
           self.pendingFirstTimeEventNames = mergedPendingEventNames
+          // Reset the per-flag $experiment_started dedup window. Without this, a flag whose
+          // variant value changed between fetches (e.g. persistence-loaded "control" →
+          // network "treatment", or a re-fetch under a new server-side rule) would serve the
+          // new value but silently skip tracking — analytics would still show the prior
+          // exposure. Clearing here means each successful fetch gets a fresh shot at firing
+          // $experiment_started for any accessed flag. Trade-off: occasional duplicate
+          // events when the variant didn't actually change across fetches; we accept that
+          // for analytics correctness.
+          self.trackedFeatures.removeAll()
           // Network response received — async lookups can stop awaiting (NetworkFirst) and
           // serve from the freshly-populated `flags`.
           self.awaitingInitialNetworkResponse = false

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -447,10 +447,10 @@ class FeatureFlagManager: MixpanelFlags {
         self.delegate = delegate
         self.flagContext = delegate?.getOptions().featureFlagOptions.context ?? [:]
 
-        // Load cached variants on the tracking queue so UserDefaults I/O doesn't block the
-        // caller (typically the main thread during MixpanelInstance construction). Only do
-        // this when the configuration actually reads from cache — NetworkOnly + cacheVariants
-        // means writes-only and shouldn't load.
+        // Dispatch the init-time cache work on the tracking queue so UserDefaults I/O doesn't
+        // block the caller (typically the main thread during MixpanelInstance construction).
+        // Caching policies load the cache; `.networkOnly` wipes any stale blob left over from
+        // a previous session that used a caching policy.
         if let options = delegate?.getOptions(), options.featureFlagOptions.enabled {
             switch options.featureFlagOptions.variantLookupPolicy {
             case .cacheFirst, .networkFirst:
@@ -458,7 +458,10 @@ class FeatureFlagManager: MixpanelFlags {
                     self?._loadCachedVariants()
                 }
             case .networkOnly:
-                break
+                trackingQueue.async { [weak self] in
+                    guard let self = self else { return }
+                    MixpanelPersistence.deleteFlagsCache(instanceName: self.instanceName)
+                }
             }
         }
     }
@@ -558,7 +561,10 @@ class FeatureFlagManager: MixpanelFlags {
     flagsLock.write {
       guard let currentFlags = self.flags else { return }
 
-      if let variant = currentFlags[flagName] {
+      // Treat expired cached variants as not-present — return the developer fallback and
+      // skip tracking, since the customer effectively didn't receive a value. The blob
+      // stays on disk; the next successful fetch overwrites it.
+      if let variant = currentFlags[flagName], !self.isVariantExpired(variant) {
         flagVariant = variant
 
         // Perform atomic check-and-set for tracking
@@ -570,7 +576,7 @@ class FeatureFlagManager: MixpanelFlags {
           capturedFetchLatencyMs = self.fetchLatencyMs
         }
       }
-      // If flag wasn't found, flagVariant remains nil
+      // If flag wasn't found OR was expired, flagVariant remains nil
     }
 
     // Now, process the results outside the lock
@@ -608,11 +614,12 @@ class FeatureFlagManager: MixpanelFlags {
       // Read state with lock. Serve immediately when flags are populated AND we're not in
       // the NetworkFirst-init window (waiting for the first network response after a cache
       // hit). For CacheFirst, awaitingInitialNetworkResponse is never set so cached values
-      // are served right away.
+      // are served right away. Expired cached variants are treated as not-present so the
+      // caller falls through to the fetch path below.
       self.flagsLock.read {
         canServeImmediately = (self.flags != nil) && !self.awaitingInitialNetworkResponse
         if canServeImmediately, let currentFlags = self.flags {
-          if let variant = currentFlags[flagName] {
+          if let variant = currentFlags[flagName], !self.isVariantExpired(variant) {
             flagVariant = variant
             needsTrackingCheck = !self.trackedFeatures.contains(flagName)
           }
@@ -692,7 +699,11 @@ class FeatureFlagManager: MixpanelFlags {
   private func _getAllVariantsSyncImpl() -> [String: MixpanelFlagVariant] {
     var result: [String: MixpanelFlagVariant] = [:]
     flagsLock.read {
-      result = self.flags ?? [:]
+      // Filter out expired cached variants — same rule as getVariantSync. Keep `.network`
+      // and unexpired `.cache(at:)` entries.
+      if let currentFlags = self.flags {
+        result = currentFlags.filter { _, variant in !self.isVariantExpired(variant) }
+      }
     }
     return result
   }
@@ -704,14 +715,14 @@ class FeatureFlagManager: MixpanelFlags {
         return
       }
 
-      var currentFlags: [String: MixpanelFlagVariant]?
       var canServeImmediately = false
       self.flagsLock.read {
         canServeImmediately = (self.flags != nil) && !self.awaitingInitialNetworkResponse
-        if canServeImmediately { currentFlags = self.flags }
       }
-      if let currentFlags = currentFlags {
-        DispatchQueue.main.async { completion(currentFlags) }
+      if canServeImmediately {
+        // Use the sync impl so the expired-filter is applied consistently.
+        let result = self._getAllVariantsSyncImpl()
+        DispatchQueue.main.async { completion(result) }
       } else {
         // Either nothing in memory yet, or NetworkFirst awaiting the initial network
         // response. Trigger a fetch and serve from `flags` afterward — on success it has
@@ -956,10 +967,14 @@ class FeatureFlagManager: MixpanelFlags {
     }
 
     // distinctId check — refuse to serve another user's variants under this user's identity.
+    // Wipe the stale blob so it doesn't sit on disk for someone who no longer uses this device.
+    // This is a parallel of the active "distinctId changes" paths (identify/reset/optOut)
+    // applied to the cross-session case where the change happened while the app was killed.
     let delegate = self.delegate
     let currentDistinctId = delegate?.getDistinctId() ?? ""
     if blob.distinctId != currentDistinctId {
-      MixpanelLogger.debug(message: "Cached flags belong to a different distinct_id; ignoring cache.")
+      MixpanelLogger.debug(message: "Cached flags belong to a different distinct_id; clearing.")
+      MixpanelPersistence.deleteFlagsCache(instanceName: self.instanceName)
       return
     }
 
@@ -1036,8 +1051,33 @@ class FeatureFlagManager: MixpanelFlags {
     return self.delegate?.getOptions().featureFlagOptions.variantLookupPolicy ?? .networkOnly
   }
 
+  /// Whether successful fetches should be persisted to disk. Derived from the lookup policy:
+  /// `.cacheFirst` and `.networkFirst` write to disk; `.networkOnly` doesn't.
   private func shouldCacheVariants() -> Bool {
-    return self.delegate?.getOptions().featureFlagOptions.cacheVariants ?? false
+    switch self.currentLookupPolicy() {
+    case .networkOnly:
+      return false
+    case .cacheFirst, .networkFirst:
+      return true
+    }
+  }
+
+  /// Returns true if the variant came from the on-disk cache and has aged past the configured
+  /// TTL. Variants stamped `.network` (or `nil` developer fallbacks) are never expired.
+  ///
+  /// Get-paths use this to skip stale cached values mid-session — once a cached blob's TTL
+  /// elapses while it's loaded in memory, subsequent `getVariant` calls return the developer
+  /// fallback instead of the stale value. The blob itself is intentionally NOT deleted (per
+  /// the "don't clear if TTL has expired on getVariant" rule); the next successful network
+  /// fetch overwrites it.
+  ///
+  /// `.networkOnly` policy returns `nil` from `cacheTtlSeconds()` so this returns false; in
+  /// practice no `.cache(at:)` variants exist under `.networkOnly` anyway.
+  /// TTL `<= 0` disables expiry entirely (matches the init-time semantics).
+  private func isVariantExpired(_ variant: MixpanelFlagVariant) -> Bool {
+    guard case .cache(let cachedAt) = variant.source else { return false }
+    guard let ttl = self.cacheTtlSeconds(), ttl > 0 else { return false }
+    return Date().timeIntervalSince(cachedAt) > ttl
   }
 
   /// Returns true if the captured `generation` no longer matches the current generation,

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -353,6 +353,10 @@ class FeatureFlagManager: MixpanelFlags {
   var timeLastFetched: Date?
   var fetchLatencyMs: Int?
 
+  /// Bumped on `reset()` so in-flight fetches dispatched pre-reset don't poison post-reset state.
+  /// Captured at the start of `_performFetchRequest` and re-checked before applying results.
+  private var fetchGeneration: Int = 0
+
   // Configuration
   private var currentOptions: MixpanelOptions? { delegate?.getOptions() }
   private var flagsRoute = "/flags/"
@@ -378,6 +382,39 @@ class FeatureFlagManager: MixpanelFlags {
     // Dispatch fetch trigger to allow caller to continue
       trackingQueue.async { [weak self] in
       self?._fetchFlagsIfNeeded(completion: completion)
+    }
+  }
+
+  /// Clears all in-memory feature flag state: cached flags, tracked-flag set, fetch timing,
+  /// and first-time event state. Intended to be called from `MixpanelInstance.reset()`.
+  ///
+  /// Posts to the tracking queue so the mutation is serialized with reads and fetches. Any
+  /// in-flight fetch dispatched before this call is discarded when it completes (via the
+  /// generation check in `_performFetchRequest`'s success/failure closures). Pending
+  /// fetch-completion handlers are invoked with `false` so callers don't hang.
+  func reset() {
+    trackingQueue.async { [weak self] in
+      guard let self = self else { return }
+
+      var orphanedHandlers: [(Bool) -> Void] = []
+      self.flagsLock.write {
+        self.fetchGeneration &+= 1
+        self.flags = nil
+        self.trackedFeatures.removeAll()
+        self.pendingFirstTimeEvents.removeAll()
+        self.pendingFirstTimeEventNames.removeAll()
+        self.activatedFirstTimeEvents.removeAll()
+        self.fetchStartTime = nil
+        self.timeLastFetched = nil
+        self.fetchLatencyMs = nil
+        orphanedHandlers = self.fetchCompletionHandlers
+        self.fetchCompletionHandlers.removeAll()
+        self.isFetching = false
+      }
+
+      DispatchQueue.main.async {
+        orphanedHandlers.forEach { $0(false) }
+      }
     }
   }
 
@@ -627,10 +664,14 @@ class FeatureFlagManager: MixpanelFlags {
 
   // Performs the actual network request construction and call
   internal func _performFetchRequest() {
-    // Record fetch start time
+    // Record fetch start time and snapshot the current generation. The snapshot is checked
+    // in the success/failure closures so a fetch that was dispatched before reset() does not
+    // overwrite the freshly cleared state.
     let startTime = Date()
+    var generation = 0
     flagsLock.write {
       self.fetchStartTime = startTime
+      generation = self.fetchGeneration
     }
 
     guard let delegate = self.delegate, let options = self.currentOptions else {
@@ -691,11 +732,22 @@ class FeatureFlagManager: MixpanelFlags {
       resource: resource,
       failure: { [weak self] reason, data, response in
         MixpanelLogger.error(message: "Failed to fetch flags. Reason: \(reason)")
-        self?._completeFetch(success: false)
+        guard let self = self else { return }
+        if self.isStaleFetch(generation: generation) {
+          MixpanelLogger.debug(
+            message: "Discarding flag fetch failure from stale generation \(generation).")
+          return
+        }
+        self._completeFetch(success: false)
       },
       success: { [weak self] (flagsResponse, response) in
         MixpanelLogger.info(message: "Successfully fetched flags.  \(flagsResponse)")
         guard let self = self else { return }
+        if self.isStaleFetch(generation: generation) {
+          MixpanelLogger.debug(
+            message: "Discarding flag fetch result from stale generation \(generation).")
+          return
+        }
         let fetchEndTime = Date()
 
         // Merge flags and update state with write lock
@@ -705,6 +757,9 @@ class FeatureFlagManager: MixpanelFlags {
         )
 
         self.flagsLock.write {
+          // Re-check generation under the lock in case reset() raced between the check above
+          // and the write. If stale, drop the result without touching state or completing.
+          guard generation == self.fetchGeneration else { return }
           self.flags = mergedFlags
           self.pendingFirstTimeEvents = mergedPendingEvents
           self.pendingFirstTimeEventNames = mergedPendingEventNames
@@ -722,6 +777,16 @@ class FeatureFlagManager: MixpanelFlags {
         self._completeFetch(success: true)
       }
     )
+  }
+
+  /// Returns true if the captured `generation` no longer matches the current generation,
+  /// meaning the fetch was started before a `reset()` and its result should be discarded.
+  private func isStaleFetch(generation: Int) -> Bool {
+    var current = 0
+    flagsLock.read {
+      current = self.fetchGeneration
+    }
+    return current != generation
   }
 
   // Centralized fetch completion logic

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -651,6 +651,7 @@ class FeatureFlagManager: MixpanelFlags {
       var flagVariant: MixpanelFlagVariant?
       var needsTrackingCheck = false
       var canServeImmediately = false
+      var servingFromPersistedBlob = false
 
       // Read state with lock. Serve immediately when flags are populated, we're not in the
       // NetworkFirst-init window (waiting for the first network response after a persistence
@@ -663,6 +664,7 @@ class FeatureFlagManager: MixpanelFlags {
               !self.awaitingInitialNetworkResponse,
               !self.loadedFlagsAreStale() else { return }
         canServeImmediately = true
+        servingFromPersistedBlob = self.loadedBlobPersistedAt != nil
         if let variant = currentFlags[flagName], !self.isVariantExpired(variant) {
           flagVariant = variant
           needsTrackingCheck = !self.trackedFeatures.contains(flagName)
@@ -670,6 +672,16 @@ class FeatureFlagManager: MixpanelFlags {
       }
 
       if canServeImmediately {
+        // PersistenceUntilNetworkSuccess "serve persisted now, refresh in background":
+        // when the immediate-serve path is satisfied by the persisted blob (not yet
+        // overwritten by a successful fetch), kick off a background fetch with no
+        // completion handler so we don't await it. Idempotent — `_fetchFlagsIfNeeded`
+        // dedupes via `isFetching`. Self-stops once the fetch clears
+        // `loadedBlobPersistedAt`.
+        if servingFromPersistedBlob,
+           case .persistenceUntilNetworkSuccess = self.resolvedLookupPolicy {
+          self._fetchFlagsIfNeeded(completion: nil)
+        }
         let result = flagVariant ?? fallback
         if flagVariant != nil, needsTrackingCheck {
           // Perform atomic check-and-track
@@ -760,12 +772,20 @@ class FeatureFlagManager: MixpanelFlags {
       }
 
       var canServeImmediately = false
+      var servingFromPersistedBlob = false
       self.flagsLock.read {
         canServeImmediately = (self.flags != nil)
           && !self.awaitingInitialNetworkResponse
           && !self.loadedFlagsAreStale()
+        servingFromPersistedBlob = self.loadedBlobPersistedAt != nil
       }
       if canServeImmediately {
+        // PersistenceUntilNetworkSuccess "serve persisted now, refresh in background":
+        // see the matching block in `getVariant` for the full rationale.
+        if servingFromPersistedBlob,
+           case .persistenceUntilNetworkSuccess = self.resolvedLookupPolicy {
+          self._fetchFlagsIfNeeded(completion: nil)
+        }
         // Use the sync impl so the expired-filter is applied consistently.
         let result = self._getAllVariantsSyncImpl()
         DispatchQueue.main.async { completion(result) }

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -400,14 +400,6 @@ class FeatureFlagManager: MixpanelFlags {
   internal var trackedFeatures: Set<String> = Set()
   private var fetchCompletionHandlers: [(Bool) -> Void] = []
 
-  /// True when `flags` was populated from the on-disk persistence layer and we have not yet
-  /// seen the initial network response for the current user/context. Only set for
-  /// `.networkFirst` — `.persistenceUntilNetworkSuccess` serves persisted values immediately. Async lookups
-  /// gate on this to honor the NetworkFirst spec ("await on network call, only serve persisted
-  /// values if it fails") while still letting sync lookups + areFlagsReady() see the persisted
-  /// values.
-  internal var awaitingInitialNetworkResponse: Bool = false
-
   /// `persistedAt` from the persisted blob currently sitting in `flags`. Lifetime matches
   /// the persistence-derived state (`flags` + `pendingFirstTimeEvents`):
   ///   - Set in `_loadPersistedVariants` when we read the blob from disk
@@ -418,6 +410,10 @@ class FeatureFlagManager: MixpanelFlags {
   /// Stored separately from the `.persistence(persistedAt:)` variant case so we can answer
   /// "is the loaded blob past TTL?" even when `flags` is empty (the previous session may
   /// have persisted an empty response).
+  ///
+  /// Also doubles as the "NetworkFirst is still awaiting a successful network response"
+  /// signal — see `isNetworkFirstAwaitingFetch()`. Stays set across failed fetches so each
+  /// subsequent NetworkFirst async lookup re-attempts the network until one succeeds.
   ///
   /// `internal` so tests that inject `.persistence` variants directly can match the
   /// production invariant.
@@ -544,7 +540,6 @@ class FeatureFlagManager: MixpanelFlags {
         self.fetchStartTime = nil
         self.timeLastFetched = nil
         self.fetchLatencyMs = nil
-        self.awaitingInitialNetworkResponse = false
         orphanedHandlers = self.fetchCompletionHandlers
         self.fetchCompletionHandlers.removeAll()
         self.isFetching = false
@@ -653,15 +648,14 @@ class FeatureFlagManager: MixpanelFlags {
       var canServeImmediately = false
       var servingFromPersistedBlob = false
 
-      // Read state with lock. Serve immediately when flags are populated, we're not in the
-      // NetworkFirst-init window (waiting for the first network response after a persistence
-      // hit), AND the loaded blob isn't past TTL. The blob-staleness check is what makes the
-      // async path fall through to a fetch when persisted values have aged out mid-session —
-      // the inline TTL check below would otherwise silently serve the developer fallback
-      // without refreshing.
+      // Read state with lock. Serve immediately when flags are populated, NetworkFirst
+      // isn't still gating on a successful network response, AND the loaded blob isn't past
+      // TTL. The blob-staleness check is what makes the async path fall through to a fetch
+      // when persisted values have aged out mid-session — the inline TTL check below would
+      // otherwise silently serve the developer fallback without refreshing.
       self.flagsLock.read {
         guard let currentFlags = self.flags,
-              !self.awaitingInitialNetworkResponse,
+              !self.isNetworkFirstAwaitingFetch(),
               !self.loadedFlagsAreStale() else { return }
         canServeImmediately = true
         servingFromPersistedBlob = self.loadedBlobPersistedAt != nil
@@ -775,7 +769,7 @@ class FeatureFlagManager: MixpanelFlags {
       var servingFromPersistedBlob = false
       self.flagsLock.read {
         canServeImmediately = (self.flags != nil)
-          && !self.awaitingInitialNetworkResponse
+          && !self.isNetworkFirstAwaitingFetch()
           && !self.loadedFlagsAreStale()
         servingFromPersistedBlob = self.loadedBlobPersistedAt != nil
       }
@@ -927,12 +921,11 @@ class FeatureFlagManager: MixpanelFlags {
             message: "Discarding flag fetch failure from stale generation \(generation).")
           return
         }
-        // Whether or not we have persisted values, we've definitively failed to get a
-        // network response. NetworkFirst async lookups can stop awaiting and serve from
-        // `flags` (persisted values stay in place since we don't touch them on failure).
-        self.flagsLock.write {
-          self.awaitingInitialNetworkResponse = false
-        }
+        // We've definitively failed to get a network response. Persisted values stay in
+        // place since we don't touch them on failure — `loadedBlobPersistedAt` also stays
+        // set, which means the next NetworkFirst async lookup will retry the network (the
+        // gate is "still serving from persistence," not "the very first call"). Per the
+        // spec, NetworkFirst retries until one fetch succeeds.
         self._completeFetch(success: false)
       },
       success: { [weak self] (flagsResponse, response) in
@@ -985,9 +978,9 @@ class FeatureFlagManager: MixpanelFlags {
           // events when the variant didn't actually change across fetches; we accept that
           // for analytics correctness.
           self.trackedFeatures.removeAll()
-          // Network response received — async lookups can stop awaiting (NetworkFirst) and
-          // serve from the freshly-populated `flags`.
-          self.awaitingInitialNetworkResponse = false
+          // Successful fetch overwrites the persisted-blob marker — derived helpers like
+          // `isNetworkFirstAwaitingFetch()` and `loadedFlagsAreStale()` correctly flip to
+          // false on the next read since `loadedBlobPersistedAt` is now nil (cleared above).
 
           // Calculate timing metrics
           if let startTime = self.fetchStartTime {
@@ -1034,10 +1027,11 @@ class FeatureFlagManager: MixpanelFlags {
 
   /// Loads the on-disk persistence blob, validates distinctId + TTL, parses, stamps every
   /// variant with `.persistence(persistedAt:)`, and writes into `flags`. Both
-  /// `.persistenceUntilNetworkSuccess` and `.networkFirst` populate `flags` directly so sync lookups and
-  /// `areFlagsReady()` reflect persisted values. The difference between policies is enforced
-  /// at async-lookup time via `awaitingInitialNetworkResponse`: `.networkFirst` sets it true
-  /// so async lookups await the network call before serving.
+  /// `.persistenceUntilNetworkSuccess` and `.networkFirst` populate `flags` directly so sync
+  /// lookups and `areFlagsReady()` reflect persisted values. The difference between policies
+  /// is enforced at async-lookup time via `isNetworkFirstAwaitingFetch()`: NetworkFirst gates
+  /// async lookups on a successful network response (i.e., until `loadedBlobPersistedAt` is
+  /// cleared by a successful fetch), per the ERD.
   ///
   /// Runs on the tracking queue (called from init).
   internal func _loadPersistedVariants() {
@@ -1092,13 +1086,6 @@ class FeatureFlagManager: MixpanelFlags {
       }
     }
 
-    let isNetworkFirst: Bool
-    if case .networkFirst = self.resolvedLookupPolicy {
-      isNetworkFirst = true
-    } else {
-      isNetworkFirst = false
-    }
-
     flagsLock.write {
       // Defer to network values if a fetch already raced ahead of us between init and now.
       guard self.flags == nil else { return }
@@ -1106,13 +1093,27 @@ class FeatureFlagManager: MixpanelFlags {
       self.loadedBlobPersistedAt = blob.persistedAt
       self.pendingFirstTimeEvents = pendingEvents
       self.pendingFirstTimeEventNames = pendingEventNames
-      // For .networkFirst, async lookups must wait for the initial network response. The
-      // fetch success/failure path will clear this flag.
-      if isNetworkFirst {
-        self.awaitingInitialNetworkResponse = true
-      }
+      // For NetworkFirst, async lookups must wait for a successful network response.
+      // `isNetworkFirstAwaitingFetch()` derives that gate from the policy +
+      // `loadedBlobPersistedAt` — no separate flag to keep in sync.
       MixpanelLogger.debug(message: "Loaded \(stamped.count) persisted variants into memory.")
     }
+  }
+
+  /// Returns `true` when the policy is `.networkFirst` and we're still serving from the
+  /// persisted blob (no successful network fetch has overwritten it yet). Async lookups
+  /// gate on this to honor the NetworkFirst spec ("wait on network call, only serve
+  /// persisted values if it fails") while still letting sync lookups + `areFlagsReady()`
+  /// see the persisted values.
+  ///
+  /// Stays true across failed fetches so each subsequent async lookup re-attempts the
+  /// network until one succeeds, matching the pre-persistence behavior where a `nil`
+  /// `flags` caused getVariant to retry indefinitely.
+  ///
+  /// Caller must hold `flagsLock`.
+  private func isNetworkFirstAwaitingFetch() -> Bool {
+    guard case .networkFirst = self.resolvedLookupPolicy else { return false }
+    return self.loadedBlobPersistedAt != nil
   }
 
   /// Returns the configured TTL in seconds, or `nil` for `.networkOnly` (no expiry check).

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -41,8 +41,8 @@ public struct MixpanelFlagVariant: Decodable {
   public let isQATester: Bool? // Corresponds to 'is_qa_tester' from API
 
   /// Where this variant was sourced from. `nil` on developer-supplied fallback instances;
-  /// `.network` or `.cache(at:)` when the SDK serves a variant. For cached variants, the
-  /// timestamp lives on the `.cache` case so invalid combinations like "network with a
+  /// `.network` or `.cache(cachedAt:)` when the SDK serves a variant. For cached variants,
+  /// the timestamp lives on the `.cache` case so invalid combinations like "network with a
   /// timestamp" are unrepresentable.
   public let source: Source?
 
@@ -50,9 +50,9 @@ public struct MixpanelFlagVariant: Decodable {
   public enum Source {
     /// Variant assigned by the most recent successful `/flags/` network call.
     case network
-    /// Variant loaded from the on-disk cache. `at` is the time the variant set was
+    /// Variant loaded from the on-disk cache. `cachedAt` is the time the variant set was
     /// originally written to the cache.
-    case cache(at: Date)
+    case cache(cachedAt: Date)
   }
 
   enum CodingKeys: String, CodingKey {
@@ -214,7 +214,7 @@ public protocol MixpanelFlags {
   ///   `.networkFirst`), this can return `true` before the SDK has spoken to the network this
   ///   session — the returned variants may be stale data from a previous session. Use the
   ///   `source` field on the served `MixpanelFlagVariant` to distinguish: `.network` for
-  ///   fresh values, `.cache(at:)` for on-disk-cache values (with the cache timestamp).
+  ///   fresh values, `.cache(cachedAt:)` for on-disk-cache values (with the cache timestamp).
   ///
   /// - Returns: `true` if flag variants are available in memory (from network or cache),
   ///            `false` otherwise.
@@ -700,7 +700,7 @@ class FeatureFlagManager: MixpanelFlags {
     var result: [String: MixpanelFlagVariant] = [:]
     flagsLock.read {
       // Filter out expired cached variants — same rule as getVariantSync. Keep `.network`
-      // and unexpired `.cache(at:)` entries.
+      // and unexpired `.cache(cachedAt:)` entries.
       if let currentFlags = self.flags {
         result = currentFlags.filter { _, variant in !self.isVariantExpired(variant) }
       }
@@ -955,7 +955,7 @@ class FeatureFlagManager: MixpanelFlags {
   // MARK: - Cache Helpers
 
   /// Loads the on-disk cache, validates distinctId + TTL, parses, stamps every variant with
-  /// `.cache(at:)`, and writes into `flags`. Both `.cacheFirst` and `.networkFirst` populate
+  /// `.cache(cachedAt:)`, and writes into `flags`. Both `.cacheFirst` and `.networkFirst` populate
   /// `flags` directly so sync lookups and `areFlagsReady()` reflect the cache. The difference
   /// between policies is enforced at async-lookup time via `awaitingInitialNetworkResponse`:
   /// `.networkFirst` sets it true so async lookups await the network call before serving.
@@ -997,7 +997,7 @@ class FeatureFlagManager: MixpanelFlags {
     }
 
     let parsedFlags = parsed.flags ?? [:]
-    let stamped = parsedFlags.mapValues { $0.withSource(.cache(at: blob.cachedAt)) }
+    let stamped = parsedFlags.mapValues { $0.withSource(.cache(cachedAt: blob.cachedAt)) }
 
     // Build pending-event lookups so first-time event matching keeps working from cache.
     var pendingEvents: [String: PendingFirstTimeEvent] = [:]
@@ -1072,7 +1072,7 @@ class FeatureFlagManager: MixpanelFlags {
   /// fetch overwrites it.
   ///
   /// `.networkOnly` policy returns `nil` from `cacheTtlSeconds()` so this returns false; in
-  /// practice no `.cache(at:)` variants exist under `.networkOnly` anyway.
+  /// practice no `.cache(cachedAt:)` variants exist under `.networkOnly` anyway.
   /// TTL `<= 0` disables expiry entirely (matches the init-time semantics).
   private func isVariantExpired(_ variant: MixpanelFlagVariant) -> Bool {
     guard case .cache(let cachedAt) = variant.source else { return false }

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -346,7 +346,7 @@ class FeatureFlagManager: MixpanelFlags {
   internal var activatedFirstTimeEvents: Set<String> = Set()
 
   // Flag evaluation context (protected by flagsLock)
-  private var flagContext: [String: Any]
+  internal var flagContext: [String: Any]
 
   // Timing tracking properties
   private var fetchStartTime: Date?

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -391,9 +391,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
       instanceName: self.name,
       lock: self.readWriteLock,
       metadata: sessionMetadata, mixpanelPersistence: mixpanelPersistence)
-    flags = FeatureFlagManager(serverURL: self.serverURL, trackingQueue: self.trackingQueue)
     trackInstance.mixpanelInstance = self
-    flags.delegate = self
     #if os(iOS) && !targetEnvironment(macCatalyst)
       // Extract hostname from serverURL and create reachability
       if let url = URL(string: self.serverURL),
@@ -438,6 +436,20 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
       setupListeners()
     #endif
     unarchive()
+
+    // Construct FeatureFlagManager AFTER unarchive() so the on-disk cache load (dispatched
+    // async by FeatureFlagManager.init when a caching policy is configured) reads the
+    // correct distinctId via `delegate.getDistinctId()`. Constructing earlier would race the
+    // async cache load against the synchronous distinctId initialization in unarchive() —
+    // a worker thread could pick up the cache-load block and read distinctId == "", computing
+    // the wrong fingerprint and silently ignoring an otherwise-valid cache. Nothing between
+    // here and `flags.loadFlags()` below references `flags`.
+    flags = FeatureFlagManager(
+      serverURL: self.serverURL,
+      trackingQueue: self.trackingQueue,
+      instanceName: self.name,
+      delegate: self
+    )
 
     // check whether we should opt out by default
     // note: we don't override opt out persistence here since opt-out default state is often
@@ -805,6 +817,12 @@ extension MixpanelInstance {
      (recommended), call `identify:` using the current distinct ID:
      `mixpanelInstance.identify(mixpanelInstance.distinctId)`.
   
+     When the distinct ID actually changes, this method also resets feature-flag state
+     (in-memory variants, on-disk cache, and activated first-time-event set) before fetching
+     flags under the new identity. Any `flags.loadFlags(completion:)` callbacks pending from
+     a fetch that was in flight at the moment identify was called will fire with `false`
+     (so callers don't hang) — they will *not* receive the result of the new identity's fetch.
+
      - parameter distinctId: string that uniquely identifies the current user
      - parameter usePeople: boolean that controls whether or not to set the people distinctId to the event distinctId.
      This should only be set to false if you wish to prevent people profile updates for that user.
@@ -847,6 +865,13 @@ extension MixpanelInstance {
           self.alias = nil
           self.distinctId = distinctId
           self.userId = distinctId
+        }
+        // Distinct ID just changed — clear in-memory feature-flag state and the on-disk
+        // cache from the prior identity (and bump the fetch generation so any in-flight
+        // fetch is discarded) before loading flags under the new identity. trackingQueue
+        // FIFO guarantees the reset runs before the loadFlags-driven fetch.
+        if let flagManager = self.flags as? FeatureFlagManager {
+          flagManager.reset()
         }
         self.flags.loadFlags()
         self.track(event: "$identify", properties: ["$anon_distinct_id": oldDistinctId])
@@ -1703,6 +1728,15 @@ extension MixpanelInstance {
         MixpanelPersistence.saveOptOutStatusFlag(value: self.optOutStatus!, instanceName: self.name)
       }
 
+      // Identity just changed (distinctId was regenerated above). Clear in-memory feature
+      // flag state and the on-disk cache from the prior identity so subsequent lookups
+      // don't serve stale variants. Mirrors `identify()` and `setContext()`. We deliberately
+      // do NOT call `loadFlags()` here — opt-out semantically means "stop tracking", and
+      // re-fetching flags under the new anon identity would defeat that intent. The next
+      // `optInTracking()` will restore the normal fetch flow.
+      if let flagManager = self.flags as? FeatureFlagManager {
+        flagManager.reset()
+      }
     }
   }
 

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -1012,16 +1012,26 @@ extension MixpanelInstance {
 
       // reset() does not call identify(), so the loadFlags() call inside identify() never
       // fires. Clear feature-flag state explicitly and refetch under the new identity if
-      // prefetching is enabled.
-      if let flagManager = self.flags as? FeatureFlagManager {
-        flagManager.reset()
-        if self.options.featureFlagOptions.prefetchFlags {
-          flagManager.loadFlags()
+      // prefetching is enabled. Defer the user-facing completion until the flag-manager
+      // reset has actually drained — otherwise a customer calling a sync flag API from
+      // their completion handler could observe pre-reset variants (the inner reset is
+      // async on the same trackingQueue, so it'd run AFTER the outer block dispatched
+      // completion to main).
+      let flagManager = self.flags as? FeatureFlagManager
+      let fireUserCompletion: () -> Void = {
+        if let completion = completion {
+          DispatchQueue.main.async(execute: completion)
         }
       }
-
-      if let completion = completion {
-        DispatchQueue.main.async(execute: completion)
+      if let flagManager = flagManager {
+        flagManager.reset {
+          if self.options.featureFlagOptions.prefetchFlags {
+            flagManager.loadFlags()
+          }
+          fireUserCompletion()
+        }
+      } else {
+        fireUserCompletion()
       }
     }
   }

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -1009,6 +1009,17 @@ extension MixpanelInstance {
 
       self.mixpanelPersistence.resetEntities()
       self.archive()
+
+      // reset() does not call identify(), so the loadFlags() call inside identify() never
+      // fires. Clear feature-flag state explicitly and refetch under the new identity if
+      // prefetching is enabled.
+      if let flagManager = self.flags as? FeatureFlagManager {
+        flagManager.reset()
+        if self.options.featureFlagOptions.prefetchFlags {
+          flagManager.loadFlags()
+        }
+      }
+
       if let completion = completion {
         DispatchQueue.main.async(execute: completion)
       }

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -82,10 +82,26 @@ public struct FeatureFlagOptions {
 ///   could reuse them). Pass a non-positive TTL to effectively disable expiry.
 /// - `networkFirst(ttl:)`: Prefer fresh values from the network, but fall back to cached
 ///   variants when the network call fails. Same TTL semantics as `cacheFirst`.
+///
+/// Convenience zero-argument forms `cacheFirst()` / `networkFirst()` use `defaultTTL`
+/// (1 hour) — equivalent to passing `ttl: VariantLookupPolicy.defaultTTL` explicitly.
 public enum VariantLookupPolicy {
   case networkOnly
   case cacheFirst(ttl: TimeInterval)
   case networkFirst(ttl: TimeInterval)
+
+  /// Default time-to-live for cached variants when no TTL is specified: 1 hour.
+  public static let defaultTTL: TimeInterval = 60 * 60
+
+  /// Convenience constructor — equivalent to `.cacheFirst(ttl: VariantLookupPolicy.defaultTTL)`.
+  public static func cacheFirst() -> VariantLookupPolicy {
+    return .cacheFirst(ttl: defaultTTL)
+  }
+
+  /// Convenience constructor — equivalent to `.networkFirst(ttl: VariantLookupPolicy.defaultTTL)`.
+  public static func networkFirst() -> VariantLookupPolicy {
+    return .networkFirst(ttl: defaultTTL)
+  }
 }
 
 public class MixpanelOptions {

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -77,15 +77,19 @@ public struct FeatureFlagOptions {
 /// - `networkOnly`: Never read or write persisted variants. Variant lookups always wait for
 ///   the network call. Default; matches behavior prior to variant persistence. If a persisted
 ///   blob exists from a previous session that used a persisting policy, it's wiped on init.
-/// - `persistenceUntilNetworkSuccess(ttl:)`: Serve persisted variants immediately when available, refresh
-///   from the network in the background. Persisted entries older than `ttl` are ignored on
-///   read but NOT deleted (the next successful fetch overwrites them; a longer TTL on a
-///   future launch could reuse them). Pass a non-positive TTL to effectively disable expiry.
+/// - `persistenceUntilNetworkSuccess(ttl:)`: Serve persisted variants immediately when
+///   available, refresh from the network in the background. Persisted entries older than
+///   `ttl` are ignored on read but NOT deleted (the next successful fetch overwrites them).
 /// - `networkFirst(ttl:)`: Prefer fresh values from the network, but fall back to persisted
 ///   variants when the network call fails. Same TTL semantics as `persistenceUntilNetworkSuccess`.
 ///
-/// Convenience zero-argument forms `persistenceUntilNetworkSuccess()` / `networkFirst()` use `defaultTTL`
-/// (24 hours) — equivalent to passing `ttl: VariantLookupPolicy.defaultTTL` explicitly.
+/// **TTL handling** (matches the JS SDK):
+/// - `ttl > 0` — entries expire after the configured number of seconds.
+/// - `ttl == 0` — entries are immediately treated as expired on every check.
+/// - `ttl < 0` — invalid; the SDK logs a warning and falls back to `defaultTTL`.
+///
+/// Convenience zero-argument forms `persistenceUntilNetworkSuccess()` / `networkFirst()` use
+/// `defaultTTL` (24 hours) — equivalent to passing `ttl: VariantLookupPolicy.defaultTTL`.
 public enum VariantLookupPolicy {
   case networkOnly
   case persistenceUntilNetworkSuccess(ttl: TimeInterval)

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -54,8 +54,8 @@ public struct FeatureFlagOptions {
   /// Persistence behavior is derived directly from this policy:
   /// - `.networkOnly` — no persistence. The on-disk blob is also wiped at init if present
   ///   (so toggling from a persisting policy back to `.networkOnly` cleans up after itself).
-  /// - `.persistenceUntilNetworkSuccess(ttl:)` / `.networkFirst(ttl:)` — successful fetches write to disk;
-  ///   persisted variants are read on init.
+  /// - `.persistenceUntilNetworkSuccess(persistenceTtl:)` / `.networkFirst(persistenceTtl:)` — successful
+  ///   fetches write to disk; persisted variants are read on init.
   public let variantLookupPolicy: VariantLookupPolicy
 
   public init(
@@ -77,61 +77,65 @@ public struct FeatureFlagOptions {
 /// - `networkOnly`: Never read or write persisted variants. Variant lookups always wait for
 ///   the network call. Default; matches behavior prior to variant persistence. If a persisted
 ///   blob exists from a previous session that used a persisting policy, it's wiped on init.
-/// - `persistenceUntilNetworkSuccess(ttl:)`: Serve persisted variants immediately when
-///   available, refresh from the network in the background. Persisted entries older than
-///   `ttl` are ignored on read but NOT deleted (the next successful fetch overwrites them).
-/// - `networkFirst(ttl:)`: Prefer fresh values from the network, but fall back to persisted
-///   variants when the network call fails. Same TTL semantics as `persistenceUntilNetworkSuccess`.
+/// - `persistenceUntilNetworkSuccess(persistenceTtl:)`: Serve persisted variants immediately
+///   when available, refresh from the network in the background. Persisted entries older
+///   than `persistenceTtl` are ignored on read but NOT deleted (the next successful fetch
+///   overwrites them).
+/// - `networkFirst(persistenceTtl:)`: Prefer fresh values from the network, but fall back to
+///   persisted variants when the network call fails. Same TTL semantics as
+///   `persistenceUntilNetworkSuccess`.
 ///
-/// **TTL handling** — non-positive TTL on a persisting policy is a misconfiguration. At SDK
-/// init the requested policy is run through `effective(_:)`, which collapses any persisting
-/// policy with `ttl <= 0` to `.networkOnly` (with a warning logged). Persistence-with-no-
-/// useful-TTL would write to disk on every fetch but never serve anything from disk, so the
-/// SDK substitutes the meaningful interpretation. The factories themselves don't sanitize —
-/// they preserve exactly what the developer asked for so callers can introspect.
+/// **TTL handling** — non-positive `persistenceTtl` on a persisting policy is a
+/// misconfiguration. At SDK init the requested policy is run through `effective(_:)`, which
+/// collapses any persisting policy with `persistenceTtl <= 0` to `.networkOnly` (with a
+/// warning logged). Persistence-with-no-useful-TTL would write to disk on every fetch but
+/// never serve anything from disk, so the SDK substitutes the meaningful interpretation. The
+/// factories themselves don't sanitize — they preserve exactly what the developer asked for
+/// so callers can introspect.
 ///
 /// Convenience zero-argument forms `persistenceUntilNetworkSuccess()` / `networkFirst()` use
-/// `defaultTTL` (24 hours) — equivalent to passing `ttl: VariantLookupPolicy.defaultTTL`.
+/// `defaultTTL` (24 hours) — equivalent to passing
+/// `persistenceTtl: VariantLookupPolicy.defaultTTL`.
 public enum VariantLookupPolicy {
   case networkOnly
-  case persistenceUntilNetworkSuccess(ttl: TimeInterval)
-  case networkFirst(ttl: TimeInterval)
+  case persistenceUntilNetworkSuccess(persistenceTtl: TimeInterval)
+  case networkFirst(persistenceTtl: TimeInterval)
 
   /// Default time-to-live for persisted variants when no TTL is specified: 24 hours.
   public static let defaultTTL: TimeInterval = 24 * 60 * 60
 
   /// Convenience constructor — equivalent to
-  /// `.persistenceUntilNetworkSuccess(ttl: VariantLookupPolicy.defaultTTL)`.
+  /// `.persistenceUntilNetworkSuccess(persistenceTtl: VariantLookupPolicy.defaultTTL)`.
   public static func persistenceUntilNetworkSuccess() -> VariantLookupPolicy {
-    return .persistenceUntilNetworkSuccess(ttl: defaultTTL)
+    return .persistenceUntilNetworkSuccess(persistenceTtl: defaultTTL)
   }
 
   /// Convenience constructor — equivalent to
-  /// `.networkFirst(ttl: VariantLookupPolicy.defaultTTL)`.
+  /// `.networkFirst(persistenceTtl: VariantLookupPolicy.defaultTTL)`.
   public static func networkFirst() -> VariantLookupPolicy {
-    return .networkFirst(ttl: defaultTTL)
+    return .networkFirst(persistenceTtl: defaultTTL)
   }
 
   /// Resolves the policy the SDK should actually use given what the developer configured.
   /// Substitutes `.networkOnly` when the requested policy is a persisting one with non-
-  /// positive TTL, since "persist on every fetch but the TTL makes nothing ever serve" does
-  /// no useful work — the developer almost certainly meant "no persistence." Logs a warning
-  /// when the substitution happens.
+  /// positive `persistenceTtl`, since "persist on every fetch but the TTL makes nothing ever
+  /// serve" does no useful work — the developer almost certainly meant "no persistence." Logs
+  /// a warning when the substitution happens.
   ///
   /// Called once at FeatureFlagManager init; downstream code can treat the returned policy
   /// as canonical.
   internal static func effective(_ requested: VariantLookupPolicy) -> VariantLookupPolicy {
-    let ttl: TimeInterval
+    let persistenceTtl: TimeInterval
     switch requested {
     case .networkOnly:
       return requested
     case .persistenceUntilNetworkSuccess(let t), .networkFirst(let t):
-      ttl = t
+      persistenceTtl = t
     }
-    if ttl <= 0 {
+    if persistenceTtl <= 0 {
       MixpanelLogger.warn(
         message:
-          "Non-positive TTL (\(ttl)s) on \(requested); falling back to networkOnly since persistence with no meaningful TTL does no useful work.")
+          "Non-positive persistenceTtl (\(persistenceTtl)s) on \(requested); falling back to networkOnly since persistence with no meaningful TTL does no useful work.")
       return .networkOnly
     }
     return requested

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -50,39 +50,38 @@ public struct FeatureFlagOptions {
   /// Strategy used to resolve flag variants relative to the on-disk cache and the network.
   /// Defaults to `.networkOnly` — variant lookups always wait for the network call,
   /// matching behavior prior to the introduction of variant persistence.
-  public let variantLookupPolicy: VariantLookupPolicy
-
-  /// Whether successful flag responses are written to the on-disk cache. Defaults to `false`.
   ///
-  /// This is independent of `variantLookupPolicy`. Setting this to `true` while keeping the
-  /// policy as `.networkOnly` lets you populate the cache today so a future migration to
-  /// `.cacheFirst` or `.networkFirst` starts with a warm cache.
-  public let cacheVariants: Bool
+  /// Caching behavior is derived directly from this policy:
+  /// - `.networkOnly` — no caching. The on-disk blob is also wiped at init if present
+  ///   (so toggling from a caching policy back to `.networkOnly` cleans up after itself).
+  /// - `.cacheFirst(ttl:)` / `.networkFirst(ttl:)` — successful fetches write to disk;
+  ///   the cache is read on init.
+  public let variantLookupPolicy: VariantLookupPolicy
 
   public init(
     enabled: Bool = false,
     context: [String: Any] = [:],
     prefetchFlags: Bool = true,
-    variantLookupPolicy: VariantLookupPolicy = .networkOnly,
-    cacheVariants: Bool = false
+    variantLookupPolicy: VariantLookupPolicy = .networkOnly
   ) {
     self.enabled = enabled
     self.context = context
     self.prefetchFlags = prefetchFlags
     self.variantLookupPolicy = variantLookupPolicy
-    self.cacheVariants = cacheVariants
   }
 }
 
 /// Strategy for resolving feature flag variants relative to the on-disk cache and the network.
 ///
 /// - `networkOnly`: Never read or write the on-disk cache. Variant lookups always wait for the
-///   network call. Default; matches behavior prior to variant persistence.
+///   network call. Default; matches behavior prior to variant persistence. If a cached blob
+///   exists from a previous session that used a caching policy, it's wiped on init.
 /// - `cacheFirst(ttl:)`: Serve cached variants immediately when available, refresh from the
-///   network in the background. Cached entries older than `ttl` are discarded. Pass a
-///   non-positive TTL to effectively disable expiry.
+///   network in the background. Cached entries older than `ttl` are ignored on read but NOT
+///   deleted (the next successful fetch overwrites them; a longer TTL on a future launch
+///   could reuse them). Pass a non-positive TTL to effectively disable expiry.
 /// - `networkFirst(ttl:)`: Prefer fresh values from the network, but fall back to cached
-///   variants when the network call fails. Cached entries older than `ttl` are discarded.
+///   variants when the network call fails. Same TTL semantics as `cacheFirst`.
 public enum VariantLookupPolicy {
   case networkOnly
   case cacheFirst(ttl: TimeInterval)

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -47,15 +47,15 @@ public struct FeatureFlagOptions {
   /// then manually trigger loading via `flags.loadFlags()`.
   public let prefetchFlags: Bool
 
-  /// Strategy used to resolve flag variants relative to the on-disk cache and the network.
-  /// Defaults to `.networkOnly` — variant lookups always wait for the network call,
-  /// matching behavior prior to the introduction of variant persistence.
+  /// Strategy used to resolve flag variants relative to the on-disk persistence layer and
+  /// the network. Defaults to `.networkOnly` — variant lookups always wait for the network
+  /// call, matching behavior prior to the introduction of variant persistence.
   ///
-  /// Caching behavior is derived directly from this policy:
-  /// - `.networkOnly` — no caching. The on-disk blob is also wiped at init if present
-  ///   (so toggling from a caching policy back to `.networkOnly` cleans up after itself).
-  /// - `.cacheFirst(ttl:)` / `.networkFirst(ttl:)` — successful fetches write to disk;
-  ///   the cache is read on init.
+  /// Persistence behavior is derived directly from this policy:
+  /// - `.networkOnly` — no persistence. The on-disk blob is also wiped at init if present
+  ///   (so toggling from a persisting policy back to `.networkOnly` cleans up after itself).
+  /// - `.persistenceFirst(ttl:)` / `.networkFirst(ttl:)` — successful fetches write to disk;
+  ///   persisted variants are read on init.
   public let variantLookupPolicy: VariantLookupPolicy
 
   public init(
@@ -71,34 +71,37 @@ public struct FeatureFlagOptions {
   }
 }
 
-/// Strategy for resolving feature flag variants relative to the on-disk cache and the network.
+/// Strategy for resolving feature flag variants relative to the on-disk persistence layer
+/// and the network.
 ///
-/// - `networkOnly`: Never read or write the on-disk cache. Variant lookups always wait for the
-///   network call. Default; matches behavior prior to variant persistence. If a cached blob
-///   exists from a previous session that used a caching policy, it's wiped on init.
-/// - `cacheFirst(ttl:)`: Serve cached variants immediately when available, refresh from the
-///   network in the background. Cached entries older than `ttl` are ignored on read but NOT
-///   deleted (the next successful fetch overwrites them; a longer TTL on a future launch
-///   could reuse them). Pass a non-positive TTL to effectively disable expiry.
-/// - `networkFirst(ttl:)`: Prefer fresh values from the network, but fall back to cached
-///   variants when the network call fails. Same TTL semantics as `cacheFirst`.
+/// - `networkOnly`: Never read or write persisted variants. Variant lookups always wait for
+///   the network call. Default; matches behavior prior to variant persistence. If a persisted
+///   blob exists from a previous session that used a persisting policy, it's wiped on init.
+/// - `persistenceFirst(ttl:)`: Serve persisted variants immediately when available, refresh
+///   from the network in the background. Persisted entries older than `ttl` are ignored on
+///   read but NOT deleted (the next successful fetch overwrites them; a longer TTL on a
+///   future launch could reuse them). Pass a non-positive TTL to effectively disable expiry.
+/// - `networkFirst(ttl:)`: Prefer fresh values from the network, but fall back to persisted
+///   variants when the network call fails. Same TTL semantics as `persistenceFirst`.
 ///
-/// Convenience zero-argument forms `cacheFirst()` / `networkFirst()` use `defaultTTL`
-/// (1 hour) — equivalent to passing `ttl: VariantLookupPolicy.defaultTTL` explicitly.
+/// Convenience zero-argument forms `persistenceFirst()` / `networkFirst()` use `defaultTTL`
+/// (24 hours) — equivalent to passing `ttl: VariantLookupPolicy.defaultTTL` explicitly.
 public enum VariantLookupPolicy {
   case networkOnly
-  case cacheFirst(ttl: TimeInterval)
+  case persistenceFirst(ttl: TimeInterval)
   case networkFirst(ttl: TimeInterval)
 
-  /// Default time-to-live for cached variants when no TTL is specified: 1 hour.
-  public static let defaultTTL: TimeInterval = 60 * 60
+  /// Default time-to-live for persisted variants when no TTL is specified: 24 hours.
+  public static let defaultTTL: TimeInterval = 24 * 60 * 60
 
-  /// Convenience constructor — equivalent to `.cacheFirst(ttl: VariantLookupPolicy.defaultTTL)`.
-  public static func cacheFirst() -> VariantLookupPolicy {
-    return .cacheFirst(ttl: defaultTTL)
+  /// Convenience constructor — equivalent to
+  /// `.persistenceFirst(ttl: VariantLookupPolicy.defaultTTL)`.
+  public static func persistenceFirst() -> VariantLookupPolicy {
+    return .persistenceFirst(ttl: defaultTTL)
   }
 
-  /// Convenience constructor — equivalent to `.networkFirst(ttl: VariantLookupPolicy.defaultTTL)`.
+  /// Convenience constructor — equivalent to
+  /// `.networkFirst(ttl: VariantLookupPolicy.defaultTTL)`.
   public static func networkFirst() -> VariantLookupPolicy {
     return .networkFirst(ttl: defaultTTL)
   }

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2025 Mixpanel. All rights reserved.
 //
 
+import Foundation
+
 /// Configuration options for feature flags behavior.
 ///
 /// Use this to control how and when feature flags are loaded by the SDK.
@@ -45,15 +47,46 @@ public struct FeatureFlagOptions {
   /// then manually trigger loading via `flags.loadFlags()`.
   public let prefetchFlags: Bool
 
+  /// Strategy used to resolve flag variants relative to the on-disk cache and the network.
+  /// Defaults to `.networkOnly` — variant lookups always wait for the network call,
+  /// matching behavior prior to the introduction of variant persistence.
+  public let variantLookupPolicy: VariantLookupPolicy
+
+  /// Whether successful flag responses are written to the on-disk cache. Defaults to `false`.
+  ///
+  /// This is independent of `variantLookupPolicy`. Setting this to `true` while keeping the
+  /// policy as `.networkOnly` lets you populate the cache today so a future migration to
+  /// `.cacheFirst` or `.networkFirst` starts with a warm cache.
+  public let cacheVariants: Bool
+
   public init(
     enabled: Bool = false,
     context: [String: Any] = [:],
-    prefetchFlags: Bool = true
+    prefetchFlags: Bool = true,
+    variantLookupPolicy: VariantLookupPolicy = .networkOnly,
+    cacheVariants: Bool = false
   ) {
     self.enabled = enabled
     self.context = context
     self.prefetchFlags = prefetchFlags
+    self.variantLookupPolicy = variantLookupPolicy
+    self.cacheVariants = cacheVariants
   }
+}
+
+/// Strategy for resolving feature flag variants relative to the on-disk cache and the network.
+///
+/// - `networkOnly`: Never read or write the on-disk cache. Variant lookups always wait for the
+///   network call. Default; matches behavior prior to variant persistence.
+/// - `cacheFirst(ttl:)`: Serve cached variants immediately when available, refresh from the
+///   network in the background. Cached entries older than `ttl` are discarded. Pass a
+///   non-positive TTL to effectively disable expiry.
+/// - `networkFirst(ttl:)`: Prefer fresh values from the network, but fall back to cached
+///   variants when the network call fails. Cached entries older than `ttl` are discarded.
+public enum VariantLookupPolicy {
+  case networkOnly
+  case cacheFirst(ttl: TimeInterval)
+  case networkFirst(ttl: TimeInterval)
 }
 
 public class MixpanelOptions {

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -83,10 +83,12 @@ public struct FeatureFlagOptions {
 /// - `networkFirst(ttl:)`: Prefer fresh values from the network, but fall back to persisted
 ///   variants when the network call fails. Same TTL semantics as `persistenceUntilNetworkSuccess`.
 ///
-/// **TTL handling** (matches the JS SDK):
-/// - `ttl > 0` — entries expire after the configured number of seconds.
-/// - `ttl == 0` — entries are immediately treated as expired on every check.
-/// - `ttl < 0` — invalid; the SDK logs a warning and falls back to `defaultTTL`.
+/// **TTL handling** — non-positive TTL on a persisting policy is a misconfiguration. At SDK
+/// init the requested policy is run through `effective(_:)`, which collapses any persisting
+/// policy with `ttl <= 0` to `.networkOnly` (with a warning logged). Persistence-with-no-
+/// useful-TTL would write to disk on every fetch but never serve anything from disk, so the
+/// SDK substitutes the meaningful interpretation. The factories themselves don't sanitize —
+/// they preserve exactly what the developer asked for so callers can introspect.
 ///
 /// Convenience zero-argument forms `persistenceUntilNetworkSuccess()` / `networkFirst()` use
 /// `defaultTTL` (24 hours) — equivalent to passing `ttl: VariantLookupPolicy.defaultTTL`.
@@ -108,6 +110,31 @@ public enum VariantLookupPolicy {
   /// `.networkFirst(ttl: VariantLookupPolicy.defaultTTL)`.
   public static func networkFirst() -> VariantLookupPolicy {
     return .networkFirst(ttl: defaultTTL)
+  }
+
+  /// Resolves the policy the SDK should actually use given what the developer configured.
+  /// Substitutes `.networkOnly` when the requested policy is a persisting one with non-
+  /// positive TTL, since "persist on every fetch but the TTL makes nothing ever serve" does
+  /// no useful work — the developer almost certainly meant "no persistence." Logs a warning
+  /// when the substitution happens.
+  ///
+  /// Called once at FeatureFlagManager init; downstream code can treat the returned policy
+  /// as canonical.
+  internal static func effective(_ requested: VariantLookupPolicy) -> VariantLookupPolicy {
+    let ttl: TimeInterval
+    switch requested {
+    case .networkOnly:
+      return requested
+    case .persistenceUntilNetworkSuccess(let t), .networkFirst(let t):
+      ttl = t
+    }
+    if ttl <= 0 {
+      MixpanelLogger.warn(
+        message:
+          "Non-positive TTL (\(ttl)s) on \(requested); falling back to networkOnly since persistence with no meaningful TTL does no useful work.")
+      return .networkOnly
+    }
+    return requested
   }
 }
 

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -54,7 +54,7 @@ public struct FeatureFlagOptions {
   /// Persistence behavior is derived directly from this policy:
   /// - `.networkOnly` — no persistence. The on-disk blob is also wiped at init if present
   ///   (so toggling from a persisting policy back to `.networkOnly` cleans up after itself).
-  /// - `.persistenceFirst(ttl:)` / `.networkFirst(ttl:)` — successful fetches write to disk;
+  /// - `.persistenceUntilNetworkSuccess(ttl:)` / `.networkFirst(ttl:)` — successful fetches write to disk;
   ///   persisted variants are read on init.
   public let variantLookupPolicy: VariantLookupPolicy
 
@@ -77,27 +77,27 @@ public struct FeatureFlagOptions {
 /// - `networkOnly`: Never read or write persisted variants. Variant lookups always wait for
 ///   the network call. Default; matches behavior prior to variant persistence. If a persisted
 ///   blob exists from a previous session that used a persisting policy, it's wiped on init.
-/// - `persistenceFirst(ttl:)`: Serve persisted variants immediately when available, refresh
+/// - `persistenceUntilNetworkSuccess(ttl:)`: Serve persisted variants immediately when available, refresh
 ///   from the network in the background. Persisted entries older than `ttl` are ignored on
 ///   read but NOT deleted (the next successful fetch overwrites them; a longer TTL on a
 ///   future launch could reuse them). Pass a non-positive TTL to effectively disable expiry.
 /// - `networkFirst(ttl:)`: Prefer fresh values from the network, but fall back to persisted
-///   variants when the network call fails. Same TTL semantics as `persistenceFirst`.
+///   variants when the network call fails. Same TTL semantics as `persistenceUntilNetworkSuccess`.
 ///
-/// Convenience zero-argument forms `persistenceFirst()` / `networkFirst()` use `defaultTTL`
+/// Convenience zero-argument forms `persistenceUntilNetworkSuccess()` / `networkFirst()` use `defaultTTL`
 /// (24 hours) — equivalent to passing `ttl: VariantLookupPolicy.defaultTTL` explicitly.
 public enum VariantLookupPolicy {
   case networkOnly
-  case persistenceFirst(ttl: TimeInterval)
+  case persistenceUntilNetworkSuccess(ttl: TimeInterval)
   case networkFirst(ttl: TimeInterval)
 
   /// Default time-to-live for persisted variants when no TTL is specified: 24 hours.
   public static let defaultTTL: TimeInterval = 24 * 60 * 60
 
   /// Convenience constructor — equivalent to
-  /// `.persistenceFirst(ttl: VariantLookupPolicy.defaultTTL)`.
-  public static func persistenceFirst() -> VariantLookupPolicy {
-    return .persistenceFirst(ttl: defaultTTL)
+  /// `.persistenceUntilNetworkSuccess(ttl: VariantLookupPolicy.defaultTTL)`.
+  public static func persistenceUntilNetworkSuccess() -> VariantLookupPolicy {
+    return .persistenceUntilNetworkSuccess(ttl: defaultTTL)
   }
 
   /// Convenience constructor — equivalent to

--- a/Sources/MixpanelPersistence.swift
+++ b/Sources/MixpanelPersistence.swift
@@ -47,7 +47,6 @@ struct MixpanelUserDefaultsKeys {
   static let userID = "MPUserId"
   static let alias = "MPAlias"
   static let hadPersistedDistinctId = "MPHadPersistedDistinctId"
-  static let flags = "MPFlags"
   static let flagsPersistence = "MPFlagsPersistence"
 }
 
@@ -246,41 +245,6 @@ class MixpanelPersistence {
         ?? InternalProperties()
     } catch {
       MixpanelLogger.warn(message: "Failed to unarchive super properties")
-      return InternalProperties()
-    }
-  }
-
-  /// -- Feature Flags --
-  /// NOT currently used
-
-  static func saveFlags(flags: InternalProperties, instanceName: String) {
-    guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
-      return
-    }
-    let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
-    do {
-      let flagsData = try NSKeyedArchiver.archivedData(
-        withRootObject: flags, requiringSecureCoding: false)
-      defaults.set(flagsData, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.flags)")
-      defaults.synchronize()
-    } catch {
-      MixpanelLogger.warn(message: "Failed to archive flags")
-    }
-  }
-
-  static func loadFlags(instanceName: String) -> InternalProperties {
-    guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
-      return InternalProperties()
-    }
-    let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
-    guard let flags = defaults.data(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.flags)") else {
-      return InternalProperties()
-    }
-    do {
-      return try NSKeyedUnarchiver.unarchivedObject(ofClasses: archivedClasses, from: flags)
-        as? InternalProperties ?? InternalProperties()
-    } catch {
-      MixpanelLogger.warn(message: "Failed to unarchive flags")
       return InternalProperties()
     }
   }

--- a/Sources/MixpanelPersistence.swift
+++ b/Sources/MixpanelPersistence.swift
@@ -48,18 +48,18 @@ struct MixpanelUserDefaultsKeys {
   static let alias = "MPAlias"
   static let hadPersistedDistinctId = "MPHadPersistedDistinctId"
   static let flags = "MPFlags"
-  static let flagsCache = "MPFlagsCache"
+  static let flagsPersistence = "MPFlagsPersistence"
 }
 
-/// On-disk cache blob for the most recent successful `/flags/` response.
+/// On-disk persistence blob for the most recent successful `/flags/` response.
 ///
 /// Stores the **raw response JSON string** (not parsed variants) so that the network parser
 /// stays the single source of truth. Pending first-time events ride along for free, and
 /// shape changes self-heal — a parse failure on read just clears the blob and the next
 /// successful fetch overwrites with the current shape.
-struct FlagsCacheBlob {
+struct FlagsPersistenceBlob {
   /// Time the blob was originally written.
-  let cachedAt: Date
+  let persistedAt: Date
   /// The distinctId the variants in `response` were evaluated under. Validated on read so a
   /// freshly-identified user can't be served the prior user's variants.
   let distinctId: String
@@ -68,21 +68,21 @@ struct FlagsCacheBlob {
 
   func toDictionary() -> [String: Any] {
     return [
-      "cachedAt": Int64(cachedAt.timeIntervalSince1970 * 1000),
+      "persistedAt": Int64(persistedAt.timeIntervalSince1970 * 1000),
       "distinctId": distinctId,
       "response": response,
     ]
   }
 
-  static func from(dictionary: [String: Any]) -> FlagsCacheBlob? {
+  static func from(dictionary: [String: Any]) -> FlagsPersistenceBlob? {
     guard
-      let cachedAtMillis = dictionary["cachedAt"] as? Int64
-        ?? (dictionary["cachedAt"] as? NSNumber).map({ $0.int64Value }),
+      let persistedAtMillis = dictionary["persistedAt"] as? Int64
+        ?? (dictionary["persistedAt"] as? NSNumber).map({ $0.int64Value }),
       let distinctId = dictionary["distinctId"] as? String,
       let response = dictionary["response"] as? String
     else { return nil }
-    return FlagsCacheBlob(
-      cachedAt: Date(timeIntervalSince1970: TimeInterval(cachedAtMillis) / 1000.0),
+    return FlagsPersistenceBlob(
+      persistedAt: Date(timeIntervalSince1970: TimeInterval(persistedAtMillis) / 1000.0),
       distinctId: distinctId,
       response: response
     )
@@ -285,62 +285,63 @@ class MixpanelPersistence {
     }
   }
 
-  // -- Feature Flag Variant Cache --
+  // -- Feature Flag Variant Persistence --
   // Wire format: a JSON-serialized dictionary stored under a single per-instance key in the
-  // shared "Mixpanel" UserDefaults suite. See `FlagsCacheBlob` for layout.
+  // shared "Mixpanel" UserDefaults suite. See `FlagsPersistenceBlob` for layout.
 
-  static func saveFlagsCache(_ blob: FlagsCacheBlob, instanceName: String) {
+  static func saveFlagsPersistence(_ blob: FlagsPersistenceBlob, instanceName: String) {
     guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
       return
     }
     let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
     do {
       let data = try JSONSerialization.data(withJSONObject: blob.toDictionary(), options: [])
-      defaults.set(data, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.flagsCache)")
+      defaults.set(data, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.flagsPersistence)")
     } catch {
-      MixpanelLogger.warn(message: "Failed to serialize flags cache blob: \(error)")
+      MixpanelLogger.warn(message: "Failed to serialize flags persistence blob: \(error)")
     }
   }
 
-  /// Reads and validates the cached flags blob.
+  /// Reads and validates the persisted flags blob.
   ///
-  /// Returns `nil` when nothing is cached or the blob is unparseable. **Self-healing:**
+  /// Returns `nil` when nothing is persisted or the blob is unparseable. **Self-healing:**
   /// malformed blobs are deleted as a side effect so the next successful fetch overwrites
   /// with the current shape — no version field needed.
   ///
-  /// Fingerprint and TTL validation are intentionally left to the caller (the manager) so
+  /// distinctId and TTL validation are intentionally left to the caller (the manager) so
   /// the persistence layer stays format-only and the manager can apply its own policy.
-  static func loadFlagsCache(instanceName: String) -> FlagsCacheBlob? {
+  static func loadFlagsPersistence(instanceName: String) -> FlagsPersistenceBlob? {
     guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
       return nil
     }
     let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
-    let key = "\(prefix)\(MixpanelUserDefaultsKeys.flagsCache)"
+    let key = "\(prefix)\(MixpanelUserDefaultsKeys.flagsPersistence)"
     guard let data = defaults.data(forKey: key) else {
       return nil
     }
     do {
       let parsed = try JSONSerialization.jsonObject(with: data, options: [])
-      guard let dict = parsed as? [String: Any], let blob = FlagsCacheBlob.from(dictionary: dict)
+      guard let dict = parsed as? [String: Any],
+            let blob = FlagsPersistenceBlob.from(dictionary: dict)
       else {
-        MixpanelLogger.warn(message: "Cached flags blob has unexpected shape; clearing.")
+        MixpanelLogger.warn(message: "Persisted flags blob has unexpected shape; clearing.")
         defaults.removeObject(forKey: key)
         return nil
       }
       return blob
     } catch {
-      MixpanelLogger.warn(message: "Failed to parse cached flags blob; clearing. \(error)")
+      MixpanelLogger.warn(message: "Failed to parse persisted flags blob; clearing. \(error)")
       defaults.removeObject(forKey: key)
       return nil
     }
   }
 
-  static func deleteFlagsCache(instanceName: String) {
+  static func deleteFlagsPersistence(instanceName: String) {
     guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
       return
     }
     let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
-    defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.flagsCache)")
+    defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.flagsPersistence)")
   }
 
   static func saveIdentity(_ mixpanelIdentity: MixpanelIdentity, instanceName: String) {
@@ -399,7 +400,7 @@ class MixpanelPersistence {
     defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.optOutStatus)")
     defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.timedEvents)")
     defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.superProperties)")
-    defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.flagsCache)")
+    defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.flagsPersistence)")
     defaults.synchronize()
   }
 

--- a/Sources/MixpanelPersistence.swift
+++ b/Sources/MixpanelPersistence.swift
@@ -48,6 +48,45 @@ struct MixpanelUserDefaultsKeys {
   static let alias = "MPAlias"
   static let hadPersistedDistinctId = "MPHadPersistedDistinctId"
   static let flags = "MPFlags"
+  static let flagsCache = "MPFlagsCache"
+}
+
+/// On-disk cache blob for the most recent successful `/flags/` response.
+///
+/// Stores the **raw response JSON string** (not parsed variants) so that the network parser
+/// stays the single source of truth. Pending first-time events ride along for free, and
+/// shape changes self-heal — a parse failure on read just clears the blob and the next
+/// successful fetch overwrites with the current shape.
+struct FlagsCacheBlob {
+  /// Time the blob was originally written.
+  let cachedAt: Date
+  /// The distinctId the variants in `response` were evaluated under. Validated on read so a
+  /// freshly-identified user can't be served the prior user's variants.
+  let distinctId: String
+  /// Raw JSON string returned by the `/flags/` endpoint. Re-parsed on read.
+  let response: String
+
+  func toDictionary() -> [String: Any] {
+    return [
+      "cachedAt": Int64(cachedAt.timeIntervalSince1970 * 1000),
+      "distinctId": distinctId,
+      "response": response,
+    ]
+  }
+
+  static func from(dictionary: [String: Any]) -> FlagsCacheBlob? {
+    guard
+      let cachedAtMillis = dictionary["cachedAt"] as? Int64
+        ?? (dictionary["cachedAt"] as? NSNumber).map({ $0.int64Value }),
+      let distinctId = dictionary["distinctId"] as? String,
+      let response = dictionary["response"] as? String
+    else { return nil }
+    return FlagsCacheBlob(
+      cachedAt: Date(timeIntervalSince1970: TimeInterval(cachedAtMillis) / 1000.0),
+      distinctId: distinctId,
+      response: response
+    )
+  }
 }
 
 class MixpanelPersistence {
@@ -246,6 +285,64 @@ class MixpanelPersistence {
     }
   }
 
+  // -- Feature Flag Variant Cache --
+  // Wire format: a JSON-serialized dictionary stored under a single per-instance key in the
+  // shared "Mixpanel" UserDefaults suite. See `FlagsCacheBlob` for layout.
+
+  static func saveFlagsCache(_ blob: FlagsCacheBlob, instanceName: String) {
+    guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
+      return
+    }
+    let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
+    do {
+      let data = try JSONSerialization.data(withJSONObject: blob.toDictionary(), options: [])
+      defaults.set(data, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.flagsCache)")
+    } catch {
+      MixpanelLogger.warn(message: "Failed to serialize flags cache blob: \(error)")
+    }
+  }
+
+  /// Reads and validates the cached flags blob.
+  ///
+  /// Returns `nil` when nothing is cached or the blob is unparseable. **Self-healing:**
+  /// malformed blobs are deleted as a side effect so the next successful fetch overwrites
+  /// with the current shape — no version field needed.
+  ///
+  /// Fingerprint and TTL validation are intentionally left to the caller (the manager) so
+  /// the persistence layer stays format-only and the manager can apply its own policy.
+  static func loadFlagsCache(instanceName: String) -> FlagsCacheBlob? {
+    guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
+      return nil
+    }
+    let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
+    let key = "\(prefix)\(MixpanelUserDefaultsKeys.flagsCache)"
+    guard let data = defaults.data(forKey: key) else {
+      return nil
+    }
+    do {
+      let parsed = try JSONSerialization.jsonObject(with: data, options: [])
+      guard let dict = parsed as? [String: Any], let blob = FlagsCacheBlob.from(dictionary: dict)
+      else {
+        MixpanelLogger.warn(message: "Cached flags blob has unexpected shape; clearing.")
+        defaults.removeObject(forKey: key)
+        return nil
+      }
+      return blob
+    } catch {
+      MixpanelLogger.warn(message: "Failed to parse cached flags blob; clearing. \(error)")
+      defaults.removeObject(forKey: key)
+      return nil
+    }
+  }
+
+  static func deleteFlagsCache(instanceName: String) {
+    guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
+      return
+    }
+    let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
+    defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.flagsCache)")
+  }
+
   static func saveIdentity(_ mixpanelIdentity: MixpanelIdentity, instanceName: String) {
     guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
       return
@@ -302,6 +399,7 @@ class MixpanelPersistence {
     defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.optOutStatus)")
     defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.timedEvents)")
     defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.superProperties)")
+    defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.flagsCache)")
     defaults.synchronize()
   }
 


### PR DESCRIPTION
<h2>Configuration types</h2>
<h3><code>VariantLookupPolicy</code></h3>
<p>Idiomatic Swift enum with associated values — TTL uses <code>TimeInterval</code> (seconds) to match Foundation conventions.</p>
<pre><code class="language-swift">public enum VariantLookupPolicy {
  case networkOnly
  case cacheFirst(ttl: TimeInterval)
  case networkFirst(ttl: TimeInterval)
}
</code></pre>
<h3><code>FeatureFlagOptions</code> — new property</h3>
<pre><code class="language-swift">public let variantLookupPolicy: VariantLookupPolicy   // default: .networkOnly
</code></pre>
<p>Caching behavior is derived directly from the policy — there is no separate <code>cacheVariants</code> toggle:</p>
<ul>
<li><code>.networkOnly</code> — no caching. The on-disk blob is also wiped on init if present, so toggling from a caching policy back to <code>.networkOnly</code> cleans up after itself.</li>
<li><code>.cacheFirst(ttl:)</code> / <code>.networkFirst(ttl:)</code> — successful fetches write to disk; the cache is read on init.</li>
</ul>
<h3><code>MixpanelFlagVariant.Source</code> (on served variants)</h3>
<p>Discriminated union surfaced via the new <code>MixpanelFlagVariant.source</code> field. <code>nil</code> on developer-supplied fallbacks; otherwise:</p>
<pre><code class="language-swift">extension MixpanelFlagVariant {
  public enum Source {
    case network                  // variant came from /flags/
    case cache(cachedAt: Date)          // variant came from on-disk cache
  }
}
</code></pre>
<p>The cache timestamp lives on the <code>.cache</code> case (not as a parallel field on <code>MixpanelFlagVariant</code>), so invalid combinations like <code>.network</code> + non-nil timestamp are unrepresentable.</p>
<h2>Behavior matrix</h2>

variantLookupPolicy | Cache writes | Cache reads on init | Async lookup | Sync lookup / areFlagsReady()
-- | -- | -- | -- | --
.networkOnly | no | no (and wipes any stale blob from a prior caching session) | network only (today's behavior) | as today
.cacheFirst(ttl:) | yes | yes | serve cached immediately, refresh in background | reflects cache
.networkFirst(ttl:) | yes | yes | await network; on failure serve cached | reflects cache


<h2>Customer usage examples</h2>
<h3>Default (no caching — current behavior, no opt-in needed)</h3>
<pre><code class="language-swift">let options = MixpanelOptions(
    token: TOKEN,
    featureFlagOptions: FeatureFlagOptions(enabled: true)
)
let mixpanel = Mixpanel.initialize(options: options)
</code></pre>
<h3>CacheFirst — consistency-across-sessions over freshness</h3>
<p>Serves cached variants immediately on app start (within TTL), refreshes from network in the background.</p>
<pre><code class="language-swift">let flags = FeatureFlagOptions(
    enabled: true,
    variantLookupPolicy: .cacheFirst(ttl: 24 * 60 * 60)
)

let options = MixpanelOptions(
    token: TOKEN,
    featureFlagOptions: flags
)
let mixpanel = Mixpanel.initialize(options: options)
</code></pre>
<h3>NetworkFirst — freshness with offline resilience</h3>
<p>Async lookups await the network call; only fall back to cached variants if it fails.</p>
<pre><code class="language-swift">let flags = FeatureFlagOptions(
    enabled: true,
    variantLookupPolicy: .networkFirst(ttl: 24 * 60 * 60)
)
</code></pre>
<h3>Inspecting where a served variant came from</h3>
<p><code>variant.source</code> is set by the SDK on every served (non-fallback) variant. Pattern matching makes the dispatch clean:</p>
<pre><code class="language-swift">mixpanel.flags.getVariant(&quot;checkout-experiment&quot;, fallback: fallback) { variant in
    switch variant.source {
    case .cache(let cachedAt):
        print(&quot;Served from cache, written at \\(cachedAt)&quot;)
    case .network:
        print(&quot;Served from a fresh /flags/ response&quot;)
    case nil:
        print(&quot;Served the developer-supplied fallback&quot;)
    }
}
</code></pre>
<h3>Sync lookups and <code>areFlagsReady()</code></h3>
<p>Both reflect cached values when a caching policy is configured. <code>areFlagsReady()</code> returns <code>true</code> once flags are in memory, regardless of whether they were loaded from network or cache — check <code>variant.source</code> if you need to distinguish.</p>
<!-- notionvc: ad809147-ef07-49ae-9cf7-8017ba6a3296 -->