### PR TITLE
chore: align changelog extraction with rest of SDK fleet

### DIFF
--- a/.github/workflows/release-spm.yml
+++ b/.github/workflows/release-spm.yml
@@ -164,9 +164,18 @@ jobs:
             exit 0
           fi
 
-          # Extract this version's changelog entry
-          # Starts with "## [VERSION]" and ends before next "## [" or EOF
-          CHANGELOG=$(awk "/^## \[$VERSION\]/,/^## \[/{if(/^## \[/ && !/^## \[$VERSION\]/)exit;print}" CHANGELOG.md)
+          # Extract this version's changelog entry via a sed range.
+          # The address `\@^## \[VERSION\]@,\@^## \[@` selects from the
+          # version header through the next `## [` line; the inner block
+          # deletes both markers and prints the body. sed range patterns
+          # don't test the end pattern against the start line, so the
+          # start doesn't self-terminate. `\@...@` switches the address
+          # delimiter from `/` to `@` for consistency with the rest of
+          # the Mixpanel SDK fleet (where some tags contain `/`). Matches
+          # both `## [VERSION]` and `## [VERSION](link)` headers because
+          # the regex is anchored to the start of the line and the `]`
+          # ends the match before whatever follows.
+          CHANGELOG=$(sed -n '\@^## \['"${VERSION}"'\]@,\@^## \[@{\@^## \['"${VERSION}"'\]@d;\@^## \[@d;p;}' CHANGELOG.md)
 
           if [ -z "$CHANGELOG" ]; then
             echo "⚠️  Changelog entry for version $VERSION not found in CHANGELOG.md"


### PR DESCRIPTION
## Summary

Replaces the bespoke awk state-machine extraction in `release-spm.yml` with the canonical sed range pattern that every other Mixpanel SDK repo already uses.

## Why

PR #730 correctly identified that the existing awk regex requires a bare `## [VERSION]` header and fails to match the link-style `## [VERSION](compare-url)` that `prepare-release.yml` now generates. This PR fixes the same bug — but with the pattern that's already validated and deployed across the rest of the fleet:

- mixpanel-android, mixpanel-java
- mixpanel-python, mixpanel-utils, mixpanel-ruby, mixpanel-php
- mixpanel-go, mixpanel-unity
- mixpanel-flutter, mixpanel-flutter-session-replay
- mixpanel-react-native, mixpanel-react-native-session-replay

Keeping Swift on a different extraction approach than the other 12 repos costs more in the long run than the small intrusiveness of swapping the awk one-liner for sed.

## The pattern

```bash
sed -n '\@^## \['"${VERSION}"'\]@,\@^## \[@{\@^## \['"${VERSION}"'\]@d;\@^## \[@d;p;}' CHANGELOG.md
```

- `\@^## \[VERSION\]@,\@^## \[@` selects from the version header through the next `## [` line
- The inner block deletes both header markers and prints the body
- `\@...@` switches the sed delimiter from `/` to `@` for fleet consistency (some repos have tags like `openfeature/v0.1.0` that conflict with the default `/`)
- The regex is anchored to the line start and ends at `]`, so it matches both `## [VERSION]` and `## [VERSION](link)` headers

## Verification

Manually tested against four cases on a representative changelog:

- [x] Link-style header `## [VERSION](url)` — PR #730's failing case
- [x] Bracket-only header `## [VERSION]` — backward-compatible
- [x] Last entry in file (no following `## [` line) — captures to EOF correctly
- [x] Missing version returns empty — existing `if [ -z "$CHANGELOG" ]` fallback triggers

## Supersedes

This PR supersedes #730 — same fix, fleet-aligned pattern. #730 can be closed in favor of this once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)