### PR TITLE
feat: add MixpanelOptions.excludeProperties to strip event keys

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -2,9 +2,9 @@
   "version": 1,
   "lineLength": 120,
   "indentation": {
-    "spaces": 4
+    "spaces": 2
   },
-  "tabWidth": 4,
+  "tabWidth": 2,
   "indentConditionalCompilationBlocks": false,
   "indentSwitchCaseLabels": true
 }

--- a/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
+++ b/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		171E4C1C2DB055BC00B7CB11 /* MixpanelFeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171E4C1B2DB055A900B7CB11 /* MixpanelFeatureFlagTests.swift */; };
 		1A1B2C3D4E5F60718293A4B0 /* MixpanelFeatureFlagPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1B2C3D4E5F60718293A4B1 /* MixpanelFeatureFlagPersistenceTests.swift */; };
 		1A1B2C3D4E5F60718293A4B2 /* MixpanelFeatureFlagPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1B2C3D4E5F60718293A4B1 /* MixpanelFeatureFlagPersistenceTests.swift */; };
+		1A1B2C3D4E5F60718293A5B0 /* MixpanelExcludePropertiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1B2C3D4E5F60718293A5B1 /* MixpanelExcludePropertiesTests.swift */; };
+		1A1B2C3D4E5F60718293A5B2 /* MixpanelExcludePropertiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1B2C3D4E5F60718293A5B1 /* MixpanelExcludePropertiesTests.swift */; };
 		174205522F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174205512F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift */; };
 		4A856A22C3D44379A5471460 /* MixpanelEventBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C72DDD552B64791AD52E1DC /* MixpanelEventBridgeTests.swift */; };
 		B1AB7B0E940444B7A9B0876A /* MixpanelEventBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DA802B4623D45938280B06A /* MixpanelEventBridgeTests.swift */; };
@@ -259,6 +261,7 @@
 /* Begin PBXFileReference section */
 		171E4C1B2DB055A900B7CB11 /* MixpanelFeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelFeatureFlagTests.swift; sourceTree = "<group>"; };
 		1A1B2C3D4E5F60718293A4B1 /* MixpanelFeatureFlagPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelFeatureFlagPersistenceTests.swift; sourceTree = "<group>"; };
+		1A1B2C3D4E5F60718293A5B1 /* MixpanelExcludePropertiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelExcludePropertiesTests.swift; sourceTree = "<group>"; };
 		174205512F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelDeviceIdProviderTests.swift; sourceTree = "<group>"; };
 		7DA802B4623D45938280B06A /* MixpanelEventBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelEventBridgeTests.swift; sourceTree = "<group>"; };
 		8C72DDD552B64791AD52E1DC /* MixpanelEventBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelEventBridgeTests.swift; sourceTree = "<group>"; };
@@ -611,6 +614,7 @@
 				174205512F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift */,
 				171E4C1B2DB055A900B7CB11 /* MixpanelFeatureFlagTests.swift */,
 				1A1B2C3D4E5F60718293A4B1 /* MixpanelFeatureFlagPersistenceTests.swift */,
+				1A1B2C3D4E5F60718293A5B1 /* MixpanelExcludePropertiesTests.swift */,
 				E124061F1D249B2500383635 /* MixpanelBaseTests.swift */,
 				E15FF7EB1D0461130076CDE3 /* MixpanelDemoTests.swift */,
 				E1C61EB91D22F6470056C56C /* MixpanelPeopleTests.swift */,
@@ -1067,6 +1071,7 @@
 				47BE9AE5B837EEAA088FB3FD /* MixpanelAutomaticEventsTests.swift in Sources */,
 				4A856A22C3D44379A5471460 /* MixpanelEventBridgeTests.swift in Sources */,
 				1A1B2C3D4E5F60718293A4B2 /* MixpanelFeatureFlagPersistenceTests.swift in Sources */,
+				1A1B2C3D4E5F60718293A5B2 /* MixpanelExcludePropertiesTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1142,6 +1147,7 @@
 				E15FF7EC1D0461130076CDE3 /* MixpanelDemoTests.swift in Sources */,
 				171E4C1C2DB055BC00B7CB11 /* MixpanelFeatureFlagTests.swift in Sources */,
 				1A1B2C3D4E5F60718293A4B0 /* MixpanelFeatureFlagPersistenceTests.swift in Sources */,
