### PR TITLE
fix: add missing comma in .swift-format config

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -5,6 +5,6 @@
     "spaces": 4
   },
   "tabWidth": 4,
-  "indentConditionalCompilationBlocks": false
+  "indentConditionalCompilationBlocks": false,
   "indentSwitchCaseLabels": true
 }


### PR DESCRIPTION
## Summary

`.swift-format` at the repo root has been **invalid JSON** since it was added in 06dfd4c (#716, 2026-05-07) — a comma is missing after `"indentConditionalCompilationBlocks": false`.

```diff
   "tabWidth": 4,
-  "indentConditionalCompilationBlocks": false
+  "indentConditionalCompilationBlocks": false,
   "indentSwitchCaseLabels": true
```

## Impact

swift-format silently falls back to defaults when it can't parse the config. The **Swift Format Check** job in `pr-checks.yml` has been flagging every changed file in every PR since 2026-05-07 with:

```
<unknown>: error: Unable to read configuration: The data couldn't be read because it isn't in the correct format.
```

…and then failing the diff comparison for every file because the default-formatted output doesn't match the project's actual style.

The job is `continue-on-error: true` so it didn't block merges, but it also wasn't actually validating anything. Several open PRs currently look like they have formatting issues — they don't; the check itself was broken.

## After this lands

The format check will use the intended rules (lineLength 120, 4-space indent, switch-case-labels indented, conditional-compilation-blocks not indented) and only flag real formatting issues. Open PRs (#730, #734, #735, etc.) should re-run cleanly.

## Verification

- [x] `python3 -c "import json; json.load(open('.swift-format'))"` parses without error after the fix

## Test plan

- [ ] After merge, re-run pr-checks on any open PR and confirm the Swift Format Check no longer emits the "Unable to read configuration" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)