### PR TITLE
chore: update the logic for extracting changelog entries in the release workflow

### DIFF
--- a/.github/workflows/release-spm.yml
+++ b/.github/workflows/release-spm.yml
@@ -165,8 +165,22 @@ jobs:
           fi
 
           # Extract this version's changelog entry
-          # Starts with "## [VERSION]" and ends before next "## [" or EOF
-          CHANGELOG=$(awk "/^## \[$VERSION\]/,/^## \[/{if(/^## \[/ && !/^## \[$VERSION\]/)exit;print}" CHANGELOG.md)
+          # Starts with "## [VERSION](...)" and ends before next "## [" or EOF
+          # The changelog format includes a link after the version number
+          # Uses state-based matching to avoid range pattern issues
+          CHANGELOG=$(awk -v ver="$VERSION" '
+          /^## \[/ {
+            if (match($0, "^## \\[" ver "\\]\\(")) {
+              inSection = 1
+              print
+              next
+            }
+            if (inSection) {
+              exit
+            }
+          }
+          inSection { print }
+          ' CHANGELOG.md)
 
           if [ -z "$CHANGELOG" ]; then
             echo "⚠️  Changelog entry for version $VERSION not found in CHANGELOG.md"

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -18,10 +18,10 @@ fi
 LAST_TAG=$(git tag --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || echo "")
 
 if [ -z "$LAST_TAG" ]; then
-  echo "No previous tags found. Generating changelog from all commits."
+  echo "No previous tags found. Generating changelog from all commits." >&2
   COMMIT_RANGE="HEAD"
 else
-  echo "Last tag: $LAST_TAG"
+  echo "Last tag: $LAST_TAG" >&2
   COMMIT_RANGE="$LAST_TAG..HEAD"
 fi
 


### PR DESCRIPTION
This pull request makes improvements to how changelog entries are extracted and how messages are output in the changelog generation scripts. The most important changes include updating the changelog extraction logic in the release workflow to better match the current format and ensuring status messages are sent to standard error in the changelog generation script.

**Changelog extraction improvements:**
* [`.github/workflows/release-spm.yml`](diffhunk://#diff-548a1b98feeb3d4c68f710250b0ca7dcdbe3adbc955229961687832b097f1276L168-R183): Updated the `awk` command to correctly extract changelog entries that use the format `## [VERSION](...)`, using state-based matching for improved reliability.

**Script output improvements:**
* [`scripts/generate-changelog.sh`](diffhunk://#diff-4c44afaa830db1afb5e7367abf37d634056acdd061461be4bfcd0c209fc2181bL21-R24): Changed echo statements for status messages to write to standard error (`>&2`), ensuring cleaner output when the script is used in pipelines.