+				1A1B2C3D4E5F60718293A5B0 /* MixpanelExcludePropertiesTests.swift in Sources */,
 				174205522F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift in Sources */,
 				B1AB7B0E940444B7A9B0876A /* MixpanelEventBridgeTests.swift in Sources */,
 			);

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelExcludePropertiesTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelExcludePropertiesTests.swift
@@ -1,0 +1,183 @@
+//
+//  MixpanelExcludePropertiesTests.swift
+//  MixpanelDemoTests
+//
+
+import XCTest
+
+@testable import Mixpanel
+
+class MixpanelExcludePropertiesTests: MixpanelBaseTests {
+
+  // MARK: - Direct helper tests (mirror Android ExcludePropertiesTest)
+
+  /// Mirrors a representative subset of what the SDK puts in the properties bag for an event:
+  /// reserved identity/routing keys, auto-properties, and a custom user property.
+  private func buildSampleEventProps() -> InternalProperties {
+    return [
+      "token": "test-token",
+      "time": 1_700_000_000_000.0,
+      "distinct_id": "abc-123",
+      "$device_id": "device-xyz",
+      "$user_id": "user-42",
+      "$had_persisted_distinct_id": true,
+      "$insert_id": "insert-1",
+      "mp_lib": "swift",
+      "$lib_version": "5.0.0",
+      "$os": "iOS",
+      "$screen_height": 1920,
+      "$screen_width": 1080,
+      "$carrier": "Verizon",
+      "custom_user_prop": "value",
+    ]
+  }
+
+  func testEmptyExcludeSetIsNoOp() {
+    var props = buildSampleEventProps()
+    let before = props.count
+    Track.applyExcludeProperties(&props, exclude: [])
+    XCTAssertEqual(props.count, before)
+  }
+
+  func testStripsAutoProperty() {
+    var props = buildSampleEventProps()
+    Track.applyExcludeProperties(&props, exclude: ["$screen_height"])
+    XCTAssertNil(props["$screen_height"])
+    // Adjacent auto-props remain untouched.
+    XCTAssertNotNil(props["$screen_width"])
+    XCTAssertNotNil(props["$lib_version"])
+  }
+
+  func testStripsCustomUserProperty() {
+    var props = buildSampleEventProps()
+    Track.applyExcludeProperties(&props, exclude: ["custom_user_prop"])
+    XCTAssertNil(props["custom_user_prop"])
+  }
+
+  func testReservedKeysAreNeverStripped() {
+    var props = buildSampleEventProps()
+    // Drive the test from the canonical reserved set so adding a new reserved key
+    // here automatically tightens this test rather than leaving it stale.
+    let exclude = MixpanelOptions.reservedPropertyKeys
+
+    // Sanity check: every reserved key we're about to try to exclude is actually
+    // present in the sample, otherwise the test would silently pass for missing keys.
+    for key in MixpanelOptions.reservedPropertyKeys {
+      XCTAssertNotNil(props[key], "Sample event props is missing reserved key \(key)")
+    }
+
+    Track.applyExcludeProperties(&props, exclude: exclude)
+
+    for key in MixpanelOptions.reservedPropertyKeys {
+      XCTAssertNotNil(props[key], "Reserved key was stripped: \(key)")
+    }
+  }
+
+  /// `$insert_id` is in the Mixpanel ingestion vocabulary but this SDK never writes it
+  /// (we use `$mp_event_id` inside `$mp_metadata` for dedup, which lives outside the
+  /// properties bag). If a customer lists `$insert_id` in their exclude set we should
+  /// honor it — there's nothing to protect.
+  func testInsertIdIsNotReserved() {
+    var props = buildSampleEventProps()
+    Track.applyExcludeProperties(&props, exclude: ["$insert_id"])
+    XCTAssertNil(props["$insert_id"])
+  }
+
+  func testMultiplePropertiesStripped() {
+    var props = buildSampleEventProps()
+    let exclude: Set<String> = [
+      "$screen_height", "$screen_width", "$carrier", "custom_user_prop",
+    ]
+
+    Track.applyExcludeProperties(&props, exclude: exclude)
+
+    XCTAssertNil(props["$screen_height"])
+    XCTAssertNil(props["$screen_width"])
+    XCTAssertNil(props["$carrier"])
+    XCTAssertNil(props["custom_user_prop"])
+    // Untouched samples
+    XCTAssertNotNil(props["$os"])
+    XCTAssertNotNil(props["$lib_version"])
+  }
+
+  func testExcludedKeyNotPresentIsNoOp() {
+    var props = buildSampleEventProps()
+    let before = props.count
+    Track.applyExcludeProperties(&props, exclude: ["never_added"])
+    XCTAssertEqual(props.count, before)
+  }
+
+  // MARK: - End-to-end integration tests
+
+  /// Pick the event by name — `identify` (and other auto-events) can land on the queue
+  /// alongside the event under test, so `.last!` is unreliable.
+  private func findEvent(
+    in mixpanel: MixpanelInstance, named eventName: String
+  ) -> InternalProperties? {
+    return eventQueue(token: mixpanel.apiToken).first(where: {
+      ($0["event"] as? String) == eventName
+    })
+  }
+
+  func testExcludePropertiesStripsAutoAndCustomFromQueuedEvent() {
+    let token = randomId()
+    let options = MixpanelOptions(
+      token: token,
+      flushInterval: 60,
+      excludeProperties: ["$lib_version", "custom_prop"])
+    let testMixpanel = Mixpanel.initialize(options: options)
+    testMixpanel.track(event: "test_event", properties: ["custom_prop": "v", "keep_me": "yes"])
+    waitForTrackingQueue(testMixpanel)
+
+    let event = findEvent(in: testMixpanel, named: "test_event")!
+    let props = event["properties"] as! InternalProperties
+
+    // Excluded keys are gone.
+    XCTAssertNil(props["$lib_version"])
+    XCTAssertNil(props["custom_prop"])
+    // Non-excluded custom property survives.
+    XCTAssertEqual(props["keep_me"] as? String, "yes")
+    // Reserved keys still present.
+    XCTAssertNotNil(props["token"])
+    XCTAssertNotNil(props["time"])
+    XCTAssertNotNil(props["distinct_id"])
+    // $mp_metadata lives at the envelope level, not inside properties — confirm it
+    // survives at the envelope (the filter's scope ends at `properties`).
+    XCTAssertNotNil(event["$mp_metadata"])
+
+    removeDBfile(testMixpanel.apiToken)
+  }
+
+  func testExcludePropertiesCannotStripReservedKeysEndToEnd() {
+    let token = randomId()
+    let options = MixpanelOptions(
+      token: token,
+      flushInterval: 60,
+      // Customer mistakenly lists a reserved key — must still be sent.
+      excludeProperties: ["distinct_id", "token"])
+    let testMixpanel = Mixpanel.initialize(options: options)
+    testMixpanel.track(event: "test_event")
+    waitForTrackingQueue(testMixpanel)
+
+    let event = findEvent(in: testMixpanel, named: "test_event")!
+    let props = event["properties"] as! InternalProperties
+    XCTAssertNotNil(props["distinct_id"], "reserved key distinct_id was stripped")
+    XCTAssertNotNil(props["token"], "reserved key token was stripped")
+
+    removeDBfile(testMixpanel.apiToken)
+  }
+
+  func testDefaultOptionsStripNothing() {
+    let testMixpanel = Mixpanel.initialize(
+      token: randomId(), trackAutomaticEvents: false, flushInterval: 60)
+    testMixpanel.track(event: "test_event", properties: ["custom_prop": "v"])
+    waitForTrackingQueue(testMixpanel)
+
+    let event = findEvent(in: testMixpanel, named: "test_event")!
+    let props = event["properties"] as! InternalProperties
+    XCTAssertEqual(props["custom_prop"] as? String, "v")
+    XCTAssertNotNil(props["$lib_version"])
+
+    removeDBfile(testMixpanel.apiToken)
+  }
+}

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelExcludePropertiesTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelExcludePropertiesTests.swift
@@ -180,4 +180,106 @@ class MixpanelExcludePropertiesTests: MixpanelBaseTests {
 
     removeDBfile(testMixpanel.apiToken)
   }
+
+  // MARK: - People exclude tests
+
+  /// Pick the People record by action key (`$set`, `$set_once`, `$add`, …). After
+  /// `identify` + a People call, the queue contains both the identify-driven merge
+  /// and the test's own action, so action-name matching is the reliable filter.
+  private func findPeopleRecord(
+    in mixpanel: MixpanelInstance, action: String
+  ) -> InternalProperties? {
+    return peopleQueue(token: mixpanel.apiToken).first(where: { $0[action] != nil })
+  }
+
+  func testExcludePropertiesStripsAutoAndCustomFromPeopleSet() {
+    let token = randomId()
+    let options = MixpanelOptions(
+      token: token,
+      flushInterval: 60,
+      excludeProperties: ["$ios_lib_version", "secret_prop"])
+    let testMixpanel = Mixpanel.initialize(options: options)
+    testMixpanel.identify(distinctId: "u1")
+    testMixpanel.people.set(properties: ["secret_prop": "x", "keep_me": "y"])
+    waitForTrackingQueue(testMixpanel)
+
+    let record = peopleQueue(token: testMixpanel.apiToken).first(where: { $0["$set"] != nil })!
+    let bag = record["$set"] as! InternalProperties
+
+    // Excluded auto-prop and custom prop are stripped.
+    XCTAssertNil(bag["$ios_lib_version"])
+    XCTAssertNil(bag["secret_prop"])
+    // Non-excluded custom prop survives.
+    XCTAssertEqual(bag["keep_me"] as? String, "y")
+    // Other auto-props are untouched.
+    XCTAssertNotNil(bag["$ios_device_model"])
+    // Envelope-level routing keys live outside the bag and are unaffected.
+    XCTAssertNotNil(record["$token"])
+    XCTAssertNotNil(record["$distinct_id"])
+
+    removeDBfile(testMixpanel.apiToken)
+  }
+
+  /// Swift-specific deviation from Android: this SDK merges
+  /// `AutomaticProperties.peopleProperties` into both `$set` and `$set_once`, so the
+  /// filter runs on `$set_once` here. Android only merges into `$set` and filters
+  /// accordingly.
+  func testExcludePropertiesAppliesToPeopleSetOnce() {
+    let token = randomId()
+    let options = MixpanelOptions(
+      token: token,
+      flushInterval: 60,
+      excludeProperties: ["$ios_lib_version", "secret_prop"])
+    let testMixpanel = Mixpanel.initialize(options: options)
+    testMixpanel.identify(distinctId: "u1")
+    testMixpanel.people.setOnce(properties: ["secret_prop": "x", "keep_me": "y"])
+    waitForTrackingQueue(testMixpanel)
+
+    let record = findPeopleRecord(in: testMixpanel, action: "$set_once")!
+    let bag = record["$set_once"] as! InternalProperties
+
+    XCTAssertNil(bag["$ios_lib_version"])
+    XCTAssertNil(bag["secret_prop"])
+    XCTAssertEqual(bag["keep_me"] as? String, "y")
+    XCTAssertNotNil(bag["$ios_device_model"])
+
+    removeDBfile(testMixpanel.apiToken)
+  }
+
+  /// Mutating operators (`$add`, `$append`, `$union`, `$unset`) treat the bag as
+  /// operands rather than a property dictionary to mutate; the filter must NOT
+  /// touch them, since stripping a key from e.g. an `$unset` list would silently
+  /// change the operation's meaning.
+  func testExcludePropertiesPassThroughForMutatingPeopleOperators() {
+    let token = randomId()
+    let options = MixpanelOptions(
+      token: token,
+      flushInterval: 60,
+      excludeProperties: ["secret_prop"])
+    let testMixpanel = Mixpanel.initialize(options: options)
+    testMixpanel.identify(distinctId: "u1")
+
+    testMixpanel.people.increment(property: "secret_prop", by: 1)
+    testMixpanel.people.append(properties: ["secret_prop": "v"])
+    testMixpanel.people.union(properties: ["secret_prop": ["v"]])
+    testMixpanel.people.unset(properties: ["secret_prop"])
+    waitForTrackingQueue(testMixpanel)
+
+    XCTAssertEqual(
+      (findPeopleRecord(in: testMixpanel, action: "$add")!["$add"] as! InternalProperties)[
+        "secret_prop"] as? Double, 1, "$add must not be filtered")
+    XCTAssertEqual(
+      (findPeopleRecord(in: testMixpanel, action: "$append")!["$append"] as! InternalProperties)[
+        "secret_prop"] as? String, "v", "$append must not be filtered")
+    XCTAssertNotNil(
+      (findPeopleRecord(in: testMixpanel, action: "$union")!["$union"] as! InternalProperties)[
+        "secret_prop"], "$union must not be filtered")
+    // $unset stores the property names as an array under the action key.
+    let unsetNames = findPeopleRecord(in: testMixpanel, action: "$unset")!["$unset"] as! [String]
+    XCTAssertTrue(
+      unsetNames.contains("secret_prop"),
+      "$unset operand list must not be filtered (would silently change semantics)")
+
+    removeDBfile(testMixpanel.apiToken)
+  }
 }

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -394,7 +394,8 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
       apiToken: self.apiToken,
       instanceName: self.name,
       lock: self.readWriteLock,
-      metadata: sessionMetadata, mixpanelPersistence: mixpanelPersistence,
+      metadata: sessionMetadata, 
+      mixpanelPersistence: mixpanelPersistence,
       excludeProperties: self.options.excludeProperties)
     trackInstance.mixpanelInstance = self
     #if os(iOS) && !targetEnvironment(macCatalyst)
@@ -433,7 +434,8 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
       apiToken: self.apiToken,
       serialQueue: trackingQueue,
       lock: self.readWriteLock,
-      metadata: sessionMetadata, mixpanelPersistence: mixpanelPersistence)
+      metadata: sessionMetadata, mixpanelPersistence: mixpanelPersistence,
+      excludeProperties: self.options.excludeProperties)
     people.mixpanelInstance = self
     people.delegate = self
     flushInstance.flushInterval = flushInterval

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -394,7 +394,8 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
       apiToken: self.apiToken,
       instanceName: self.name,
       lock: self.readWriteLock,
-      metadata: sessionMetadata, mixpanelPersistence: mixpanelPersistence)
+      metadata: sessionMetadata, mixpanelPersistence: mixpanelPersistence,
+      excludeProperties: self.options.excludeProperties)
     trackInstance.mixpanelInstance = self
     #if os(iOS) && !targetEnvironment(macCatalyst)
       // Extract hostname from serverURL and create reachability

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -586,9 +586,9 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
       MixpanelLogger.warn(
         message:
           "MixpanelOptions.excludeProperties is stripping 'mp_lib' and/or '$lib_version'. "
-            + "These are not required for ingestion or identity, but Mixpanel uses them to "
-            + "identify the SDK source and version of each event — stripping them is not "
-            + "recommended.")
+          + "These are not required for ingestion or identity, but Mixpanel uses them to "
+          + "identify the SDK source and version of each event — stripping them is not "
+          + "recommended.")
     }
   }
 

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -390,11 +390,12 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
     readWriteLock = ReadWriteLock(label: "com.mixpanel.globallock")
     flushInstance = Flush(serverURL: self.serverURL, useGzipCompression: useGzipCompression)
     sessionMetadata = SessionMetadata(trackingQueue: trackingQueue)
+    MixpanelInstance.warnIfStrippingLibProperties(self.options.excludeProperties)
     trackInstance = Track(
       apiToken: self.apiToken,
       instanceName: self.name,
       lock: self.readWriteLock,
-      metadata: sessionMetadata, 
+      metadata: sessionMetadata,
       mixpanelPersistence: mixpanelPersistence,
       excludeProperties: self.options.excludeProperties)
     trackInstance.mixpanelInstance = self
@@ -578,6 +579,17 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
 
   static func isiOSAppExtension() -> Bool {
     return Bundle.main.bundlePath.hasSuffix(".appex")
+  }
+
+  private static func warnIfStrippingLibProperties(_ excludeProperties: Set<String>) {
+    if excludeProperties.contains("mp_lib") || excludeProperties.contains("$lib_version") {
+      MixpanelLogger.warn(
+        message:
+          "MixpanelOptions.excludeProperties is stripping 'mp_lib' and/or '$lib_version'. "
+            + "These are not required for ingestion or identity, but Mixpanel uses them to "
+            + "identify the SDK source and version of each event — stripping them is not "
+            + "recommended.")
+    }
   }
 
   #if !os(OSX) && !os(watchOS)

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -143,6 +143,13 @@ public enum VariantLookupPolicy {
 }
 
 public class MixpanelOptions {
+  /// Property keys that ingestion or identity resolution require and that will never be
+  /// stripped by ``excludeProperties``, even if a customer lists them. Single source of truth
+  /// for both the runtime filter (see `Track.applyExcludeProperties`) and the documentation.
+  public static let reservedPropertyKeys: Set<String> = [
+    "token", "time", "distinct_id", "$device_id", "$user_id", "$had_persisted_distinct_id",
+  ]
+
   public let token: String
   public let flushInterval: Double
   public let instanceName: String?
@@ -153,6 +160,20 @@ public class MixpanelOptions {
   public let serverURL: String?
   public let proxyServerConfig: ProxyServerConfig?
   public let useGzipCompression: Bool
+
+  /// Property keys that will be stripped from every event before it is persisted and sent to
+  /// Mixpanel. Defaults to empty (no filtering, zero per-event overhead).
+  ///
+  /// Use this to reduce per-event payload size or to suppress properties the project has no
+  /// interest in. Matching is **exact and case-sensitive**.
+  ///
+  /// Keys in ``MixpanelOptions/reservedPropertyKeys`` are never stripped, even if
+  /// listed — they are required for ingestion and identity resolution.
+  ///
+  /// Applies to **events only**, not to People or Group profile updates. `$mp_metadata` is a
+  /// sibling of `properties` in the event envelope and is structurally outside the filter's
+  /// scope by design.
+  public let excludeProperties: Set<String>
   @available(*, deprecated, message: "Use featureFlagOptions.enabled instead")
   public var featureFlagsEnabled: Bool { return featureFlagOptions.enabled }
 
@@ -224,7 +245,8 @@ public class MixpanelOptions {
     featureFlagsEnabled: Bool = false,
     featureFlagsContext: [String: Any] = [:],
     deviceIdProvider: (() -> String?)? = nil,
-    featureFlagOptions: FeatureFlagOptions? = nil
+    featureFlagOptions: FeatureFlagOptions? = nil,
+    excludeProperties: Set<String> = []
   ) {
     self.token = token
     self.flushInterval = flushInterval
@@ -237,6 +259,7 @@ public class MixpanelOptions {
     self.proxyServerConfig = proxyServerConfig
     self.useGzipCompression = useGzipCompression
     self.deviceIdProvider = deviceIdProvider
+    self.excludeProperties = excludeProperties
 
     // When featureFlagOptions is explicitly provided, it takes precedence
     if let featureFlagOptions = featureFlagOptions {

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -161,18 +161,32 @@ public class MixpanelOptions {
   public let proxyServerConfig: ProxyServerConfig?
   public let useGzipCompression: Bool
 
-  /// Property keys that will be stripped from every event before it is persisted and sent to
-  /// Mixpanel. Defaults to empty (no filtering, zero per-event overhead).
+  /// Property keys that will be stripped from outgoing event and People payloads before they
+  /// are persisted and sent to Mixpanel. Defaults to empty (no filtering, zero per-payload
+  /// overhead).
   ///
-  /// Use this to reduce per-event payload size or to suppress properties the project has no
-  /// interest in. Matching is **exact and case-sensitive**.
+  /// Use this to reduce payload size or to suppress properties the project has no interest in.
+  /// Matching is **exact and case-sensitive**.
   ///
-  /// Keys in ``MixpanelOptions/reservedPropertyKeys`` are never stripped, even if
-  /// listed — they are required for ingestion and identity resolution.
+  /// Keys in ``MixpanelOptions/reservedPropertyKeys`` are never stripped, even if listed —
+  /// they are required for ingestion and identity resolution.
   ///
-  /// Applies to **events only**, not to People or Group profile updates. `$mp_metadata` is a
-  /// sibling of `properties` in the event envelope and is structurally outside the filter's
-  /// scope by design.
+  /// **Scope:**
+  /// - **Events** — applied at the persistence chokepoint, covering super properties, caller
+  ///   properties, and SDK auto-properties uniformly.
+  /// - **People `$set` and `$set_once`** — applied after the SDK merges
+  ///   `AutomaticProperties.peopleProperties` (the auto-injected `$ios_*` device keys) so
+  ///   those auto-injected keys are subject to the same exclude set as event auto-properties.
+  ///
+  /// **Not in scope:**
+  /// - Other People operators (`$add`, `$append`, `$union`, `$unset`, `$merge`, `$remove`,
+  ///   `$delete`) are pass-through. Their property keys are operands rather than a bag to
+  ///   mutate, and filtering inside them would silently change semantics (e.g. dropping a
+  ///   name from an `$unset` list).
+  /// - **Group updates** never merge auto-properties, so there is nothing the filter would
+  ///   contribute that the caller couldn't omit themselves.
+  /// - **`$mp_metadata`** is a sibling of `properties` in the event envelope and is
+  ///   structurally outside the filter's scope by design.
   public let excludeProperties: Set<String>
   @available(*, deprecated, message: "Use featureFlagOptions.enabled instead")
   public var featureFlagsEnabled: Bool { return featureFlagOptions.enabled }

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -187,6 +187,13 @@ public class MixpanelOptions {
   ///   contribute that the caller couldn't omit themselves.
   /// - **`$mp_metadata`** is a sibling of `properties` in the event envelope and is
   ///   structurally outside the filter's scope by design.
+  ///
+  /// **Recommended: do not strip `mp_lib` or `$lib_version`.** Mixpanel does not need them
+  /// for ingestion or identity resolution, so stripping them is permitted — but they are how
+  /// Mixpanel identifies which SDK (and which version) produced an event. Removing them
+  /// limits reporting accuracy (e.g. per-platform breakdowns) and makes it harder for support
+  /// to debug issues on your project. If either key is included here, the SDK logs a warning
+  /// at instance creation time.
   public let excludeProperties: Set<String>
   @available(*, deprecated, message: "Use featureFlagOptions.enabled instead")
   public var featureFlagsEnabled: Bool { return featureFlagOptions.enabled }

--- a/Sources/People.swift
+++ b/Sources/People.swift
@@ -26,6 +26,7 @@ open class People {
   weak var delegate: FlushDelegate?
   let metadata: SessionMetadata
   let mixpanelPersistence: MixpanelPersistence
+  let excludeProperties: Set<String>
   weak var mixpanelInstance: MixpanelInstance?
 
   init(
@@ -33,13 +34,15 @@ open class People {
     serialQueue: DispatchQueue,
     lock: ReadWriteLock,
     metadata: SessionMetadata,
-    mixpanelPersistence: MixpanelPersistence
+    mixpanelPersistence: MixpanelPersistence,
+    excludeProperties: Set<String> = []
   ) {
     self.apiToken = apiToken
     self.serialQueue = serialQueue
     self.lock = lock
     self.metadata = metadata
     self.mixpanelPersistence = mixpanelPersistence
+    self.excludeProperties = excludeProperties
   }
 
   func addPeopleRecordToQueueWithAction(_ action: String, properties: InternalProperties) {
@@ -70,6 +73,15 @@ open class People {
           }
         }
         p += properties
+        // Filter only the bag-style operators where the SDK merges peopleProperties
+        // ($set and $set_once on Swift — note: Android only merges into $set, so the
+        // Android port filters $set alone). The operand-style operators ($add,
+        // $append, $union, $unset, $merge, $delete) treat property keys as inputs
+        // rather than a bag to mutate, and filtering inside them would silently
+        // change semantics.
+        if action == "$set" || action == "$set_once" {
+          Track.applyExcludeProperties(&p, exclude: self.excludeProperties)
+        }
         r[action] = p
       }
       self.metadata.toDict(isEvent: false).forEach { (k, v) in r[k] = v }

--- a/Sources/Track.swift
+++ b/Sources/Track.swift
@@ -21,17 +21,32 @@ class Track {
   let lock: ReadWriteLock
   let metadata: SessionMetadata
   let mixpanelPersistence: MixpanelPersistence
+  let excludeProperties: Set<String>
   weak var mixpanelInstance: MixpanelInstance?
 
   init(
     apiToken: String, instanceName: String, lock: ReadWriteLock, metadata: SessionMetadata,
-    mixpanelPersistence: MixpanelPersistence
+    mixpanelPersistence: MixpanelPersistence, excludeProperties: Set<String> = []
   ) {
     self.instanceName = instanceName
     self.apiToken = apiToken
     self.lock = lock
     self.metadata = metadata
     self.mixpanelPersistence = mixpanelPersistence
+    self.excludeProperties = excludeProperties
+  }
+
+  /// Removes any key in `exclude` from `properties`, skipping keys in
+  /// ``MixpanelOptions/reservedPropertyKeys`` that ingestion or identity require.
+  /// `internal` so it can be unit-tested directly. No-op on an empty exclude set.
+  static func applyExcludeProperties(
+    _ properties: inout InternalProperties, exclude: Set<String>
+  ) {
+    if exclude.isEmpty { return }
+    for key in exclude {
+      if MixpanelOptions.reservedPropertyKeys.contains(key) { continue }
+      properties.removeValue(forKey: key)
+    }
   }
 
   func track(
@@ -95,6 +110,11 @@ class Track {
        let flagManager = mixpanelInstance.flags as? FeatureFlagManager {
       flagManager.checkFirstTimeEvents(eventName: ev, properties: p)
     }
+
+    // Filter just before persistence so internal observers above (event bridge,
+    // first-time-events check) still see the full property set, matching Android's
+    // network-send chokepoint.
+    Track.applyExcludeProperties(&p, exclude: excludeProperties)
 
     var trackEvent: InternalProperties = ["event": ev, "properties": p]
     metadata.toDict().forEach { (k, v) in trackEvent[k] = v }


### PR DESCRIPTION
## Summary

Ports [mixpanel-android#975](https://github.com/mixpanel/mixpanel-android/pull/975) to Swift: opt-in `MixpanelOptions.excludeProperties` lets a project list property keys (typically large SDK auto-properties) to strip from outgoing payloads before they are persisted and sent. Motivation is downstream contracts / warehouses that cap per-payload size — projects can shed properties at the source without forking the SDK.

- Empty set is the default and a zero-overhead no-op.
- Matching is **exact and case-sensitive**.
- A reserved keys allowlist (`token`, `time`, `distinct_id`, `$device_id`, `$user_id`, `$had_persisted_distinct_id`) is never stripped, even if listed — required for ingestion and identity resolution. Exposed as `MixpanelOptions.reservedPropertyKeys` so tests and downstream code can introspect it.

## Scope

| Surface | Filtered? | Notes |
|---|---|---|
| Events | ✅ | Applied in `Track.track(...)` after the event-bridge notification and `checkFirstTimeEvents` check, before persistence. Mirrors Android's "filter at network-send" placement. |
| People `$set` | ✅ | Applied after `AutomaticProperties.peopleProperties` is merged, so the six auto-injected `$ios_*` device keys are subject to the same exclude set as event auto-properties. |
| People `$set_once` | ✅ | **Swift-specific deviation from Android.** This SDK merges `peopleProperties` into both `$set` and `$set_once`; Android only merges into `$set`. The principle is the same — filter wherever auto-properties are injected. |
| People `$add`, `$append`, `$union`, `$unset`, `$merge`, `$remove`, `$delete` | ❌ | Pass-through. Their property keys are operands, not a bag to mutate. Filtering would silently change semantics (e.g. dropping a name from an `$unset` list). |
| Group updates | ❌ | Never merge auto-properties; nothing for the filter to contribute that the caller couldn't omit themselves. |
| `$mp_metadata` | ❌ | Sibling of `properties` in the event envelope — structurally outside the filter's scope. |

## Other call-outs

1. **Filter runs after the event bridge and first-time-events check.** Internal observers see the full property set; only what is persisted-and-sent is filtered. If we'd rather filter earlier so observers also see the trimmed set, that's a deliberate Android divergence worth a call.
2. **Source-compatible init.** `excludeProperties: Set<String> = []` is the trailing defaulted parameter on `MixpanelOptions.init`, so existing call sites compile unchanged.