### PR TITLE
chore: formatted entire code using swift format

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -2,9 +2,9 @@
   "version": 1,
   "lineLength": 120,
   "indentation": {
-    "spaces": 2
+    "spaces": 4
   },
-  "tabWidth": 2,
+  "tabWidth": 4,
   "indentConditionalCompilationBlocks": false,
   "indentSwitchCaseLabels": true,
   "trailingCommas": "neverUsed"

--- a/MixpanelDemo/MixpanelDemo/ActionCompleteViewController.swift
+++ b/MixpanelDemo/MixpanelDemo/ActionCompleteViewController.swift
@@ -9,35 +9,35 @@
 import UIKit
 
 class ActionCompleteViewController: UIViewController {
-  @IBOutlet weak var popupView: UIView!
-  @IBOutlet weak var actionLabel: UILabel!
-  @IBOutlet weak var descLabel: UILabel!
-  var actionStr: String?
-  var descStr: String?
+    @IBOutlet weak var popupView: UIView!
+    @IBOutlet weak var actionLabel: UILabel!
+    @IBOutlet weak var descLabel: UILabel!
+    var actionStr: String?
+    var descStr: String?
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
+    override func viewDidLoad() {
+        super.viewDidLoad()
 
-    popupView.clipsToBounds = true
-    popupView.layer.cornerRadius = 6
+        popupView.clipsToBounds = true
+        popupView.layer.cornerRadius = 6
 
-    let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap))
-    view.addGestureRecognizer(tap)
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+        view.addGestureRecognizer(tap)
 
-    actionLabel.text = actionStr
-    descLabel.text = descStr
-  }
-
-  override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
-
-    DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-      self.dismiss(animated: true, completion: nil)
+        actionLabel.text = actionStr
+        descLabel.text = descStr
     }
-  }
 
-  @objc func handleTap(gesture: UITapGestureRecognizer) {
-    dismiss(animated: true, completion: nil)
-  }
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            self.dismiss(animated: true, completion: nil)
+        }
+    }
+
+    @objc func handleTap(gesture: UITapGestureRecognizer) {
+        dismiss(animated: true, completion: nil)
+    }
 
 }

--- a/MixpanelDemo/MixpanelDemo/AppDelegate.swift
+++ b/MixpanelDemo/MixpanelDemo/AppDelegate.swift
@@ -12,89 +12,89 @@ import UIKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-  var window: UIWindow?
+    var window: UIWindow?
 
-  // MARK: - Device ID Provider Options (uncomment ONE to test)
+    // MARK: - Device ID Provider Options (uncomment ONE to test)
 
-  // Cache for persistent device ID - populated once at app launch
-  private var cachedPersistentDeviceId: String?
+    // Cache for persistent device ID - populated once at app launch
+    private var cachedPersistentDeviceId: String?
 
-  /// Option 1: PERSISTENT Device ID - survives reset() and app reinstalls
-  /// IMPORTANT: Cache is populated BEFORE Mixpanel init to avoid blocking in the provider.
-  /// In production, use Keychain instead of UserDefaults for reinstall persistence.
-  private lazy var persistentDeviceIdProvider: (() -> String?) = { [weak self] in
-    print("📱 [Persistent] Returning cached device ID: \(self?.cachedPersistentDeviceId ?? "nil")")
-    return self?.cachedPersistentDeviceId
-  }
-
-  /// Populate the device ID cache - call this BEFORE initializing Mixpanel
-  private func loadPersistentDeviceId() {
-    let key = "com.mixpanel.demo.persistentDeviceId"
-    if let existingId = UserDefaults.standard.string(forKey: key) {
-      print("📱 [Persistent] Loaded existing device ID: \(existingId)")
-      cachedPersistentDeviceId = existingId
-      return
+    /// Option 1: PERSISTENT Device ID - survives reset() and app reinstalls
+    /// IMPORTANT: Cache is populated BEFORE Mixpanel init to avoid blocking in the provider.
+    /// In production, use Keychain instead of UserDefaults for reinstall persistence.
+    private lazy var persistentDeviceIdProvider: (() -> String?) = { [weak self] in
+        print("📱 [Persistent] Returning cached device ID: \(self?.cachedPersistentDeviceId ?? "nil")")
+        return self?.cachedPersistentDeviceId
     }
-    let newId = "persistent-\(UUID().uuidString)"
-    UserDefaults.standard.set(newId, forKey: key)
-    print("📱 [Persistent] Created new device ID: \(newId)")
-    cachedPersistentDeviceId = newId
-  }
 
-  /// Option 2: EPHEMERAL Device ID - changes on every reset()
-  /// A new UUID is generated each time the provider is called
-  private lazy var ephemeralDeviceIdProvider: (() -> String?) = {
-    let newId = "ephemeral-\(UUID().uuidString)"
-    print("📱 [Ephemeral] Generated new device ID: \(newId)")
-    return newId
-  }
+    /// Populate the device ID cache - call this BEFORE initializing Mixpanel
+    private func loadPersistentDeviceId() {
+        let key = "com.mixpanel.demo.persistentDeviceId"
+        if let existingId = UserDefaults.standard.string(forKey: key) {
+            print("📱 [Persistent] Loaded existing device ID: \(existingId)")
+            cachedPersistentDeviceId = existingId
+            return
+        }
+        let newId = "persistent-\(UUID().uuidString)"
+        UserDefaults.standard.set(newId, forKey: key)
+        print("📱 [Persistent] Created new device ID: \(newId)")
+        cachedPersistentDeviceId = newId
+    }
 
-  /// Option 3: FAILING Provider - returns nil to test fallback behavior
-  /// Simulates a provider that cannot generate a device ID (e.g., server fetch failed)
-  private lazy var failingDeviceIdProvider: (() -> String?) = {
-    print("📱 [Failing] Returning nil - will use SDK default")
-    return nil
-  }
+    /// Option 2: EPHEMERAL Device ID - changes on every reset()
+    /// A new UUID is generated each time the provider is called
+    private lazy var ephemeralDeviceIdProvider: (() -> String?) = {
+        let newId = "ephemeral-\(UUID().uuidString)"
+        print("📱 [Ephemeral] Generated new device ID: \(newId)")
+        return newId
+    }
 
-  func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
-  ) -> Bool {
-    var ADD_YOUR_MIXPANEL_TOKEN_BELOW_🛠🛠🛠🛠🛠🛠: String
+    /// Option 3: FAILING Provider - returns nil to test fallback behavior
+    /// Simulates a provider that cannot generate a device ID (e.g., server fetch failed)
+    private lazy var failingDeviceIdProvider: (() -> String?) = {
+        print("📱 [Failing] Returning nil - will use SDK default")
+        return nil
+    }
 
-    // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-    // 🧪 DEVICE ID PROVIDER QA - Uncomment ONE of the following:
-    // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        var ADD_YOUR_MIXPANEL_TOKEN_BELOW_🛠🛠🛠🛠🛠🛠: String
 
-    // Test 1: PERSISTENT - Device ID survives reset() calls
-    // loadPersistentDeviceId()  // ⚠️ MUST call before Mixpanel init!
-    // let deviceIdProvider = persistentDeviceIdProvider
+        // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+        // 🧪 DEVICE ID PROVIDER QA - Uncomment ONE of the following:
+        // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-    // Test 2: EPHEMERAL - Device ID changes on every reset() call
-    // let deviceIdProvider = ephemeralDeviceIdProvider
+        // Test 1: PERSISTENT - Device ID survives reset() calls
+        // loadPersistentDeviceId()  // ⚠️ MUST call before Mixpanel init!
+        // let deviceIdProvider = persistentDeviceIdProvider
 
-    // Test 3: FAILING Provider - returns nil to test SDK fallback
-    // let deviceIdProvider = failingDeviceIdProvider
+        // Test 2: EPHEMERAL - Device ID changes on every reset() call
+        // let deviceIdProvider = ephemeralDeviceIdProvider
 
-    // Test 4: NO PROVIDER - Default SDK behavior (UUID or IDFV)
-    let deviceIdProvider: (() -> String?)? = nil
+        // Test 3: FAILING Provider - returns nil to test SDK fallback
+        // let deviceIdProvider = failingDeviceIdProvider
 
-    // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+        // Test 4: NO PROVIDER - Default SDK behavior (UUID or IDFV)
+        let deviceIdProvider: (() -> String?)? = nil
 
-    let mixpanelOptions = MixpanelOptions(
-      token: "MIXPANEL_TOKEN",
-      trackAutomaticEvents: true,
-      deviceIdProvider: deviceIdProvider
-    )
-    Mixpanel.initialize(options: mixpanelOptions)
-    Mixpanel.mainInstance().loggingEnabled = true
+        // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-    print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-    print("📊 Mixpanel initialized")
-    print("   anonymousId: \(Mixpanel.mainInstance().anonymousId ?? "nil")")
-    print("   distinctId:  \(Mixpanel.mainInstance().distinctId)")
-    print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+        let mixpanelOptions = MixpanelOptions(
+            token: "MIXPANEL_TOKEN",
+            trackAutomaticEvents: true,
+            deviceIdProvider: deviceIdProvider
+        )
+        Mixpanel.initialize(options: mixpanelOptions)
+        Mixpanel.mainInstance().loggingEnabled = true
 
-    return true
-  }
+        print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+        print("📊 Mixpanel initialized")
+        print("   anonymousId: \(Mixpanel.mainInstance().anonymousId ?? "nil")")
+        print("   distinctId:  \(Mixpanel.mainInstance().distinctId)")
+        print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+
+        return true
+    }
 }

--- a/MixpanelDemo/MixpanelDemo/GDPRViewController.swift
+++ b/MixpanelDemo/MixpanelDemo/GDPRViewController.swift
@@ -11,85 +11,85 @@ import UIKit
 
 class GDPRViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
 
-  @IBOutlet weak var tableView: UITableView!
-  var tableViewItems = [
-    "Opt Out",
-    "Check Opted Out Flag",
-    "Opt In",
-    "Opt In w DistinctId",
-    "Opt In w DistinctId & Properties",
-    "Init with default opt-out",
-    "Init with default opt-in",
-  ]
+    @IBOutlet weak var tableView: UITableView!
+    var tableViewItems = [
+        "Opt Out",
+        "Check Opted Out Flag",
+        "Opt In",
+        "Opt In w DistinctId",
+        "Opt In w DistinctId & Properties",
+        "Init with default opt-out",
+        "Init with default opt-in",
+    ]
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    tableView.delegate = self
-    tableView.dataSource = self
-  }
-
-  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    let cell = self.tableView.dequeueReusableCell(withIdentifier: "cell")! as UITableViewCell
-    cell.textLabel?.text = tableViewItems[indexPath.item]
-    cell.textLabel?.textColor = #colorLiteral(
-      red: 0.200000003, green: 0.200000003, blue: 0.200000003, alpha: 1)
-    return cell
-  }
-
-  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    tableView.deselectRow(at: indexPath, animated: true)
-
-    let actionStr = tableViewItems[indexPath.item]
-    var descStr = ""
-
-    switch indexPath.item {
-    case 0:
-      Mixpanel.mainInstance().optOutTracking()
-      descStr = "Opted out"
-    case 1:
-      descStr = "Opt-out flag is \(Mixpanel.mainInstance().hasOptedOutTracking())"
-    case 2:
-      Mixpanel.mainInstance().optInTracking()
-      descStr = "Opted In"
-    case 3:
-      Mixpanel.mainInstance().optInTracking(distinctId: "aDistinctIdForOptIn")
-      descStr = "Opt In with distinctId 'aDistinctIdForOptIn'"
-    case 4:
-      let p: Properties = [
-        "a": 1,
-        "b": 2.3,
-        "c": ["4", 5] as [Any],
-        "d": URL(string: "https://mixpanel.com")!,
-        "e": NSNull(),
-        "f": Date(),
-      ]
-      Mixpanel.mainInstance().optInTracking(distinctId: "aDistinctIdForOptIn", properties: p)
-      descStr = "Opt In with distinctId 'aDistinctIdForOptIn' and \(p)"
-    case 5:
-      Mixpanel.initialize(
-        token: "testtoken", trackAutomaticEvents: true, optOutTrackingByDefault: true)
-      descStr =
-        "Init Mixpanel with default opt-out(sample only), to make it work, place it in your startup stage of your app"
-    case 6:
-      Mixpanel.initialize(
-        token: "testtoken", trackAutomaticEvents: true, optOutTrackingByDefault: false)
-      descStr =
-        "Init Mixpanel with default opt-in(sample only), to make it work, place it in your startup stage of your app"
-    default:
-      break
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.delegate = self
+        tableView.dataSource = self
     }
 
-    let vc =
-      storyboard!.instantiateViewController(withIdentifier: "ActionCompleteViewController")
-      as! ActionCompleteViewController
-    vc.actionStr = actionStr
-    vc.descStr = descStr
-    vc.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
-    vc.modalPresentationStyle = UIModalPresentationStyle.overFullScreen
-    present(vc, animated: true, completion: nil)
-  }
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = self.tableView.dequeueReusableCell(withIdentifier: "cell")! as UITableViewCell
+        cell.textLabel?.text = tableViewItems[indexPath.item]
+        cell.textLabel?.textColor = #colorLiteral(
+            red: 0.200000003, green: 0.200000003, blue: 0.200000003, alpha: 1)
+        return cell
+    }
 
-  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return tableViewItems.count
-  }
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        let actionStr = tableViewItems[indexPath.item]
+        var descStr = ""
+
+        switch indexPath.item {
+            case 0:
+                Mixpanel.mainInstance().optOutTracking()
+                descStr = "Opted out"
+            case 1:
+                descStr = "Opt-out flag is \(Mixpanel.mainInstance().hasOptedOutTracking())"
+            case 2:
+                Mixpanel.mainInstance().optInTracking()
+                descStr = "Opted In"
+            case 3:
+                Mixpanel.mainInstance().optInTracking(distinctId: "aDistinctIdForOptIn")
+                descStr = "Opt In with distinctId 'aDistinctIdForOptIn'"
+            case 4:
+                let p: Properties = [
+                    "a": 1,
+                    "b": 2.3,
+                    "c": ["4", 5] as [Any],
+                    "d": URL(string: "https://mixpanel.com")!,
+                    "e": NSNull(),
+                    "f": Date(),
+                ]
+                Mixpanel.mainInstance().optInTracking(distinctId: "aDistinctIdForOptIn", properties: p)
+                descStr = "Opt In with distinctId 'aDistinctIdForOptIn' and \(p)"
+            case 5:
+                Mixpanel.initialize(
+                    token: "testtoken", trackAutomaticEvents: true, optOutTrackingByDefault: true)
+                descStr =
+                    "Init Mixpanel with default opt-out(sample only), to make it work, place it in your startup stage of your app"
+            case 6:
+                Mixpanel.initialize(
+                    token: "testtoken", trackAutomaticEvents: true, optOutTrackingByDefault: false)
+                descStr =
+                    "Init Mixpanel with default opt-in(sample only), to make it work, place it in your startup stage of your app"
+            default:
+                break
+        }
+
+        let vc =
+            storyboard!.instantiateViewController(withIdentifier: "ActionCompleteViewController")
+            as! ActionCompleteViewController
+        vc.actionStr = actionStr
+        vc.descStr = descStr
+        vc.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
+        vc.modalPresentationStyle = UIModalPresentationStyle.overFullScreen
+        present(vc, animated: true, completion: nil)
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return tableViewItems.count
+    }
 }

--- a/MixpanelDemo/MixpanelDemo/GroupsViewController.swift
+++ b/MixpanelDemo/MixpanelDemo/GroupsViewController.swift
@@ -11,126 +11,126 @@ import UIKit
 
 class GroupsViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
 
-  @IBOutlet weak var tableView: UITableView!
-  var tableViewItems = [
-    "Set Properties",
-    "Set One Property",
-    "Set Properties Once",
-    "Unset Property",
-    "Remove Property",
-    "Union Properties",
-    "Delete Group",
-    "Set Group",
-    "Set One Group",
-    "Add Group",
-    "Remove Group",
-    "Track with Groups",
-  ]
+    @IBOutlet weak var tableView: UITableView!
+    var tableViewItems = [
+        "Set Properties",
+        "Set One Property",
+        "Set Properties Once",
+        "Unset Property",
+        "Remove Property",
+        "Union Properties",
+        "Delete Group",
+        "Set Group",
+        "Set One Group",
+        "Add Group",
+        "Remove Group",
+        "Track with Groups",
+    ]
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    tableView.delegate = self
-    tableView.dataSource = self
-  }
-
-  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    let cell = self.tableView.dequeueReusableCell(withIdentifier: "cell")! as UITableViewCell
-    cell.textLabel?.text = tableViewItems[indexPath.item]
-    cell.textLabel?.textColor = #colorLiteral(
-      red: 0.200000003, green: 0.200000003, blue: 0.200000003, alpha: 1)
-    return cell
-  }
-
-  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    tableView.deselectRow(at: indexPath, animated: true)
-
-    let actionStr = tableViewItems[indexPath.item]
-    var descStr = ""
-
-    let groupKey = "Cool Property"
-    let groupID = 12345
-
-    switch indexPath.item {
-    case 0:
-      let p: Properties = [
-        "a": 1,
-        "b": 2.3,
-        "c": ["4", 5] as [Any],
-        "d": URL(string: "https://mixpanel.com")!,
-        "e": NSNull(),
-        "f": Date(),
-      ]
-      Mixpanel.mainInstance().getGroup(groupKey: groupKey, groupID: groupID).set(properties: p)
-      descStr = "Properties: \(p)"
-    case 1:
-      Mixpanel.mainInstance().getGroup(groupKey: groupKey, groupID: groupID).set(
-        property: "g", to: "yo")
-      descStr = "Property key: g, value: yo"
-    case 2:
-      let p = ["h": "just once"]
-      Mixpanel.mainInstance().getGroup(groupKey: groupKey, groupID: groupID).setOnce(properties: p)
-      descStr = "Properties: \(p)"
-    case 3:
-      let p = "b"
-      Mixpanel.mainInstance().getGroup(groupKey: groupKey, groupID: groupID).unset(property: p)
-      descStr = "Unset Property: \(p)"
-    case 4:
-      Mixpanel.mainInstance().getGroup(groupKey: groupKey, groupID: groupID).remove(
-        key: "c", value: 5)
-      descStr = "Remove Property: [\"c\" : 5]"
-    case 5:
-      let p = ["c": [5, 4]]
-      Mixpanel.mainInstance().getGroup(groupKey: groupKey, groupID: groupID).union(
-        key: "c", values: p["c"]!)
-      descStr = "Properties: \(p)"
-    case 6:
-      Mixpanel.mainInstance().getGroup(groupKey: groupKey, groupID: groupID).deleteGroup()
-      descStr = "Deleted Group"
-    case 7:
-      let groupIDs = [groupID, 301]
-      Mixpanel.mainInstance().setGroup(groupKey: groupKey, groupIDs: groupIDs)
-      descStr = "Set Group \(groupKey) to \(groupIDs)"
-    case 8:
-      Mixpanel.mainInstance().setGroup(groupKey: groupKey, groupID: groupID)
-      descStr = "Set Group \(groupKey) to \(groupID)"
-    case 9:
-      let newID = "iris_test3"
-      Mixpanel.mainInstance().addGroup(groupKey: groupKey, groupID: newID)
-      descStr = "Add Group \(groupKey), ID \(newID)"
-    case 10:
-      Mixpanel.mainInstance().removeGroup(groupKey: groupKey, groupID: groupID)
-      descStr = "Remove Group \(groupKey), ID \(groupID)"
-    case 11:
-      let p: Properties = [
-        "a": 1,
-        "b": 2.3,
-        "c": ["4", 5] as [Any],
-        "d": URL(string: "https://mixpanel.com")!,
-        "e": NSNull(),
-        "f": Date(),
-        "Cool Property": "foo",
-      ]
-      let groups: Properties = ["Cool Property": "actual group value"]
-      Mixpanel.mainInstance().trackWithGroups(
-        event: "tracked with groups", properties: p, groups: groups)
-      descStr = "Track with groups: properties \(p), groups \(groups)"
-    default:
-      break
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.delegate = self
+        tableView.dataSource = self
     }
 
-    let vc =
-      storyboard!.instantiateViewController(withIdentifier: "ActionCompleteViewController")
-      as! ActionCompleteViewController
-    vc.actionStr = actionStr
-    vc.descStr = descStr
-    vc.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
-    vc.modalPresentationStyle = UIModalPresentationStyle.overFullScreen
-    present(vc, animated: true, completion: nil)
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = self.tableView.dequeueReusableCell(withIdentifier: "cell")! as UITableViewCell
+        cell.textLabel?.text = tableViewItems[indexPath.item]
+        cell.textLabel?.textColor = #colorLiteral(
+            red: 0.200000003, green: 0.200000003, blue: 0.200000003, alpha: 1)
+        return cell
+    }
 
-  }
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
 
-  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return tableViewItems.count
-  }
+        let actionStr = tableViewItems[indexPath.item]
+        var descStr = ""
+
+        let groupKey = "Cool Property"
+        let groupID = 12345
+
+        switch indexPath.item {
+            case 0:
+                let p: Properties = [
+                    "a": 1,
+                    "b": 2.3,
+                    "c": ["4", 5] as [Any],
+                    "d": URL(string: "https://mixpanel.com")!,
+                    "e": NSNull(),
+                    "f": Date(),
+                ]
+                Mixpanel.mainInstance().getGroup(groupKey: groupKey, groupID: groupID).set(properties: p)
+                descStr = "Properties: \(p)"
+            case 1:
+                Mixpanel.mainInstance().getGroup(groupKey: groupKey, groupID: groupID).set(
+                    property: "g", to: "yo")
+                descStr = "Property key: g, value: yo"
+            case 2:
+                let p = ["h": "just once"]
+                Mixpanel.mainInstance().getGroup(groupKey: groupKey, groupID: groupID).setOnce(properties: p)
+                descStr = "Properties: \(p)"
+            case 3:
+                let p = "b"
+                Mixpanel.mainInstance().getGroup(groupKey: groupKey, groupID: groupID).unset(property: p)
+                descStr = "Unset Property: \(p)"
+            case 4:
+                Mixpanel.mainInstance().getGroup(groupKey: groupKey, groupID: groupID).remove(
+                    key: "c", value: 5)
+                descStr = "Remove Property: [\"c\" : 5]"
+            case 5:
+                let p = ["c": [5, 4]]
+                Mixpanel.mainInstance().getGroup(groupKey: groupKey, groupID: groupID).union(
+                    key: "c", values: p["c"]!)
+                descStr = "Properties: \(p)"
+            case 6:
+                Mixpanel.mainInstance().getGroup(groupKey: groupKey, groupID: groupID).deleteGroup()
+                descStr = "Deleted Group"
+            case 7:
+                let groupIDs = [groupID, 301]
+                Mixpanel.mainInstance().setGroup(groupKey: groupKey, groupIDs: groupIDs)
+                descStr = "Set Group \(groupKey) to \(groupIDs)"
+            case 8:
+                Mixpanel.mainInstance().setGroup(groupKey: groupKey, groupID: groupID)
+                descStr = "Set Group \(groupKey) to \(groupID)"
+            case 9:
+                let newID = "iris_test3"
+                Mixpanel.mainInstance().addGroup(groupKey: groupKey, groupID: newID)
+                descStr = "Add Group \(groupKey), ID \(newID)"
+            case 10:
+                Mixpanel.mainInstance().removeGroup(groupKey: groupKey, groupID: groupID)
+                descStr = "Remove Group \(groupKey), ID \(groupID)"
+            case 11:
+                let p: Properties = [
+                    "a": 1,
+                    "b": 2.3,
+                    "c": ["4", 5] as [Any],
+                    "d": URL(string: "https://mixpanel.com")!,
+                    "e": NSNull(),
+                    "f": Date(),
+                    "Cool Property": "foo",
+                ]
+                let groups: Properties = ["Cool Property": "actual group value"]
+                Mixpanel.mainInstance().trackWithGroups(
+                    event: "tracked with groups", properties: p, groups: groups)
+                descStr = "Track with groups: properties \(p), groups \(groups)"
+            default:
+                break
+        }
+
+        let vc =
+            storyboard!.instantiateViewController(withIdentifier: "ActionCompleteViewController")
+            as! ActionCompleteViewController
+        vc.actionStr = actionStr
+        vc.descStr = descStr
+        vc.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
+        vc.modalPresentationStyle = UIModalPresentationStyle.overFullScreen
+        present(vc, animated: true, completion: nil)
+
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return tableViewItems.count
+    }
 
 }

--- a/MixpanelDemo/MixpanelDemo/LoginViewController.swift
+++ b/MixpanelDemo/MixpanelDemo/LoginViewController.swift
@@ -3,45 +3,45 @@ import UIKit
 
 class LoginViewController: UIViewController {
 
-  let delegate = UIApplication.shared.delegate as! AppDelegate
+    let delegate = UIApplication.shared.delegate as! AppDelegate
 
-  @IBOutlet weak var projectTokenTextField: UITextField!
+    @IBOutlet weak var projectTokenTextField: UITextField!
 
-  @IBOutlet weak var distinctIdTextField: UITextField!
+    @IBOutlet weak var distinctIdTextField: UITextField!
 
-  @IBOutlet weak var nameTextField: UITextField!
+    @IBOutlet weak var nameTextField: UITextField!
 
-  @IBOutlet weak var startButton: UIButton!
+    @IBOutlet weak var startButton: UIButton!
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    let token = Mixpanel.mainInstance().apiToken
-    projectTokenTextField.text = token
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        let token = Mixpanel.mainInstance().apiToken
+        projectTokenTextField.text = token
 
-    distinctIdTextField.text = "demo_user"
-    nameTextField.text = "Demo User"
-  }
-
-  open func goToMainView() {
-    if let vc = storyboard?.instantiateViewController(withIdentifier: "mainNav") {
-      self.view.window?.rootViewController = vc
-    } else {
-      NSLog("Unable to find view controller with name \"mainView\"")
+        distinctIdTextField.text = "demo_user"
+        nameTextField.text = "Demo User"
     }
-  }
 
-  @IBAction func start(_ sender: Any) {
-    Mixpanel.mainInstance().identify(distinctId: distinctIdTextField.text ?? "demo_user")
-    Mixpanel.mainInstance().people.set(property: "$name", to: nameTextField.text ?? "")
-    Mixpanel.mainInstance().track(event: "Logged in")
-    Mixpanel.mainInstance().flush()
-
-    goToMainView()
-  }
-
-  @IBAction func rateDevX(_ sender: Any) {
-    if let url = URL(string: "https://www.mixpanel.com/devnps") {
-      UIApplication.shared.open(url)
+    open func goToMainView() {
+        if let vc = storyboard?.instantiateViewController(withIdentifier: "mainNav") {
+            self.view.window?.rootViewController = vc
+        } else {
+            NSLog("Unable to find view controller with name \"mainView\"")
+        }
     }
-  }
+
+    @IBAction func start(_ sender: Any) {
+        Mixpanel.mainInstance().identify(distinctId: distinctIdTextField.text ?? "demo_user")
+        Mixpanel.mainInstance().people.set(property: "$name", to: nameTextField.text ?? "")
+        Mixpanel.mainInstance().track(event: "Logged in")
+        Mixpanel.mainInstance().flush()
+
+        goToMainView()
+    }
+
+    @IBAction func rateDevX(_ sender: Any) {
+        if let url = URL(string: "https://www.mixpanel.com/devnps") {
+            UIApplication.shared.open(url)
+        }
+    }
 }

--- a/MixpanelDemo/MixpanelDemo/PeopleViewController.swift
+++ b/MixpanelDemo/MixpanelDemo/PeopleViewController.swift
@@ -11,120 +11,120 @@ import UIKit
 
 class PeopleViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
 
-  @IBOutlet weak var tableView: UITableView!
-  var tableViewItems = [
-    "Set Properties",
-    "Set One Property",
-    "Set Properties Once",
-    "Unset Properties",
-    "Incremet Properties",
-    "Increment Property",
-    "Append Properties",
-    "Union Properties",
-    "Track Charge w/o Properties",
-    "Track Charge w Properties",
-    "Clear Charges",
-    "Delete User",
-    "Identify",
-  ]
+    @IBOutlet weak var tableView: UITableView!
+    var tableViewItems = [
+        "Set Properties",
+        "Set One Property",
+        "Set Properties Once",
+        "Unset Properties",
+        "Incremet Properties",
+        "Increment Property",
+        "Append Properties",
+        "Union Properties",
+        "Track Charge w/o Properties",
+        "Track Charge w Properties",
+        "Clear Charges",
+        "Delete User",
+        "Identify",
+    ]
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    tableView.delegate = self
-    tableView.dataSource = self
-  }
-
-  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    let cell = self.tableView.dequeueReusableCell(withIdentifier: "cell")! as UITableViewCell
-    cell.textLabel?.text = tableViewItems[indexPath.item]
-    cell.textLabel?.textColor = #colorLiteral(
-      red: 0.200000003, green: 0.200000003, blue: 0.200000003, alpha: 1)
-    return cell
-  }
-
-  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    tableView.deselectRow(at: indexPath, animated: true)
-
-    let actionStr = tableViewItems[indexPath.item]
-    var descStr = ""
-
-    switch indexPath.item {
-    case 0:
-      let p: Properties = [
-        "a": 1,
-        "b": 2.3,
-        "c": ["4", 5] as [Any],
-        "d": URL(string: "https://mixpanel.com")!,
-        "e": NSNull(),
-        "f": Date(),
-      ]
-      Mixpanel.mainInstance().people.set(properties: p)
-      descStr = "Properties: \(p)"
-    case 1:
-      Mixpanel.mainInstance().people.set(property: "g", to: "yo")
-      descStr = "Property key: g, value: yo"
-    case 2:
-      let p = ["h": "just once"]
-      Mixpanel.mainInstance().people.setOnce(properties: p)
-      descStr = "Properties: \(p)"
-    case 3:
-      let p = ["b", "h"]
-      Mixpanel.mainInstance().people.unset(properties: p)
-      descStr = "Unset Properties: \(p)"
-    case 4:
-      let p = ["a": 1.2, "b": 3]
-      Mixpanel.mainInstance().people.increment(properties: p)
-      descStr = "Properties: \(p)"
-    case 5:
-      Mixpanel.mainInstance().people.increment(property: "b", by: 2.3)
-      descStr = "Property key: b, value increment: 2.3"
-    case 6:
-      let p = ["c": "hello", "d": "goodbye"]
-      Mixpanel.mainInstance().people.append(properties: p)
-      descStr = "Properties: \(p)"
-    case 7:
-      let p = ["c": ["goodbye", "hi"], "d": ["hello"]]
-      Mixpanel.mainInstance().people.union(properties: p)
-      descStr = "Properties: \(p)"
-    case 8:
-      Mixpanel.mainInstance().people.trackCharge(amount: 20.5)
-      descStr = "Amount: 20.5"
-    case 9:
-      let p = ["sandwich": 1]
-      Mixpanel.mainInstance().people.trackCharge(amount: 12.8, properties: p)
-      descStr = "Amount: 12.8, Properties: \(p)"
-    case 10:
-      Mixpanel.mainInstance().people.clearCharges()
-      descStr = "Cleared Charges"
-    case 11:
-      Mixpanel.mainInstance().people.deleteUser()
-      descStr = "Deleted User"
-    case 12:
-      // Mixpanel People requires that you explicitly set a distinct ID for the current user. In this case,
-      // we're using the automatically generated distinct ID from event tracking, based on the device's MAC address.
-      // It is strongly recommended that you use the same distinct IDs for Mixpanel Engagement and Mixpanel People.
-      // Note that the call to Mixpanel People identify: can come after properties have been set. We queue them until
-      // identify: is called and flush them at that time. That way, you can set properties before a user is logged in
-      // and identify them once you know their user ID.
-      Mixpanel.mainInstance().identify(distinctId: "testDistinctId111")
-      descStr = "Identified User"
-    default:
-      break
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.delegate = self
+        tableView.dataSource = self
     }
 
-    let vc =
-      storyboard!.instantiateViewController(withIdentifier: "ActionCompleteViewController")
-      as! ActionCompleteViewController
-    vc.actionStr = actionStr
-    vc.descStr = descStr
-    vc.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
-    vc.modalPresentationStyle = UIModalPresentationStyle.overFullScreen
-    present(vc, animated: true, completion: nil)
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = self.tableView.dequeueReusableCell(withIdentifier: "cell")! as UITableViewCell
+        cell.textLabel?.text = tableViewItems[indexPath.item]
+        cell.textLabel?.textColor = #colorLiteral(
+            red: 0.200000003, green: 0.200000003, blue: 0.200000003, alpha: 1)
+        return cell
+    }
 
-  }
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
 
-  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return tableViewItems.count
-  }
+        let actionStr = tableViewItems[indexPath.item]
+        var descStr = ""
+
+        switch indexPath.item {
+            case 0:
+                let p: Properties = [
+                    "a": 1,
+                    "b": 2.3,
+                    "c": ["4", 5] as [Any],
+                    "d": URL(string: "https://mixpanel.com")!,
+                    "e": NSNull(),
+                    "f": Date(),
+                ]
+                Mixpanel.mainInstance().people.set(properties: p)
+                descStr = "Properties: \(p)"
+            case 1:
+                Mixpanel.mainInstance().people.set(property: "g", to: "yo")
+                descStr = "Property key: g, value: yo"
+            case 2:
+                let p = ["h": "just once"]
+                Mixpanel.mainInstance().people.setOnce(properties: p)
+                descStr = "Properties: \(p)"
+            case 3:
+                let p = ["b", "h"]
+                Mixpanel.mainInstance().people.unset(properties: p)
+                descStr = "Unset Properties: \(p)"
+            case 4:
+                let p = ["a": 1.2, "b": 3]
+                Mixpanel.mainInstance().people.increment(properties: p)
+                descStr = "Properties: \(p)"
+            case 5:
+                Mixpanel.mainInstance().people.increment(property: "b", by: 2.3)
+                descStr = "Property key: b, value increment: 2.3"
+            case 6:
+                let p = ["c": "hello", "d": "goodbye"]
+                Mixpanel.mainInstance().people.append(properties: p)
+                descStr = "Properties: \(p)"
+            case 7:
+                let p = ["c": ["goodbye", "hi"], "d": ["hello"]]
+                Mixpanel.mainInstance().people.union(properties: p)
+                descStr = "Properties: \(p)"
+            case 8:
+                Mixpanel.mainInstance().people.trackCharge(amount: 20.5)
+                descStr = "Amount: 20.5"
+            case 9:
+                let p = ["sandwich": 1]
+                Mixpanel.mainInstance().people.trackCharge(amount: 12.8, properties: p)
+                descStr = "Amount: 12.8, Properties: \(p)"
+            case 10:
+                Mixpanel.mainInstance().people.clearCharges()
+                descStr = "Cleared Charges"
+            case 11:
+                Mixpanel.mainInstance().people.deleteUser()
+                descStr = "Deleted User"
+            case 12:
+                // Mixpanel People requires that you explicitly set a distinct ID for the current user. In this case,
+                // we're using the automatically generated distinct ID from event tracking, based on the device's MAC address.
+                // It is strongly recommended that you use the same distinct IDs for Mixpanel Engagement and Mixpanel People.
+                // Note that the call to Mixpanel People identify: can come after properties have been set. We queue them until
+                // identify: is called and flush them at that time. That way, you can set properties before a user is logged in
+                // and identify them once you know their user ID.
+                Mixpanel.mainInstance().identify(distinctId: "testDistinctId111")
+                descStr = "Identified User"
+            default:
+                break
+        }
+
+        let vc =
+            storyboard!.instantiateViewController(withIdentifier: "ActionCompleteViewController")
+            as! ActionCompleteViewController
+        vc.actionStr = actionStr
+        vc.descStr = descStr
+        vc.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
+        vc.modalPresentationStyle = UIModalPresentationStyle.overFullScreen
+        present(vc, animated: true, completion: nil)
+
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return tableViewItems.count
+    }
 
 }

--- a/MixpanelDemo/MixpanelDemo/TrackingViewController.swift
+++ b/MixpanelDemo/MixpanelDemo/TrackingViewController.swift
@@ -11,107 +11,107 @@ import UIKit
 
 class TrackingViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
 
-  @IBOutlet weak var tableView: UITableView!
-  var tableViewItems = [
-    "Track w/o Properties",
-    "Track w Properties",
-    "Time Event 5secs",
-    "Clear Timed Events",
-    "Get Current SuperProperties",
-    "Clear SuperProperties",
-    "Register SuperProperties",
-    "Register SuperProperties Once",
-    "Register SP Once w Default Value",
-    "Unregister SuperProperty",
-  ]
+    @IBOutlet weak var tableView: UITableView!
+    var tableViewItems = [
+        "Track w/o Properties",
+        "Track w Properties",
+        "Time Event 5secs",
+        "Clear Timed Events",
+        "Get Current SuperProperties",
+        "Clear SuperProperties",
+        "Register SuperProperties",
+        "Register SuperProperties Once",
+        "Register SP Once w Default Value",
+        "Unregister SuperProperty",
+    ]
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
+    override func viewDidLoad() {
+        super.viewDidLoad()
 
-    tableView.delegate = self
-    tableView.dataSource = self
-  }
-
-  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    let cell = self.tableView.dequeueReusableCell(withIdentifier: "cell")! as UITableViewCell
-    cell.textLabel?.text = tableViewItems[indexPath.item]
-    cell.textLabel?.textColor = #colorLiteral(
-      red: 0.200000003, green: 0.200000003, blue: 0.200000003, alpha: 1)
-    return cell
-  }
-
-  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    tableView.deselectRow(at: indexPath, animated: true)
-
-    let actionStr = self.tableViewItems[indexPath.item]
-    var descStr = ""
-
-    switch indexPath.item {
-    case 0:
-      let ev = "Track Event!"
-      Mixpanel.mainInstance().track(event: ev)
-      descStr = "Event: \"\(ev)\""
-    case 1:
-      let ev = "Track Event With Properties!"
-      let p = ["Cool Property": "Property Value"]
-      Mixpanel.mainInstance().track(event: ev, properties: p)
-      descStr = "Event: \"\(ev)\"\n Properties: \(p)"
-    case 2:
-      let ev = "Timed Event"
-      Mixpanel.mainInstance().time(event: ev)
-      DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-        Mixpanel.mainInstance().track(event: ev)
-      }
-      descStr = "Timed Event: \"\(ev)\""
-    case 3:
-      Mixpanel.mainInstance().clearTimedEvents()
-      descStr = "Timed Events Cleared"
-    case 4:
-      descStr = "Super Properties:\n"
-      descStr += "\(Mixpanel.mainInstance().currentSuperProperties())"
-    case 5:
-      Mixpanel.mainInstance().clearSuperProperties()
-      descStr = "Cleared Super Properties"
-    case 6:
-      let p: Properties = [
-        "Super Property 1": 1,
-        "Super Property 2": "p2",
-        "Super Property 3": Date(),
-        "Super Property 4": ["a": "b"],
-        "Super Property 5": [3, "a", Date()] as [Any],
-        "Super Property 6":
-          URL(string: "https://mixpanel.com")!,
-        "Super Property 7": NSNull(),
-      ]
-      Mixpanel.mainInstance().registerSuperProperties(p)
-      descStr = "Properties: \(p)"
-    case 7:
-      let p = ["Super Property 1": 2.3]
-      Mixpanel.mainInstance().registerSuperPropertiesOnce(p)
-      descStr = "Properties: \(p)"
-    case 8:
-      let p = ["Super Property 1": 1.2]
-      Mixpanel.mainInstance().registerSuperPropertiesOnce(p, defaultValue: 2.3)
-      descStr = "Properties: \(p) with Default Value: 2.3"
-    case 9:
-      let p = "Super Property 2"
-      Mixpanel.mainInstance().unregisterSuperProperty(p)
-      descStr = "Properties: \(p)"
-    default:
-      break
+        tableView.delegate = self
+        tableView.dataSource = self
     }
 
-    let vc =
-      storyboard!.instantiateViewController(withIdentifier: "ActionCompleteViewController")
-      as! ActionCompleteViewController
-    vc.actionStr = actionStr
-    vc.descStr = descStr
-    vc.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
-    vc.modalPresentationStyle = UIModalPresentationStyle.overFullScreen
-    present(vc, animated: true, completion: nil)
-  }
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = self.tableView.dequeueReusableCell(withIdentifier: "cell")! as UITableViewCell
+        cell.textLabel?.text = tableViewItems[indexPath.item]
+        cell.textLabel?.textColor = #colorLiteral(
+            red: 0.200000003, green: 0.200000003, blue: 0.200000003, alpha: 1)
+        return cell
+    }
 
-  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return tableViewItems.count
-  }
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        let actionStr = self.tableViewItems[indexPath.item]
+        var descStr = ""
+
+        switch indexPath.item {
+            case 0:
+                let ev = "Track Event!"
+                Mixpanel.mainInstance().track(event: ev)
+                descStr = "Event: \"\(ev)\""
+            case 1:
+                let ev = "Track Event With Properties!"
+                let p = ["Cool Property": "Property Value"]
+                Mixpanel.mainInstance().track(event: ev, properties: p)
+                descStr = "Event: \"\(ev)\"\n Properties: \(p)"
+            case 2:
+                let ev = "Timed Event"
+                Mixpanel.mainInstance().time(event: ev)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                    Mixpanel.mainInstance().track(event: ev)
+                }
+                descStr = "Timed Event: \"\(ev)\""
+            case 3:
+                Mixpanel.mainInstance().clearTimedEvents()
+                descStr = "Timed Events Cleared"
+            case 4:
+                descStr = "Super Properties:\n"
+                descStr += "\(Mixpanel.mainInstance().currentSuperProperties())"
+            case 5:
+                Mixpanel.mainInstance().clearSuperProperties()
+                descStr = "Cleared Super Properties"
+            case 6:
+                let p: Properties = [
+                    "Super Property 1": 1,
+                    "Super Property 2": "p2",
+                    "Super Property 3": Date(),
+                    "Super Property 4": ["a": "b"],
+                    "Super Property 5": [3, "a", Date()] as [Any],
+                    "Super Property 6":
+                        URL(string: "https://mixpanel.com")!,
+                    "Super Property 7": NSNull(),
+                ]
+                Mixpanel.mainInstance().registerSuperProperties(p)
+                descStr = "Properties: \(p)"
+            case 7:
+                let p = ["Super Property 1": 2.3]
+                Mixpanel.mainInstance().registerSuperPropertiesOnce(p)
+                descStr = "Properties: \(p)"
+            case 8:
+                let p = ["Super Property 1": 1.2]
+                Mixpanel.mainInstance().registerSuperPropertiesOnce(p, defaultValue: 2.3)
+                descStr = "Properties: \(p) with Default Value: 2.3"
+            case 9:
+                let p = "Super Property 2"
+                Mixpanel.mainInstance().unregisterSuperProperty(p)
+                descStr = "Properties: \(p)"
+            default:
+                break
+        }
+
+        let vc =
+            storyboard!.instantiateViewController(withIdentifier: "ActionCompleteViewController")
+            as! ActionCompleteViewController
+        vc.actionStr = actionStr
+        vc.descStr = descStr
+        vc.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
+        vc.modalPresentationStyle = UIModalPresentationStyle.overFullScreen
+        present(vc, animated: true, completion: nil)
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return tableViewItems.count
+    }
 }

--- a/MixpanelDemo/MixpanelDemo/UtilityViewController.swift
+++ b/MixpanelDemo/MixpanelDemo/UtilityViewController.swift
@@ -11,131 +11,131 @@ import StoreKit
 import UIKit
 
 class UtilityViewController: UIViewController, UITableViewDelegate, UITableViewDataSource,
-  SKProductsRequestDelegate, SKPaymentTransactionObserver
+    SKProductsRequestDelegate, SKPaymentTransactionObserver
 {
 
-  @IBOutlet weak var tableView: UITableView!
-  var tableViewItems = [
-    "Create Alias",
-    "Reset",
-    "Archive",
-    "Flush",
-    "In-App Purchase",
-  ]
+    @IBOutlet weak var tableView: UITableView!
+    var tableViewItems = [
+        "Create Alias",
+        "Reset",
+        "Archive",
+        "Flush",
+        "In-App Purchase",
+    ]
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    tableView.delegate = self
-    tableView.dataSource = self
-  }
-
-  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    let cell = self.tableView.dequeueReusableCell(withIdentifier: "cell")! as UITableViewCell
-    cell.textLabel?.text = tableViewItems[indexPath.item]
-    cell.textLabel?.textColor = #colorLiteral(
-      red: 0.200000003, green: 0.200000003, blue: 0.200000003, alpha: 1)
-    return cell
-  }
-
-  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    tableView.deselectRow(at: indexPath, animated: true)
-
-    let actionStr = tableViewItems[indexPath.item]
-    var descStr = ""
-
-    switch indexPath.item {
-    case 0:
-      Mixpanel.mainInstance().createAlias(
-        "New Alias", distinctId: Mixpanel.mainInstance().distinctId)
-      descStr = "Alias: New Alias, from: \(Mixpanel.mainInstance().distinctId)"
-    case 1:
-      let beforeId = Mixpanel.mainInstance().anonymousId ?? "nil"
-      let beforeDistinctId = Mixpanel.mainInstance().distinctId
-      print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-      print("🔄 BEFORE reset()")
-      print("   anonymousId: \(beforeId)")
-      print("   distinctId:  \(beforeDistinctId)")
-
-      Mixpanel.mainInstance().reset {
-        let afterId = Mixpanel.mainInstance().anonymousId ?? "nil"
-        print("🔄 AFTER reset()")
-        print("   anonymousId: \(afterId)")
-        print("   distinctId:  \(Mixpanel.mainInstance().distinctId)")
-        print("   ID changed:  \(beforeId != afterId ? "✅ YES" : "❌ NO (persistent)")")
-        print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-      }
-      descStr = "Reset Instance (check console)"
-    case 2:
-      Mixpanel.mainInstance().archive()
-      descStr = "Archived Data"
-    case 3:
-      Mixpanel.mainInstance().flush()
-      descStr = "Flushed Data"
-    case 4:
-      IAPFlow()
-    default:
-      break
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.delegate = self
+        tableView.dataSource = self
     }
 
-    let vc =
-      storyboard!.instantiateViewController(withIdentifier: "ActionCompleteViewController")
-      as! ActionCompleteViewController
-    vc.actionStr = actionStr
-    vc.descStr = descStr
-    vc.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
-    vc.modalPresentationStyle = UIModalPresentationStyle.overFullScreen
-    present(vc, animated: true, completion: nil)
-  }
-
-  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return tableViewItems.count
-  }
-
-  func IAPFlow() {
-    let productIdentifiers = NSSet(
-      objects:
-        "com.iaptutorial.fun",
-      "com.mixpanel.swiftsdkdemo.fun"
-    )
-    let productsRequest = SKProductsRequest(productIdentifiers: productIdentifiers as! Set<String>)
-    productsRequest.delegate = self
-    productsRequest.start()
-  }
-
-  func productsRequest(_ request: SKProductsRequest, didReceive response: SKProductsResponse) {
-    if response.products.count > 0 {
-      if let firstProduct = response.products.first {
-        let payment = SKPayment(product: firstProduct)
-        SKPaymentQueue.default().add(self)
-        SKPaymentQueue.default().add(payment)
-      }
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = self.tableView.dequeueReusableCell(withIdentifier: "cell")! as UITableViewCell
+        cell.textLabel?.text = tableViewItems[indexPath.item]
+        cell.textLabel?.textColor = #colorLiteral(
+            red: 0.200000003, green: 0.200000003, blue: 0.200000003, alpha: 1)
+        return cell
     }
-  }
 
-  func paymentQueue(
-    _ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]
-  ) {
-    for transaction: AnyObject in transactions {
-      if let trans = transaction as? SKPaymentTransaction {
-        switch trans.transactionState {
-        case .purchased:
-          SKPaymentQueue.default().finishTransaction(transaction as! SKPaymentTransaction)
-          print("IAP purchased")
-          break
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
 
-        case .failed:
-          SKPaymentQueue.default().finishTransaction(transaction as! SKPaymentTransaction)
-          print("IAP failed")
-          break
-        case .restored:
-          SKPaymentQueue.default().finishTransaction(transaction as! SKPaymentTransaction)
-          print("IAP restored")
-          break
+        let actionStr = tableViewItems[indexPath.item]
+        var descStr = ""
 
-        default: break
+        switch indexPath.item {
+            case 0:
+                Mixpanel.mainInstance().createAlias(
+                    "New Alias", distinctId: Mixpanel.mainInstance().distinctId)
+                descStr = "Alias: New Alias, from: \(Mixpanel.mainInstance().distinctId)"
+            case 1:
+                let beforeId = Mixpanel.mainInstance().anonymousId ?? "nil"
+                let beforeDistinctId = Mixpanel.mainInstance().distinctId
+                print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+                print("🔄 BEFORE reset()")
+                print("   anonymousId: \(beforeId)")
+                print("   distinctId:  \(beforeDistinctId)")
+
+                Mixpanel.mainInstance().reset {
+                    let afterId = Mixpanel.mainInstance().anonymousId ?? "nil"
+                    print("🔄 AFTER reset()")
+                    print("   anonymousId: \(afterId)")
+                    print("   distinctId:  \(Mixpanel.mainInstance().distinctId)")
+                    print("   ID changed:  \(beforeId != afterId ? "✅ YES" : "❌ NO (persistent)")")
+                    print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+                }
+                descStr = "Reset Instance (check console)"
+            case 2:
+                Mixpanel.mainInstance().archive()
+                descStr = "Archived Data"
+            case 3:
+                Mixpanel.mainInstance().flush()
+                descStr = "Flushed Data"
+            case 4:
+                IAPFlow()
+            default:
+                break
         }
-      }
+
+        let vc =
+            storyboard!.instantiateViewController(withIdentifier: "ActionCompleteViewController")
+            as! ActionCompleteViewController
+        vc.actionStr = actionStr
+        vc.descStr = descStr
+        vc.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
+        vc.modalPresentationStyle = UIModalPresentationStyle.overFullScreen
+        present(vc, animated: true, completion: nil)
     }
-  }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return tableViewItems.count
+    }
+
+    func IAPFlow() {
+        let productIdentifiers = NSSet(
+            objects:
+                "com.iaptutorial.fun",
+            "com.mixpanel.swiftsdkdemo.fun"
+        )
+        let productsRequest = SKProductsRequest(productIdentifiers: productIdentifiers as! Set<String>)
+        productsRequest.delegate = self
+        productsRequest.start()
+    }
+
+    func productsRequest(_ request: SKProductsRequest, didReceive response: SKProductsResponse) {
+        if response.products.count > 0 {
+            if let firstProduct = response.products.first {
+                let payment = SKPayment(product: firstProduct)
+                SKPaymentQueue.default().add(self)
+                SKPaymentQueue.default().add(payment)
+            }
+        }
+    }
+
+    func paymentQueue(
+        _ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]
+    ) {
+        for transaction: AnyObject in transactions {
+            if let trans = transaction as? SKPaymentTransaction {
+                switch trans.transactionState {
+                    case .purchased:
+                        SKPaymentQueue.default().finishTransaction(transaction as! SKPaymentTransaction)
+                        print("IAP purchased")
+                        break
+
+                    case .failed:
+                        SKPaymentQueue.default().finishTransaction(transaction as! SKPaymentTransaction)
+                        print("IAP failed")
+                        break
+                    case .restored:
+                        SKPaymentQueue.default().finishTransaction(transaction as! SKPaymentTransaction)
+                        print("IAP restored")
+                        break
+
+                    default: break
+                }
+            }
+        }
+    }
 
 }

--- a/MixpanelDemo/MixpanelDemoMac/AppDelegate.swift
+++ b/MixpanelDemo/MixpanelDemoMac/AppDelegate.swift
@@ -12,19 +12,19 @@ import Mixpanel
 @main
 class AppDelegate: NSObject, NSApplicationDelegate {
 
-  func applicationDidFinishLaunching(_ aNotification: Notification) {
-    // Insert code here to initialize your application
+    func applicationDidFinishLaunching(_ aNotification: Notification) {
+        // Insert code here to initialize your application
 
-    var ADD_YOUR_MIXPANEL_TOKEN_BELOW_🛠🛠🛠🛠🛠🛠: String
+        var ADD_YOUR_MIXPANEL_TOKEN_BELOW_🛠🛠🛠🛠🛠🛠: String
 
-    Mixpanel.initialize(token: "MIXPANEL_TOKEN")
-    Mixpanel.mainInstance().loggingEnabled = true
-    Mixpanel.mainInstance().track(event: "Tracked Event")
+        Mixpanel.initialize(token: "MIXPANEL_TOKEN")
+        Mixpanel.mainInstance().loggingEnabled = true
+        Mixpanel.mainInstance().track(event: "Tracked Event")
 
-  }
+    }
 
-  func applicationWillTerminate(_ aNotification: Notification) {
-    // Insert code here to tear down your application
-  }
+    func applicationWillTerminate(_ aNotification: Notification) {
+        // Insert code here to tear down your application
+    }
 
 }

--- a/MixpanelDemo/MixpanelDemoMac/ViewController.swift
+++ b/MixpanelDemo/MixpanelDemoMac/ViewController.swift
@@ -11,16 +11,16 @@ import Mixpanel
 
 class ViewController: NSViewController {
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
+    override func viewDidLoad() {
+        super.viewDidLoad()
 
-    // Do any additional setup after loading the view.
-  }
-
-  override var representedObject: Any? {
-    didSet {
-      // Update the view, if already loaded.
+        // Do any additional setup after loading the view.
     }
-  }
+
+    override var representedObject: Any? {
+        didSet {
+            // Update the view, if already loaded.
+        }
+    }
 
 }

--- a/MixpanelDemo/MixpanelDemoMacTests/MixpanelAutomaticEventsTests.swift
+++ b/MixpanelDemo/MixpanelDemoMacTests/MixpanelAutomaticEventsTests.swift
@@ -13,160 +13,160 @@ import XCTest
 
 class MixpanelAutomaticEventsTests: MixpanelBaseTests {
 
-  func testSession() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), flushInterval: 60, trackAutomaticEvents: true)
-    testMixpanel.minimumSessionDuration = 0
-    testMixpanel.identify(distinctId: "d1")
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.automaticEvents.perform(
-      #selector(AutomaticEvents.appWillResignActive(_:)),
-      with: Notification(name: Notification.Name(rawValue: "test")))
-    waitForTrackingQueue(testMixpanel)
+    func testSession() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), flushInterval: 60, trackAutomaticEvents: true)
+        testMixpanel.minimumSessionDuration = 0
+        testMixpanel.identify(distinctId: "d1")
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.automaticEvents.perform(
+            #selector(AutomaticEvents.appWillResignActive(_:)),
+            with: Notification(name: Notification.Name(rawValue: "test")))
+        waitForTrackingQueue(testMixpanel)
 
-    let event = eventQueue(token: testMixpanel.apiToken).last
-    let people1 = peopleQueue(token: testMixpanel.apiToken)[1]["$add"] as! InternalProperties
-    let people2 = peopleQueue(token: testMixpanel.apiToken)[2]["$add"] as! InternalProperties
-    XCTAssertEqual(
-      (people1["$ae_total_app_sessions"] as? NSNumber)?.intValue, 1,
-      "total app sessions should be added by 1")
-    XCTAssertNotNil(
-      (people2["$ae_total_app_session_length"], "should have session length in $add queue"))
-    XCTAssertNotNil(event, "Should have an event")
-    XCTAssertEqual(event?["event"] as? String, "$ae_session", "should be app session event")
-    XCTAssertNotNil(
-      (event?["properties"] as? [String: Any])?["$ae_session_length"], "should have session length")
-    removeDBfile(testMixpanel)
-  }
+        let event = eventQueue(token: testMixpanel.apiToken).last
+        let people1 = peopleQueue(token: testMixpanel.apiToken)[1]["$add"] as! InternalProperties
+        let people2 = peopleQueue(token: testMixpanel.apiToken)[2]["$add"] as! InternalProperties
+        XCTAssertEqual(
+            (people1["$ae_total_app_sessions"] as? NSNumber)?.intValue, 1,
+            "total app sessions should be added by 1")
+        XCTAssertNotNil(
+            (people2["$ae_total_app_session_length"], "should have session length in $add queue"))
+        XCTAssertNotNil(event, "Should have an event")
+        XCTAssertEqual(event?["event"] as? String, "$ae_session", "should be app session event")
+        XCTAssertNotNil(
+            (event?["properties"] as? [String: Any])?["$ae_session_length"], "should have session length")
+        removeDBfile(testMixpanel)
+    }
 
-  func testKeepAutomaticEventsIfNetworkNotAvailable() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), flushInterval: 60, trackAutomaticEvents: true)
-    testMixpanel.minimumSessionDuration = 0
-    testMixpanel.automaticEvents.perform(
-      #selector(AutomaticEvents.appWillResignActive(_:)),
-      with: Notification(name: Notification.Name(rawValue: "test")))
+    func testKeepAutomaticEventsIfNetworkNotAvailable() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), flushInterval: 60, trackAutomaticEvents: true)
+        testMixpanel.minimumSessionDuration = 0
+        testMixpanel.automaticEvents.perform(
+            #selector(AutomaticEvents.appWillResignActive(_:)),
+            with: Notification(name: Notification.Name(rawValue: "test")))
 
-    waitForTrackingQueue(testMixpanel)
-    let event = eventQueue(token: testMixpanel.apiToken).last
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 2,
-      "automatic events should be accumulated if device is offline")
-    XCTAssertEqual(event?["event"] as? String, "$ae_session", "should be app session event")
-    removeDBfile(testMixpanel)
-  }
+        waitForTrackingQueue(testMixpanel)
+        let event = eventQueue(token: testMixpanel.apiToken).last
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 2,
+            "automatic events should be accumulated if device is offline")
+        XCTAssertEqual(event?["event"] as? String, "$ae_session", "should be app session event")
+        removeDBfile(testMixpanel)
+    }
 
-  func testDiscardAutomaticEventsIfTrackAutomaticEventsEnabledIsFalse() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), flushInterval: 60, trackAutomaticEvents: false)
-    testMixpanel.minimumSessionDuration = 0
-    testMixpanel.automaticEvents.perform(
-      #selector(AutomaticEvents.appWillResignActive(_:)),
-      with: Notification(name: Notification.Name(rawValue: "test")))
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 0, "automatic events should not be tracked")
-    removeDBfile(testMixpanel)
-  }
+    func testDiscardAutomaticEventsIfTrackAutomaticEventsEnabledIsFalse() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), flushInterval: 60, trackAutomaticEvents: false)
+        testMixpanel.minimumSessionDuration = 0
+        testMixpanel.automaticEvents.perform(
+            #selector(AutomaticEvents.appWillResignActive(_:)),
+            with: Notification(name: Notification.Name(rawValue: "test")))
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 0, "automatic events should not be tracked")
+        removeDBfile(testMixpanel)
+    }
 
-  func testFlushAutomaticEventsIfTrackAutomaticEventsEnabledIsTrue() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), flushInterval: 60, trackAutomaticEvents: true)
-    testMixpanel.minimumSessionDuration = 0
-    testMixpanel.automaticEvents.perform(
-      #selector(AutomaticEvents.appWillResignActive(_:)),
-      with: Notification(name: Notification.Name(rawValue: "test")))
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 2, "automatic events should be tracked")
+    func testFlushAutomaticEventsIfTrackAutomaticEventsEnabledIsTrue() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), flushInterval: 60, trackAutomaticEvents: true)
+        testMixpanel.minimumSessionDuration = 0
+        testMixpanel.automaticEvents.perform(
+            #selector(AutomaticEvents.appWillResignActive(_:)),
+            with: Notification(name: Notification.Name(rawValue: "test")))
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 2, "automatic events should be tracked")
 
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 0, "automatic events should be flushed")
-    removeDBfile(testMixpanel)
-  }
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 0, "automatic events should be flushed")
+        removeDBfile(testMixpanel)
+    }
 
-  func testUpdated() {
-    let defaults = UserDefaults(suiteName: "Mixpanel")
-    let infoDict = Bundle.main.infoDictionary
-    let appVersionValue = infoDict?["CFBundleShortVersionString"]
-    let savedVersionValue = defaults?.string(forKey: "MPAppVersion")
-    XCTAssertEqual(
-      appVersionValue as? String, savedVersionValue,
-      "Saved version and current version need to be the same")
-  }
+    func testUpdated() {
+        let defaults = UserDefaults(suiteName: "Mixpanel")
+        let infoDict = Bundle.main.infoDictionary
+        let appVersionValue = infoDict?["CFBundleShortVersionString"]
+        let savedVersionValue = defaults?.string(forKey: "MPAppVersion")
+        XCTAssertEqual(
+            appVersionValue as? String, savedVersionValue,
+            "Saved version and current version need to be the same")
+    }
 
-  func testFirstAppShouldOnlyBeTrackedOnce() {
-    let testToken = randomId()
-    let mp = Mixpanel.initialize(token: testToken, trackAutomaticEvents: true)
-    mp.minimumSessionDuration = 0
-    waitForTrackingQueue(mp)
-    XCTAssertEqual(
-      eventQueue(token: mp.apiToken).count, 1, "First app open should be tracked")
-    flushAndWaitForTrackingQueue(mp)
+    func testFirstAppShouldOnlyBeTrackedOnce() {
+        let testToken = randomId()
+        let mp = Mixpanel.initialize(token: testToken, trackAutomaticEvents: true)
+        mp.minimumSessionDuration = 0
+        waitForTrackingQueue(mp)
+        XCTAssertEqual(
+            eventQueue(token: mp.apiToken).count, 1, "First app open should be tracked")
+        flushAndWaitForTrackingQueue(mp)
 
-    let mp2 = Mixpanel.initialize(token: testToken, trackAutomaticEvents: true)
-    mp2.minimumSessionDuration = 0
-    waitForTrackingQueue(mp2)
-    XCTAssertEqual(
-      eventQueue(token: mp2.apiToken).count, 0, "First app open should not be tracked again")
-  }
+        let mp2 = Mixpanel.initialize(token: testToken, trackAutomaticEvents: true)
+        mp2.minimumSessionDuration = 0
+        waitForTrackingQueue(mp2)
+        XCTAssertEqual(
+            eventQueue(token: mp2.apiToken).count, 0, "First app open should not be tracked again")
+    }
 
-  func testAutomaticEventsInMultipleInstances() {
-    // remove UserDefaults key and archive files to simulate first app open state
-    let defaults = UserDefaults(suiteName: "Mixpanel")
-    defaults?.removeObject(forKey: "MPFirstOpen")
+    func testAutomaticEventsInMultipleInstances() {
+        // remove UserDefaults key and archive files to simulate first app open state
+        let defaults = UserDefaults(suiteName: "Mixpanel")
+        defaults?.removeObject(forKey: "MPFirstOpen")
 
-    let mp = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: true)
-    mp.minimumSessionDuration = 0
-    waitForTrackingQueue(mp)
-    let mp2 = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: true)
-    mp2.minimumSessionDuration = 0
-    waitForTrackingQueue(mp2)
+        let mp = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: true)
+        mp.minimumSessionDuration = 0
+        waitForTrackingQueue(mp)
+        let mp2 = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: true)
+        mp2.minimumSessionDuration = 0
+        waitForTrackingQueue(mp2)
 
-    XCTAssertEqual(eventQueue(token: mp.apiToken).count, 1, "there should be only 1 event")
-    let appOpenEvent = eventQueue(token: mp.apiToken).last
-    XCTAssertEqual(
-      appOpenEvent?["event"] as? String, "$ae_first_open", "should be first app open event")
+        XCTAssertEqual(eventQueue(token: mp.apiToken).count, 1, "there should be only 1 event")
+        let appOpenEvent = eventQueue(token: mp.apiToken).last
+        XCTAssertEqual(
+            appOpenEvent?["event"] as? String, "$ae_first_open", "should be first app open event")
 
-    XCTAssertEqual(eventQueue(token: mp2.apiToken).count, 1, "there should be only 1 event")
-    let otherAppOpenEvent = eventQueue(token: mp2.apiToken).last
-    XCTAssertEqual(
-      otherAppOpenEvent?["event"] as? String, "$ae_first_open", "should be first app open event")
+        XCTAssertEqual(eventQueue(token: mp2.apiToken).count, 1, "there should be only 1 event")
+        let otherAppOpenEvent = eventQueue(token: mp2.apiToken).last
+        XCTAssertEqual(
+            otherAppOpenEvent?["event"] as? String, "$ae_first_open", "should be first app open event")
 
-    mp.automaticEvents.perform(
-      #selector(AutomaticEvents.appWillResignActive(_:)),
-      with: Notification(name: Notification.Name(rawValue: "test")))
-    mp2.automaticEvents.perform(
-      #selector(AutomaticEvents.appWillResignActive(_:)),
-      with: Notification(name: Notification.Name(rawValue: "test")))
-    mp.trackingQueue.sync {}
-    mp2.trackingQueue.sync {}
-    let appSessionEvent = eventQueue(token: mp.apiToken).last
-    XCTAssertNotNil(appSessionEvent, "Should have an event")
-    XCTAssertEqual(
-      appSessionEvent?["event"] as? String, "$ae_session", "should be app session event")
-    XCTAssertNotNil(
-      (appSessionEvent?["properties"] as? [String: Any])?["$ae_session_length"],
-      "should have session length")
-    let otherAppSessionEvent = eventQueue(token: mp2.apiToken).last
-    XCTAssertEqual(
-      otherAppSessionEvent?["event"] as? String, "$ae_session", "should be app session event")
-    XCTAssertNotNil(
-      (otherAppSessionEvent?["properties"] as? [String: Any])?["$ae_session_length"],
-      "should have session length")
-    removeDBfile(mp)
-    removeDBfile(mp2)
-  }
+        mp.automaticEvents.perform(
+            #selector(AutomaticEvents.appWillResignActive(_:)),
+            with: Notification(name: Notification.Name(rawValue: "test")))
+        mp2.automaticEvents.perform(
+            #selector(AutomaticEvents.appWillResignActive(_:)),
+            with: Notification(name: Notification.Name(rawValue: "test")))
+        mp.trackingQueue.sync {}
+        mp2.trackingQueue.sync {}
+        let appSessionEvent = eventQueue(token: mp.apiToken).last
+        XCTAssertNotNil(appSessionEvent, "Should have an event")
+        XCTAssertEqual(
+            appSessionEvent?["event"] as? String, "$ae_session", "should be app session event")
+        XCTAssertNotNil(
+            (appSessionEvent?["properties"] as? [String: Any])?["$ae_session_length"],
+            "should have session length")
+        let otherAppSessionEvent = eventQueue(token: mp2.apiToken).last
+        XCTAssertEqual(
+            otherAppSessionEvent?["event"] as? String, "$ae_session", "should be app session event")
+        XCTAssertNotNil(
+            (otherAppSessionEvent?["properties"] as? [String: Any])?["$ae_session_length"],
+            "should have session length")
+        removeDBfile(mp)
+        removeDBfile(mp2)
+    }
 
-  func testAutomaticEventsDefaultsToFalse() {
-    // When trackAutomaticEvents is omitted, it should default to false on macOS
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.minimumSessionDuration = 0
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 0,
-      "automatic events should not be tracked when trackAutomaticEvents defaults to false")
-    removeDBfile(testMixpanel)
-  }
+    func testAutomaticEventsDefaultsToFalse() {
+        // When trackAutomaticEvents is omitted, it should default to false on macOS
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.minimumSessionDuration = 0
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 0,
+            "automatic events should not be tracked when trackAutomaticEvents defaults to false")
+        removeDBfile(testMixpanel)
+    }
 }

--- a/MixpanelDemo/MixpanelDemoMacTests/MixpanelBaseTests.swift
+++ b/MixpanelDemo/MixpanelDemoMacTests/MixpanelBaseTests.swift
@@ -13,152 +13,152 @@ import XCTest
 @testable import MixpanelDemoMac
 
 class MixpanelBaseTests: XCTestCase, MixpanelDelegate {
-  var mixpanelWillFlush: Bool!
-  static var requestCount = 0
+    var mixpanelWillFlush: Bool!
+    static var requestCount = 0
 
-  override func setUp() {
-    NSLog("starting test setup...")
-    super.setUp()
-    mixpanelWillFlush = false
+    override func setUp() {
+        NSLog("starting test setup...")
+        super.setUp()
+        mixpanelWillFlush = false
 
-    NSLog("finished test setup")
-  }
-
-  override func tearDown() {
-    super.tearDown()
-  }
-
-  func removeDBfile(apiToken: String) {
-    do {
-      let fileManager = FileManager.default
-
-      // Check if file exists
-      if fileManager.fileExists(atPath: dbFilePath(apiToken)) {
-        // Delete file
-        try fileManager.removeItem(atPath: dbFilePath(apiToken))
-      } else {
-        print(
-          "Unable to delete the test db file at \(dbFilePath(apiToken)), the file does not exist")
-      }
-    } catch let error as NSError {
-      print("An error took place: \(error)")
-    }
-  }
-
-  func removeDBfile(_ mixpanel: MixpanelInstance) {
-    waitForTrackingQueue(mixpanel)
-    mixpanel.mixpanelPersistence.closeDB()
-    removeDBfile(apiToken: mixpanel.apiToken)
-  }
-
-  func dbFilePath(_ token: String? = nil) -> String {
-    let manager = FileManager.default
-    #if os(iOS)
-      let url = manager.urls(for: .libraryDirectory, in: .userDomainMask).last
-    #else
-      let url = manager.urls(for: .cachesDirectory, in: .userDomainMask).last
-    #endif  // os(iOS)
-    guard let apiToken = token else {
-      return ""
+        NSLog("finished test setup")
     }
 
-    guard let urlUnwrapped = url?.appendingPathComponent("\(apiToken)_MPDB.sqlite").path
-    else {
-      return ""
-    }
-    return urlUnwrapped
-  }
-
-  func mixpanelWillFlush(_ mixpanel: MixpanelInstance) -> Bool {
-    return mixpanelWillFlush
-  }
-
-  func waitForTrackingQueue(_ mixpanel: MixpanelInstance) {
-    mixpanel.trackingQueue.sync {
-      mixpanel.networkQueue.sync {
-        return
-      }
+    override func tearDown() {
+        super.tearDown()
     }
 
-    mixpanel.trackingQueue.sync {
-      mixpanel.networkQueue.sync {
-        return
-      }
+    func removeDBfile(apiToken: String) {
+        do {
+            let fileManager = FileManager.default
+
+            // Check if file exists
+            if fileManager.fileExists(atPath: dbFilePath(apiToken)) {
+                // Delete file
+                try fileManager.removeItem(atPath: dbFilePath(apiToken))
+            } else {
+                print(
+                    "Unable to delete the test db file at \(dbFilePath(apiToken)), the file does not exist")
+            }
+        } catch let error as NSError {
+            print("An error took place: \(error)")
+        }
     }
-  }
 
-  func randomId() -> String {
-    return String(format: "%08x%08x", arc4random(), arc4random())
-  }
-
-  func waitForAsyncTasks() {
-    var hasCompletedTask = false
-    DispatchQueue.main.async {
-      hasCompletedTask = true
+    func removeDBfile(_ mixpanel: MixpanelInstance) {
+        waitForTrackingQueue(mixpanel)
+        mixpanel.mixpanelPersistence.closeDB()
+        removeDBfile(apiToken: mixpanel.apiToken)
     }
 
-    let loopUntil = Date(timeIntervalSinceNow: 10)
-    while !hasCompletedTask && loopUntil.timeIntervalSinceNow > 0 {
-      RunLoop.current.run(mode: RunLoop.Mode.default, before: loopUntil)
+    func dbFilePath(_ token: String? = nil) -> String {
+        let manager = FileManager.default
+        #if os(iOS)
+        let url = manager.urls(for: .libraryDirectory, in: .userDomainMask).last
+        #else
+        let url = manager.urls(for: .cachesDirectory, in: .userDomainMask).last
+        #endif  // os(iOS)
+        guard let apiToken = token else {
+            return ""
+        }
+
+        guard let urlUnwrapped = url?.appendingPathComponent("\(apiToken)_MPDB.sqlite").path
+        else {
+            return ""
+        }
+        return urlUnwrapped
     }
-  }
 
-  func eventQueue(token: String) -> Queue {
-    return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(type: .events)
-  }
+    func mixpanelWillFlush(_ mixpanel: MixpanelInstance) -> Bool {
+        return mixpanelWillFlush
+    }
 
-  func peopleQueue(token: String) -> Queue {
-    return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(type: .people)
-  }
+    func waitForTrackingQueue(_ mixpanel: MixpanelInstance) {
+        mixpanel.trackingQueue.sync {
+            mixpanel.networkQueue.sync {
+                return
+            }
+        }
 
-  func unIdentifiedPeopleQueue(token: String) -> Queue {
-    return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(
-      type: .people, flag: PersistenceConstant.unIdentifiedFlag)
-  }
+        mixpanel.trackingQueue.sync {
+            mixpanel.networkQueue.sync {
+                return
+            }
+        }
+    }
 
-  func groupQueue(token: String) -> Queue {
-    return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(type: .groups)
-  }
+    func randomId() -> String {
+        return String(format: "%08x%08x", arc4random(), arc4random())
+    }
 
-  func flushAndWaitForTrackingQueue(_ mixpanel: MixpanelInstance) {
-    mixpanel.flush()
-    waitForTrackingQueue(mixpanel)
-    mixpanel.flush()
-    waitForTrackingQueue(mixpanel)
-  }
+    func waitForAsyncTasks() {
+        var hasCompletedTask = false
+        DispatchQueue.main.async {
+            hasCompletedTask = true
+        }
 
-  func assertDefaultPeopleProperties(_ properties: InternalProperties) {
-    XCTAssertNotNil(properties["$ios_device_model"], "missing $ios_device_model property")
-    XCTAssertNotNil(properties["$ios_lib_version"], "missing $ios_lib_version property")
-    XCTAssertNotNil(properties["$ios_version"], "missing $ios_version property")
-    XCTAssertNotNil(properties["$ios_app_version"], "missing $ios_app_version property")
-    XCTAssertNotNil(properties["$ios_app_release"], "missing $ios_app_release property")
-  }
+        let loopUntil = Date(timeIntervalSinceNow: 10)
+        while !hasCompletedTask && loopUntil.timeIntervalSinceNow > 0 {
+            RunLoop.current.run(mode: RunLoop.Mode.default, before: loopUntil)
+        }
+    }
 
-  func compareDate(dateString: String, dateDate: Date) {
-    let dateFormatter: ISO8601DateFormatter = ISO8601DateFormatter()
-    let date = dateFormatter.string(from: dateDate)
-    XCTAssertEqual(String(date.prefix(19)), String(dateString.prefix(19)))
-  }
+    func eventQueue(token: String) -> Queue {
+        return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(type: .events)
+    }
 
-  func allPropertyTypes() -> Properties {
-    let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss zzz"
-    let date = dateFormatter.date(from: "2012-09-28 19:14:36 PDT")
-    let nested = ["p1": ["p2": ["p3": ["bottom"]]]]
-    let opt: String? = nil
-    return [
-      "string": "yello",
-      "number": 3,
-      "date": date!,
-      "dictionary": ["k": "v", "opt": opt as Any],
-      "array": ["1", opt as Any],
-      "null": NSNull(),
-      "nested": nested,
-      "url": URL(string: "https://mixpanel.com/")!,
-      "float": 1.3,
-      "optional": opt,
-    ]
-  }
+    func peopleQueue(token: String) -> Queue {
+        return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(type: .people)
+    }
+
+    func unIdentifiedPeopleQueue(token: String) -> Queue {
+        return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(
+            type: .people, flag: PersistenceConstant.unIdentifiedFlag)
+    }
+
+    func groupQueue(token: String) -> Queue {
+        return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(type: .groups)
+    }
+
+    func flushAndWaitForTrackingQueue(_ mixpanel: MixpanelInstance) {
+        mixpanel.flush()
+        waitForTrackingQueue(mixpanel)
+        mixpanel.flush()
+        waitForTrackingQueue(mixpanel)
+    }
+
+    func assertDefaultPeopleProperties(_ properties: InternalProperties) {
+        XCTAssertNotNil(properties["$ios_device_model"], "missing $ios_device_model property")
+        XCTAssertNotNil(properties["$ios_lib_version"], "missing $ios_lib_version property")
+        XCTAssertNotNil(properties["$ios_version"], "missing $ios_version property")
+        XCTAssertNotNil(properties["$ios_app_version"], "missing $ios_app_version property")
+        XCTAssertNotNil(properties["$ios_app_release"], "missing $ios_app_release property")
+    }
+
+    func compareDate(dateString: String, dateDate: Date) {
+        let dateFormatter: ISO8601DateFormatter = ISO8601DateFormatter()
+        let date = dateFormatter.string(from: dateDate)
+        XCTAssertEqual(String(date.prefix(19)), String(dateString.prefix(19)))
+    }
+
+    func allPropertyTypes() -> Properties {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss zzz"
+        let date = dateFormatter.date(from: "2012-09-28 19:14:36 PDT")
+        let nested = ["p1": ["p2": ["p3": ["bottom"]]]]
+        let opt: String? = nil
+        return [
+            "string": "yello",
+            "number": 3,
+            "date": date!,
+            "dictionary": ["k": "v", "opt": opt as Any],
+            "array": ["1", opt as Any],
+            "null": NSNull(),
+            "nested": nested,
+            "url": URL(string: "https://mixpanel.com/")!,
+            "float": 1.3,
+            "optional": opt,
+        ]
+    }
 
 }

--- a/MixpanelDemo/MixpanelDemoMacTests/MixpanelDemoTests.swift
+++ b/MixpanelDemo/MixpanelDemoMacTests/MixpanelDemoTests.swift
@@ -14,1071 +14,1071 @@ import XCTest
 private let devicePrefix = "$device:"
 class MixpanelDemoTests: MixpanelBaseTests {
 
-  func test5XXResponse() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.serverURL = kFakeServerUrl
-    testMixpanel.track(event: "Fake Event")
-    flushAndWaitForTrackingQueue(testMixpanel)
-    // Failure count should be 3
-    let waitTime =
-      testMixpanel.flushInstance.flushRequest.networkRequestsAllowedAfterTime
-      - Date().timeIntervalSince1970
-    print("Delta wait time is \(waitTime)")
-    XCTAssert(waitTime >= 110, "Network backoff time is less than 2 minutes.")
-    XCTAssert(
-      testMixpanel.flushInstance.flushRequest.networkConsecutiveFailures == 2,
-      "Network failures did not equal 2")
+    func test5XXResponse() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.serverURL = kFakeServerUrl
+        testMixpanel.track(event: "Fake Event")
+        flushAndWaitForTrackingQueue(testMixpanel)
+        // Failure count should be 3
+        let waitTime =
+            testMixpanel.flushInstance.flushRequest.networkRequestsAllowedAfterTime
+            - Date().timeIntervalSince1970
+        print("Delta wait time is \(waitTime)")
+        XCTAssert(waitTime >= 110, "Network backoff time is less than 2 minutes.")
+        XCTAssert(
+            testMixpanel.flushInstance.flushRequest.networkConsecutiveFailures == 2,
+            "Network failures did not equal 2")
 
-    XCTAssert(
-      eventQueue(token: testMixpanel.apiToken).count == 1,
-      "Removed an event from the queue that was not sent")
-    removeDBfile(testMixpanel)
-  }
-
-  func testFlushEvents() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    for i in 0..<50 {
-      testMixpanel.track(event: "event \(i)")
+        XCTAssert(
+            eventQueue(token: testMixpanel.apiToken).count == 1,
+            "Removed an event from the queue that was not sent")
+        removeDBfile(testMixpanel)
     }
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).isEmpty,
-      "events should have been flushed")
 
-    for i in 0..<60 {
-      testMixpanel.track(event: "event \(i)")
-    }
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).isEmpty,
-      "events should have been flushed")
-    removeDBfile(testMixpanel)
-  }
-
-  func testFlushPeople() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    for i in 0..<50 {
-      testMixpanel.people.set(property: "p1", to: "\(i)")
-    }
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel.apiToken).isEmpty, "people should have been flushed")
-    for i in 0..<60 {
-      testMixpanel.people.set(property: "p1", to: "\(i)")
-    }
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel.apiToken).isEmpty, "people should have been flushed")
-    removeDBfile(testMixpanel)
-  }
-
-  func testFlushGroups() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    let groupKey = "test_key"
-    let groupValue = "test_value"
-    for i in 0..<50 {
-      testMixpanel.getGroup(groupKey: groupKey, groupID: groupValue).set(property: "p1", to: "\(i)")
-    }
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      groupQueue(token: testMixpanel.apiToken).isEmpty, "groups should have been flushed")
-    for i in 0..<60 {
-      testMixpanel.getGroup(groupKey: groupKey, groupID: groupValue).set(property: "p1", to: "\(i)")
-    }
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel.apiToken).isEmpty, "groups should have been flushed")
-    removeDBfile(testMixpanel)
-  }
-
-  func testFlushNetworkFailure() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.serverURL = kFakeServerUrl
-    for i in 0..<50 {
-      testMixpanel.track(event: "event \(UInt(i))")
-    }
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 50, "50 events should be queued up")
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 50,
-      "events should still be in the queue if flush fails")
-    removeDBfile(testMixpanel)
-  }
-
-  func testFlushQueueContainsCorruptedEvent() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.trackingQueue.async {
-      testMixpanel.mixpanelPersistence.saveEntity(
-        ["event": "bad event1", "properties": ["BadProp": Double.nan]], type: .events)
-      testMixpanel.mixpanelPersistence.saveEntity(
-        ["event": "bad event2", "properties": ["BadProp": Float.nan]], type: .events)
-      testMixpanel.mixpanelPersistence.saveEntity(
-        ["event": "bad event3", "properties": ["BadProp": Double.infinity]], type: .events)
-      testMixpanel.mixpanelPersistence.saveEntity(
-        ["event": "bad event4", "properties": ["BadProp": Float.infinity]], type: .events)
-    }
-    for i in 0..<10 {
-      testMixpanel.track(event: "event \(UInt(i))")
-    }
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 0, "good events should still be flushed")
-    removeDBfile(testMixpanel)
-  }
-
-  func testAddEventContainsInvalidJsonObjectDoubleNaN() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.track(event: "bad event", properties: ["BadProp": Double.nan])
-    }
-    removeDBfile(testMixpanel)
-  }
-
-  func testAddEventContainsInvalidJsonObjectFloatNaN() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.track(event: "bad event", properties: ["BadProp": Float.nan])
-    }
-    removeDBfile(testMixpanel)
-  }
-
-  func testAddEventContainsInvalidJsonObjectDoubleInfinity() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.track(event: "bad event", properties: ["BadProp": Double.infinity])
-    }
-    removeDBfile(testMixpanel)
-  }
-
-  func testAddEventContainsInvalidJsonObjectFloatInfinity() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.track(event: "bad event", properties: ["BadProp": Float.infinity])
-    }
-    removeDBfile(testMixpanel)
-  }
-
-  func testAddingEventsAfterFlush() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    for i in 0..<10 {
-      testMixpanel.track(event: "event \(UInt(i))")
-    }
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 10, "10 events should be queued up")
-    flushAndWaitForTrackingQueue(testMixpanel)
-    for i in 0..<5 {
-      testMixpanel.track(event: "event \(UInt(i))")
-    }
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 5, "5 more events should be queued up")
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).isEmpty, "events should have been flushed")
-    removeDBfile(testMixpanel)
-  }
-
-  func testIdentify() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    for _ in 0..<2 {
-      // run this twice to test reset works correctly wrt to distinct ids
-      let distinctId: String = "d1"
-      // try this for ODIN and nil
-      #if MIXPANEL_UNIQUE_DISTINCT_ID
-        XCTAssertEqual(
-          testMixpanel.distinctId,
-          devicePrefix + testMixpanel.defaultDeviceId(),
-          "mixpanel identify failed to set default distinct id")
-        XCTAssertEqual(
-          testMixpanel.anonymousId,
-          testMixpanel.defaultDeviceId(),
-          "mixpanel failed to set default anonymous id")
-      #endif
-      XCTAssertNil(
-        testMixpanel.people.distinctId,
-        "mixpanel people distinct id should default to nil")
-      XCTAssertNil(
-        testMixpanel.people.distinctId,
-        "mixpanel user id should default to nil")
-      testMixpanel.track(event: "e1")
-      waitForTrackingQueue(testMixpanel)
-      let eventsQueue = eventQueue(token: testMixpanel.apiToken)
-      XCTAssertTrue(
-        eventsQueue.count == 1,
-        "events should be sent right away with default distinct id")
-      #if MIXPANEL_UNIQUE_DISTINCT_ID
-        XCTAssertEqual(
-          (eventsQueue.last?["properties"] as? InternalProperties)?["distinct_id"] as? String,
-          devicePrefix + mixpanel.defaultDeviceId(),
-          "events should use default distinct id if none set")
-      #endif
-      XCTAssertEqual(
-        (eventsQueue.last?["properties"] as? InternalProperties)?["$lib_version"] as? String,
-        AutomaticProperties.libVersion(),
-        "events should has lib version in internal properties")
-      testMixpanel.people.set(property: "p1", to: "a")
-      waitForTrackingQueue(testMixpanel)
-      var peopleQueue_value = peopleQueue(token: testMixpanel.apiToken)
-      var unidentifiedQueue = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)
-      XCTAssertTrue(
-        peopleQueue_value.isEmpty,
-        "people records should go to unidentified queue before identify:")
-      XCTAssertTrue(
-        unidentifiedQueue.count == 1,
-        "unidentified people records not queued")
-      XCTAssertEqual(
-        unidentifiedQueue.last?["$token"] as? String,
-        testMixpanel.apiToken,
-        "incorrect project token in people record")
-      testMixpanel.identify(distinctId: distinctId)
-      waitForTrackingQueue(testMixpanel)
-      let anonymousId = testMixpanel.anonymousId
-      peopleQueue_value = peopleQueue(token: testMixpanel.apiToken)
-      unidentifiedQueue = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)
-      XCTAssertEqual(
-        testMixpanel.distinctId, distinctId,
-        "mixpanel identify failed to set distinct id")
-      XCTAssertEqual(
-        testMixpanel.userId, distinctId,
-        "mixpanel identify failed to set user id")
-      XCTAssertEqual(
-        testMixpanel.anonymousId, anonymousId,
-        "mixpanel identify shouldn't change anonymousId")
-      XCTAssertEqual(
-        testMixpanel.people.distinctId, distinctId,
-        "mixpanel identify failed to set people distinct id")
-      XCTAssertTrue(
-        unidentifiedQueue.isEmpty,
-        "identify: should move records from unidentified queue")
-      XCTAssertTrue(
-        peopleQueue_value.count > 0,
-        "identify: should move records to main people queue")
-      XCTAssertEqual(
-        peopleQueue_value.last?["$token"] as? String,
-        testMixpanel.apiToken, "incorrect project token in people record")
-      let p: InternalProperties = peopleQueue_value.last?["$set"] as! InternalProperties
-      XCTAssertEqual(p["p1"] as? String, "a", "custom people property not queued")
-      assertDefaultPeopleProperties(p)
-      peopleQueue_value = peopleQueue(token: testMixpanel.apiToken)
-
-      testMixpanel.people.set(property: "p1", to: "a")
-      waitForTrackingQueue(testMixpanel)
-
-      peopleQueue_value = peopleQueue(token: testMixpanel.apiToken)
-      unidentifiedQueue = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)
-      XCTAssertEqual(
-        peopleQueue_value.last?["$distinct_id"] as? String,
-        distinctId, "distinct id not set properly on unidentified people record")
-      XCTAssertTrue(
-        unidentifiedQueue.isEmpty,
-        "once idenitfy: is called, unidentified queue should be skipped")
-      XCTAssertTrue(
-        peopleQueue_value.count > 0,
-        "once identify: is called, records should go straight to main queue")
-      testMixpanel.track(event: "e2")
-      waitForTrackingQueue(testMixpanel)
-      let newDistinctId =
-        (eventQueue(token: testMixpanel.apiToken).last?["properties"] as? InternalProperties)?[
-          "distinct_id"] as? String
-      XCTAssertEqual(
-        newDistinctId, distinctId,
-        "events should use new distinct id after identify:")
-      testMixpanel.reset()
-      waitForTrackingQueue(testMixpanel)
-    }
-    removeDBfile(testMixpanel)
-  }
-
-  func testIdentifyTrack() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let distinctIdBeforeIdentify: String? = testMixpanel.distinctId
-    let distinctId = "testIdentifyTrack"
-
-    testMixpanel.identify(distinctId: distinctId)
-    waitForTrackingQueue(testMixpanel)
-    let e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(e["event"] as? String, "$identify", "incorrect event name")
-    let p: InternalProperties = e["properties"] as! InternalProperties
-    XCTAssertEqual(p["distinct_id"] as? String, distinctId, "wrong distinct_id")
-    XCTAssertEqual(
-      p["$anon_distinct_id"] as? String, distinctIdBeforeIdentify, "wrong $anon_distinct_id")
-    removeDBfile(testMixpanel)
-  }
-
-  func testIdentifyResetTrack() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let originalDistinctId: String? = testMixpanel.distinctId
-    let distinctId = "testIdentifyTrack"
-    testMixpanel.reset()
-    waitForTrackingQueue(testMixpanel)
-
-    for i in 1...3 {
-      let prevDistinctId: String? = testMixpanel.distinctId
-      let newDistinctId = distinctId + String(i)
-      testMixpanel.identify(distinctId: newDistinctId)
-      waitForTrackingQueue(testMixpanel)
-      waitForTrackingQueue(testMixpanel)
-      let e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
-      XCTAssertEqual(e["event"] as? String, "$identify", "incorrect event name")
-      let p: InternalProperties = e["properties"] as! InternalProperties
-      XCTAssertEqual(p["distinct_id"] as? String, newDistinctId, "wrong distinct_id")
-      XCTAssertEqual(p["$anon_distinct_id"] as? String, prevDistinctId, "wrong $anon_distinct_id")
-      XCTAssertNotEqual(
-        prevDistinctId, originalDistinctId, "After reset, UUID will be used - never the same")
-      #if MIXPANEL_UNIQUE_DISTINCT_ID
-        XCTAssertEqual(
-          prevDistinctId, originalDistinctId, "After reset, IFV will be used - always the same")
-      #endif
-      testMixpanel.reset()
-      waitForTrackingQueue(testMixpanel)
-    }
-    removeDBfile(testMixpanel)
-  }
-
-  func testPersistentIdentity() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let distinctId: String = "d1"
-    let alias: String = "a1"
-    testMixpanel.identify(distinctId: distinctId)
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.createAlias(alias, distinctId: testMixpanel.distinctId)
-    waitForTrackingQueue(testMixpanel)
-    var mixpanelIdentity = MixpanelPersistence.loadIdentity(instanceName: testMixpanel.apiToken)
-    XCTAssertTrue(
-      distinctId == mixpanelIdentity.distinctID && distinctId == mixpanelIdentity.peopleDistinctID
-        && distinctId == mixpanelIdentity.userId && alias == mixpanelIdentity.alias)
-    testMixpanel.archive()
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.unarchive()
-    waitForTrackingQueue(testMixpanel)
-    mixpanelIdentity = MixpanelPersistence.loadIdentity(instanceName: testMixpanel.apiToken)
-    XCTAssertTrue(
-      testMixpanel.distinctId == mixpanelIdentity.distinctID
-        && testMixpanel.people.distinctId == mixpanelIdentity.peopleDistinctID
-        && testMixpanel.anonymousId == mixpanelIdentity.anonymousId
-        && testMixpanel.userId == mixpanelIdentity.userId
-        && testMixpanel.alias == mixpanelIdentity.alias)
-    MixpanelPersistence.deleteMPUserDefaultsData(instanceName: testMixpanel.apiToken)
-    waitForTrackingQueue(testMixpanel)
-    mixpanelIdentity = MixpanelPersistence.loadIdentity(instanceName: testMixpanel.apiToken)
-    XCTAssertTrue(
-      "" == mixpanelIdentity.distinctID && nil == mixpanelIdentity.peopleDistinctID
-        && nil == mixpanelIdentity.anonymousId && nil == mixpanelIdentity.userId
-        && nil == mixpanelIdentity.alias)
-    removeDBfile(testMixpanel)
-  }
-
-  func testHadPersistedDistinctId() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    XCTAssertNotNil(testMixpanel.distinctId)
-    let distinctId: String = "d1"
-    testMixpanel.anonymousId = nil
-    testMixpanel.userId = nil
-    testMixpanel.alias = nil
-    testMixpanel.distinctId = distinctId
-    testMixpanel.archive()
-
-    XCTAssertEqual(testMixpanel.distinctId, distinctId)
-
-    let userId: String = "u1"
-    testMixpanel.identify(distinctId: userId)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(testMixpanel.anonymousId, distinctId)
-    XCTAssertEqual(testMixpanel.userId, userId)
-    XCTAssertEqual(testMixpanel.distinctId, userId)
-    XCTAssertTrue(testMixpanel.hadPersistedDistinctId!)
-    removeDBfile(testMixpanel)
-  }
-
-  func testTrackWithDefaultProperties() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.track(event: "Something Happened")
-    waitForTrackingQueue(testMixpanel)
-    let e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(e["event"] as? String, "Something Happened", "incorrect event name")
-    let p: InternalProperties = e["properties"] as! InternalProperties
-    XCTAssertNotNil(p["$app_build_number"], "$app_build_number not set")
-    XCTAssertNotNil(p["$app_version_string"], "$app_version_string not set")
-    XCTAssertNotNil(p["$lib_version"], "$lib_version not set")
-    XCTAssertNotNil(p["$model"], "$model not set")
-    XCTAssertNotNil(p["$os"], "$os not set")
-    XCTAssertNotNil(p["$os_version"], "$os_version not set")
-    XCTAssertNotNil(p["$screen_height"], "$screen_height not set")
-    XCTAssertNotNil(p["$screen_width"], "$screen_width not set")
-    XCTAssertNotNil(p["distinct_id"], "distinct_id not set")
-    XCTAssertNotNil(p["time"], "time not set")
-    XCTAssertEqual(p["$manufacturer"] as? String, "Apple", "incorrect $manufacturer")
-    XCTAssertEqual(p["mp_lib"] as? String, "swift", "incorrect mp_lib")
-    XCTAssertEqual(p["token"] as? String, testMixpanel.apiToken, "incorrect token")
-    removeDBfile(testMixpanel)
-  }
-
-  func testTrackWithCustomProperties() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let now = Date()
-    let p: Properties = [
-      "string": "yello",
-      "number": 3,
-      "date": now,
-      "$app_version": "override",
-    ]
-    testMixpanel.track(event: "Something Happened", properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let props: InternalProperties =
-      eventQueue(token: testMixpanel.apiToken).last?["properties"] as! InternalProperties
-    XCTAssertEqual(props["string"] as? String, "yello")
-    XCTAssertEqual(props["number"] as? Int, 3)
-    let dateValue = props["date"] as! String
-    compareDate(dateString: dateValue, dateDate: now)
-    XCTAssertEqual(
-      props["$app_version"] as? String, "override",
-      "reserved property override failed")
-    removeDBfile(testMixpanel)
-  }
-
-  func testTrackWithOptionalProperties() {
-    let optNil: Double? = nil
-    let optDouble: Double? = 1.0
-    let optArray: [Double?] = [nil, 1.0, 2.0]
-    let optDict: [String: Double?] = ["nil": nil, "double": 1.0]
-    let nested: [String: Any] = ["list": optArray, "dict": optDict]
-    let p: Properties = [
-      "nil": optNil,
-      "double": optDouble,
-      "list": optArray,
-      "dict": optDict,
-      "nested": nested,
-    ]
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.track(event: "Optional Test", properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let props: InternalProperties =
-      eventQueue(token: testMixpanel.apiToken).last?["properties"] as! InternalProperties
-    XCTAssertNil(props["nil"] as? Double)
-    XCTAssertEqual(props["double"] as? Double, 1.0)
-    XCTAssertEqual(props["list"] as? Array, [1.0, 2.0])
-    XCTAssertEqual(props["dict"] as? Dictionary, ["nil": nil, "double": 1.0])
-    let nestedProp = props["nested"] as? [String: Any]
-    XCTAssertEqual(nestedProp?["dict"] as? Dictionary, ["nil": nil, "double": 1.0])
-    XCTAssertEqual(nestedProp?["list"] as? Array, [1.0, 2.0])
-    removeDBfile(testMixpanel)
-  }
-
-  func testTrackWithCustomDistinctIdAndToken() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let p: Properties = ["token": "t1", "distinct_id": "d1"]
-    testMixpanel.track(event: "e1", properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let trackToken =
-      (eventQueue(token: testMixpanel.apiToken).last?["properties"] as? InternalProperties)?[
-        "token"] as? String
-    let trackDistinctId =
-      (eventQueue(token: testMixpanel.apiToken).last?["properties"] as? InternalProperties)?[
-        "distinct_id"] as? String
-    XCTAssertEqual(trackToken, "t1", "user-defined distinct id not used in track.")
-    XCTAssertEqual(trackDistinctId, "d1", "user-defined distinct id not used in track.")
-    removeDBfile(testMixpanel)
-  }
-
-  func testTrackWithGroups() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    testMixpanel.trackWithGroups(
-      event: "Something Happened", properties: [groupKey: "some other value", "p1": "value"],
-      groups: [groupKey: groupID])
-    waitForTrackingQueue(testMixpanel)
-    let e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(e["event"] as? String, "Something Happened", "incorrect event name")
-    let p: InternalProperties = e["properties"] as! InternalProperties
-    XCTAssertNotNil(p["$app_build_number"], "$app_build_number not set")
-    XCTAssertNotNil(p["$app_version_string"], "$app_version_string not set")
-    XCTAssertNotNil(p["$lib_version"], "$lib_version not set")
-    XCTAssertNotNil(p["$model"], "$model not set")
-    XCTAssertNotNil(p["$os"], "$os not set")
-    XCTAssertNotNil(p["$os_version"], "$os_version not set")
-    XCTAssertNotNil(p["$screen_height"], "$screen_height not set")
-    XCTAssertNotNil(p["$screen_width"], "$screen_width not set")
-    XCTAssertNotNil(p["distinct_id"], "distinct_id not set")
-    XCTAssertNotNil(p["time"], "time not set")
-    XCTAssertEqual(p["$manufacturer"] as? String, "Apple", "incorrect $manufacturer")
-    XCTAssertEqual(p["mp_lib"] as? String, "swift", "incorrect mp_lib")
-    XCTAssertEqual(p["token"] as? String, testMixpanel.apiToken, "incorrect token")
-    XCTAssertEqual(p[groupKey] as? String, groupID, "incorrect group id")
-    XCTAssertEqual(p["p1"] as? String, "value", "incorrect group value")
-    removeDBfile(testMixpanel)
-  }
-
-  func testRegisterSuperProperties() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    var p: Properties = ["p1": "a", "p2": 3, "p3": Date()]
-    testMixpanel.registerSuperProperties(p)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(
-      NSDictionary(dictionary: testMixpanel.currentSuperProperties()),
-      NSDictionary(dictionary: p),
-      "register super properties failed")
-    p = ["p1": "b"]
-    testMixpanel.registerSuperProperties(p)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(
-      testMixpanel.currentSuperProperties()["p1"] as? String, "b",
-      "register super properties failed to overwrite existing value")
-    p = ["p4": "a"]
-    testMixpanel.registerSuperPropertiesOnce(p)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(
-      testMixpanel.currentSuperProperties()["p4"] as? String, "a",
-      "register super properties once failed first time")
-    p = ["p4": "b"]
-    testMixpanel.registerSuperPropertiesOnce(p)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(
-      testMixpanel.currentSuperProperties()["p4"] as? String, "a",
-      "register super properties once failed second time")
-    p = ["p4": "c"]
-    testMixpanel.registerSuperPropertiesOnce(p, defaultValue: "d")
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(
-      testMixpanel.currentSuperProperties()["p4"] as? String, "a",
-      "register super properties once with default value failed when no match")
-    testMixpanel.registerSuperPropertiesOnce(p, defaultValue: "a")
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(
-      testMixpanel.currentSuperProperties()["p4"] as? String, "c",
-      "register super properties once with default value failed when match")
-    testMixpanel.unregisterSuperProperty("a")
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertNil(
-      testMixpanel.currentSuperProperties()["a"],
-      "unregister super property failed")
-    // unregister non-existent super property should not throw
-    testMixpanel.unregisterSuperProperty("a")
-    testMixpanel.clearSuperProperties()
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      testMixpanel.currentSuperProperties().isEmpty,
-      "clear super properties failed")
-    removeDBfile(testMixpanel)
-  }
-
-  func testInvalidPropertiesTrack() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let p: Properties = ["data": [Data()]]
-    XCTExpectAssert("property type should not be allowed") {
-      testMixpanel.track(event: "e1", properties: p)
-    }
-    removeDBfile(testMixpanel)
-  }
-
-  func testInvalidSuperProperties() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let p: Properties = ["data": [Data()]]
-    XCTExpectAssert("property type should not be allowed") {
-      testMixpanel.registerSuperProperties(p)
-    }
-    removeDBfile(testMixpanel)
-  }
-
-  func testInvalidSuperProperties2() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let p: Properties = ["data": [Data()]]
-    XCTExpectAssert("property type should not be allowed") {
-      testMixpanel.registerSuperPropertiesOnce(p)
-    }
-    removeDBfile(testMixpanel)
-  }
-
-  func testInvalidSuperProperties3() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let p: Properties = ["data": [Data()]]
-    XCTExpectAssert("property type should not be allowed") {
-      testMixpanel.registerSuperPropertiesOnce(p, defaultValue: "v")
-    }
-    removeDBfile(testMixpanel)
-  }
-
-  func testValidPropertiesTrack() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let p: Properties = allPropertyTypes()
-    testMixpanel.track(event: "e1", properties: p)
-    removeDBfile(testMixpanel)
-  }
-
-  func testValidSuperProperties() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let p: Properties = allPropertyTypes()
-    testMixpanel.registerSuperProperties(p)
-    testMixpanel.registerSuperPropertiesOnce(p)
-    testMixpanel.registerSuperPropertiesOnce(p, defaultValue: "v")
-    removeDBfile(testMixpanel)
-  }
-
-  func testReset() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.track(event: "e1")
-    waitForTrackingQueue(testMixpanel)
-    let p: Properties = ["p1": "a"]
-    testMixpanel.registerSuperProperties(p)
-    testMixpanel.people.set(properties: p)
-    testMixpanel.archive()
-    testMixpanel.reset()
-    waitForTrackingQueue(testMixpanel)
-    #if MIXPANEL_UNIQUE_DISTINCT_ID
-      XCTAssertEqual(
-        testMixpanel.distinctId,
-        devicePrefix + testMixpanel.defaultDeviceId(),
-        "distinct id failed to reset")
-    #endif
-    XCTAssertNil(testMixpanel.people.distinctId, "people distinct id failed to reset")
-    XCTAssertTrue(
-      testMixpanel.currentSuperProperties().isEmpty,
-      "super properties failed to reset")
-    XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).isEmpty, "events queue failed to reset")
-    XCTAssertTrue(peopleQueue(token: testMixpanel.apiToken).isEmpty, "people queue failed to reset")
-    let testMixpanel2 = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    waitForTrackingQueue(testMixpanel2)
-    #if MIXPANEL_UNIQUE_DISTINCT_ID
-      XCTAssertEqual(
-        testMixpanel2.distinctId, devicePrefix + testMixpanel2.defaultDeviceId(),
-        "distinct id failed to reset after archive")
-    #endif
-    XCTAssertNil(
-      testMixpanel2.people.distinctId,
-      "people distinct id failed to reset after archive")
-    XCTAssertTrue(
-      testMixpanel2.currentSuperProperties().isEmpty,
-      "super properties failed to reset after archive")
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel2.apiToken).isEmpty,
-      "events queue failed to reset after archive")
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel2.apiToken).isEmpty,
-      "people queue failed to reset after archive")
-    removeDBfile(testMixpanel)
-    removeDBfile(testMixpanel2)
-  }
-
-  func testArchiveNSNumberBoolIntProperty() {
-    let testToken = randomId()
-    let testMixpanel = Mixpanel.initialize(token: testToken, flushInterval: 60)
-    testMixpanel.serverURL = kFakeServerUrl
-    let aBoolNumber: Bool = true
-    let aBoolNSNumber = NSNumber(value: aBoolNumber)
-
-    let aIntNumber: Int = 1
-    let aIntNSNumber = NSNumber(value: aIntNumber)
-
-    testMixpanel.track(event: "e1", properties: ["p1": aBoolNSNumber, "p2": aIntNSNumber])
-    testMixpanel.archive()
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.mixpanelPersistence.closeDB()
-    let testMixpanel2 = Mixpanel.initialize(token: testToken, flushInterval: 60)
-    testMixpanel2.serverURL = kFakeServerUrl
-    waitForTrackingQueue(testMixpanel2)
-    let properties: [String: Any] =
-      eventQueue(token: testMixpanel2.apiToken)[0]["properties"] as! [String: Any]
-
-    XCTAssertTrue(
-      isBoolNumber(num: properties["p1"]! as! NSNumber),
-      "The bool value should be unarchived as bool")
-    XCTAssertFalse(
-      isBoolNumber(num: properties["p2"]! as! NSNumber),
-      "The int value should not be unarchived as bool")
-    removeDBfile(testMixpanel2)
-  }
-
-  private func isBoolNumber(num: NSNumber) -> Bool {
-    let boolID = CFBooleanGetTypeID()  // the type ID of CFBoolean
-    let numID = CFGetTypeID(num)  // the type ID of num
-    return numID == boolID
-  }
-
-  func testArchive() {
-    let testToken = randomId()
-    let testMixpanel = Mixpanel.initialize(token: testToken, flushInterval: 60)
-    testMixpanel.serverURL = kFakeServerUrl
-    #if MIXPANEL_UNIQUE_DISTINCT_ID
-      XCTAssertEqual(
-        testMixpanel.distinctId, devicePrefix + testMixpanel.defaultDeviceId(),
-        "default distinct id archive failed")
-    #endif
-    XCTAssertTrue(
-      testMixpanel.currentSuperProperties().isEmpty,
-      "default super properties archive failed")
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).isEmpty, "default events queue archive failed")
-    XCTAssertNil(testMixpanel.people.distinctId, "default people distinct id archive failed")
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel.apiToken).isEmpty, "default people queue archive failed")
-    let p: Properties = ["p1": "a"]
-    testMixpanel.identify(distinctId: "d1")
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.registerSuperProperties(p)
-    testMixpanel.track(event: "e1")
-    testMixpanel.track(event: "e2")
-    testMixpanel.track(event: "e3")
-    testMixpanel.track(event: "e4")
-    testMixpanel.track(event: "e5")
-    testMixpanel.track(event: "e6")
-    testMixpanel.track(event: "e7")
-    testMixpanel.track(event: "e8")
-    testMixpanel.track(event: "e9")
-    testMixpanel.people.set(properties: p)
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.timedEvents["e2"] = 5
-    testMixpanel.archive()
-    testMixpanel.mixpanelPersistence.closeDB()
-    let testMixpanel2 = Mixpanel.initialize(token: testToken, flushInterval: 60)
-    testMixpanel2.serverURL = kFakeServerUrl
-    waitForTrackingQueue(testMixpanel2)
-    XCTAssertEqual(testMixpanel2.distinctId, "d1", "custom distinct archive failed")
-    XCTAssertTrue(
-      testMixpanel2.currentSuperProperties().count == 1,
-      "custom super properties archive failed")
-    let eventQueueValue = eventQueue(token: testMixpanel2.apiToken)
-
-    XCTAssertEqual(
-      eventQueueValue[1]["event"] as? String, "e1",
-      "event was not successfully archived/unarchived")
-    XCTAssertEqual(
-      eventQueueValue[2]["event"] as? String, "e2",
-      "event was not successfully archived/unarchived or order is incorrect")
-    XCTAssertEqual(
-      eventQueueValue[3]["event"] as? String, "e3",
-      "event was not successfully archived/unarchived or order is incorrect")
-    XCTAssertEqual(
-      eventQueueValue[4]["event"] as? String, "e4",
-      "event was not successfully archived/unarchived or order is incorrect")
-    XCTAssertEqual(
-      eventQueueValue[5]["event"] as? String, "e5",
-      "event was not successfully archived/unarchived or order is incorrect")
-    XCTAssertEqual(
-      eventQueueValue[6]["event"] as? String, "e6",
-      "event was not successfully archived/unarchived or order is incorrect")
-    XCTAssertEqual(
-      eventQueueValue[7]["event"] as? String, "e7",
-      "event was not successfully archived/unarchived or order is incorrect")
-    XCTAssertEqual(
-      eventQueueValue[8]["event"] as? String, "e8",
-      "event was not successfully archived/unarchived or order is incorrect")
-    XCTAssertEqual(
-      eventQueueValue[9]["event"] as? String, "e9",
-      "event was not successfully archived/unarchived or order is incorrect")
-    XCTAssertEqual(
-      testMixpanel2.people.distinctId, "d1",
-      "custom people distinct id archive failed")
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel2.apiToken).count == 1, "pending people queue archive failed")
-    XCTAssertEqual(
-      testMixpanel2.timedEvents["e2"] as? Int, 5,
-      "timedEvents archive failed")
-    testMixpanel2.mixpanelPersistence.closeDB()
-    let testMixpanel3 = Mixpanel.initialize(token: testToken, flushInterval: 60)
-    testMixpanel3.serverURL = kFakeServerUrl
-    XCTAssertEqual(testMixpanel3.distinctId, "d1", "expecting d1 as distinct id as initialised")
-    XCTAssertTrue(
-      testMixpanel3.currentSuperProperties().count == 1,
-      "default super properties expected to have 1 item")
-    XCTAssertNotNil(eventQueue(token: testMixpanel3.apiToken), "default events queue is nil")
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel3.apiToken).count == 10,
-      "default events queue expecting 10 items ($identify call added)")
-    XCTAssertNotNil(
-      testMixpanel3.people.distinctId,
-      "default people distinct id from no file failed")
-    XCTAssertNotNil(
-      peopleQueue(token: testMixpanel3.apiToken), "default people queue from no file is nil")
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel3.apiToken).count == 1, "default people queue expecting 1 item"
-    )
-    XCTAssertTrue(testMixpanel3.timedEvents.count == 1, "timedEvents expecting 1 item")
-    testMixpanel3.mixpanelPersistence.closeDB()
-    removeDBfile(testMixpanel)
-  }
-
-  func testMixpanelDelegate() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.delegate = self
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.track(event: "e1")
-    testMixpanel.people.set(property: "p1", to: "a")
-    waitForTrackingQueue(testMixpanel)
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 2, "delegate should have stopped flush")
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel.apiToken).count == 1, "delegate should have stopped flush")
-    removeDBfile(testMixpanel)
-  }
-
-  func testEventTiming() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.track(event: "Something Happened")
-    waitForTrackingQueue(testMixpanel)
-    var e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
-    var p = e["properties"] as! InternalProperties
-    XCTAssertNil(p["$duration"], "New events should not be timed.")
-    testMixpanel.time(event: "400 Meters")
-    testMixpanel.track(event: "500 Meters")
-    waitForTrackingQueue(testMixpanel)
-    e = eventQueue(token: testMixpanel.apiToken).last!
-    p = e["properties"] as! InternalProperties
-    XCTAssertNil(p["$duration"], "The exact same event name is required for timing.")
-    testMixpanel.track(event: "400 Meters")
-    waitForTrackingQueue(testMixpanel)
-    e = eventQueue(token: testMixpanel.apiToken).last!
-    p = e["properties"] as! InternalProperties
-    XCTAssertNotNil(p["$duration"], "This event should be timed.")
-    testMixpanel.track(event: "400 Meters")
-    waitForTrackingQueue(testMixpanel)
-    e = eventQueue(token: testMixpanel.apiToken).last!
-    p = e["properties"] as! InternalProperties
-    XCTAssertNil(
-      p["$duration"],
-      "Tracking the same event should require a second call to timeEvent.")
-    testMixpanel.time(event: "Time Event A")
-    testMixpanel.time(event: "Time Event B")
-    testMixpanel.time(event: "Time Event C")
-    waitForTrackingQueue(testMixpanel)
-    var testTimedEvents = MixpanelPersistence.loadTimedEvents(instanceName: testMixpanel.apiToken)
-    XCTAssertTrue(
-      testTimedEvents.count == 3, "Each call to time() should add an event to timedEvents")
-    XCTAssertNotNil(testTimedEvents["Time Event A"], "Keys in timedEvents should be event names")
-    testMixpanel.clearTimedEvent(event: "Time Event A")
-    waitForTrackingQueue(testMixpanel)
-    testTimedEvents = MixpanelPersistence.loadTimedEvents(instanceName: testMixpanel.apiToken)
-    XCTAssertNil(testTimedEvents["Time Event A"], "clearTimedEvent should remove key/value pair")
-    XCTAssertTrue(
-      testTimedEvents.count == 2, "clearTimedEvent shoud remove only one key/value pair")
-    testMixpanel.clearTimedEvents()
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      MixpanelPersistence.loadTimedEvents(instanceName: testMixpanel.apiToken).count == 0,
-      "clearTimedEvents should remove all key/value pairs")
-    removeDBfile(testMixpanel)
-  }
-
-  func testReadWriteLock() {
-    var array = [Int]()
-    let lock = ReadWriteLock(label: "test")
-    let queue = DispatchQueue(label: "concurrent", qos: .utility, attributes: .concurrent)
-    for _ in 0..<10 {
-      queue.async {
-        lock.write {
-          for i in 0..<100 {
-            array.append(i)
-          }
+    func testFlushEvents() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        for i in 0..<50 {
+            testMixpanel.track(event: "event \(i)")
         }
-      }
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).isEmpty,
+            "events should have been flushed")
 
-      queue.async {
-        lock.read {
-          XCTAssertTrue(array.count % 100 == 0, "supposed to happen after write")
+        for i in 0..<60 {
+            testMixpanel.track(event: "event \(i)")
         }
-      }
-    }
-  }
-
-  func testSetGroup() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    let groupKey = "test_key"
-    let groupValue = "test_value"
-    testMixpanel.setGroup(groupKey: groupKey, groupIDs: [groupValue])
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue])
-    let q = peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
-    XCTAssertEqual(q[groupKey] as? [String], [groupValue], "group value people property not queued")
-    assertDefaultPeopleProperties(q)
-    removeDBfile(testMixpanel)
-  }
-
-  func testAddGroup() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    let groupKey = "test_key"
-    let groupValue = "test_value"
-
-    testMixpanel.addGroup(groupKey: groupKey, groupID: groupValue)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue])
-    waitForTrackingQueue(testMixpanel)
-    let q = peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
-    XCTAssertEqual(q[groupKey] as? [String], [groupValue], "addGroup people update not queued")
-    assertDefaultPeopleProperties(q)
-
-    testMixpanel.addGroup(groupKey: groupKey, groupID: groupValue)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue])
-    waitForTrackingQueue(testMixpanel)
-    waitForTrackingQueue(testMixpanel)
-    let q2 = peopleQueue(token: testMixpanel.apiToken).last!["$union"] as! InternalProperties
-    XCTAssertEqual(q2[groupKey] as? [String], [groupValue], "addGroup people update not queued")
-
-    let newVal = "new_group"
-    testMixpanel.addGroup(groupKey: groupKey, groupID: newVal)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(
-      testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue, newVal])
-    waitForTrackingQueue(testMixpanel)
-    waitForTrackingQueue(testMixpanel)
-    let q3 = peopleQueue(token: testMixpanel.apiToken).last!["$union"] as! InternalProperties
-    XCTAssertEqual(q3[groupKey] as? [String], [newVal], "addGroup people update not queued")
-    removeDBfile(testMixpanel)
-  }
-
-  func testRemoveGroup() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    let groupKey = "test_key"
-    let groupValue = "test_value"
-    let newVal = "new_group"
-
-    testMixpanel.setGroup(groupKey: groupKey, groupIDs: [groupValue, newVal])
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(
-      testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue, newVal])
-
-    testMixpanel.removeGroup(groupKey: groupKey, groupID: groupValue)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(testMixpanel.currentSuperProperties()[groupKey] as? [String], [newVal])
-    waitForTrackingQueue(testMixpanel)
-    let q2 = peopleQueue(token: testMixpanel.apiToken).last!["$remove"] as! InternalProperties
-    XCTAssertEqual(q2[groupKey] as? String, groupValue, "removeGroup people update not queued")
-
-    testMixpanel.removeGroup(groupKey: groupKey, groupID: groupValue)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertNil(testMixpanel.currentSuperProperties()[groupKey])
-    waitForTrackingQueue(testMixpanel)
-    let q3 = peopleQueue(token: testMixpanel.apiToken).last!["$unset"] as! [String]
-    XCTAssertEqual(q3, [groupKey], "removeGroup people update not queued")
-    removeDBfile(testMixpanel)
-  }
-
-  func testMultipleInstancesWithSameToken() {
-    let testToken = randomId()
-    let concurentQueue = DispatchQueue(label: "multithread", attributes: .concurrent)
-
-    var testMixpanel: MixpanelInstance?
-    for _ in 1...10 {
-      concurentQueue.async {
-        testMixpanel = Mixpanel.initialize(token: testToken, flushInterval: 60)
-        testMixpanel?.loggingEnabled = true
-        testMixpanel?.track(event: "test")
-      }
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).isEmpty,
+            "events should have been flushed")
+        removeDBfile(testMixpanel)
     }
 
-    var testMixpanel2: MixpanelInstance?
-    for _ in 1...10 {
-      concurentQueue.async {
-        testMixpanel2 = Mixpanel.initialize(token: testToken, flushInterval: 60)
-        testMixpanel2?.loggingEnabled = true
-        testMixpanel2?.track(event: "test")
-      }
+    func testFlushPeople() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        for i in 0..<50 {
+            testMixpanel.people.set(property: "p1", to: "\(i)")
+        }
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel.apiToken).isEmpty, "people should have been flushed")
+        for i in 0..<60 {
+            testMixpanel.people.set(property: "p1", to: "\(i)")
+        }
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel.apiToken).isEmpty, "people should have been flushed")
+        removeDBfile(testMixpanel)
     }
-    sleep(5)
-    testMixpanel = Mixpanel.initialize(token: testToken, flushInterval: 60)
-    testMixpanel2 = Mixpanel.initialize(token: testToken, flushInterval: 60)
-    XCTAssertTrue(
-      testMixpanel === testMixpanel2,
-      "instance with same token should be reused and no sqlite db locked error should be populated")
-  }
 
-  func testReadWriteMultiThreadShouldNotCrash() {
-    let concurentQueue = DispatchQueue(label: "multithread", attributes: .concurrent)
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+    func testFlushGroups() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        let groupKey = "test_key"
+        let groupValue = "test_value"
+        for i in 0..<50 {
+            testMixpanel.getGroup(groupKey: groupKey, groupID: groupValue).set(property: "p1", to: "\(i)")
+        }
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            groupQueue(token: testMixpanel.apiToken).isEmpty, "groups should have been flushed")
+        for i in 0..<60 {
+            testMixpanel.getGroup(groupKey: groupKey, groupID: groupValue).set(property: "p1", to: "\(i)")
+        }
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel.apiToken).isEmpty, "groups should have been flushed")
+        removeDBfile(testMixpanel)
+    }
 
-    for n in 1...10 {
-      concurentQueue.async {
-        testMixpanel.track(event: "event\(n)")
-      }
-      concurentQueue.async {
-        testMixpanel.flush()
-      }
-      concurentQueue.async {
-        testMixpanel.archive()
-      }
-      concurentQueue.async {
+    func testFlushNetworkFailure() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.serverURL = kFakeServerUrl
+        for i in 0..<50 {
+            testMixpanel.track(event: "event \(UInt(i))")
+        }
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 50, "50 events should be queued up")
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 50,
+            "events should still be in the queue if flush fails")
+        removeDBfile(testMixpanel)
+    }
+
+    func testFlushQueueContainsCorruptedEvent() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.trackingQueue.async {
+            testMixpanel.mixpanelPersistence.saveEntity(
+                ["event": "bad event1", "properties": ["BadProp": Double.nan]], type: .events)
+            testMixpanel.mixpanelPersistence.saveEntity(
+                ["event": "bad event2", "properties": ["BadProp": Float.nan]], type: .events)
+            testMixpanel.mixpanelPersistence.saveEntity(
+                ["event": "bad event3", "properties": ["BadProp": Double.infinity]], type: .events)
+            testMixpanel.mixpanelPersistence.saveEntity(
+                ["event": "bad event4", "properties": ["BadProp": Float.infinity]], type: .events)
+        }
+        for i in 0..<10 {
+            testMixpanel.track(event: "event \(UInt(i))")
+        }
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 0, "good events should still be flushed")
+        removeDBfile(testMixpanel)
+    }
+
+    func testAddEventContainsInvalidJsonObjectDoubleNaN() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.track(event: "bad event", properties: ["BadProp": Double.nan])
+        }
+        removeDBfile(testMixpanel)
+    }
+
+    func testAddEventContainsInvalidJsonObjectFloatNaN() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.track(event: "bad event", properties: ["BadProp": Float.nan])
+        }
+        removeDBfile(testMixpanel)
+    }
+
+    func testAddEventContainsInvalidJsonObjectDoubleInfinity() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.track(event: "bad event", properties: ["BadProp": Double.infinity])
+        }
+        removeDBfile(testMixpanel)
+    }
+
+    func testAddEventContainsInvalidJsonObjectFloatInfinity() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.track(event: "bad event", properties: ["BadProp": Float.infinity])
+        }
+        removeDBfile(testMixpanel)
+    }
+
+    func testAddingEventsAfterFlush() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        for i in 0..<10 {
+            testMixpanel.track(event: "event \(UInt(i))")
+        }
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 10, "10 events should be queued up")
+        flushAndWaitForTrackingQueue(testMixpanel)
+        for i in 0..<5 {
+            testMixpanel.track(event: "event \(UInt(i))")
+        }
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 5, "5 more events should be queued up")
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).isEmpty, "events should have been flushed")
+        removeDBfile(testMixpanel)
+    }
+
+    func testIdentify() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        for _ in 0..<2 {
+            // run this twice to test reset works correctly wrt to distinct ids
+            let distinctId: String = "d1"
+            // try this for ODIN and nil
+            #if MIXPANEL_UNIQUE_DISTINCT_ID
+            XCTAssertEqual(
+                testMixpanel.distinctId,
+                devicePrefix + testMixpanel.defaultDeviceId(),
+                "mixpanel identify failed to set default distinct id")
+            XCTAssertEqual(
+                testMixpanel.anonymousId,
+                testMixpanel.defaultDeviceId(),
+                "mixpanel failed to set default anonymous id")
+            #endif
+            XCTAssertNil(
+                testMixpanel.people.distinctId,
+                "mixpanel people distinct id should default to nil")
+            XCTAssertNil(
+                testMixpanel.people.distinctId,
+                "mixpanel user id should default to nil")
+            testMixpanel.track(event: "e1")
+            waitForTrackingQueue(testMixpanel)
+            let eventsQueue = eventQueue(token: testMixpanel.apiToken)
+            XCTAssertTrue(
+                eventsQueue.count == 1,
+                "events should be sent right away with default distinct id")
+            #if MIXPANEL_UNIQUE_DISTINCT_ID
+            XCTAssertEqual(
+                (eventsQueue.last?["properties"] as? InternalProperties)?["distinct_id"] as? String,
+                devicePrefix + mixpanel.defaultDeviceId(),
+                "events should use default distinct id if none set")
+            #endif
+            XCTAssertEqual(
+                (eventsQueue.last?["properties"] as? InternalProperties)?["$lib_version"] as? String,
+                AutomaticProperties.libVersion(),
+                "events should has lib version in internal properties")
+            testMixpanel.people.set(property: "p1", to: "a")
+            waitForTrackingQueue(testMixpanel)
+            var peopleQueue_value = peopleQueue(token: testMixpanel.apiToken)
+            var unidentifiedQueue = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)
+            XCTAssertTrue(
+                peopleQueue_value.isEmpty,
+                "people records should go to unidentified queue before identify:")
+            XCTAssertTrue(
+                unidentifiedQueue.count == 1,
+                "unidentified people records not queued")
+            XCTAssertEqual(
+                unidentifiedQueue.last?["$token"] as? String,
+                testMixpanel.apiToken,
+                "incorrect project token in people record")
+            testMixpanel.identify(distinctId: distinctId)
+            waitForTrackingQueue(testMixpanel)
+            let anonymousId = testMixpanel.anonymousId
+            peopleQueue_value = peopleQueue(token: testMixpanel.apiToken)
+            unidentifiedQueue = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)
+            XCTAssertEqual(
+                testMixpanel.distinctId, distinctId,
+                "mixpanel identify failed to set distinct id")
+            XCTAssertEqual(
+                testMixpanel.userId, distinctId,
+                "mixpanel identify failed to set user id")
+            XCTAssertEqual(
+                testMixpanel.anonymousId, anonymousId,
+                "mixpanel identify shouldn't change anonymousId")
+            XCTAssertEqual(
+                testMixpanel.people.distinctId, distinctId,
+                "mixpanel identify failed to set people distinct id")
+            XCTAssertTrue(
+                unidentifiedQueue.isEmpty,
+                "identify: should move records from unidentified queue")
+            XCTAssertTrue(
+                peopleQueue_value.count > 0,
+                "identify: should move records to main people queue")
+            XCTAssertEqual(
+                peopleQueue_value.last?["$token"] as? String,
+                testMixpanel.apiToken, "incorrect project token in people record")
+            let p: InternalProperties = peopleQueue_value.last?["$set"] as! InternalProperties
+            XCTAssertEqual(p["p1"] as? String, "a", "custom people property not queued")
+            assertDefaultPeopleProperties(p)
+            peopleQueue_value = peopleQueue(token: testMixpanel.apiToken)
+
+            testMixpanel.people.set(property: "p1", to: "a")
+            waitForTrackingQueue(testMixpanel)
+
+            peopleQueue_value = peopleQueue(token: testMixpanel.apiToken)
+            unidentifiedQueue = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)
+            XCTAssertEqual(
+                peopleQueue_value.last?["$distinct_id"] as? String,
+                distinctId, "distinct id not set properly on unidentified people record")
+            XCTAssertTrue(
+                unidentifiedQueue.isEmpty,
+                "once idenitfy: is called, unidentified queue should be skipped")
+            XCTAssertTrue(
+                peopleQueue_value.count > 0,
+                "once identify: is called, records should go straight to main queue")
+            testMixpanel.track(event: "e2")
+            waitForTrackingQueue(testMixpanel)
+            let newDistinctId =
+                (eventQueue(token: testMixpanel.apiToken).last?["properties"] as? InternalProperties)?[
+                    "distinct_id"] as? String
+            XCTAssertEqual(
+                newDistinctId, distinctId,
+                "events should use new distinct id after identify:")
+            testMixpanel.reset()
+            waitForTrackingQueue(testMixpanel)
+        }
+        removeDBfile(testMixpanel)
+    }
+
+    func testIdentifyTrack() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let distinctIdBeforeIdentify: String? = testMixpanel.distinctId
+        let distinctId = "testIdentifyTrack"
+
+        testMixpanel.identify(distinctId: distinctId)
+        waitForTrackingQueue(testMixpanel)
+        let e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(e["event"] as? String, "$identify", "incorrect event name")
+        let p: InternalProperties = e["properties"] as! InternalProperties
+        XCTAssertEqual(p["distinct_id"] as? String, distinctId, "wrong distinct_id")
+        XCTAssertEqual(
+            p["$anon_distinct_id"] as? String, distinctIdBeforeIdentify, "wrong $anon_distinct_id")
+        removeDBfile(testMixpanel)
+    }
+
+    func testIdentifyResetTrack() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let originalDistinctId: String? = testMixpanel.distinctId
+        let distinctId = "testIdentifyTrack"
         testMixpanel.reset()
-      }
-      concurentQueue.async {
-        testMixpanel.createAlias("aaa11", distinctId: testMixpanel.distinctId)
-        testMixpanel.identify(distinctId: "test")
-      }
-      concurentQueue.async {
-        testMixpanel.registerSuperProperties(["Plan": "Mega"])
-      }
-      concurentQueue.async {
-        let _ = testMixpanel.currentSuperProperties()
-      }
-      concurentQueue.async {
-        testMixpanel.people.set(property: "aaa", to: "SwiftSDK Cocoapods")
-        testMixpanel.getGroup(groupKey: "test", groupID: 123).set(properties: ["test": 123])
-        testMixpanel.removeGroup(groupKey: "test", groupID: 123)
-      }
-      concurentQueue.async {
-        testMixpanel.track(event: "test")
-        testMixpanel.time(event: "test")
+        waitForTrackingQueue(testMixpanel)
+
+        for i in 1...3 {
+            let prevDistinctId: String? = testMixpanel.distinctId
+            let newDistinctId = distinctId + String(i)
+            testMixpanel.identify(distinctId: newDistinctId)
+            waitForTrackingQueue(testMixpanel)
+            waitForTrackingQueue(testMixpanel)
+            let e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
+            XCTAssertEqual(e["event"] as? String, "$identify", "incorrect event name")
+            let p: InternalProperties = e["properties"] as! InternalProperties
+            XCTAssertEqual(p["distinct_id"] as? String, newDistinctId, "wrong distinct_id")
+            XCTAssertEqual(p["$anon_distinct_id"] as? String, prevDistinctId, "wrong $anon_distinct_id")
+            XCTAssertNotEqual(
+                prevDistinctId, originalDistinctId, "After reset, UUID will be used - never the same")
+            #if MIXPANEL_UNIQUE_DISTINCT_ID
+            XCTAssertEqual(
+                prevDistinctId, originalDistinctId, "After reset, IFV will be used - always the same")
+            #endif
+            testMixpanel.reset()
+            waitForTrackingQueue(testMixpanel)
+        }
+        removeDBfile(testMixpanel)
+    }
+
+    func testPersistentIdentity() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let distinctId: String = "d1"
+        let alias: String = "a1"
+        testMixpanel.identify(distinctId: distinctId)
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.createAlias(alias, distinctId: testMixpanel.distinctId)
+        waitForTrackingQueue(testMixpanel)
+        var mixpanelIdentity = MixpanelPersistence.loadIdentity(instanceName: testMixpanel.apiToken)
+        XCTAssertTrue(
+            distinctId == mixpanelIdentity.distinctID && distinctId == mixpanelIdentity.peopleDistinctID
+                && distinctId == mixpanelIdentity.userId && alias == mixpanelIdentity.alias)
+        testMixpanel.archive()
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.unarchive()
+        waitForTrackingQueue(testMixpanel)
+        mixpanelIdentity = MixpanelPersistence.loadIdentity(instanceName: testMixpanel.apiToken)
+        XCTAssertTrue(
+            testMixpanel.distinctId == mixpanelIdentity.distinctID
+                && testMixpanel.people.distinctId == mixpanelIdentity.peopleDistinctID
+                && testMixpanel.anonymousId == mixpanelIdentity.anonymousId
+                && testMixpanel.userId == mixpanelIdentity.userId
+                && testMixpanel.alias == mixpanelIdentity.alias)
+        MixpanelPersistence.deleteMPUserDefaultsData(instanceName: testMixpanel.apiToken)
+        waitForTrackingQueue(testMixpanel)
+        mixpanelIdentity = MixpanelPersistence.loadIdentity(instanceName: testMixpanel.apiToken)
+        XCTAssertTrue(
+            "" == mixpanelIdentity.distinctID && nil == mixpanelIdentity.peopleDistinctID
+                && nil == mixpanelIdentity.anonymousId && nil == mixpanelIdentity.userId
+                && nil == mixpanelIdentity.alias)
+        removeDBfile(testMixpanel)
+    }
+
+    func testHadPersistedDistinctId() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        XCTAssertNotNil(testMixpanel.distinctId)
+        let distinctId: String = "d1"
+        testMixpanel.anonymousId = nil
+        testMixpanel.userId = nil
+        testMixpanel.alias = nil
+        testMixpanel.distinctId = distinctId
+        testMixpanel.archive()
+
+        XCTAssertEqual(testMixpanel.distinctId, distinctId)
+
+        let userId: String = "u1"
+        testMixpanel.identify(distinctId: userId)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(testMixpanel.anonymousId, distinctId)
+        XCTAssertEqual(testMixpanel.userId, userId)
+        XCTAssertEqual(testMixpanel.distinctId, userId)
+        XCTAssertTrue(testMixpanel.hadPersistedDistinctId!)
+        removeDBfile(testMixpanel)
+    }
+
+    func testTrackWithDefaultProperties() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.track(event: "Something Happened")
+        waitForTrackingQueue(testMixpanel)
+        let e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(e["event"] as? String, "Something Happened", "incorrect event name")
+        let p: InternalProperties = e["properties"] as! InternalProperties
+        XCTAssertNotNil(p["$app_build_number"], "$app_build_number not set")
+        XCTAssertNotNil(p["$app_version_string"], "$app_version_string not set")
+        XCTAssertNotNil(p["$lib_version"], "$lib_version not set")
+        XCTAssertNotNil(p["$model"], "$model not set")
+        XCTAssertNotNil(p["$os"], "$os not set")
+        XCTAssertNotNil(p["$os_version"], "$os_version not set")
+        XCTAssertNotNil(p["$screen_height"], "$screen_height not set")
+        XCTAssertNotNil(p["$screen_width"], "$screen_width not set")
+        XCTAssertNotNil(p["distinct_id"], "distinct_id not set")
+        XCTAssertNotNil(p["time"], "time not set")
+        XCTAssertEqual(p["$manufacturer"] as? String, "Apple", "incorrect $manufacturer")
+        XCTAssertEqual(p["mp_lib"] as? String, "swift", "incorrect mp_lib")
+        XCTAssertEqual(p["token"] as? String, testMixpanel.apiToken, "incorrect token")
+        removeDBfile(testMixpanel)
+    }
+
+    func testTrackWithCustomProperties() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let now = Date()
+        let p: Properties = [
+            "string": "yello",
+            "number": 3,
+            "date": now,
+            "$app_version": "override",
+        ]
+        testMixpanel.track(event: "Something Happened", properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let props: InternalProperties =
+            eventQueue(token: testMixpanel.apiToken).last?["properties"] as! InternalProperties
+        XCTAssertEqual(props["string"] as? String, "yello")
+        XCTAssertEqual(props["number"] as? Int, 3)
+        let dateValue = props["date"] as! String
+        compareDate(dateString: dateValue, dateDate: now)
+        XCTAssertEqual(
+            props["$app_version"] as? String, "override",
+            "reserved property override failed")
+        removeDBfile(testMixpanel)
+    }
+
+    func testTrackWithOptionalProperties() {
+        let optNil: Double? = nil
+        let optDouble: Double? = 1.0
+        let optArray: [Double?] = [nil, 1.0, 2.0]
+        let optDict: [String: Double?] = ["nil": nil, "double": 1.0]
+        let nested: [String: Any] = ["list": optArray, "dict": optDict]
+        let p: Properties = [
+            "nil": optNil,
+            "double": optDouble,
+            "list": optArray,
+            "dict": optDict,
+            "nested": nested,
+        ]
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.track(event: "Optional Test", properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let props: InternalProperties =
+            eventQueue(token: testMixpanel.apiToken).last?["properties"] as! InternalProperties
+        XCTAssertNil(props["nil"] as? Double)
+        XCTAssertEqual(props["double"] as? Double, 1.0)
+        XCTAssertEqual(props["list"] as? Array, [1.0, 2.0])
+        XCTAssertEqual(props["dict"] as? Dictionary, ["nil": nil, "double": 1.0])
+        let nestedProp = props["nested"] as? [String: Any]
+        XCTAssertEqual(nestedProp?["dict"] as? Dictionary, ["nil": nil, "double": 1.0])
+        XCTAssertEqual(nestedProp?["list"] as? Array, [1.0, 2.0])
+        removeDBfile(testMixpanel)
+    }
+
+    func testTrackWithCustomDistinctIdAndToken() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let p: Properties = ["token": "t1", "distinct_id": "d1"]
+        testMixpanel.track(event: "e1", properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let trackToken =
+            (eventQueue(token: testMixpanel.apiToken).last?["properties"] as? InternalProperties)?[
+                "token"] as? String
+        let trackDistinctId =
+            (eventQueue(token: testMixpanel.apiToken).last?["properties"] as? InternalProperties)?[
+                "distinct_id"] as? String
+        XCTAssertEqual(trackToken, "t1", "user-defined distinct id not used in track.")
+        XCTAssertEqual(trackDistinctId, "d1", "user-defined distinct id not used in track.")
+        removeDBfile(testMixpanel)
+    }
+
+    func testTrackWithGroups() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        testMixpanel.trackWithGroups(
+            event: "Something Happened", properties: [groupKey: "some other value", "p1": "value"],
+            groups: [groupKey: groupID])
+        waitForTrackingQueue(testMixpanel)
+        let e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(e["event"] as? String, "Something Happened", "incorrect event name")
+        let p: InternalProperties = e["properties"] as! InternalProperties
+        XCTAssertNotNil(p["$app_build_number"], "$app_build_number not set")
+        XCTAssertNotNil(p["$app_version_string"], "$app_version_string not set")
+        XCTAssertNotNil(p["$lib_version"], "$lib_version not set")
+        XCTAssertNotNil(p["$model"], "$model not set")
+        XCTAssertNotNil(p["$os"], "$os not set")
+        XCTAssertNotNil(p["$os_version"], "$os_version not set")
+        XCTAssertNotNil(p["$screen_height"], "$screen_height not set")
+        XCTAssertNotNil(p["$screen_width"], "$screen_width not set")
+        XCTAssertNotNil(p["distinct_id"], "distinct_id not set")
+        XCTAssertNotNil(p["time"], "time not set")
+        XCTAssertEqual(p["$manufacturer"] as? String, "Apple", "incorrect $manufacturer")
+        XCTAssertEqual(p["mp_lib"] as? String, "swift", "incorrect mp_lib")
+        XCTAssertEqual(p["token"] as? String, testMixpanel.apiToken, "incorrect token")
+        XCTAssertEqual(p[groupKey] as? String, groupID, "incorrect group id")
+        XCTAssertEqual(p["p1"] as? String, "value", "incorrect group value")
+        removeDBfile(testMixpanel)
+    }
+
+    func testRegisterSuperProperties() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        var p: Properties = ["p1": "a", "p2": 3, "p3": Date()]
+        testMixpanel.registerSuperProperties(p)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(
+            NSDictionary(dictionary: testMixpanel.currentSuperProperties()),
+            NSDictionary(dictionary: p),
+            "register super properties failed")
+        p = ["p1": "b"]
+        testMixpanel.registerSuperProperties(p)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(
+            testMixpanel.currentSuperProperties()["p1"] as? String, "b",
+            "register super properties failed to overwrite existing value")
+        p = ["p4": "a"]
+        testMixpanel.registerSuperPropertiesOnce(p)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(
+            testMixpanel.currentSuperProperties()["p4"] as? String, "a",
+            "register super properties once failed first time")
+        p = ["p4": "b"]
+        testMixpanel.registerSuperPropertiesOnce(p)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(
+            testMixpanel.currentSuperProperties()["p4"] as? String, "a",
+            "register super properties once failed second time")
+        p = ["p4": "c"]
+        testMixpanel.registerSuperPropertiesOnce(p, defaultValue: "d")
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(
+            testMixpanel.currentSuperProperties()["p4"] as? String, "a",
+            "register super properties once with default value failed when no match")
+        testMixpanel.registerSuperPropertiesOnce(p, defaultValue: "a")
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(
+            testMixpanel.currentSuperProperties()["p4"] as? String, "c",
+            "register super properties once with default value failed when match")
+        testMixpanel.unregisterSuperProperty("a")
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertNil(
+            testMixpanel.currentSuperProperties()["a"],
+            "unregister super property failed")
+        // unregister non-existent super property should not throw
+        testMixpanel.unregisterSuperProperty("a")
+        testMixpanel.clearSuperProperties()
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            testMixpanel.currentSuperProperties().isEmpty,
+            "clear super properties failed")
+        removeDBfile(testMixpanel)
+    }
+
+    func testInvalidPropertiesTrack() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let p: Properties = ["data": [Data()]]
+        XCTExpectAssert("property type should not be allowed") {
+            testMixpanel.track(event: "e1", properties: p)
+        }
+        removeDBfile(testMixpanel)
+    }
+
+    func testInvalidSuperProperties() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let p: Properties = ["data": [Data()]]
+        XCTExpectAssert("property type should not be allowed") {
+            testMixpanel.registerSuperProperties(p)
+        }
+        removeDBfile(testMixpanel)
+    }
+
+    func testInvalidSuperProperties2() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let p: Properties = ["data": [Data()]]
+        XCTExpectAssert("property type should not be allowed") {
+            testMixpanel.registerSuperPropertiesOnce(p)
+        }
+        removeDBfile(testMixpanel)
+    }
+
+    func testInvalidSuperProperties3() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let p: Properties = ["data": [Data()]]
+        XCTExpectAssert("property type should not be allowed") {
+            testMixpanel.registerSuperPropertiesOnce(p, defaultValue: "v")
+        }
+        removeDBfile(testMixpanel)
+    }
+
+    func testValidPropertiesTrack() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let p: Properties = allPropertyTypes()
+        testMixpanel.track(event: "e1", properties: p)
+        removeDBfile(testMixpanel)
+    }
+
+    func testValidSuperProperties() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let p: Properties = allPropertyTypes()
+        testMixpanel.registerSuperProperties(p)
+        testMixpanel.registerSuperPropertiesOnce(p)
+        testMixpanel.registerSuperPropertiesOnce(p, defaultValue: "v")
+        removeDBfile(testMixpanel)
+    }
+
+    func testReset() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.track(event: "e1")
+        waitForTrackingQueue(testMixpanel)
+        let p: Properties = ["p1": "a"]
+        testMixpanel.registerSuperProperties(p)
+        testMixpanel.people.set(properties: p)
+        testMixpanel.archive()
+        testMixpanel.reset()
+        waitForTrackingQueue(testMixpanel)
+        #if MIXPANEL_UNIQUE_DISTINCT_ID
+        XCTAssertEqual(
+            testMixpanel.distinctId,
+            devicePrefix + testMixpanel.defaultDeviceId(),
+            "distinct id failed to reset")
+        #endif
+        XCTAssertNil(testMixpanel.people.distinctId, "people distinct id failed to reset")
+        XCTAssertTrue(
+            testMixpanel.currentSuperProperties().isEmpty,
+            "super properties failed to reset")
+        XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).isEmpty, "events queue failed to reset")
+        XCTAssertTrue(peopleQueue(token: testMixpanel.apiToken).isEmpty, "people queue failed to reset")
+        let testMixpanel2 = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        waitForTrackingQueue(testMixpanel2)
+        #if MIXPANEL_UNIQUE_DISTINCT_ID
+        XCTAssertEqual(
+            testMixpanel2.distinctId, devicePrefix + testMixpanel2.defaultDeviceId(),
+            "distinct id failed to reset after archive")
+        #endif
+        XCTAssertNil(
+            testMixpanel2.people.distinctId,
+            "people distinct id failed to reset after archive")
+        XCTAssertTrue(
+            testMixpanel2.currentSuperProperties().isEmpty,
+            "super properties failed to reset after archive")
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel2.apiToken).isEmpty,
+            "events queue failed to reset after archive")
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel2.apiToken).isEmpty,
+            "people queue failed to reset after archive")
+        removeDBfile(testMixpanel)
+        removeDBfile(testMixpanel2)
+    }
+
+    func testArchiveNSNumberBoolIntProperty() {
+        let testToken = randomId()
+        let testMixpanel = Mixpanel.initialize(token: testToken, flushInterval: 60)
+        testMixpanel.serverURL = kFakeServerUrl
+        let aBoolNumber: Bool = true
+        let aBoolNSNumber = NSNumber(value: aBoolNumber)
+
+        let aIntNumber: Int = 1
+        let aIntNSNumber = NSNumber(value: aIntNumber)
+
+        testMixpanel.track(event: "e1", properties: ["p1": aBoolNSNumber, "p2": aIntNSNumber])
+        testMixpanel.archive()
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.mixpanelPersistence.closeDB()
+        let testMixpanel2 = Mixpanel.initialize(token: testToken, flushInterval: 60)
+        testMixpanel2.serverURL = kFakeServerUrl
+        waitForTrackingQueue(testMixpanel2)
+        let properties: [String: Any] =
+            eventQueue(token: testMixpanel2.apiToken)[0]["properties"] as! [String: Any]
+
+        XCTAssertTrue(
+            isBoolNumber(num: properties["p1"]! as! NSNumber),
+            "The bool value should be unarchived as bool")
+        XCTAssertFalse(
+            isBoolNumber(num: properties["p2"]! as! NSNumber),
+            "The int value should not be unarchived as bool")
+        removeDBfile(testMixpanel2)
+    }
+
+    private func isBoolNumber(num: NSNumber) -> Bool {
+        let boolID = CFBooleanGetTypeID()  // the type ID of CFBoolean
+        let numID = CFGetTypeID(num)  // the type ID of num
+        return numID == boolID
+    }
+
+    func testArchive() {
+        let testToken = randomId()
+        let testMixpanel = Mixpanel.initialize(token: testToken, flushInterval: 60)
+        testMixpanel.serverURL = kFakeServerUrl
+        #if MIXPANEL_UNIQUE_DISTINCT_ID
+        XCTAssertEqual(
+            testMixpanel.distinctId, devicePrefix + testMixpanel.defaultDeviceId(),
+            "default distinct id archive failed")
+        #endif
+        XCTAssertTrue(
+            testMixpanel.currentSuperProperties().isEmpty,
+            "default super properties archive failed")
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).isEmpty, "default events queue archive failed")
+        XCTAssertNil(testMixpanel.people.distinctId, "default people distinct id archive failed")
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel.apiToken).isEmpty, "default people queue archive failed")
+        let p: Properties = ["p1": "a"]
+        testMixpanel.identify(distinctId: "d1")
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.registerSuperProperties(p)
+        testMixpanel.track(event: "e1")
+        testMixpanel.track(event: "e2")
+        testMixpanel.track(event: "e3")
+        testMixpanel.track(event: "e4")
+        testMixpanel.track(event: "e5")
+        testMixpanel.track(event: "e6")
+        testMixpanel.track(event: "e7")
+        testMixpanel.track(event: "e8")
+        testMixpanel.track(event: "e9")
+        testMixpanel.people.set(properties: p)
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.timedEvents["e2"] = 5
+        testMixpanel.archive()
+        testMixpanel.mixpanelPersistence.closeDB()
+        let testMixpanel2 = Mixpanel.initialize(token: testToken, flushInterval: 60)
+        testMixpanel2.serverURL = kFakeServerUrl
+        waitForTrackingQueue(testMixpanel2)
+        XCTAssertEqual(testMixpanel2.distinctId, "d1", "custom distinct archive failed")
+        XCTAssertTrue(
+            testMixpanel2.currentSuperProperties().count == 1,
+            "custom super properties archive failed")
+        let eventQueueValue = eventQueue(token: testMixpanel2.apiToken)
+
+        XCTAssertEqual(
+            eventQueueValue[1]["event"] as? String, "e1",
+            "event was not successfully archived/unarchived")
+        XCTAssertEqual(
+            eventQueueValue[2]["event"] as? String, "e2",
+            "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(
+            eventQueueValue[3]["event"] as? String, "e3",
+            "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(
+            eventQueueValue[4]["event"] as? String, "e4",
+            "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(
+            eventQueueValue[5]["event"] as? String, "e5",
+            "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(
+            eventQueueValue[6]["event"] as? String, "e6",
+            "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(
+            eventQueueValue[7]["event"] as? String, "e7",
+            "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(
+            eventQueueValue[8]["event"] as? String, "e8",
+            "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(
+            eventQueueValue[9]["event"] as? String, "e9",
+            "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(
+            testMixpanel2.people.distinctId, "d1",
+            "custom people distinct id archive failed")
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel2.apiToken).count == 1, "pending people queue archive failed")
+        XCTAssertEqual(
+            testMixpanel2.timedEvents["e2"] as? Int, 5,
+            "timedEvents archive failed")
+        testMixpanel2.mixpanelPersistence.closeDB()
+        let testMixpanel3 = Mixpanel.initialize(token: testToken, flushInterval: 60)
+        testMixpanel3.serverURL = kFakeServerUrl
+        XCTAssertEqual(testMixpanel3.distinctId, "d1", "expecting d1 as distinct id as initialised")
+        XCTAssertTrue(
+            testMixpanel3.currentSuperProperties().count == 1,
+            "default super properties expected to have 1 item")
+        XCTAssertNotNil(eventQueue(token: testMixpanel3.apiToken), "default events queue is nil")
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel3.apiToken).count == 10,
+            "default events queue expecting 10 items ($identify call added)")
+        XCTAssertNotNil(
+            testMixpanel3.people.distinctId,
+            "default people distinct id from no file failed")
+        XCTAssertNotNil(
+            peopleQueue(token: testMixpanel3.apiToken), "default people queue from no file is nil")
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel3.apiToken).count == 1, "default people queue expecting 1 item"
+        )
+        XCTAssertTrue(testMixpanel3.timedEvents.count == 1, "timedEvents expecting 1 item")
+        testMixpanel3.mixpanelPersistence.closeDB()
+        removeDBfile(testMixpanel)
+    }
+
+    func testMixpanelDelegate() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.delegate = self
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.track(event: "e1")
+        testMixpanel.people.set(property: "p1", to: "a")
+        waitForTrackingQueue(testMixpanel)
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 2, "delegate should have stopped flush")
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel.apiToken).count == 1, "delegate should have stopped flush")
+        removeDBfile(testMixpanel)
+    }
+
+    func testEventTiming() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.track(event: "Something Happened")
+        waitForTrackingQueue(testMixpanel)
+        var e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
+        var p = e["properties"] as! InternalProperties
+        XCTAssertNil(p["$duration"], "New events should not be timed.")
+        testMixpanel.time(event: "400 Meters")
+        testMixpanel.track(event: "500 Meters")
+        waitForTrackingQueue(testMixpanel)
+        e = eventQueue(token: testMixpanel.apiToken).last!
+        p = e["properties"] as! InternalProperties
+        XCTAssertNil(p["$duration"], "The exact same event name is required for timing.")
+        testMixpanel.track(event: "400 Meters")
+        waitForTrackingQueue(testMixpanel)
+        e = eventQueue(token: testMixpanel.apiToken).last!
+        p = e["properties"] as! InternalProperties
+        XCTAssertNotNil(p["$duration"], "This event should be timed.")
+        testMixpanel.track(event: "400 Meters")
+        waitForTrackingQueue(testMixpanel)
+        e = eventQueue(token: testMixpanel.apiToken).last!
+        p = e["properties"] as! InternalProperties
+        XCTAssertNil(
+            p["$duration"],
+            "Tracking the same event should require a second call to timeEvent.")
+        testMixpanel.time(event: "Time Event A")
+        testMixpanel.time(event: "Time Event B")
+        testMixpanel.time(event: "Time Event C")
+        waitForTrackingQueue(testMixpanel)
+        var testTimedEvents = MixpanelPersistence.loadTimedEvents(instanceName: testMixpanel.apiToken)
+        XCTAssertTrue(
+            testTimedEvents.count == 3, "Each call to time() should add an event to timedEvents")
+        XCTAssertNotNil(testTimedEvents["Time Event A"], "Keys in timedEvents should be event names")
+        testMixpanel.clearTimedEvent(event: "Time Event A")
+        waitForTrackingQueue(testMixpanel)
+        testTimedEvents = MixpanelPersistence.loadTimedEvents(instanceName: testMixpanel.apiToken)
+        XCTAssertNil(testTimedEvents["Time Event A"], "clearTimedEvent should remove key/value pair")
+        XCTAssertTrue(
+            testTimedEvents.count == 2, "clearTimedEvent shoud remove only one key/value pair")
         testMixpanel.clearTimedEvents()
-      }
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            MixpanelPersistence.loadTimedEvents(instanceName: testMixpanel.apiToken).count == 0,
+            "clearTimedEvents should remove all key/value pairs")
+        removeDBfile(testMixpanel)
     }
-    removeDBfile(testMixpanel)
-  }
 
-  func testMPDB() {
-    let testToken = randomId()
-    let numRows = 50
-    let halfRows = numRows / 2
-    let eventName = "Test Event"
-    func _inner() {
-      removeDBfile(apiToken: testToken)
-      let mpdb = MPDB.init(token: testToken)
-      mpdb.open()
-      for pType in PersistenceType.allCases {
-        let emptyArray: [InternalProperties] = mpdb.readRows(pType, numRows: numRows)
-        XCTAssertTrue(emptyArray.isEmpty, "Table should be empty")
-        for i in 0...numRows - 1 {
-          let eventObj: InternalProperties = ["event": eventName, "properties": ["index": i]]
-          let eventData = JSONHandler.serializeJSONObject(eventObj)!
-          mpdb.insertRow(pType, data: eventData)
-        }
-        let dataArray: [InternalProperties] = mpdb.readRows(pType, numRows: halfRows)
-        XCTAssertEqual(dataArray.count, halfRows, "Should have read only half of the rows")
-        var ids: [Int32] = []
-        for (n, entity) in dataArray.enumerated() {
-          guard let id = entity["id"] as? Int32 else {
-            continue
-          }
-          ids.append(id)
-          XCTAssertEqual(entity["event"] as! String, eventName, "Event name should be unchanged")
-          // index should be oldest events, 0 - 24
-          XCTAssertEqual(
-            entity["properties"] as! [String: Int], ["index": n], "Should read oldest events first")
-        }
+    func testReadWriteLock() {
+        var array = [Int]()
+        let lock = ReadWriteLock(label: "test")
+        let queue = DispatchQueue(label: "concurrent", qos: .utility, attributes: .concurrent)
+        for _ in 0..<10 {
+            queue.async {
+                lock.write {
+                    for i in 0..<100 {
+                        array.append(i)
+                    }
+                }
+            }
 
-        mpdb.deleteRows(pType, ids: [1, 2, 3])
-        let dataArray2: [InternalProperties] = mpdb.readRows(pType, numRows: numRows)
-        // even though we requested numRows, there should only be halfRows left
-        XCTAssertEqual(dataArray2.count, numRows - 3, "Should have deleted half the rows")
-        for (n, entity) in dataArray2.enumerated() {
-          XCTAssertEqual(entity["event"] as! String, eventName, "Event name should be unchanged")
-          // old events (0-24) should have been deleted so index should be recent events 25-49
-          XCTAssertEqual(
-            entity["properties"] as! [String: Int], ["index": n + halfRows],
-            "Should have deleted oldest events first")
+            queue.async {
+                lock.read {
+                    XCTAssertTrue(array.count % 100 == 0, "supposed to happen after write")
+                }
+            }
         }
-        mpdb.close()
-      }
     }
-    removeDBfile(apiToken: testToken)
-  }
+
+    func testSetGroup() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        let groupKey = "test_key"
+        let groupValue = "test_value"
+        testMixpanel.setGroup(groupKey: groupKey, groupIDs: [groupValue])
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue])
+        let q = peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
+        XCTAssertEqual(q[groupKey] as? [String], [groupValue], "group value people property not queued")
+        assertDefaultPeopleProperties(q)
+        removeDBfile(testMixpanel)
+    }
+
+    func testAddGroup() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        let groupKey = "test_key"
+        let groupValue = "test_value"
+
+        testMixpanel.addGroup(groupKey: groupKey, groupID: groupValue)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue])
+        waitForTrackingQueue(testMixpanel)
+        let q = peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
+        XCTAssertEqual(q[groupKey] as? [String], [groupValue], "addGroup people update not queued")
+        assertDefaultPeopleProperties(q)
+
+        testMixpanel.addGroup(groupKey: groupKey, groupID: groupValue)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue])
+        waitForTrackingQueue(testMixpanel)
+        waitForTrackingQueue(testMixpanel)
+        let q2 = peopleQueue(token: testMixpanel.apiToken).last!["$union"] as! InternalProperties
+        XCTAssertEqual(q2[groupKey] as? [String], [groupValue], "addGroup people update not queued")
+
+        let newVal = "new_group"
+        testMixpanel.addGroup(groupKey: groupKey, groupID: newVal)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(
+            testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue, newVal])
+        waitForTrackingQueue(testMixpanel)
+        waitForTrackingQueue(testMixpanel)
+        let q3 = peopleQueue(token: testMixpanel.apiToken).last!["$union"] as! InternalProperties
+        XCTAssertEqual(q3[groupKey] as? [String], [newVal], "addGroup people update not queued")
+        removeDBfile(testMixpanel)
+    }
+
+    func testRemoveGroup() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        let groupKey = "test_key"
+        let groupValue = "test_value"
+        let newVal = "new_group"
+
+        testMixpanel.setGroup(groupKey: groupKey, groupIDs: [groupValue, newVal])
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(
+            testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue, newVal])
+
+        testMixpanel.removeGroup(groupKey: groupKey, groupID: groupValue)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(testMixpanel.currentSuperProperties()[groupKey] as? [String], [newVal])
+        waitForTrackingQueue(testMixpanel)
+        let q2 = peopleQueue(token: testMixpanel.apiToken).last!["$remove"] as! InternalProperties
+        XCTAssertEqual(q2[groupKey] as? String, groupValue, "removeGroup people update not queued")
+
+        testMixpanel.removeGroup(groupKey: groupKey, groupID: groupValue)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertNil(testMixpanel.currentSuperProperties()[groupKey])
+        waitForTrackingQueue(testMixpanel)
+        let q3 = peopleQueue(token: testMixpanel.apiToken).last!["$unset"] as! [String]
+        XCTAssertEqual(q3, [groupKey], "removeGroup people update not queued")
+        removeDBfile(testMixpanel)
+    }
+
+    func testMultipleInstancesWithSameToken() {
+        let testToken = randomId()
+        let concurentQueue = DispatchQueue(label: "multithread", attributes: .concurrent)
+
+        var testMixpanel: MixpanelInstance?
+        for _ in 1...10 {
+            concurentQueue.async {
+                testMixpanel = Mixpanel.initialize(token: testToken, flushInterval: 60)
+                testMixpanel?.loggingEnabled = true
+                testMixpanel?.track(event: "test")
+            }
+        }
+
+        var testMixpanel2: MixpanelInstance?
+        for _ in 1...10 {
+            concurentQueue.async {
+                testMixpanel2 = Mixpanel.initialize(token: testToken, flushInterval: 60)
+                testMixpanel2?.loggingEnabled = true
+                testMixpanel2?.track(event: "test")
+            }
+        }
+        sleep(5)
+        testMixpanel = Mixpanel.initialize(token: testToken, flushInterval: 60)
+        testMixpanel2 = Mixpanel.initialize(token: testToken, flushInterval: 60)
+        XCTAssertTrue(
+            testMixpanel === testMixpanel2,
+            "instance with same token should be reused and no sqlite db locked error should be populated")
+    }
+
+    func testReadWriteMultiThreadShouldNotCrash() {
+        let concurentQueue = DispatchQueue(label: "multithread", attributes: .concurrent)
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+
+        for n in 1...10 {
+            concurentQueue.async {
+                testMixpanel.track(event: "event\(n)")
+            }
+            concurentQueue.async {
+                testMixpanel.flush()
+            }
+            concurentQueue.async {
+                testMixpanel.archive()
+            }
+            concurentQueue.async {
+                testMixpanel.reset()
+            }
+            concurentQueue.async {
+                testMixpanel.createAlias("aaa11", distinctId: testMixpanel.distinctId)
+                testMixpanel.identify(distinctId: "test")
+            }
+            concurentQueue.async {
+                testMixpanel.registerSuperProperties(["Plan": "Mega"])
+            }
+            concurentQueue.async {
+                let _ = testMixpanel.currentSuperProperties()
+            }
+            concurentQueue.async {
+                testMixpanel.people.set(property: "aaa", to: "SwiftSDK Cocoapods")
+                testMixpanel.getGroup(groupKey: "test", groupID: 123).set(properties: ["test": 123])
+                testMixpanel.removeGroup(groupKey: "test", groupID: 123)
+            }
+            concurentQueue.async {
+                testMixpanel.track(event: "test")
+                testMixpanel.time(event: "test")
+                testMixpanel.clearTimedEvents()
+            }
+        }
+        removeDBfile(testMixpanel)
+    }
+
+    func testMPDB() {
+        let testToken = randomId()
+        let numRows = 50
+        let halfRows = numRows / 2
+        let eventName = "Test Event"
+        func _inner() {
+            removeDBfile(apiToken: testToken)
+            let mpdb = MPDB.init(token: testToken)
+            mpdb.open()
+            for pType in PersistenceType.allCases {
+                let emptyArray: [InternalProperties] = mpdb.readRows(pType, numRows: numRows)
+                XCTAssertTrue(emptyArray.isEmpty, "Table should be empty")
+                for i in 0...numRows - 1 {
+                    let eventObj: InternalProperties = ["event": eventName, "properties": ["index": i]]
+                    let eventData = JSONHandler.serializeJSONObject(eventObj)!
+                    mpdb.insertRow(pType, data: eventData)
+                }
+                let dataArray: [InternalProperties] = mpdb.readRows(pType, numRows: halfRows)
+                XCTAssertEqual(dataArray.count, halfRows, "Should have read only half of the rows")
+                var ids: [Int32] = []
+                for (n, entity) in dataArray.enumerated() {
+                    guard let id = entity["id"] as? Int32 else {
+                        continue
+                    }
+                    ids.append(id)
+                    XCTAssertEqual(entity["event"] as! String, eventName, "Event name should be unchanged")
+                    // index should be oldest events, 0 - 24
+                    XCTAssertEqual(
+                        entity["properties"] as! [String: Int], ["index": n], "Should read oldest events first")
+                }
+
+                mpdb.deleteRows(pType, ids: [1, 2, 3])
+                let dataArray2: [InternalProperties] = mpdb.readRows(pType, numRows: numRows)
+                // even though we requested numRows, there should only be halfRows left
+                XCTAssertEqual(dataArray2.count, numRows - 3, "Should have deleted half the rows")
+                for (n, entity) in dataArray2.enumerated() {
+                    XCTAssertEqual(entity["event"] as! String, eventName, "Event name should be unchanged")
+                    // old events (0-24) should have been deleted so index should be recent events 25-49
+                    XCTAssertEqual(
+                        entity["properties"] as! [String: Int], ["index": n + halfRows],
+                        "Should have deleted oldest events first")
+                }
+                mpdb.close()
+            }
+        }
+        removeDBfile(apiToken: testToken)
+    }
 
 }

--- a/MixpanelDemo/MixpanelDemoMacTests/MixpanelEventBridgeTests.swift
+++ b/MixpanelDemo/MixpanelDemoMacTests/MixpanelEventBridgeTests.swift
@@ -6,91 +6,91 @@
 //  Copyright © 2026 Mixpanel. All rights reserved.
 //
 
-import XCTest
 import MixpanelSwiftCommon
+import XCTest
 
 @testable import Mixpanel
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 class MixpanelEventBridgeTests: MixpanelBaseTests {
 
-  // MARK: - Event Bridge Notified on Track
+    // MARK: - Event Bridge Notified on Track
 
-  func testEventBridgeNotifiedOnTrack() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: false)
-    let eventName = "BridgeTestEvent_\(randomId())"
-    let expectation = XCTestExpectation(description: "Event bridge is notified when event is tracked")
+    func testEventBridgeNotifiedOnTrack() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: false)
+        let eventName = "BridgeTestEvent_\(randomId())"
+        let expectation = XCTestExpectation(description: "Event bridge is notified when event is tracked")
 
-    let stream = MixpanelEventBridge.shared.eventStream()
-    let task = Task {
-      for await event in stream {
-        if event.eventName == eventName {
-          expectation.fulfill()
-          break
+        let stream = MixpanelEventBridge.shared.eventStream()
+        let task = Task {
+            for await event in stream {
+                if event.eventName == eventName {
+                    expectation.fulfill()
+                    break
+                }
+            }
         }
-      }
+
+        testMixpanel.track(event: eventName)
+        waitForTrackingQueue(testMixpanel)
+
+        wait(for: [expectation], timeout: 2.0)
+        task.cancel()
+        removeDBfile(apiToken: testMixpanel.apiToken)
     }
 
-    testMixpanel.track(event: eventName)
-    waitForTrackingQueue(testMixpanel)
+    // MARK: - Event Bridge Receives Properties
 
-    wait(for: [expectation], timeout: 2.0)
-    task.cancel()
-      removeDBfile(apiToken: testMixpanel.apiToken)
-  }
+    func testEventBridgeReceivesEventProperties() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: false)
+        let eventName = "BridgePropsTest_\(randomId())"
+        let expectation = XCTestExpectation(
+            description: "Event bridge receives event with correct properties")
 
-  // MARK: - Event Bridge Receives Properties
-
-  func testEventBridgeReceivesEventProperties() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: false)
-    let eventName = "BridgePropsTest_\(randomId())"
-    let expectation = XCTestExpectation(
-      description: "Event bridge receives event with correct properties")
-
-    let stream = MixpanelEventBridge.shared.eventStream()
-    let task = Task {
-      for await event in stream {
-        if event.eventName == eventName {
-          XCTAssertEqual(event.properties["testKey"] as? String, "testValue")
-          expectation.fulfill()
-          break
+        let stream = MixpanelEventBridge.shared.eventStream()
+        let task = Task {
+            for await event in stream {
+                if event.eventName == eventName {
+                    XCTAssertEqual(event.properties["testKey"] as? String, "testValue")
+                    expectation.fulfill()
+                    break
+                }
+            }
         }
-      }
+
+        testMixpanel.track(event: eventName, properties: ["testKey": "testValue"])
+        waitForTrackingQueue(testMixpanel)
+
+        wait(for: [expectation], timeout: 2.0)
+        task.cancel()
+        removeDBfile(apiToken: testMixpanel.apiToken)
     }
 
-    testMixpanel.track(event: eventName, properties: ["testKey": "testValue"])
-    waitForTrackingQueue(testMixpanel)
+    // MARK: - Event Bridge Not Notified When Opted Out
 
-    wait(for: [expectation], timeout: 2.0)
-    task.cancel()
-      removeDBfile(apiToken: testMixpanel.apiToken)
-  }
+    func testEventBridgeNotNotifiedWhenOptedOut() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), optOutTrackingByDefault: true, trackAutomaticEvents: false)
+        let eventName = "BridgeOptOutTest_\(randomId())"
+        let noEventExpectation = XCTestExpectation(
+            description: "Event bridge should not be notified when tracking is opted out")
+        noEventExpectation.isInverted = true
 
-  // MARK: - Event Bridge Not Notified When Opted Out
-
-  func testEventBridgeNotNotifiedWhenOptedOut() {
-    let testMixpanel = Mixpanel.initialize(
-        token: randomId(), optOutTrackingByDefault: true, trackAutomaticEvents: false)
-    let eventName = "BridgeOptOutTest_\(randomId())"
-    let noEventExpectation = XCTestExpectation(
-      description: "Event bridge should not be notified when tracking is opted out")
-    noEventExpectation.isInverted = true
-
-    let stream = MixpanelEventBridge.shared.eventStream()
-    let task = Task {
-      for await event in stream {
-        if event.eventName == eventName {
-          noEventExpectation.fulfill()
+        let stream = MixpanelEventBridge.shared.eventStream()
+        let task = Task {
+            for await event in stream {
+                if event.eventName == eventName {
+                    noEventExpectation.fulfill()
+                }
+            }
         }
-      }
+
+        testMixpanel.track(event: eventName)
+        waitForTrackingQueue(testMixpanel)
+
+        wait(for: [noEventExpectation], timeout: 1.0)
+        task.cancel()
+        removeDBfile(apiToken: testMixpanel.apiToken)
     }
-
-    testMixpanel.track(event: eventName)
-    waitForTrackingQueue(testMixpanel)
-
-    wait(for: [noEventExpectation], timeout: 1.0)
-    task.cancel()
-      removeDBfile(apiToken: testMixpanel.apiToken)
-  }
 
 }

--- a/MixpanelDemo/MixpanelDemoMacTests/MixpanelGroupTests.swift
+++ b/MixpanelDemo/MixpanelDemoMacTests/MixpanelGroupTests.swift
@@ -13,131 +13,131 @@ import XCTest
 
 class MixpanelGroupTests: MixpanelBaseTests {
 
-  func testGroupSet() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    let p: Properties = ["p1": "a"]
-    testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let msg = groupQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(msg["$group_key"] as! String, groupKey)
-    XCTAssertEqual(msg["$group_id"] as! String, groupID)
-    let q = msg["$set"] as! InternalProperties
-    XCTAssertEqual(q["p1"] as? String, "a", "custom group property not queued")
-    removeDBfile(testMixpanel)
-  }
-
-  func testGroupSetIntegerID() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = 3
-    let p: Properties = ["p1": "a"]
-    testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let msg = groupQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(msg["$group_key"] as! String, groupKey)
-    XCTAssertEqual(msg["$group_id"] as! Int, groupID)
-    let q = msg["$set"] as! InternalProperties
-    XCTAssertEqual(q["p1"] as? String, "a", "custom group property not queued")
-    removeDBfile(testMixpanel)
-  }
-
-  func testGroupSetOnce() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    let p: Properties = ["p1": "a"]
-    testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).setOnce(properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let msg = groupQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(msg["$group_key"] as! String, groupKey)
-    XCTAssertEqual(msg["$group_id"] as! String, groupID)
-    let q = msg["$set_once"] as! InternalProperties
-    XCTAssertEqual(q["p1"] as? String, "a", "custom group property not queued")
-    removeDBfile(testMixpanel)
-  }
-
-  func testGroupSetTo() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(property: "p1", to: "a")
-    waitForTrackingQueue(testMixpanel)
-    let msg = groupQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(msg["$group_key"] as! String, groupKey)
-    XCTAssertEqual(msg["$group_id"] as! String, groupID)
-    let p = msg["$set"] as! InternalProperties
-    XCTAssertEqual(p["p1"] as? String, "a", "custom group property not queued")
-    removeDBfile(testMixpanel)
-  }
-
-  func testGroupUnset() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).unset(property: "p1")
-    waitForTrackingQueue(testMixpanel)
-    let msg = groupQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(msg["$group_key"] as! String, groupKey)
-    XCTAssertEqual(msg["$group_id"] as! String, groupID)
-    XCTAssertEqual(msg["$unset"] as! [String], ["p1"], "group property unset not queued")
-    removeDBfile(testMixpanel)
-  }
-
-  func testGroupRemove() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).remove(key: "p1", value: "a")
-    waitForTrackingQueue(testMixpanel)
-    let msg = groupQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(msg["$group_key"] as! String, groupKey)
-    XCTAssertEqual(msg["$group_id"] as! String, groupID)
-    XCTAssertEqual(
-      msg["$remove"] as? [String: String], ["p1": "a"], "group property remove not queued")
-    removeDBfile(testMixpanel)
-  }
-
-  func testGroupUnion() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).union(key: "p1", values: ["a"])
-    waitForTrackingQueue(testMixpanel)
-    let msg = groupQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(msg["$group_key"] as! String, groupKey)
-    XCTAssertEqual(msg["$group_id"] as! String, groupID)
-    XCTAssertEqual(
-      msg["$union"] as? [String: [String]], ["p1": ["a"]], "group property union not queued")
-    removeDBfile(testMixpanel)
-  }
-
-  func testGroupAssertPropertyTypes() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    let p: Properties = ["URL": [Data()]]
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(properties: p)
+    func testGroupSet() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        let p: Properties = ["p1": "a"]
+        testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let msg = groupQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(msg["$group_key"] as! String, groupKey)
+        XCTAssertEqual(msg["$group_id"] as! String, groupID)
+        let q = msg["$set"] as! InternalProperties
+        XCTAssertEqual(q["p1"] as? String, "a", "custom group property not queued")
+        removeDBfile(testMixpanel)
     }
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(property: "p1", to: [Data()])
-    }
-    removeDBfile(testMixpanel)
-  }
 
-  func testDeleteGroup() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).deleteGroup()
-    waitForTrackingQueue(testMixpanel)
-    let msg = groupQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(msg["$group_key"] as! String, groupKey)
-    XCTAssertEqual(msg["$group_id"] as! String, groupID)
-    let p: InternalProperties = msg["$delete"] as! InternalProperties
-    XCTAssertTrue(p.isEmpty, "incorrect group properties: \(p)")
-    removeDBfile(testMixpanel)
-  }
+    func testGroupSetIntegerID() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = 3
+        let p: Properties = ["p1": "a"]
+        testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let msg = groupQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(msg["$group_key"] as! String, groupKey)
+        XCTAssertEqual(msg["$group_id"] as! Int, groupID)
+        let q = msg["$set"] as! InternalProperties
+        XCTAssertEqual(q["p1"] as? String, "a", "custom group property not queued")
+        removeDBfile(testMixpanel)
+    }
+
+    func testGroupSetOnce() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        let p: Properties = ["p1": "a"]
+        testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).setOnce(properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let msg = groupQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(msg["$group_key"] as! String, groupKey)
+        XCTAssertEqual(msg["$group_id"] as! String, groupID)
+        let q = msg["$set_once"] as! InternalProperties
+        XCTAssertEqual(q["p1"] as? String, "a", "custom group property not queued")
+        removeDBfile(testMixpanel)
+    }
+
+    func testGroupSetTo() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(property: "p1", to: "a")
+        waitForTrackingQueue(testMixpanel)
+        let msg = groupQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(msg["$group_key"] as! String, groupKey)
+        XCTAssertEqual(msg["$group_id"] as! String, groupID)
+        let p = msg["$set"] as! InternalProperties
+        XCTAssertEqual(p["p1"] as? String, "a", "custom group property not queued")
+        removeDBfile(testMixpanel)
+    }
+
+    func testGroupUnset() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).unset(property: "p1")
+        waitForTrackingQueue(testMixpanel)
+        let msg = groupQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(msg["$group_key"] as! String, groupKey)
+        XCTAssertEqual(msg["$group_id"] as! String, groupID)
+        XCTAssertEqual(msg["$unset"] as! [String], ["p1"], "group property unset not queued")
+        removeDBfile(testMixpanel)
+    }
+
+    func testGroupRemove() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).remove(key: "p1", value: "a")
+        waitForTrackingQueue(testMixpanel)
+        let msg = groupQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(msg["$group_key"] as! String, groupKey)
+        XCTAssertEqual(msg["$group_id"] as! String, groupID)
+        XCTAssertEqual(
+            msg["$remove"] as? [String: String], ["p1": "a"], "group property remove not queued")
+        removeDBfile(testMixpanel)
+    }
+
+    func testGroupUnion() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).union(key: "p1", values: ["a"])
+        waitForTrackingQueue(testMixpanel)
+        let msg = groupQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(msg["$group_key"] as! String, groupKey)
+        XCTAssertEqual(msg["$group_id"] as! String, groupID)
+        XCTAssertEqual(
+            msg["$union"] as? [String: [String]], ["p1": ["a"]], "group property union not queued")
+        removeDBfile(testMixpanel)
+    }
+
+    func testGroupAssertPropertyTypes() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        let p: Properties = ["URL": [Data()]]
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(properties: p)
+        }
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(property: "p1", to: [Data()])
+        }
+        removeDBfile(testMixpanel)
+    }
+
+    func testDeleteGroup() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).deleteGroup()
+        waitForTrackingQueue(testMixpanel)
+        let msg = groupQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(msg["$group_key"] as! String, groupKey)
+        XCTAssertEqual(msg["$group_id"] as! String, groupID)
+        let p: InternalProperties = msg["$delete"] as! InternalProperties
+        XCTAssertTrue(p.isEmpty, "incorrect group properties: \(p)")
+        removeDBfile(testMixpanel)
+    }
 }

--- a/MixpanelDemo/MixpanelDemoMacTests/MixpanelOptOutTests.swift
+++ b/MixpanelDemo/MixpanelDemoMacTests/MixpanelOptOutTests.swift
@@ -12,305 +12,305 @@ import XCTest
 
 class MixpanelOptOutTests: MixpanelBaseTests {
 
-  func testHasOptOutTrackingFlagBeingSetProperlyAfterInitializedWithOptedOutYES() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      testMixpanel.hasOptedOutTracking(),
-      "When initialize with opted out flag set to YES, the current user should have opted out tracking"
-    )
-    testMixpanel.reset()
-    removeDBfile(testMixpanel)
-  }
-
-  func testOptInWillAddOptInEvent() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
-    testMixpanel.optInTracking()
-    XCTAssertFalse(
-      testMixpanel.hasOptedOutTracking(), "The current user should have opted in tracking")
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 1,
-      "When opted in, event queue should have one even(opt in) being queued")
-
-    if eventQueue(token: testMixpanel.apiToken).count > 0 {
-      let event = eventQueue(token: testMixpanel.apiToken).first
-      XCTAssertEqual(
-        (event!["event"] as? String), "$opt_in",
-        "When opted in, a track '$opt_in' should have been queued")
-    } else {
-      XCTAssertTrue(
-        eventQueue(token: testMixpanel.apiToken).count == 1,
-        "When opted in, event queue should have one even(opt in) being queued")
-    }
-    removeDBfile(testMixpanel)
-  }
-
-  func testOptInTrackingForDistinctId() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
-    testMixpanel.optInTracking(distinctId: "testDistinctId")
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertFalse(
-      testMixpanel.hasOptedOutTracking(), "The current user should have opted in tracking")
-    waitForTrackingQueue(testMixpanel)
-    let event = eventQueue(token: testMixpanel.apiToken).first
-    XCTAssertEqual(
-      (event!["event"] as? String), "$opt_in",
-      "When opted in, a track '$opt_in' should have been queued")
-    XCTAssertEqual(
-      testMixpanel.distinctId, "testDistinctId", "mixpanel identify failed to set distinct id")
-    XCTAssertEqual(
-      testMixpanel.people.distinctId, "testDistinctId",
-      "mixpanel identify failed to set people distinct id")
-    XCTAssertTrue(
-      unIdentifiedPeopleQueue(token: testMixpanel.apiToken).count == 0,
-      "identify: should move records from unidentified queue")
-    removeDBfile(testMixpanel)
-  }
-
-  func testOptInTrackingForDistinctIdAndWithEventProperties() {
-    let now = Date()
-    let testProperties: Properties = [
-      "string": "yello",
-      "number": 3,
-      "date": now,
-      "$app_version": "override",
-    ]
-    let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
-    testMixpanel.optInTracking(distinctId: "testDistinctId", properties: testProperties)
-    waitForTrackingQueue(testMixpanel)
-    waitForTrackingQueue(testMixpanel)
-    let eventQueueValue = eventQueue(token: testMixpanel.apiToken)
-
-    let props = eventQueueValue.first!["properties"] as? InternalProperties
-    XCTAssertEqual(props!["string"] as? String, "yello")
-    XCTAssertEqual(props!["number"] as? NSNumber, 3)
-    compareDate(dateString: props!["date"] as! String, dateDate: now)
-    XCTAssertEqual(
-      props!["$app_version"] as? String, "override", "reserved property override failed")
-
-    if eventQueueValue.count > 0 {
-      let event = eventQueueValue.first
-      XCTAssertEqual(
-        (event!["event"] as? String), "$opt_in",
-        "When opted in, a track '$opt_in' should have been queued")
-    } else {
-      XCTAssertTrue(
-        eventQueueValue.count == 1,
-        "When opted in, event queue should have one even(opt in) being queued")
+    func testHasOptOutTrackingFlagBeingSetProperlyAfterInitializedWithOptedOutYES() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            testMixpanel.hasOptedOutTracking(),
+            "When initialize with opted out flag set to YES, the current user should have opted out tracking"
+        )
+        testMixpanel.reset()
+        removeDBfile(testMixpanel)
     }
 
-    XCTAssertEqual(
-      testMixpanel.distinctId, "testDistinctId", "mixpanel identify failed to set distinct id")
-    XCTAssertEqual(
-      testMixpanel.people.distinctId, "testDistinctId",
-      "mixpanel identify failed to set people distinct id")
-    XCTAssertTrue(
-      unIdentifiedPeopleQueue(token: testMixpanel.apiToken).count == 0,
-      "identify: should move records from unidentified queue")
-    removeDBfile(testMixpanel)
-  }
+    func testOptInWillAddOptInEvent() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
+        testMixpanel.optInTracking()
+        XCTAssertFalse(
+            testMixpanel.hasOptedOutTracking(), "The current user should have opted in tracking")
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 1,
+            "When opted in, event queue should have one even(opt in) being queued")
 
-  func testHasOptOutTrackingFlagBeingSetProperlyForMultipleInstances() {
-    let mixpanel1 = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
-    waitForTrackingQueue(mixpanel1)
-    XCTAssertTrue(
-      mixpanel1.hasOptedOutTracking(),
-      "When initialize with opted out flag set to YES, the current user should have opted out tracking"
-    )
-    removeDBfile(mixpanel1)
-
-    let mixpanel2 = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: false)
-    XCTAssertFalse(
-      mixpanel2.hasOptedOutTracking(),
-      "When initialize with opted out flag set to NO, the current user should have opted in tracking"
-    )
-    removeDBfile(mixpanel2)
-  }
-
-  func testHasOptOutTrackingFlagBeingSetProperlyAfterInitializedWithOptedOutNO() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: false)
-    XCTAssertFalse(
-      testMixpanel.hasOptedOutTracking(),
-      "When initialize with opted out flag set to NO, the current user should have opted out tracking"
-    )
-    removeDBfile(testMixpanel)
-  }
-
-  func testHasOptOutTrackingFlagBeingSetProperlyByDefault() {
-    let testMixpanel = Mixpanel.initialize(token: randomId())
-    XCTAssertFalse(
-      testMixpanel.hasOptedOutTracking(),
-      "By default, the current user should not opted out tracking")
-    removeDBfile(testMixpanel)
-  }
-
-  func testHasOptOutTrackingFlagBeingSetProperlyForOptOut() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.optOutTracking()
-    XCTAssertTrue(
-      testMixpanel.hasOptedOutTracking(),
-      "When optOutTracking is called, the current user should have opted out tracking")
-    removeDBfile(testMixpanel)
-  }
-
-  func testHasOptOutTrackingFlagBeingSetProperlyForOptIn() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.optOutTracking()
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      testMixpanel.hasOptedOutTracking(),
-      "When optOutTracking is called, the current user should have opted out tracking")
-    testMixpanel.optInTracking()
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertFalse(
-      testMixpanel.hasOptedOutTracking(),
-      "When optOutTracking is called, the current user should have opted in tracking")
-    removeDBfile(testMixpanel)
-  }
-
-  func testOptOutTrackingWillNotGenerateEventQueue() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.optOutTracking()
-    for i in 0..<50 {
-      testMixpanel.track(event: "event \(i)")
+        if eventQueue(token: testMixpanel.apiToken).count > 0 {
+            let event = eventQueue(token: testMixpanel.apiToken).first
+            XCTAssertEqual(
+                (event!["event"] as? String), "$opt_in",
+                "When opted in, a track '$opt_in' should have been queued")
+        } else {
+            XCTAssertTrue(
+                eventQueue(token: testMixpanel.apiToken).count == 1,
+                "When opted in, event queue should have one even(opt in) being queued")
+        }
+        removeDBfile(testMixpanel)
     }
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 0,
-      "When opted out, events should not be queued")
-    removeDBfile(testMixpanel)
-  }
 
-  func testOptOutTrackingWillNotGeneratePeopleQueue() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
-    testMixpanel.optOutTracking()
-    for i in 0..<50 {
-      testMixpanel.people.set(property: "p1", to: "\(i)")
+    func testOptInTrackingForDistinctId() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
+        testMixpanel.optInTracking(distinctId: "testDistinctId")
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertFalse(
+            testMixpanel.hasOptedOutTracking(), "The current user should have opted in tracking")
+        waitForTrackingQueue(testMixpanel)
+        let event = eventQueue(token: testMixpanel.apiToken).first
+        XCTAssertEqual(
+            (event!["event"] as? String), "$opt_in",
+            "When opted in, a track '$opt_in' should have been queued")
+        XCTAssertEqual(
+            testMixpanel.distinctId, "testDistinctId", "mixpanel identify failed to set distinct id")
+        XCTAssertEqual(
+            testMixpanel.people.distinctId, "testDistinctId",
+            "mixpanel identify failed to set people distinct id")
+        XCTAssertTrue(
+            unIdentifiedPeopleQueue(token: testMixpanel.apiToken).count == 0,
+            "identify: should move records from unidentified queue")
+        removeDBfile(testMixpanel)
     }
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel.apiToken).count == 0,
-      "When opted out, events should not be queued")
-    removeDBfile(testMixpanel)
-  }
 
-  func testOptOutTrackingWillSkipAlias() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
-    testMixpanel.optOutTracking()
-    testMixpanel.createAlias("testAlias", distinctId: "aDistinctId")
-    XCTAssertNotEqual(testMixpanel.alias, "testAlias", "When opted out, alias should not be set")
-    removeDBfile(testMixpanel)
-  }
+    func testOptInTrackingForDistinctIdAndWithEventProperties() {
+        let now = Date()
+        let testProperties: Properties = [
+            "string": "yello",
+            "number": 3,
+            "date": now,
+            "$app_version": "override",
+        ]
+        let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
+        testMixpanel.optInTracking(distinctId: "testDistinctId", properties: testProperties)
+        waitForTrackingQueue(testMixpanel)
+        waitForTrackingQueue(testMixpanel)
+        let eventQueueValue = eventQueue(token: testMixpanel.apiToken)
 
-  func testEventBeingTrackedBeforeOptOutShouldNotBeCleared() {
-    let testMixpanel = Mixpanel.initialize(token: randomId())
-    testMixpanel.track(event: "a normal event")
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).count == 1, "events should be queued")
-    testMixpanel.optOutTracking()
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 1,
-      "When opted out, any events tracked before opted out should not be cleared")
-    removeDBfile(testMixpanel)
-  }
+        let props = eventQueueValue.first!["properties"] as? InternalProperties
+        XCTAssertEqual(props!["string"] as? String, "yello")
+        XCTAssertEqual(props!["number"] as? NSNumber, 3)
+        compareDate(dateString: props!["date"] as! String, dateDate: now)
+        XCTAssertEqual(
+            props!["$app_version"] as? String, "override", "reserved property override failed")
 
-  func testOptOutTrackingRegisterSuperProperties() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
-    waitForTrackingQueue(testMixpanel)
-    let properties: Properties = ["p1": "a", "p2": 3, "p3": Date()]
-    testMixpanel.optOutTracking()
-    waitForTrackingQueue(testMixpanel)
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.registerSuperProperties(properties)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertNotEqual(
-      NSDictionary(dictionary: testMixpanel.currentSuperProperties()),
-      NSDictionary(dictionary: properties),
-      "When opted out, register super properties should not be successful")
-    removeDBfile(testMixpanel)
-  }
+        if eventQueueValue.count > 0 {
+            let event = eventQueueValue.first
+            XCTAssertEqual(
+                (event!["event"] as? String), "$opt_in",
+                "When opted in, a track '$opt_in' should have been queued")
+        } else {
+            XCTAssertTrue(
+                eventQueueValue.count == 1,
+                "When opted in, event queue should have one even(opt in) being queued")
+        }
 
-  func testOptOutTrackingRegisterSuperPropertiesOnce() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
-    waitForTrackingQueue(testMixpanel)
-    let properties: Properties = ["p1": "a", "p2": 3, "p3": Date()]
-    testMixpanel.optOutTracking()
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.registerSuperPropertiesOnce(properties)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertNotEqual(
-      NSDictionary(dictionary: testMixpanel.currentSuperProperties()),
-      NSDictionary(dictionary: properties),
-      "When opted out, register super properties once should not be successful")
-    removeDBfile(testMixpanel)
-  }
-
-  func testOptOutWilSkipTimeEvent() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
-    testMixpanel.optOutTracking()
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.time(event: "400 Meters")
-    testMixpanel.track(event: "400 Meters")
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertNil(
-      eventQueue(token: testMixpanel.apiToken).last,
-      "When opted out, this event should not be timed.")
-    removeDBfile(testMixpanel)
-  }
-
-  func testOptOutWillSkipFlushPeople() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.optInTracking()
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.identify(distinctId: "d1")
-    waitForTrackingQueue(testMixpanel)
-    for i in 0..<1 {
-      testMixpanel.people.set(property: "p1", to: "\(i)")
+        XCTAssertEqual(
+            testMixpanel.distinctId, "testDistinctId", "mixpanel identify failed to set distinct id")
+        XCTAssertEqual(
+            testMixpanel.people.distinctId, "testDistinctId",
+            "mixpanel identify failed to set people distinct id")
+        XCTAssertTrue(
+            unIdentifiedPeopleQueue(token: testMixpanel.apiToken).count == 0,
+            "identify: should move records from unidentified queue")
+        removeDBfile(testMixpanel)
     }
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel.apiToken).count == 1,
-      "When opted in, people queue should have been queued")
 
-    testMixpanel.optOutTracking()
-    waitForTrackingQueue(testMixpanel)
+    func testHasOptOutTrackingFlagBeingSetProperlyForMultipleInstances() {
+        let mixpanel1 = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
+        waitForTrackingQueue(mixpanel1)
+        XCTAssertTrue(
+            mixpanel1.hasOptedOutTracking(),
+            "When initialize with opted out flag set to YES, the current user should have opted out tracking"
+        )
+        removeDBfile(mixpanel1)
 
-    testMixpanel.flush()
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel.apiToken).count == 1,
-      "When opted out, people queue should not be flushed")
-    removeDBfile(testMixpanel)
-  }
-
-  func testOptOutWillSkipFlushEvent() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
-    testMixpanel.optInTracking()
-    testMixpanel.identify(distinctId: "d1")
-    waitForTrackingQueue(testMixpanel)
-    for i in 0..<1 {
-      testMixpanel.track(event: "event \(i)")
+        let mixpanel2 = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: false)
+        XCTAssertFalse(
+            mixpanel2.hasOptedOutTracking(),
+            "When initialize with opted out flag set to NO, the current user should have opted in tracking"
+        )
+        removeDBfile(mixpanel2)
     }
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 3,
-      "When opted in, events should have been queued")
 
-    testMixpanel.optOutTracking()
-    waitForTrackingQueue(testMixpanel)
+    func testHasOptOutTrackingFlagBeingSetProperlyAfterInitializedWithOptedOutNO() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: false)
+        XCTAssertFalse(
+            testMixpanel.hasOptedOutTracking(),
+            "When initialize with opted out flag set to NO, the current user should have opted out tracking"
+        )
+        removeDBfile(testMixpanel)
+    }
 
-    testMixpanel.flush()
-    waitForTrackingQueue(testMixpanel)
+    func testHasOptOutTrackingFlagBeingSetProperlyByDefault() {
+        let testMixpanel = Mixpanel.initialize(token: randomId())
+        XCTAssertFalse(
+            testMixpanel.hasOptedOutTracking(),
+            "By default, the current user should not opted out tracking")
+        removeDBfile(testMixpanel)
+    }
 
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 3,
-      "When opted out, events should not be flushed")
-    removeDBfile(testMixpanel)
-  }
+    func testHasOptOutTrackingFlagBeingSetProperlyForOptOut() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.optOutTracking()
+        XCTAssertTrue(
+            testMixpanel.hasOptedOutTracking(),
+            "When optOutTracking is called, the current user should have opted out tracking")
+        removeDBfile(testMixpanel)
+    }
+
+    func testHasOptOutTrackingFlagBeingSetProperlyForOptIn() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.optOutTracking()
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            testMixpanel.hasOptedOutTracking(),
+            "When optOutTracking is called, the current user should have opted out tracking")
+        testMixpanel.optInTracking()
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertFalse(
+            testMixpanel.hasOptedOutTracking(),
+            "When optOutTracking is called, the current user should have opted in tracking")
+        removeDBfile(testMixpanel)
+    }
+
+    func testOptOutTrackingWillNotGenerateEventQueue() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.optOutTracking()
+        for i in 0..<50 {
+            testMixpanel.track(event: "event \(i)")
+        }
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 0,
+            "When opted out, events should not be queued")
+        removeDBfile(testMixpanel)
+    }
+
+    func testOptOutTrackingWillNotGeneratePeopleQueue() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
+        testMixpanel.optOutTracking()
+        for i in 0..<50 {
+            testMixpanel.people.set(property: "p1", to: "\(i)")
+        }
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel.apiToken).count == 0,
+            "When opted out, events should not be queued")
+        removeDBfile(testMixpanel)
+    }
+
+    func testOptOutTrackingWillSkipAlias() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
+        testMixpanel.optOutTracking()
+        testMixpanel.createAlias("testAlias", distinctId: "aDistinctId")
+        XCTAssertNotEqual(testMixpanel.alias, "testAlias", "When opted out, alias should not be set")
+        removeDBfile(testMixpanel)
+    }
+
+    func testEventBeingTrackedBeforeOptOutShouldNotBeCleared() {
+        let testMixpanel = Mixpanel.initialize(token: randomId())
+        testMixpanel.track(event: "a normal event")
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).count == 1, "events should be queued")
+        testMixpanel.optOutTracking()
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 1,
+            "When opted out, any events tracked before opted out should not be cleared")
+        removeDBfile(testMixpanel)
+    }
+
+    func testOptOutTrackingRegisterSuperProperties() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
+        waitForTrackingQueue(testMixpanel)
+        let properties: Properties = ["p1": "a", "p2": 3, "p3": Date()]
+        testMixpanel.optOutTracking()
+        waitForTrackingQueue(testMixpanel)
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.registerSuperProperties(properties)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertNotEqual(
+            NSDictionary(dictionary: testMixpanel.currentSuperProperties()),
+            NSDictionary(dictionary: properties),
+            "When opted out, register super properties should not be successful")
+        removeDBfile(testMixpanel)
+    }
+
+    func testOptOutTrackingRegisterSuperPropertiesOnce() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
+        waitForTrackingQueue(testMixpanel)
+        let properties: Properties = ["p1": "a", "p2": 3, "p3": Date()]
+        testMixpanel.optOutTracking()
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.registerSuperPropertiesOnce(properties)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertNotEqual(
+            NSDictionary(dictionary: testMixpanel.currentSuperProperties()),
+            NSDictionary(dictionary: properties),
+            "When opted out, register super properties once should not be successful")
+        removeDBfile(testMixpanel)
+    }
+
+    func testOptOutWilSkipTimeEvent() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
+        testMixpanel.optOutTracking()
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.time(event: "400 Meters")
+        testMixpanel.track(event: "400 Meters")
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertNil(
+            eventQueue(token: testMixpanel.apiToken).last,
+            "When opted out, this event should not be timed.")
+        removeDBfile(testMixpanel)
+    }
+
+    func testOptOutWillSkipFlushPeople() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.optInTracking()
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.identify(distinctId: "d1")
+        waitForTrackingQueue(testMixpanel)
+        for i in 0..<1 {
+            testMixpanel.people.set(property: "p1", to: "\(i)")
+        }
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel.apiToken).count == 1,
+            "When opted in, people queue should have been queued")
+
+        testMixpanel.optOutTracking()
+        waitForTrackingQueue(testMixpanel)
+
+        testMixpanel.flush()
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel.apiToken).count == 1,
+            "When opted out, people queue should not be flushed")
+        removeDBfile(testMixpanel)
+    }
+
+    func testOptOutWillSkipFlushEvent() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), optOutTrackingByDefault: true)
+        testMixpanel.optInTracking()
+        testMixpanel.identify(distinctId: "d1")
+        waitForTrackingQueue(testMixpanel)
+        for i in 0..<1 {
+            testMixpanel.track(event: "event \(i)")
+        }
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 3,
+            "When opted in, events should have been queued")
+
+        testMixpanel.optOutTracking()
+        waitForTrackingQueue(testMixpanel)
+
+        testMixpanel.flush()
+        waitForTrackingQueue(testMixpanel)
+
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 3,
+            "When opted out, events should not be flushed")
+        removeDBfile(testMixpanel)
+    }
 }

--- a/MixpanelDemo/MixpanelDemoMacTests/MixpanelPeopleTests.swift
+++ b/MixpanelDemo/MixpanelDemoMacTests/MixpanelPeopleTests.swift
@@ -13,215 +13,215 @@ import XCTest
 
 class MixpanelPeopleTests: MixpanelBaseTests {
 
-  func testPeopleSet() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    waitForTrackingQueue(testMixpanel)
-    let p: Properties = ["p1": "a"]
-    testMixpanel.people.set(properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let q = peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
-    XCTAssertEqual(q["p1"] as? String, "a", "custom people property not queued")
-    assertDefaultPeopleProperties(q)
-    removeDBfile(testMixpanel)
-  }
-
-  func testPeopleSetOnce() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    let p: Properties = ["p1": "a"]
-    testMixpanel.people.setOnce(properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let q = peopleQueue(token: testMixpanel.apiToken).last!["$set_once"] as! InternalProperties
-    XCTAssertEqual(q["p1"] as? String, "a", "custom people property not queued")
-    assertDefaultPeopleProperties(q)
-    removeDBfile(testMixpanel)
-  }
-
-  func testPeopleSetReservedProperty() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    let p: Properties = ["$ios_app_version": "override"]
-    testMixpanel.people.set(properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let q = peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
-    XCTAssertEqual(
-      q["$ios_app_version"] as? String,
-      "override",
-      "reserved property override failed")
-    assertDefaultPeopleProperties(q)
-    removeDBfile(testMixpanel)
-  }
-
-  func testPeopleSetTo() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.people.set(property: "p1", to: "a")
-    waitForTrackingQueue(testMixpanel)
-    let p: InternalProperties =
-      peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
-    XCTAssertEqual(p["p1"] as? String, "a", "custom people property not queued")
-    assertDefaultPeopleProperties(p)
-    removeDBfile(testMixpanel)
-  }
-
-  func testDropUnidentifiedPeopleRecords() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    for i in 0..<505 {
-      testMixpanel.people.set(property: "i", to: i)
+    func testPeopleSet() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        waitForTrackingQueue(testMixpanel)
+        let p: Properties = ["p1": "a"]
+        testMixpanel.people.set(properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let q = peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
+        XCTAssertEqual(q["p1"] as? String, "a", "custom people property not queued")
+        assertDefaultPeopleProperties(q)
+        removeDBfile(testMixpanel)
     }
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(unIdentifiedPeopleQueue(token: testMixpanel.apiToken).count == 505)
-    var r: InternalProperties = unIdentifiedPeopleQueue(token: testMixpanel.apiToken).first!
-    XCTAssertEqual((r["$set"] as? InternalProperties)?["i"] as? Int, 0)
-    r = unIdentifiedPeopleQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual((r["$set"] as? InternalProperties)?["i"] as? Int, 504)
-    removeDBfile(testMixpanel)
-  }
 
-  func testPeopleAssertPropertyTypes() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    var p: Properties = ["URL": [Data()]]
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.people.set(properties: p)
+    func testPeopleSetOnce() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        let p: Properties = ["p1": "a"]
+        testMixpanel.people.setOnce(properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let q = peopleQueue(token: testMixpanel.apiToken).last!["$set_once"] as! InternalProperties
+        XCTAssertEqual(q["p1"] as? String, "a", "custom people property not queued")
+        assertDefaultPeopleProperties(q)
+        removeDBfile(testMixpanel)
     }
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.people.set(property: "p1", to: [Data()])
+
+    func testPeopleSetReservedProperty() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        let p: Properties = ["$ios_app_version": "override"]
+        testMixpanel.people.set(properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let q = peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
+        XCTAssertEqual(
+            q["$ios_app_version"] as? String,
+            "override",
+            "reserved property override failed")
+        assertDefaultPeopleProperties(q)
+        removeDBfile(testMixpanel)
     }
-    p = ["p1": "a"]
-    // increment should require a number
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.people.increment(properties: p)
+
+    func testPeopleSetTo() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.people.set(property: "p1", to: "a")
+        waitForTrackingQueue(testMixpanel)
+        let p: InternalProperties =
+            peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
+        XCTAssertEqual(p["p1"] as? String, "a", "custom people property not queued")
+        assertDefaultPeopleProperties(p)
+        removeDBfile(testMixpanel)
     }
-    removeDBfile(testMixpanel)
-  }
 
-  func testPeopleIncrement() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    let p: Properties = ["p1": 3]
-    testMixpanel.people.increment(properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let q = peopleQueue(token: testMixpanel.apiToken).last!["$add"] as! InternalProperties
-    XCTAssertTrue(q.count == 1, "incorrect people properties: \(p)")
-    XCTAssertEqual(q["p1"] as? Int, 3, "custom people property not queued")
-    removeDBfile(testMixpanel)
-  }
+    func testDropUnidentifiedPeopleRecords() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        for i in 0..<505 {
+            testMixpanel.people.set(property: "i", to: i)
+        }
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(unIdentifiedPeopleQueue(token: testMixpanel.apiToken).count == 505)
+        var r: InternalProperties = unIdentifiedPeopleQueue(token: testMixpanel.apiToken).first!
+        XCTAssertEqual((r["$set"] as? InternalProperties)?["i"] as? Int, 0)
+        r = unIdentifiedPeopleQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual((r["$set"] as? InternalProperties)?["i"] as? Int, 504)
+        removeDBfile(testMixpanel)
+    }
 
-  func testPeopleIncrementBy() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.people.increment(property: "p1", by: 3)
-    waitForTrackingQueue(testMixpanel)
-    let p: InternalProperties =
-      peopleQueue(token: testMixpanel.apiToken).last!["$add"] as! InternalProperties
-    XCTAssertTrue(p.count == 1, "incorrect people properties: \(p)")
-    XCTAssertEqual(p["p1"] as? Double, 3, "custom people property not queued")
-    removeDBfile(testMixpanel)
-  }
+    func testPeopleAssertPropertyTypes() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        var p: Properties = ["URL": [Data()]]
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.people.set(properties: p)
+        }
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.people.set(property: "p1", to: [Data()])
+        }
+        p = ["p1": "a"]
+        // increment should require a number
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.people.increment(properties: p)
+        }
+        removeDBfile(testMixpanel)
+    }
 
-  func testPeopleDeleteUser() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.people.deleteUser()
-    waitForTrackingQueue(testMixpanel)
-    let p: InternalProperties =
-      peopleQueue(token: testMixpanel.apiToken).last!["$delete"] as! InternalProperties
-    XCTAssertTrue(p.isEmpty, "incorrect people properties: \(p)")
-    removeDBfile(testMixpanel)
-  }
+    func testPeopleIncrement() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        let p: Properties = ["p1": 3]
+        testMixpanel.people.increment(properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let q = peopleQueue(token: testMixpanel.apiToken).last!["$add"] as! InternalProperties
+        XCTAssertTrue(q.count == 1, "incorrect people properties: \(p)")
+        XCTAssertEqual(q["p1"] as? Int, 3, "custom people property not queued")
+        removeDBfile(testMixpanel)
+    }
 
-  func testPeopleTrackChargeDecimal() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.people.trackCharge(amount: 25.34)
-    waitForTrackingQueue(testMixpanel)
-    let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
-    let prop =
-      ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
-      as? Double
-    let prop2 = ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?[
-      "$time"]
-    XCTAssertEqual(prop, 25.34)
-    XCTAssertNotNil(prop2)
-    removeDBfile(testMixpanel)
-  }
+    func testPeopleIncrementBy() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.people.increment(property: "p1", by: 3)
+        waitForTrackingQueue(testMixpanel)
+        let p: InternalProperties =
+            peopleQueue(token: testMixpanel.apiToken).last!["$add"] as! InternalProperties
+        XCTAssertTrue(p.count == 1, "incorrect people properties: \(p)")
+        XCTAssertEqual(p["p1"] as? Double, 3, "custom people property not queued")
+        removeDBfile(testMixpanel)
+    }
 
-  func testPeopleTrackChargeZero() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.people.trackCharge(amount: 0)
-    waitForTrackingQueue(testMixpanel)
-    let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
-    let prop =
-      ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
-      as? Double
-    let prop2 = ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?[
-      "$time"]
-    XCTAssertEqual(prop, 0)
-    XCTAssertNotNil(prop2)
-    removeDBfile(testMixpanel)
-  }
+    func testPeopleDeleteUser() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.people.deleteUser()
+        waitForTrackingQueue(testMixpanel)
+        let p: InternalProperties =
+            peopleQueue(token: testMixpanel.apiToken).last!["$delete"] as! InternalProperties
+        XCTAssertTrue(p.isEmpty, "incorrect people properties: \(p)")
+        removeDBfile(testMixpanel)
+    }
 
-  func testPeopleTrackChargeWithTime() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    let p: Properties = allPropertyTypes()
-    testMixpanel.people.trackCharge(amount: 25, properties: ["$time": p["date"]!])
-    waitForTrackingQueue(testMixpanel)
-    let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
-    let prop =
-      ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
-      as? Double
-    let prop2 =
-      ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$time"]
-      as? String
-    XCTAssertEqual(prop, 25)
-    compareDate(dateString: prop2!, dateDate: p["date"] as! Date)
-    removeDBfile(testMixpanel)
-  }
+    func testPeopleTrackChargeDecimal() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.people.trackCharge(amount: 25.34)
+        waitForTrackingQueue(testMixpanel)
+        let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
+        let prop =
+            ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
+            as? Double
+        let prop2 = ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?[
+            "$time"]
+        XCTAssertEqual(prop, 25.34)
+        XCTAssertNotNil(prop2)
+        removeDBfile(testMixpanel)
+    }
 
-  func testPeopleTrackChargeWithProperties() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.people.trackCharge(amount: 25, properties: ["p1": "a"])
-    waitForTrackingQueue(testMixpanel)
-    let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
-    let prop =
-      ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
-      as? Double
-    let prop2 = ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?[
-      "p1"]
-    XCTAssertEqual(prop, 25)
-    XCTAssertEqual(prop2 as? String, "a")
-    removeDBfile(testMixpanel)
-  }
+    func testPeopleTrackChargeZero() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.people.trackCharge(amount: 0)
+        waitForTrackingQueue(testMixpanel)
+        let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
+        let prop =
+            ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
+            as? Double
+        let prop2 = ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?[
+            "$time"]
+        XCTAssertEqual(prop, 0)
+        XCTAssertNotNil(prop2)
+        removeDBfile(testMixpanel)
+    }
 
-  func testPeopleTrackCharge() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.people.trackCharge(amount: 25)
-    waitForTrackingQueue(testMixpanel)
-    let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
-    let prop =
-      ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
-      as? Double
-    let prop2 = ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?[
-      "$time"]
-    XCTAssertEqual(prop, 25)
-    XCTAssertNotNil(prop2)
-    removeDBfile(testMixpanel)
-  }
+    func testPeopleTrackChargeWithTime() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        let p: Properties = allPropertyTypes()
+        testMixpanel.people.trackCharge(amount: 25, properties: ["$time": p["date"]!])
+        waitForTrackingQueue(testMixpanel)
+        let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
+        let prop =
+            ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
+            as? Double
+        let prop2 =
+            ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$time"]
+            as? String
+        XCTAssertEqual(prop, 25)
+        compareDate(dateString: prop2!, dateDate: p["date"] as! Date)
+        removeDBfile(testMixpanel)
+    }
 
-  func testPeopleClearCharges() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.people.clearCharges()
-    waitForTrackingQueue(testMixpanel)
-    let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
-    let transactions = (r["$set"] as? InternalProperties)?["$transactions"] as? [MixpanelType]
-    XCTAssertEqual(transactions?.count, 0)
-    removeDBfile(testMixpanel)
-  }
+    func testPeopleTrackChargeWithProperties() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.people.trackCharge(amount: 25, properties: ["p1": "a"])
+        waitForTrackingQueue(testMixpanel)
+        let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
+        let prop =
+            ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
+            as? Double
+        let prop2 = ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?[
+            "p1"]
+        XCTAssertEqual(prop, 25)
+        XCTAssertEqual(prop2 as? String, "a")
+        removeDBfile(testMixpanel)
+    }
+
+    func testPeopleTrackCharge() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.people.trackCharge(amount: 25)
+        waitForTrackingQueue(testMixpanel)
+        let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
+        let prop =
+            ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
+            as? Double
+        let prop2 = ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?[
+            "$time"]
+        XCTAssertEqual(prop, 25)
+        XCTAssertNotNil(prop2)
+        removeDBfile(testMixpanel)
+    }
+
+    func testPeopleClearCharges() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.people.clearCharges()
+        waitForTrackingQueue(testMixpanel)
+        let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
+        let transactions = (r["$set"] as? InternalProperties)?["$transactions"] as? [MixpanelType]
+        XCTAssertEqual(transactions?.count, 0)
+        removeDBfile(testMixpanel)
+    }
 }

--- a/MixpanelDemo/MixpanelDemoMacTests/TestConstants.swift
+++ b/MixpanelDemo/MixpanelDemoMacTests/TestConstants.swift
@@ -14,22 +14,22 @@ let kFakeServerUrl = "https://34a272abf23d.com"
 
 extension XCTestCase {
 
-  func XCTExpectAssert(
-    _ expectedMessage: String, file: StaticString = #file, line: UInt = #line, block: () -> Void
-  ) {
-    let exp = expectation(description: expectedMessage)
+    func XCTExpectAssert(
+        _ expectedMessage: String, file: StaticString = #file, line: UInt = #line, block: () -> Void
+    ) {
+        let exp = expectation(description: expectedMessage)
 
-    Assertions.assertClosure = {
-      (condition, message, file, line) in
-      if !condition {
-        exp.fulfill()
-      }
+        Assertions.assertClosure = {
+            (condition, message, file, line) in
+            if !condition {
+                exp.fulfill()
+            }
+        }
+
+        // Call code.
+        block()
+        waitForExpectations(timeout: 0.5, handler: nil)
+        Assertions.assertClosure = Assertions.swiftAssertClosure
     }
-
-    // Call code.
-    block()
-    waitForExpectations(timeout: 0.5, handler: nil)
-    Assertions.assertClosure = Assertions.swiftAssertClosure
-  }
 
 }

--- a/MixpanelDemo/MixpanelDemoMacUITests/MixpanelDemoMacUITests.swift
+++ b/MixpanelDemo/MixpanelDemoMacUITests/MixpanelDemoMacUITests.swift
@@ -10,34 +10,34 @@ import XCTest
 
 class MixpanelDemoMacUITests: XCTestCase {
 
-  override func setUpWithError() throws {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
 
-    // In UI tests it is usually best to stop immediately when a failure occurs.
-    continueAfterFailure = false
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
 
-    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
-  }
-
-  override func tearDownWithError() throws {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-  }
-
-  func testExample() throws {
-    // UI tests must launch the application that they test.
-    let app = XCUIApplication()
-    app.launch()
-
-    // Use recording to get started writing UI tests.
-    // Use XCTAssert and related functions to verify your tests produce the correct results.
-  }
-
-  func testLaunchPerformance() throws {
-    if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // This measures how long it takes to launch your application.
-      measure(metrics: [XCTApplicationLaunchMetric()]) {
-        XCUIApplication().launch()
-      }
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
     }
-  }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
 }

--- a/MixpanelDemo/MixpanelDemoTV/AppDelegate.swift
+++ b/MixpanelDemo/MixpanelDemoTV/AppDelegate.swift
@@ -12,49 +12,49 @@ import UIKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-  var window: UIWindow?
+    var window: UIWindow?
 
-  func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-  ) -> Bool {
-    // Override point for customization after application launch.
-    print("didFinishLaunchingWithOptions")
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        // Override point for customization after application launch.
+        print("didFinishLaunchingWithOptions")
 
-    var ADD_YOUR_MIXPANEL_TOKEN_BELOW_🛠🛠🛠🛠🛠🛠: String
-    Mixpanel.initialize(token: "MIXPANEL_TOKEN")
-    Mixpanel.mainInstance().loggingEnabled = true
-    Mixpanel.mainInstance().registerSuperProperties(["super apple tv properties": 1])
-    Mixpanel.mainInstance().track(event: "apple tv track")
+        var ADD_YOUR_MIXPANEL_TOKEN_BELOW_🛠🛠🛠🛠🛠🛠: String
+        Mixpanel.initialize(token: "MIXPANEL_TOKEN")
+        Mixpanel.mainInstance().loggingEnabled = true
+        Mixpanel.mainInstance().registerSuperProperties(["super apple tv properties": 1])
+        Mixpanel.mainInstance().track(event: "apple tv track")
 
-    return true
-  }
+        return true
+    }
 
-  func applicationWillResignActive(_ application: UIApplication) {
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
-    print("applicationWillResignActive")
-  }
+    func applicationWillResignActive(_ application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+        print("applicationWillResignActive")
+    }
 
-  func applicationDidEnterBackground(_ application: UIApplication) {
-    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    print("applicationDidEnterBackground")
-  }
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+        print("applicationDidEnterBackground")
+    }
 
-  func applicationWillEnterForeground(_ application: UIApplication) {
-    // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
-    print("applicationWillEnterForeground")
-  }
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+        print("applicationWillEnterForeground")
+    }
 
-  func applicationDidBecomeActive(_ application: UIApplication) {
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-    print("applicationDidBecomeActive")
-  }
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+        print("applicationDidBecomeActive")
+    }
 
-  func applicationWillTerminate(_ application: UIApplication) {
-    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-    print("applicationWillTerminate")
-  }
+    func applicationWillTerminate(_ application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+        print("applicationWillTerminate")
+    }
 
 }

--- a/MixpanelDemo/MixpanelDemoTV/ViewController.swift
+++ b/MixpanelDemo/MixpanelDemoTV/ViewController.swift
@@ -11,26 +11,26 @@ import UIKit
 
 class ViewController: UIViewController {
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    // Do any additional setup after loading the view, typically from a nib.
-  }
-
-  @IBAction func timeEventClicked(_ sender: Any) {
-    Mixpanel.mainInstance().time(event: "time something")
-    DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-      Mixpanel.mainInstance().track(event: "time something")
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
     }
-  }
 
-  @IBAction func TrackEventClicked(_ sender: Any) {
-    Mixpanel.mainInstance().track(
-      event: "Player Create", properties: ["gender": "Male", "weapon": "Pistol"])
-  }
+    @IBAction func timeEventClicked(_ sender: Any) {
+        Mixpanel.mainInstance().time(event: "time something")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            Mixpanel.mainInstance().track(event: "time something")
+        }
+    }
 
-  @IBAction func peopleClicked(_ sender: Any) {
-    let mixpanel = Mixpanel.mainInstance()
-    mixpanel.people.set(properties: ["gender": "Male", "weapon": "Pistol"])
-    mixpanel.identify(distinctId: mixpanel.distinctId)
-  }
+    @IBAction func TrackEventClicked(_ sender: Any) {
+        Mixpanel.mainInstance().track(
+            event: "Player Create", properties: ["gender": "Male", "weapon": "Pistol"])
+    }
+
+    @IBAction func peopleClicked(_ sender: Any) {
+        let mixpanel = Mixpanel.mainInstance()
+        mixpanel.people.set(properties: ["gender": "Male", "weapon": "Pistol"])
+        mixpanel.identify(distinctId: mixpanel.distinctId)
+    }
 }

--- a/MixpanelDemo/MixpanelDemoTVTests/MixpanelDemoTVTests.swift
+++ b/MixpanelDemo/MixpanelDemoTVTests/MixpanelDemoTVTests.swift
@@ -12,24 +12,24 @@ import XCTest
 
 class MixpanelDemoTVTests: XCTestCase {
 
-  override func setUp() {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-  }
-
-  override func tearDown() {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-  }
-
-  func testExample() {
-    // This is an example of a functional test case.
-    // Use XCTAssert and related functions to verify your tests produce the correct results.
-  }
-
-  func testPerformanceExample() {
-    // This is an example of a performance test case.
-    self.measure {
-      // Put the code you want to measure the time of here.
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-  }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
 
 }

--- a/MixpanelDemo/MixpanelDemoTVTests/MixpanelEventBridgeTests.swift
+++ b/MixpanelDemo/MixpanelDemoTVTests/MixpanelEventBridgeTests.swift
@@ -6,112 +6,112 @@
 //  Copyright © 2026 Mixpanel. All rights reserved.
 //
 
-import XCTest
 import MixpanelSwiftCommon
+import XCTest
 
 @testable import Mixpanel
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 class MixpanelEventBridgeTests: XCTestCase {
 
-  private func randomId() -> String {
-    return String(format: "%08x%08x", arc4random(), arc4random())
-  }
-
-  private func waitForTrackingQueue(_ mixpanel: MixpanelInstance) {
-    mixpanel.trackingQueue.sync {
-      mixpanel.networkQueue.sync { return }
+    private func randomId() -> String {
+        return String(format: "%08x%08x", arc4random(), arc4random())
     }
-    mixpanel.trackingQueue.sync {
-      mixpanel.networkQueue.sync { return }
-    }
-  }
 
-  private func removeDBfile(_ apiToken: String) {
-    let manager = FileManager.default
-    let url = manager.urls(for: .cachesDirectory, in: .userDomainMask).last
-    guard let path = url?.appendingPathComponent("\(apiToken)_MPDB.sqlite").path else { return }
-    guard manager.fileExists(atPath: path) else { return }
-    try? manager.removeItem(atPath: path)
-  }
-
-  // MARK: - Event Bridge Notified on Track
-
-  func testEventBridgeNotifiedOnTrack() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: false)
-    let eventName = "BridgeTestEvent_\(randomId())"
-    let expectation = XCTestExpectation(description: "Event bridge is notified when event is tracked")
-
-    let stream = MixpanelEventBridge.shared.eventStream()
-    let task = Task {
-      for await event in stream {
-        if event.eventName == eventName {
-          expectation.fulfill()
-          break
+    private func waitForTrackingQueue(_ mixpanel: MixpanelInstance) {
+        mixpanel.trackingQueue.sync {
+            mixpanel.networkQueue.sync { return }
         }
-      }
-    }
-
-    testMixpanel.track(event: eventName)
-    waitForTrackingQueue(testMixpanel)
-
-    wait(for: [expectation], timeout: 2.0)
-    task.cancel()
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  // MARK: - Event Bridge Receives Properties
-
-  func testEventBridgeReceivesEventProperties() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: false)
-    let eventName = "BridgePropsTest_\(randomId())"
-    let expectation = XCTestExpectation(
-      description: "Event bridge receives event with correct properties")
-
-    let stream = MixpanelEventBridge.shared.eventStream()
-    let task = Task {
-      for await event in stream {
-        if event.eventName == eventName {
-          XCTAssertEqual(event.properties["testKey"] as? String, "testValue")
-          expectation.fulfill()
-          break
+        mixpanel.trackingQueue.sync {
+            mixpanel.networkQueue.sync { return }
         }
-      }
     }
 
-    testMixpanel.track(event: eventName, properties: ["testKey": "testValue"])
-    waitForTrackingQueue(testMixpanel)
+    private func removeDBfile(_ apiToken: String) {
+        let manager = FileManager.default
+        let url = manager.urls(for: .cachesDirectory, in: .userDomainMask).last
+        guard let path = url?.appendingPathComponent("\(apiToken)_MPDB.sqlite").path else { return }
+        guard manager.fileExists(atPath: path) else { return }
+        try? manager.removeItem(atPath: path)
+    }
 
-    wait(for: [expectation], timeout: 2.0)
-    task.cancel()
-    removeDBfile(testMixpanel.apiToken)
-  }
+    // MARK: - Event Bridge Notified on Track
 
-  // MARK: - Event Bridge Not Notified When Opted Out
+    func testEventBridgeNotifiedOnTrack() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: false)
+        let eventName = "BridgeTestEvent_\(randomId())"
+        let expectation = XCTestExpectation(description: "Event bridge is notified when event is tracked")
 
-  func testEventBridgeNotNotifiedWhenOptedOut() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: false, optOutTrackingByDefault: true)
-    let eventName = "BridgeOptOutTest_\(randomId())"
-    let noEventExpectation = XCTestExpectation(
-      description: "Event bridge should not be notified when tracking is opted out")
-    noEventExpectation.isInverted = true
-
-    let stream = MixpanelEventBridge.shared.eventStream()
-    let task = Task {
-      for await event in stream {
-        if event.eventName == eventName {
-          noEventExpectation.fulfill()
+        let stream = MixpanelEventBridge.shared.eventStream()
+        let task = Task {
+            for await event in stream {
+                if event.eventName == eventName {
+                    expectation.fulfill()
+                    break
+                }
+            }
         }
-      }
+
+        testMixpanel.track(event: eventName)
+        waitForTrackingQueue(testMixpanel)
+
+        wait(for: [expectation], timeout: 2.0)
+        task.cancel()
+        removeDBfile(testMixpanel.apiToken)
     }
 
-    testMixpanel.track(event: eventName)
-    waitForTrackingQueue(testMixpanel)
+    // MARK: - Event Bridge Receives Properties
 
-    wait(for: [noEventExpectation], timeout: 1.0)
-    task.cancel()
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testEventBridgeReceivesEventProperties() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: false)
+        let eventName = "BridgePropsTest_\(randomId())"
+        let expectation = XCTestExpectation(
+            description: "Event bridge receives event with correct properties")
+
+        let stream = MixpanelEventBridge.shared.eventStream()
+        let task = Task {
+            for await event in stream {
+                if event.eventName == eventName {
+                    XCTAssertEqual(event.properties["testKey"] as? String, "testValue")
+                    expectation.fulfill()
+                    break
+                }
+            }
+        }
+
+        testMixpanel.track(event: eventName, properties: ["testKey": "testValue"])
+        waitForTrackingQueue(testMixpanel)
+
+        wait(for: [expectation], timeout: 2.0)
+        task.cancel()
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    // MARK: - Event Bridge Not Notified When Opted Out
+
+    func testEventBridgeNotNotifiedWhenOptedOut() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: false, optOutTrackingByDefault: true)
+        let eventName = "BridgeOptOutTest_\(randomId())"
+        let noEventExpectation = XCTestExpectation(
+            description: "Event bridge should not be notified when tracking is opted out")
+        noEventExpectation.isInverted = true
+
+        let stream = MixpanelEventBridge.shared.eventStream()
+        let task = Task {
+            for await event in stream {
+                if event.eventName == eventName {
+                    noEventExpectation.fulfill()
+                }
+            }
+        }
+
+        testMixpanel.track(event: eventName)
+        waitForTrackingQueue(testMixpanel)
+
+        wait(for: [noEventExpectation], timeout: 1.0)
+        task.cancel()
+        removeDBfile(testMixpanel.apiToken)
+    }
 
 }

--- a/MixpanelDemo/MixpanelDemoTVUITests/MixpanelDemoTVUITests.swift
+++ b/MixpanelDemo/MixpanelDemoTVUITests/MixpanelDemoTVUITests.swift
@@ -10,25 +10,25 @@ import XCTest
 
 class MixpanelDemoTVUITests: XCTestCase {
 
-  override func setUp() {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
 
-    // In UI tests it is usually best to stop immediately when a failure occurs.
-    continueAfterFailure = false
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
 
-    // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
-    XCUIApplication().launch()
+        // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
+        XCUIApplication().launch()
 
-    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
-  }
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
 
-  override func tearDown() {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-  }
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
 
-  func testExample() {
-    // Use recording to get started writing UI tests.
-    // Use XCTAssert and related functions to verify your tests produce the correct results.
-  }
+    func testExample() {
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
 
 }

--- a/MixpanelDemo/MixpanelDemoTests/JSONHandlerTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/JSONHandlerTests.swift
@@ -12,78 +12,78 @@ import XCTest
 
 class JSONHandlerTests: XCTestCase {
 
-  func testSerializeJSONObject() {
-    let nSNumberProp: NSNumber = NSNumber(value: 1)
-    let doubleProp: Double = 2.0
-    let floatProp: Float = Float(3.5)
-    let stringProp: String = "string"
-    let intProp: Int = -4
-    let uIntProp: UInt = 4
-    let uInt64Prop: UInt64 = 5_000_000_000
-    let boolProp: Bool = true
-    let optArrayProp: [Double?] = [nil, 1.0, 2.0]
-    let arrayProp: [Double] = [0.0, 1.0, 2.0]
-    let dictProp: [String: String?] = ["nil": nil, "a": "a", "b": "b"]
-    let dateProp: Date = Date()
-    let urlProp: URL = URL(string: "https://www.mixpanel.com")!
-    let nilProp: String? = nil
-    let nestedDictProp: [String: [String: String?]] = ["nested": dictProp]
-    let nestedArraryProp: [[Double?]] = [optArrayProp]
+    func testSerializeJSONObject() {
+        let nSNumberProp: NSNumber = NSNumber(value: 1)
+        let doubleProp: Double = 2.0
+        let floatProp: Float = Float(3.5)
+        let stringProp: String = "string"
+        let intProp: Int = -4
+        let uIntProp: UInt = 4
+        let uInt64Prop: UInt64 = 5_000_000_000
+        let boolProp: Bool = true
+        let optArrayProp: [Double?] = [nil, 1.0, 2.0]
+        let arrayProp: [Double] = [0.0, 1.0, 2.0]
+        let dictProp: [String: String?] = ["nil": nil, "a": "a", "b": "b"]
+        let dateProp: Date = Date()
+        let urlProp: URL = URL(string: "https://www.mixpanel.com")!
+        let nilProp: String? = nil
+        let nestedDictProp: [String: [String: String?]] = ["nested": dictProp]
+        let nestedArraryProp: [[Double?]] = [optArrayProp]
 
-    let event: [String: Any] = [
-      "event": "test",
-      "properties": [
-        "nSNumberProp": nSNumberProp,
-        "doubleProp": doubleProp,
-        "floatProp": floatProp,
-        "stringProp": stringProp,
-        "intProp": intProp,
-        "uIntProp": uIntProp,
-        "uInt64Prop": uInt64Prop,
-        "boolProp": boolProp,
-        "optArrayProp": optArrayProp,
-        "arrayProp": arrayProp,
-        "dictProp": dictProp,
-        "dateProp": dateProp,
-        "urlProp": urlProp,
-        "nilProp": nilProp as Any,
-        "nestedDictProp": nestedDictProp,
-        "nestedArraryProp": nestedArraryProp,
-      ],
-    ]
+        let event: [String: Any] = [
+            "event": "test",
+            "properties": [
+                "nSNumberProp": nSNumberProp,
+                "doubleProp": doubleProp,
+                "floatProp": floatProp,
+                "stringProp": stringProp,
+                "intProp": intProp,
+                "uIntProp": uIntProp,
+                "uInt64Prop": uInt64Prop,
+                "boolProp": boolProp,
+                "optArrayProp": optArrayProp,
+                "arrayProp": arrayProp,
+                "dictProp": dictProp,
+                "dateProp": dateProp,
+                "urlProp": urlProp,
+                "nilProp": nilProp as Any,
+                "nestedDictProp": nestedDictProp,
+                "nestedArraryProp": nestedArraryProp,
+            ],
+        ]
 
-    let serializedQueue = JSONHandler.serializeJSONObject([event])
-    let deserializedQueue =
-      try! JSONSerialization.jsonObject(with: serializedQueue!, options: []) as! [[String: Any]]
-    XCTAssertEqual(deserializedQueue[0]["event"] as! String, "test")
-    let props = deserializedQueue[0]["properties"] as! [String: Any]
-    XCTAssertEqual(props["nSNumberProp"] as! NSNumber, nSNumberProp)
-    XCTAssertEqual(props["doubleProp"] as! Double, doubleProp)
-    XCTAssertEqual(props["floatProp"] as! Float, floatProp)
-    XCTAssertEqual(props["stringProp"] as! String, stringProp)
-    XCTAssertEqual(props["intProp"] as! Int, intProp)
-    XCTAssertEqual(props["uIntProp"] as! UInt, uIntProp)
-    XCTAssertEqual(props["uInt64Prop"] as! UInt64, uInt64Prop)
-    XCTAssertEqual(props["boolProp"] as! Bool, boolProp)
-    // nil should be dropped from Array properties
-    XCTAssertEqual(props["optArrayProp"] as! Array, [1.0, 2.0])
-    XCTAssertEqual(props["arrayProp"] as! Array, arrayProp)
-    let deserializedDictProp = props["dictProp"] as! [String: Any]
-    // nil should be convereted to NSNull() inside Dictionary properties
-    XCTAssertEqual(deserializedDictProp["nil"] as! NSNull, NSNull())
-    XCTAssertEqual(deserializedDictProp["a"] as! String, "a")
-    XCTAssertEqual(deserializedDictProp["b"] as! String, "b")
-    XCTAssertEqual(props["urlProp"] as! String, urlProp.absoluteString)
-    // nil properties themselves should also be converted to NSNull()
-    XCTAssertEqual(props["nilProp"] as! NSNull, NSNull())
-    let deserializedNestedDictProp = props["nestedDictProp"] as! [String: [String: Any]]
-    let nestedDict = deserializedNestedDictProp["nested"]!
-    // the same nil logic from above should be applied to nested Collections as well
-    XCTAssertEqual(nestedDict["nil"] as! NSNull, NSNull())
-    XCTAssertEqual(nestedDict["a"] as! String, "a")
-    XCTAssertEqual(nestedDict["b"] as! String, "b")
-    let deserializednestedArraryProp = props["nestedArraryProp"] as! [[Double?]]
-    XCTAssertEqual(deserializednestedArraryProp[0] as! Array, [1.0, 2.0])
-  }
+        let serializedQueue = JSONHandler.serializeJSONObject([event])
+        let deserializedQueue =
+            try! JSONSerialization.jsonObject(with: serializedQueue!, options: []) as! [[String: Any]]
+        XCTAssertEqual(deserializedQueue[0]["event"] as! String, "test")
+        let props = deserializedQueue[0]["properties"] as! [String: Any]
+        XCTAssertEqual(props["nSNumberProp"] as! NSNumber, nSNumberProp)
+        XCTAssertEqual(props["doubleProp"] as! Double, doubleProp)
+        XCTAssertEqual(props["floatProp"] as! Float, floatProp)
+        XCTAssertEqual(props["stringProp"] as! String, stringProp)
+        XCTAssertEqual(props["intProp"] as! Int, intProp)
+        XCTAssertEqual(props["uIntProp"] as! UInt, uIntProp)
+        XCTAssertEqual(props["uInt64Prop"] as! UInt64, uInt64Prop)
+        XCTAssertEqual(props["boolProp"] as! Bool, boolProp)
+        // nil should be dropped from Array properties
+        XCTAssertEqual(props["optArrayProp"] as! Array, [1.0, 2.0])
+        XCTAssertEqual(props["arrayProp"] as! Array, arrayProp)
+        let deserializedDictProp = props["dictProp"] as! [String: Any]
+        // nil should be convereted to NSNull() inside Dictionary properties
+        XCTAssertEqual(deserializedDictProp["nil"] as! NSNull, NSNull())
+        XCTAssertEqual(deserializedDictProp["a"] as! String, "a")
+        XCTAssertEqual(deserializedDictProp["b"] as! String, "b")
+        XCTAssertEqual(props["urlProp"] as! String, urlProp.absoluteString)
+        // nil properties themselves should also be converted to NSNull()
+        XCTAssertEqual(props["nilProp"] as! NSNull, NSNull())
+        let deserializedNestedDictProp = props["nestedDictProp"] as! [String: [String: Any]]
+        let nestedDict = deserializedNestedDictProp["nested"]!
+        // the same nil logic from above should be applied to nested Collections as well
+        XCTAssertEqual(nestedDict["nil"] as! NSNull, NSNull())
+        XCTAssertEqual(nestedDict["a"] as! String, "a")
+        XCTAssertEqual(nestedDict["b"] as! String, "b")
+        let deserializednestedArraryProp = props["nestedArraryProp"] as! [[Double?]]
+        XCTAssertEqual(deserializednestedArraryProp[0] as! Array, [1.0, 2.0])
+    }
 
 }

--- a/MixpanelDemo/MixpanelDemoTests/LoggerTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/LoggerTests.swift
@@ -13,65 +13,65 @@ import XCTest
 
 class MixpanelLoggerTests: XCTestCase {
 
-  func testEnableDebug() {
-    let counter = CounterLogging()
-    MixpanelLogger.addLogging(counter)
-    MixpanelLogger.enableLevel(.debug)
+    func testEnableDebug() {
+        let counter = CounterLogging()
+        MixpanelLogger.addLogging(counter)
+        MixpanelLogger.enableLevel(.debug)
 
-    MixpanelLogger.debug(message: "logged")
-    XCTAssertEqual(1, counter.count)
-  }
+        MixpanelLogger.debug(message: "logged")
+        XCTAssertEqual(1, counter.count)
+    }
 
-  func testEnableInfo() {
-    let counter = CounterLogging()
-    MixpanelLogger.addLogging(counter)
-    MixpanelLogger.enableLevel(.info)
-    MixpanelLogger.info(message: "logged")
-    XCTAssertEqual(1, counter.count)
-  }
+    func testEnableInfo() {
+        let counter = CounterLogging()
+        MixpanelLogger.addLogging(counter)
+        MixpanelLogger.enableLevel(.info)
+        MixpanelLogger.info(message: "logged")
+        XCTAssertEqual(1, counter.count)
+    }
 
-  func testEnableWarning() {
-    let counter = CounterLogging()
-    MixpanelLogger.addLogging(counter)
-    MixpanelLogger.enableLevel(.warning)
-    MixpanelLogger.warn(message: "logged")
-    XCTAssertEqual(1, counter.count)
-  }
+    func testEnableWarning() {
+        let counter = CounterLogging()
+        MixpanelLogger.addLogging(counter)
+        MixpanelLogger.enableLevel(.warning)
+        MixpanelLogger.warn(message: "logged")
+        XCTAssertEqual(1, counter.count)
+    }
 
-  func testEnableError() {
-    let counter = CounterLogging()
-    MixpanelLogger.addLogging(counter)
-    MixpanelLogger.enableLevel(.error)
-    MixpanelLogger.error(message: "logged")
-    XCTAssertEqual(1, counter.count)
-  }
+    func testEnableError() {
+        let counter = CounterLogging()
+        MixpanelLogger.addLogging(counter)
+        MixpanelLogger.enableLevel(.error)
+        MixpanelLogger.error(message: "logged")
+        XCTAssertEqual(1, counter.count)
+    }
 
-  func testDisabledLogging() {
-    let counter = CounterLogging()
-    MixpanelLogger.addLogging(counter)
-    MixpanelLogger.disableLevel(.debug)
-    MixpanelLogger.debug(message: "not logged")
-    XCTAssertEqual(0, counter.count)
+    func testDisabledLogging() {
+        let counter = CounterLogging()
+        MixpanelLogger.addLogging(counter)
+        MixpanelLogger.disableLevel(.debug)
+        MixpanelLogger.debug(message: "not logged")
+        XCTAssertEqual(0, counter.count)
 
-    MixpanelLogger.disableLevel(.error)
-    MixpanelLogger.error(message: "not logged")
-    XCTAssertEqual(0, counter.count)
+        MixpanelLogger.disableLevel(.error)
+        MixpanelLogger.error(message: "not logged")
+        XCTAssertEqual(0, counter.count)
 
-    MixpanelLogger.disableLevel(.info)
-    MixpanelLogger.info(message: "not logged")
-    XCTAssertEqual(0, counter.count)
+        MixpanelLogger.disableLevel(.info)
+        MixpanelLogger.info(message: "not logged")
+        XCTAssertEqual(0, counter.count)
 
-    MixpanelLogger.disableLevel(.warning)
-    MixpanelLogger.warn(message: "not logged")
-    XCTAssertEqual(0, counter.count)
-  }
+        MixpanelLogger.disableLevel(.warning)
+        MixpanelLogger.warn(message: "not logged")
+        XCTAssertEqual(0, counter.count)
+    }
 }
 
 /// This is a stub that implements `MixpanelLogging` to be passed to our `MixpanelLogger` instance for testing
 class CounterLogging: MixpanelLogging {
-  var count = 0
+    var count = 0
 
-  func addMessage(message: MixpanelLogMessage) {
-    count = count + 1
-  }
+    func addMessage(message: MixpanelLogMessage) {
+        count = count + 1
+    }
 }

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelAutomaticEventsTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelAutomaticEventsTests.swift
@@ -13,157 +13,157 @@ import XCTest
 
 class MixpanelAutomaticEventsTests: MixpanelBaseTests {
 
-  func testSession() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    waitForAsyncTasks()
-    testMixpanel.minimumSessionDuration = 0
-    testMixpanel.identify(distinctId: "d1")
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.automaticEvents.perform(
-      #selector(AutomaticEvents.appWillResignActive(_:)),
-      with: Notification(name: Notification.Name(rawValue: "test")))
-    waitForTrackingQueue(testMixpanel)
+    func testSession() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        waitForAsyncTasks()
+        testMixpanel.minimumSessionDuration = 0
+        testMixpanel.identify(distinctId: "d1")
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.automaticEvents.perform(
+            #selector(AutomaticEvents.appWillResignActive(_:)),
+            with: Notification(name: Notification.Name(rawValue: "test")))
+        waitForTrackingQueue(testMixpanel)
 
-    let event = eventQueue(token: testMixpanel.apiToken).last
-    let people1 = peopleQueue(token: testMixpanel.apiToken)[1]["$add"] as! InternalProperties
-    let people2 = peopleQueue(token: testMixpanel.apiToken)[2]["$add"] as! InternalProperties
-    XCTAssertEqual(
-      (people1["$ae_total_app_sessions"] as? NSNumber)?.intValue, 1,
-      "total app sessions should be added by 1")
-    XCTAssertNotNil(
-      (people2["$ae_total_app_session_length"], "should have session length in $add queue"))
-    XCTAssertNotNil(event, "Should have an event")
-    XCTAssertEqual(event?["event"] as? String, "$ae_session", "should be app session event")
-    XCTAssertNotNil(
-      (event?["properties"] as? [String: Any])?["$ae_session_length"], "should have session length")
-    removeDBfile(testMixpanel.apiToken)
-  }
+        let event = eventQueue(token: testMixpanel.apiToken).last
+        let people1 = peopleQueue(token: testMixpanel.apiToken)[1]["$add"] as! InternalProperties
+        let people2 = peopleQueue(token: testMixpanel.apiToken)[2]["$add"] as! InternalProperties
+        XCTAssertEqual(
+            (people1["$ae_total_app_sessions"] as? NSNumber)?.intValue, 1,
+            "total app sessions should be added by 1")
+        XCTAssertNotNil(
+            (people2["$ae_total_app_session_length"], "should have session length in $add queue"))
+        XCTAssertNotNil(event, "Should have an event")
+        XCTAssertEqual(event?["event"] as? String, "$ae_session", "should be app session event")
+        XCTAssertNotNil(
+            (event?["properties"] as? [String: Any])?["$ae_session_length"], "should have session length")
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-  func testKeepAutomaticEventsIfNetworkNotAvailable() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    waitForAsyncTasks()
-    testMixpanel.minimumSessionDuration = 0
-    testMixpanel.automaticEvents.perform(
-      #selector(AutomaticEvents.appWillResignActive(_:)),
-      with: Notification(name: Notification.Name(rawValue: "test")))
+    func testKeepAutomaticEventsIfNetworkNotAvailable() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        waitForAsyncTasks()
+        testMixpanel.minimumSessionDuration = 0
+        testMixpanel.automaticEvents.perform(
+            #selector(AutomaticEvents.appWillResignActive(_:)),
+            with: Notification(name: Notification.Name(rawValue: "test")))
 
-    waitForTrackingQueue(testMixpanel)
-    let event = eventQueue(token: testMixpanel.apiToken).last
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 2,
-      "automatic events should be accumulated if device is offline")
-    XCTAssertEqual(event?["event"] as? String, "$ae_session", "should be app session event")
-    removeDBfile(testMixpanel.apiToken)
-  }
+        waitForTrackingQueue(testMixpanel)
+        let event = eventQueue(token: testMixpanel.apiToken).last
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 2,
+            "automatic events should be accumulated if device is offline")
+        XCTAssertEqual(event?["event"] as? String, "$ae_session", "should be app session event")
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-  func testDiscardAutomaticEventsIftrackAutomaticEventsEnabledIsFalse() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: false, flushInterval: 60)
-    testMixpanel.minimumSessionDuration = 0
-    testMixpanel.automaticEvents.perform(
-      #selector(AutomaticEvents.appWillResignActive(_:)),
-      with: Notification(name: Notification.Name(rawValue: "test")))
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 0, "automatic events should not be tracked")
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testDiscardAutomaticEventsIftrackAutomaticEventsEnabledIsFalse() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: false, flushInterval: 60)
+        testMixpanel.minimumSessionDuration = 0
+        testMixpanel.automaticEvents.perform(
+            #selector(AutomaticEvents.appWillResignActive(_:)),
+            with: Notification(name: Notification.Name(rawValue: "test")))
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 0, "automatic events should not be tracked")
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-  func testFlushAutomaticEventsIftrackAutomaticEventsEnabledIsTrue() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    waitForAsyncTasks()
-    testMixpanel.minimumSessionDuration = 0
-    testMixpanel.automaticEvents.perform(
-      #selector(AutomaticEvents.appWillResignActive(_:)),
-      with: Notification(name: Notification.Name(rawValue: "test")))
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 2, "automatic events should be tracked")
+    func testFlushAutomaticEventsIftrackAutomaticEventsEnabledIsTrue() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        waitForAsyncTasks()
+        testMixpanel.minimumSessionDuration = 0
+        testMixpanel.automaticEvents.perform(
+            #selector(AutomaticEvents.appWillResignActive(_:)),
+            with: Notification(name: Notification.Name(rawValue: "test")))
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 2, "automatic events should be tracked")
 
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 0, "automatic events should be flushed")
-    removeDBfile(testMixpanel.apiToken)
-  }
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 0, "automatic events should be flushed")
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-  func testUpdated() {
-    waitForAsyncTasks()
-    let defaults = UserDefaults(suiteName: "Mixpanel")
-    let infoDict = Bundle.main.infoDictionary
-    let appVersionValue = infoDict?["CFBundleShortVersionString"]
-    let savedVersionValue = defaults?.string(forKey: "MPAppVersion")
-    XCTAssertEqual(
-      appVersionValue as? String, savedVersionValue,
-      "Saved version and current version need to be the same")
-  }
+    func testUpdated() {
+        waitForAsyncTasks()
+        let defaults = UserDefaults(suiteName: "Mixpanel")
+        let infoDict = Bundle.main.infoDictionary
+        let appVersionValue = infoDict?["CFBundleShortVersionString"]
+        let savedVersionValue = defaults?.string(forKey: "MPAppVersion")
+        XCTAssertEqual(
+            appVersionValue as? String, savedVersionValue,
+            "Saved version and current version need to be the same")
+    }
 
-  func testFirstAppShouldOnlyBeTrackedOnce() {
-    let testToken = randomId()
-    let mp = Mixpanel.initialize(token: testToken, trackAutomaticEvents: true)
-    waitForAsyncTasks()
-    mp.minimumSessionDuration = 0
-    waitForTrackingQueue(mp)
-    XCTAssertEqual(
-      eventQueue(token: mp.apiToken).count, 1, "First app open should be tracked again")
-    flushAndWaitForTrackingQueue(mp)
+    func testFirstAppShouldOnlyBeTrackedOnce() {
+        let testToken = randomId()
+        let mp = Mixpanel.initialize(token: testToken, trackAutomaticEvents: true)
+        waitForAsyncTasks()
+        mp.minimumSessionDuration = 0
+        waitForTrackingQueue(mp)
+        XCTAssertEqual(
+            eventQueue(token: mp.apiToken).count, 1, "First app open should be tracked again")
+        flushAndWaitForTrackingQueue(mp)
 
-    let mp2 = Mixpanel.initialize(token: testToken, trackAutomaticEvents: true)
-    waitForAsyncTasks()
-    mp2.minimumSessionDuration = 0
-    waitForTrackingQueue(mp2)
-    XCTAssertEqual(
-      eventQueue(token: mp2.apiToken).count, 0, "First app open should not be tracked again")
-  }
+        let mp2 = Mixpanel.initialize(token: testToken, trackAutomaticEvents: true)
+        waitForAsyncTasks()
+        mp2.minimumSessionDuration = 0
+        waitForTrackingQueue(mp2)
+        XCTAssertEqual(
+            eventQueue(token: mp2.apiToken).count, 0, "First app open should not be tracked again")
+    }
 
-  func testAutomaticEventsInMultipleInstances() {
-    // remove UserDefaults key and archive files to simulate first app open state
-    let defaults = UserDefaults(suiteName: "Mixpanel")
-    defaults?.removeObject(forKey: "MPFirstOpen")
+    func testAutomaticEventsInMultipleInstances() {
+        // remove UserDefaults key and archive files to simulate first app open state
+        let defaults = UserDefaults(suiteName: "Mixpanel")
+        defaults?.removeObject(forKey: "MPFirstOpen")
 
-    let mp = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: true)
-    waitForAsyncTasks()
-    mp.minimumSessionDuration = 0
-    waitForTrackingQueue(mp)
-    let mp2 = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: true)
-    waitForAsyncTasks()
-    mp2.minimumSessionDuration = 0
-    waitForTrackingQueue(mp2)
+        let mp = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: true)
+        waitForAsyncTasks()
+        mp.minimumSessionDuration = 0
+        waitForTrackingQueue(mp)
+        let mp2 = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: true)
+        waitForAsyncTasks()
+        mp2.minimumSessionDuration = 0
+        waitForTrackingQueue(mp2)
 
-    XCTAssertEqual(eventQueue(token: mp.apiToken).count, 1, "there should be only 1 event")
-    let appOpenEvent = eventQueue(token: mp.apiToken).last
-    XCTAssertEqual(
-      appOpenEvent?["event"] as? String, "$ae_first_open", "should be first app open event")
+        XCTAssertEqual(eventQueue(token: mp.apiToken).count, 1, "there should be only 1 event")
+        let appOpenEvent = eventQueue(token: mp.apiToken).last
+        XCTAssertEqual(
+            appOpenEvent?["event"] as? String, "$ae_first_open", "should be first app open event")
 
-    XCTAssertEqual(eventQueue(token: mp2.apiToken).count, 1, "there should be only 1 event")
-    let otherAppOpenEvent = eventQueue(token: mp2.apiToken).last
-    XCTAssertEqual(
-      otherAppOpenEvent?["event"] as? String, "$ae_first_open", "should be first app open event")
+        XCTAssertEqual(eventQueue(token: mp2.apiToken).count, 1, "there should be only 1 event")
+        let otherAppOpenEvent = eventQueue(token: mp2.apiToken).last
+        XCTAssertEqual(
+            otherAppOpenEvent?["event"] as? String, "$ae_first_open", "should be first app open event")
 
-    mp.automaticEvents.perform(
-      #selector(AutomaticEvents.appWillResignActive(_:)),
-      with: Notification(name: Notification.Name(rawValue: "test")))
-    mp2.automaticEvents.perform(
-      #selector(AutomaticEvents.appWillResignActive(_:)),
-      with: Notification(name: Notification.Name(rawValue: "test")))
-    mp.trackingQueue.sync {}
-    mp2.trackingQueue.sync {}
-    let appSessionEvent = eventQueue(token: mp.apiToken).last
-    XCTAssertNotNil(appSessionEvent, "Should have an event")
-    XCTAssertEqual(
-      appSessionEvent?["event"] as? String, "$ae_session", "should be app session event")
-    XCTAssertNotNil(
-      (appSessionEvent?["properties"] as? [String: Any])?["$ae_session_length"],
-      "should have session length")
-    let otherAppSessionEvent = eventQueue(token: mp2.apiToken).last
-    XCTAssertEqual(
-      otherAppSessionEvent?["event"] as? String, "$ae_session", "should be app session event")
-    XCTAssertNotNil(
-      (otherAppSessionEvent?["properties"] as? [String: Any])?["$ae_session_length"],
-      "should have session length")
-    removeDBfile(mp.apiToken)
-    removeDBfile(mp2.apiToken)
-  }
+        mp.automaticEvents.perform(
+            #selector(AutomaticEvents.appWillResignActive(_:)),
+            with: Notification(name: Notification.Name(rawValue: "test")))
+        mp2.automaticEvents.perform(
+            #selector(AutomaticEvents.appWillResignActive(_:)),
+            with: Notification(name: Notification.Name(rawValue: "test")))
+        mp.trackingQueue.sync {}
+        mp2.trackingQueue.sync {}
+        let appSessionEvent = eventQueue(token: mp.apiToken).last
+        XCTAssertNotNil(appSessionEvent, "Should have an event")
+        XCTAssertEqual(
+            appSessionEvent?["event"] as? String, "$ae_session", "should be app session event")
+        XCTAssertNotNil(
+            (appSessionEvent?["properties"] as? [String: Any])?["$ae_session_length"],
+            "should have session length")
+        let otherAppSessionEvent = eventQueue(token: mp2.apiToken).last
+        XCTAssertEqual(
+            otherAppSessionEvent?["event"] as? String, "$ae_session", "should be app session event")
+        XCTAssertNotNil(
+            (otherAppSessionEvent?["properties"] as? [String: Any])?["$ae_session_length"],
+            "should have session length")
+        removeDBfile(mp.apiToken)
+        removeDBfile(mp2.apiToken)
+    }
 }

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelBaseTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelBaseTests.swift
@@ -12,147 +12,147 @@ import XCTest
 @testable import Mixpanel
 
 class MixpanelBaseTests: XCTestCase, MixpanelDelegate {
-  var mixpanelWillFlush: Bool!
-  static var requestCount = 0
+    var mixpanelWillFlush: Bool!
+    static var requestCount = 0
 
-  override func setUp() {
-    NSLog("starting test setup...")
-    super.setUp()
-    mixpanelWillFlush = false
-    let defaults = UserDefaults(suiteName: "Mixpanel")
-    defaults?.removeObject(forKey: "MPFirstOpen")
+    override func setUp() {
+        NSLog("starting test setup...")
+        super.setUp()
+        mixpanelWillFlush = false
+        let defaults = UserDefaults(suiteName: "Mixpanel")
+        defaults?.removeObject(forKey: "MPFirstOpen")
 
-    NSLog("finished test setup")
-  }
-
-  override func tearDown() {
-    super.tearDown()
-  }
-
-  func removeDBfile(_ token: String? = nil) {
-    do {
-      let fileManager = FileManager.default
-
-      // Check if file exists
-      if fileManager.fileExists(atPath: dbFilePath(token)) {
-        // Delete file
-        try fileManager.removeItem(atPath: dbFilePath(token))
-      } else {
-        print("Unable to delete the test db file at \(dbFilePath(token)), the file does not exist")
-      }
-
-    } catch let error as NSError {
-      print("An error took place: \(error)")
-    }
-  }
-
-  func dbFilePath(_ token: String? = nil) -> String {
-    let manager = FileManager.default
-    #if os(iOS)
-      let url = manager.urls(for: .libraryDirectory, in: .userDomainMask).last
-    #else
-      let url = manager.urls(for: .cachesDirectory, in: .userDomainMask).last
-    #endif  // os(iOS)
-    guard let apiToken = token else {
-      return ""
+        NSLog("finished test setup")
     }
 
-    guard let urlUnwrapped = url?.appendingPathComponent("\(apiToken)_MPDB.sqlite").path
-    else {
-      return ""
-    }
-    return urlUnwrapped
-  }
-
-  func mixpanelWillFlush(_ mixpanel: MixpanelInstance) -> Bool {
-    return mixpanelWillFlush
-  }
-
-  func waitForTrackingQueue(_ mixpanel: MixpanelInstance) {
-    mixpanel.trackingQueue.sync {
-      mixpanel.networkQueue.sync {
-        return
-      }
-    }
-    mixpanel.trackingQueue.sync {
-      mixpanel.networkQueue.sync {
-        return
-      }
-    }
-  }
-
-  func randomId() -> String {
-    return String(format: "%08x%08x", arc4random(), arc4random())
-  }
-
-  func waitForAsyncTasks() {
-    var hasCompletedTask = false
-    DispatchQueue.main.async {
-      hasCompletedTask = true
+    override func tearDown() {
+        super.tearDown()
     }
 
-    let loopUntil = Date(timeIntervalSinceNow: 10)
-    while !hasCompletedTask && loopUntil.timeIntervalSinceNow > 0 {
-      RunLoop.current.run(mode: RunLoop.Mode.default, before: loopUntil)
+    func removeDBfile(_ token: String? = nil) {
+        do {
+            let fileManager = FileManager.default
+
+            // Check if file exists
+            if fileManager.fileExists(atPath: dbFilePath(token)) {
+                // Delete file
+                try fileManager.removeItem(atPath: dbFilePath(token))
+            } else {
+                print("Unable to delete the test db file at \(dbFilePath(token)), the file does not exist")
+            }
+
+        } catch let error as NSError {
+            print("An error took place: \(error)")
+        }
     }
-  }
 
-  func eventQueue(token: String) -> Queue {
-    return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(type: .events)
-  }
+    func dbFilePath(_ token: String? = nil) -> String {
+        let manager = FileManager.default
+        #if os(iOS)
+        let url = manager.urls(for: .libraryDirectory, in: .userDomainMask).last
+        #else
+        let url = manager.urls(for: .cachesDirectory, in: .userDomainMask).last
+        #endif  // os(iOS)
+        guard let apiToken = token else {
+            return ""
+        }
 
-  func peopleQueue(token: String) -> Queue {
-    return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(type: .people)
-  }
+        guard let urlUnwrapped = url?.appendingPathComponent("\(apiToken)_MPDB.sqlite").path
+        else {
+            return ""
+        }
+        return urlUnwrapped
+    }
 
-  func unIdentifiedPeopleQueue(token: String) -> Queue {
-    return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(
-      type: .people, flag: PersistenceConstant.unIdentifiedFlag)
-  }
+    func mixpanelWillFlush(_ mixpanel: MixpanelInstance) -> Bool {
+        return mixpanelWillFlush
+    }
 
-  func groupQueue(token: String) -> Queue {
-    return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(type: .groups)
-  }
+    func waitForTrackingQueue(_ mixpanel: MixpanelInstance) {
+        mixpanel.trackingQueue.sync {
+            mixpanel.networkQueue.sync {
+                return
+            }
+        }
+        mixpanel.trackingQueue.sync {
+            mixpanel.networkQueue.sync {
+                return
+            }
+        }
+    }
 
-  func flushAndWaitForTrackingQueue(_ mixpanel: MixpanelInstance) {
-    mixpanel.flush()
-    waitForTrackingQueue(mixpanel)
-    mixpanel.flush()
-    waitForTrackingQueue(mixpanel)
-  }
+    func randomId() -> String {
+        return String(format: "%08x%08x", arc4random(), arc4random())
+    }
 
-  func assertDefaultPeopleProperties(_ properties: InternalProperties) {
-    XCTAssertNotNil(properties["$ios_device_model"], "missing $ios_device_model property")
-    XCTAssertNotNil(properties["$ios_lib_version"], "missing $ios_lib_version property")
-    XCTAssertNotNil(properties["$ios_version"], "missing $ios_version property")
-    XCTAssertNotNil(properties["$ios_app_version"], "missing $ios_app_version property")
-    XCTAssertNotNil(properties["$ios_app_release"], "missing $ios_app_release property")
-  }
+    func waitForAsyncTasks() {
+        var hasCompletedTask = false
+        DispatchQueue.main.async {
+            hasCompletedTask = true
+        }
 
-  func compareDate(dateString: String, dateDate: Date) {
-    let dateFormatter: ISO8601DateFormatter = ISO8601DateFormatter()
-    let date = dateFormatter.string(from: dateDate)
-    XCTAssertEqual(String(date.prefix(19)), String(dateString.prefix(19)))
-  }
+        let loopUntil = Date(timeIntervalSinceNow: 10)
+        while !hasCompletedTask && loopUntil.timeIntervalSinceNow > 0 {
+            RunLoop.current.run(mode: RunLoop.Mode.default, before: loopUntil)
+        }
+    }
 
-  func allPropertyTypes() -> Properties {
-    let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss zzz"
-    let date = dateFormatter.date(from: "2012-09-28 19:14:36 PDT")
-    let nested = ["p1": ["p2": ["p3": ["bottom"]]]]
-    let opt: String? = nil
-    return [
-      "string": "yello",
-      "number": 3,
-      "date": date!,
-      "dictionary": ["k": "v", "opt": opt as Any],
-      "array": ["1", opt as Any],
-      "null": NSNull(),
-      "nested": nested,
-      "url": URL(string: "https://mixpanel.com/")!,
-      "float": 1.3,
-      "optional": opt,
-    ]
-  }
+    func eventQueue(token: String) -> Queue {
+        return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(type: .events)
+    }
+
+    func peopleQueue(token: String) -> Queue {
+        return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(type: .people)
+    }
+
+    func unIdentifiedPeopleQueue(token: String) -> Queue {
+        return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(
+            type: .people, flag: PersistenceConstant.unIdentifiedFlag)
+    }
+
+    func groupQueue(token: String) -> Queue {
+        return MixpanelPersistence.init(instanceName: token).loadEntitiesInBatch(type: .groups)
+    }
+
+    func flushAndWaitForTrackingQueue(_ mixpanel: MixpanelInstance) {
+        mixpanel.flush()
+        waitForTrackingQueue(mixpanel)
+        mixpanel.flush()
+        waitForTrackingQueue(mixpanel)
+    }
+
+    func assertDefaultPeopleProperties(_ properties: InternalProperties) {
+        XCTAssertNotNil(properties["$ios_device_model"], "missing $ios_device_model property")
+        XCTAssertNotNil(properties["$ios_lib_version"], "missing $ios_lib_version property")
+        XCTAssertNotNil(properties["$ios_version"], "missing $ios_version property")
+        XCTAssertNotNil(properties["$ios_app_version"], "missing $ios_app_version property")
+        XCTAssertNotNil(properties["$ios_app_release"], "missing $ios_app_release property")
+    }
+
+    func compareDate(dateString: String, dateDate: Date) {
+        let dateFormatter: ISO8601DateFormatter = ISO8601DateFormatter()
+        let date = dateFormatter.string(from: dateDate)
+        XCTAssertEqual(String(date.prefix(19)), String(dateString.prefix(19)))
+    }
+
+    func allPropertyTypes() -> Properties {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss zzz"
+        let date = dateFormatter.date(from: "2012-09-28 19:14:36 PDT")
+        let nested = ["p1": ["p2": ["p3": ["bottom"]]]]
+        let opt: String? = nil
+        return [
+            "string": "yello",
+            "number": 3,
+            "date": date!,
+            "dictionary": ["k": "v", "opt": opt as Any],
+            "array": ["1", opt as Any],
+            "null": NSNull(),
+            "nested": nested,
+            "url": URL(string: "https://mixpanel.com/")!,
+            "float": 1.3,
+            "optional": opt,
+        ]
+    }
 
 }

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelDemoTests.swift
@@ -14,1495 +14,1495 @@ import XCTest
 private let devicePrefix = "$device:"
 class MixpanelDemoTests: MixpanelBaseTests {
 
-  func test5XXResponse() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    waitForAsyncTasks()
-    testMixpanel.serverURL = kFakeServerUrl
-    testMixpanel.track(event: "Fake Event")
-    flushAndWaitForTrackingQueue(testMixpanel)
-    // Failure count should be 3
-    let waitTime =
-      testMixpanel.flushInstance.flushRequest.networkRequestsAllowedAfterTime
-      - Date().timeIntervalSince1970
-    print("Delta wait time is \(waitTime)")
-    XCTAssert(waitTime >= 110, "Network backoff time is less than 2 minutes.")
-    XCTAssert(
-      testMixpanel.flushInstance.flushRequest.networkConsecutiveFailures == 2,
-      "Network failures did not equal 2")
-
-    XCTAssert(
-      eventQueue(token: testMixpanel.apiToken).count == 2,
-      "Removed an event from the queue that was not sent")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testFlushEvents() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    for i in 0..<50 {
-      testMixpanel.track(event: "event \(i)")
-    }
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).isEmpty,
-      "events should have been flushed")
-
-    for i in 0..<60 {
-      testMixpanel.track(event: "event \(i)")
-    }
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).isEmpty,
-      "events should have been flushed")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testFlushProperties() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    XCTAssertTrue(testMixpanel.flushBatchSize == 50, "the default flush batch size is set to 50")
-    XCTAssertTrue(testMixpanel.flushInterval == 60, "flush interval is set correctly")
-    testMixpanel.flushBatchSize = 10
-    XCTAssertTrue(testMixpanel.flushBatchSize == 10, "flush batch size is set correctly")
-    testMixpanel.flushBatchSize = 60
-    XCTAssertTrue(testMixpanel.flushBatchSize == 50, "flush batch size is max at 50")
-    testMixpanel.flushInterval = 30
-    XCTAssertTrue(testMixpanel.flushInterval == 30, "flush interval is set correctly")
-  }
-
-  func testFlushPeople() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    for i in 0..<50 {
-      testMixpanel.people.set(property: "p1", to: "\(i)")
-    }
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel.apiToken).isEmpty, "people should have been flushed")
-    for i in 0..<60 {
-      testMixpanel.people.set(property: "p1", to: "\(i)")
-    }
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel.apiToken).isEmpty, "people should have been flushed")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testFlushGroups() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    let groupKey = "test_key"
-    let groupValue = "test_value"
-    for i in 0..<50 {
-      testMixpanel.getGroup(groupKey: groupKey, groupID: groupValue).set(property: "p1", to: "\(i)")
-    }
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      groupQueue(token: testMixpanel.apiToken).isEmpty, "groups should have been flushed")
-    for i in 0..<60 {
-      testMixpanel.getGroup(groupKey: groupKey, groupID: groupValue).set(property: "p1", to: "\(i)")
-    }
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel.apiToken).isEmpty, "groups should have been flushed")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testFlushNetworkFailure() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    waitForAsyncTasks()
-    testMixpanel.serverURL = kFakeServerUrl
-    for i in 0..<50 {
-      testMixpanel.track(event: "event \(UInt(i))")
-    }
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 51, "51 events should be queued up")
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 51,
-      "events should still be in the queue if flush fails")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testFlushQueueContainsCorruptedEvent() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.trackingQueue.async {
-      testMixpanel.mixpanelPersistence.saveEntity(
-        ["event": "bad event1", "properties": ["BadProp": Double.nan]], type: .events)
-      testMixpanel.mixpanelPersistence.saveEntity(
-        ["event": "bad event2", "properties": ["BadProp": Float.nan]], type: .events)
-      testMixpanel.mixpanelPersistence.saveEntity(
-        ["event": "bad event3", "properties": ["BadProp": Double.infinity]], type: .events)
-      testMixpanel.mixpanelPersistence.saveEntity(
-        ["event": "bad event4", "properties": ["BadProp": Float.infinity]], type: .events)
-    }
-
-    for i in 0..<10 {
-      testMixpanel.track(event: "event \(UInt(i))")
-    }
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 0, "good events should still be flushed")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testAddEventContainsInvalidJsonObjectDoubleNaN() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.track(event: "bad event", properties: ["BadProp": Double.nan])
-    }
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testAddEventContainsInvalidJsonObjectFloatNaN() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.track(event: "bad event", properties: ["BadProp": Float.nan])
-    }
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testAddEventContainsInvalidJsonObjectDoubleInfinity() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.track(event: "bad event", properties: ["BadProp": Double.infinity])
-    }
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testAddEventContainsInvalidJsonObjectFloatInfinity() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.track(event: "bad event", properties: ["BadProp": Float.infinity])
-    }
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testAddingEventsAfterFlush() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    waitForAsyncTasks()
-    for i in 0..<10 {
-      testMixpanel.track(event: "event \(UInt(i))")
-    }
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 11, "11 events should be queued up")
-    flushAndWaitForTrackingQueue(testMixpanel)
-    for i in 0..<5 {
-      testMixpanel.track(event: "event \(UInt(i))")
-    }
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 5, "5 more events should be queued up")
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).isEmpty, "events should have been flushed")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  // Mock implementation of MixpanelFlags to track loadFlags calls
-  class MockMixpanelFlags: MixpanelFlags {
-    var delegate: MixpanelFlagDelegate?
-    var loadFlagsCallCount = 0
-
-    func loadFlags() {
-      loadFlagsCallCount += 1
-    }
-
-    func setContext(_ context: [String: Any], completion: @escaping () -> Void) {
-      completion()
-    }
-
-    func loadFlags(completion: ((Bool) -> Void)?) {
-      loadFlagsCallCount += 1
-      completion?(true)
-    }
-
-    func areFlagsReady() -> Bool {
-      return true
-    }
-
-    func getVariantSync(_ flagName: String, fallback: MixpanelFlagVariant) -> MixpanelFlagVariant {
-      return fallback
-    }
-
-    func getVariant(
-      _ flagName: String, fallback: MixpanelFlagVariant,
-      completion: @escaping (MixpanelFlagVariant) -> Void
-    ) {
-      completion(fallback)
-    }
-
-    func getVariantValueSync(_ flagName: String, fallbackValue: Any?) -> Any? {
-      return fallbackValue
-    }
-
-    func getVariantValue(
-      _ flagName: String, fallbackValue: Any?, completion: @escaping (Any?) -> Void
-    ) {
-      completion(fallbackValue)
-    }
-
-    func isEnabledSync(_ flagName: String, fallbackValue: Bool) -> Bool {
-      return fallbackValue
-    }
-
-    func isEnabled(_ flagName: String, fallbackValue: Bool, completion: @escaping (Bool) -> Void) {
-      completion(fallbackValue)
-    }
-
-    func getAllVariantsSync() -> [String: MixpanelFlagVariant] {
-      return [:]
-    }
-
-    func getAllVariants(completion: @escaping ([String: MixpanelFlagVariant]) -> Void) {
-      completion([:])
-    }
-  }
-
-  func testIdentify() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-
-    // Inject our mock flags object
-    let mockFlags = MockMixpanelFlags()
-    testMixpanel.flags = mockFlags
-
-    for _ in 0..<2 {
-      // run this twice to test reset works correctly wrt to distinct ids
-      let distinctId: String = "d1"
-      // try this for ODIN and nil
-      #if MIXPANEL_UNIQUE_DISTINCT_ID
-        XCTAssertEqual(
-          testMixpanel.distinctId,
-          devicePrefix + testMixpanel.defaultDeviceId(),
-          "mixpanel identify failed to set default distinct id")
-        XCTAssertEqual(
-          testMixpanel.anonymousId,
-          testMixpanel.defaultDeviceId(),
-          "mixpanel failed to set default anonymous id")
-      #endif
-      XCTAssertNil(
-        testMixpanel.people.distinctId,
-        "mixpanel people distinct id should default to nil")
-      XCTAssertNil(
-        testMixpanel.people.distinctId,
-        "mixpanel user id should default to nil")
-      testMixpanel.track(event: "e1")
-      waitForTrackingQueue(testMixpanel)
-      let eventsQueue = eventQueue(token: testMixpanel.apiToken)
-      XCTAssertTrue(
-        eventsQueue.count == 2 || eventsQueue.count == 1,  // first app open should not be tracked for the second run,
-        "events should be sent right away with default distinct id")
-      #if MIXPANEL_UNIQUE_DISTINCT_ID
-        XCTAssertEqual(
-          (eventsQueue.last?["properties"] as? InternalProperties)?["distinct_id"] as? String,
-          devicePrefix + mixpanel.defaultDeviceId(),
-          "events should use default distinct id if none set")
-      #endif
-      XCTAssertEqual(
-        (eventsQueue.last?["properties"] as? InternalProperties)?["$lib_version"] as? String,
-        AutomaticProperties.libVersion(),
-        "events should has lib version in internal properties")
-      testMixpanel.people.set(property: "p1", to: "a")
-      waitForTrackingQueue(testMixpanel)
-      var peopleQueue_value = peopleQueue(token: testMixpanel.apiToken)
-      var unidentifiedQueue = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)
-      XCTAssertTrue(
-        peopleQueue_value.isEmpty,
-        "people records should go to unidentified queue before identify:")
-      XCTAssertTrue(
-        unidentifiedQueue.count == 2 || eventsQueue.count == 1,  // first app open should not be tracked for the second run,
-        "unidentified people records not queued")
-      XCTAssertEqual(
-        unidentifiedQueue.last?["$token"] as? String,
-        testMixpanel.apiToken,
-        "incorrect project token in people record")
-      // Record the loadFlags call count before identify
-      let loadFlagsCallCountBefore = mockFlags.loadFlagsCallCount
-
-      testMixpanel.identify(distinctId: distinctId)
-      waitForTrackingQueue(testMixpanel)
-
-      // Assert that loadFlags was called when distinctId changed
-      XCTAssertEqual(
-        mockFlags.loadFlagsCallCount, loadFlagsCallCountBefore + 1,
-        "loadFlags should be called when distinctId changes during identify")
-
-      let anonymousId = testMixpanel.anonymousId
-      peopleQueue_value = peopleQueue(token: testMixpanel.apiToken)
-      unidentifiedQueue = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)
-      XCTAssertEqual(
-        peopleQueue_value.last?["$distinct_id"] as? String,
-        distinctId, "distinct id not set properly on unidentified people record")
-      XCTAssertEqual(
-        testMixpanel.distinctId, distinctId,
-        "mixpanel identify failed to set distinct id")
-      XCTAssertEqual(
-        testMixpanel.userId, distinctId,
-        "mixpanel identify failed to set user id")
-      XCTAssertEqual(
-        testMixpanel.anonymousId, anonymousId,
-        "mixpanel identify shouldn't change anonymousId")
-      XCTAssertEqual(
-        testMixpanel.people.distinctId, distinctId,
-        "mixpanel identify failed to set people distinct id")
-      XCTAssertTrue(
-        unidentifiedQueue.isEmpty,
-        "identify: should move records from unidentified queue")
-      XCTAssertTrue(
-        peopleQueue_value.count > 0,
-        "identify: should move records to main people queue")
-      XCTAssertEqual(
-        peopleQueue_value.last?["$token"] as? String,
-        testMixpanel.apiToken, "incorrect project token in people record")
-      let p: InternalProperties = peopleQueue_value.last?["$set"] as! InternalProperties
-      XCTAssertEqual(p["p1"] as? String, "a", "custom people property not queued")
-      assertDefaultPeopleProperties(p)
-      peopleQueue_value = peopleQueue(token: testMixpanel.apiToken)
-
-      testMixpanel.people.set(property: "p1", to: "a")
-      waitForTrackingQueue(testMixpanel)
-
-      peopleQueue_value = peopleQueue(token: testMixpanel.apiToken)
-      unidentifiedQueue = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)
-      XCTAssertEqual(
-        peopleQueue_value.last?["$distinct_id"] as? String,
-        distinctId, "distinct id not set properly on unidentified people record")
-      XCTAssertTrue(
-        unidentifiedQueue.isEmpty,
-        "once idenitfy: is called, unidentified queue should be skipped")
-      XCTAssertTrue(
-        peopleQueue_value.count > 0,
-        "once identify: is called, records should go straight to main queue")
-      testMixpanel.track(event: "e2")
-      waitForTrackingQueue(testMixpanel)
-      let newDistinctId =
-        (eventQueue(token: testMixpanel.apiToken).last?["properties"] as? InternalProperties)?[
-          "distinct_id"] as? String
-      XCTAssertEqual(
-        newDistinctId, distinctId,
-        "events should use new distinct id after identify:")
-
-      // Test that calling identify with the same distinctId does NOT trigger loadFlags
-      let loadFlagsCountBeforeSameId = mockFlags.loadFlagsCallCount
-      testMixpanel.identify(distinctId: distinctId)  // Same distinctId
-      waitForTrackingQueue(testMixpanel)
-      XCTAssertEqual(
-        mockFlags.loadFlagsCallCount, loadFlagsCountBeforeSameId,
-        "loadFlags should NOT be called when distinctId doesn't change")
-
-      testMixpanel.reset()
-      waitForTrackingQueue(testMixpanel)
-    }
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testIdentifyTrack() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let distinctIdBeforeIdentify: String? = testMixpanel.distinctId
-    let distinctId = "testIdentifyTrack"
-
-    testMixpanel.identify(distinctId: distinctId)
-    waitForTrackingQueue(testMixpanel)
-    let e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(e["event"] as? String, "$identify", "incorrect event name")
-    let p: InternalProperties = e["properties"] as! InternalProperties
-    XCTAssertEqual(p["distinct_id"] as? String, distinctId, "wrong distinct_id")
-    XCTAssertEqual(
-      p["$anon_distinct_id"] as? String, distinctIdBeforeIdentify, "wrong $anon_distinct_id")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testIdentifyResetTrack() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let originalDistinctId: String? = testMixpanel.distinctId
-    let distinctId = "testIdentifyTrack"
-    testMixpanel.reset()
-    waitForTrackingQueue(testMixpanel)
-
-    for i in 1...3 {
-      let prevDistinctId: String? = testMixpanel.distinctId
-      let newDistinctId = distinctId + String(i)
-      testMixpanel.identify(distinctId: newDistinctId)
-      waitForTrackingQueue(testMixpanel)
-
-      let e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
-      XCTAssertEqual(e["event"] as? String, "$identify", "incorrect event name")
-      let p: InternalProperties = e["properties"] as! InternalProperties
-      XCTAssertEqual(p["distinct_id"] as? String, newDistinctId, "wrong distinct_id")
-      XCTAssertEqual(p["$anon_distinct_id"] as? String, prevDistinctId, "wrong $anon_distinct_id")
-      XCTAssertNotEqual(
-        prevDistinctId, originalDistinctId, "After reset, UUID will be used - never the same")
-      #if MIXPANEL_UNIQUE_DISTINCT_ID
-        XCTAssertEqual(
-          prevDistinctId, originalDistinctId, "After reset, IFV will be used - always the same")
-      #endif
-      testMixpanel.reset()
-      waitForTrackingQueue(testMixpanel)
-    }
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testCreateAlias() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.people.set(properties: ["p1": "a"])
-    waitForTrackingQueue(testMixpanel)
-    var unidentifiedQueue = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)
-    // the user profile update has been queued up in unidentifiedQueue until identify is called
-    XCTAssertTrue(!unidentifiedQueue.isEmpty)
-
-    let distinctId = testMixpanel.distinctId
-    let alias: String = "a1"
-    testMixpanel.createAlias(alias, distinctId: testMixpanel.distinctId)
-    waitForTrackingQueue(testMixpanel)
-
-    let mixpanelIdentity = MixpanelPersistence.loadIdentity(instanceName: testMixpanel.apiToken)
-    XCTAssertTrue(
-      distinctId == mixpanelIdentity.distinctID && distinctId == mixpanelIdentity.peopleDistinctID
-        && distinctId == mixpanelIdentity.userId && alias == mixpanelIdentity.alias)
-    removeDBfile(testMixpanel.apiToken)
-    unidentifiedQueue = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)
-    // unidentifiedQueue has been flushed
-    XCTAssertTrue(unidentifiedQueue.isEmpty)
-
-    let testMixpanel2 = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel2.people.set(properties: ["p1": "a"])
-    waitForTrackingQueue(testMixpanel2)
-
-    let distinctId2 = testMixpanel2.distinctId
-    testMixpanel2.createAlias(alias, distinctId: testMixpanel.distinctId, andIdentify: false)
-    waitForTrackingQueue(testMixpanel2)
-
-    let unidentifiedQueue2 = unIdentifiedPeopleQueue(token: testMixpanel2.apiToken)
-    // The user profile updates should still be held in unidentifiedQueue cause no identify is called
-    XCTAssertTrue(!unidentifiedQueue2.isEmpty)
-    let mixpanelIdentity2 = MixpanelPersistence.loadIdentity(instanceName: testMixpanel2.apiToken)
-    XCTAssertTrue(
-      distinctId2 == mixpanelIdentity2.distinctID && nil == mixpanelIdentity2.peopleDistinctID
-        && nil == mixpanelIdentity2.userId && alias == mixpanelIdentity2.alias)
-    removeDBfile(testMixpanel2.apiToken)
-  }
-
-  func testPersistentIdentity() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let distinctId: String = "d1"
-    let alias: String = "a1"
-    testMixpanel.identify(distinctId: distinctId)
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.createAlias(alias, distinctId: testMixpanel.distinctId)
-    waitForTrackingQueue(testMixpanel)
-    var mixpanelIdentity = MixpanelPersistence.loadIdentity(instanceName: testMixpanel.apiToken)
-    XCTAssertTrue(
-      distinctId == mixpanelIdentity.distinctID && distinctId == mixpanelIdentity.peopleDistinctID
-        && distinctId == mixpanelIdentity.userId && alias == mixpanelIdentity.alias)
-    testMixpanel.archive()
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.unarchive()
-    waitForTrackingQueue(testMixpanel)
-    mixpanelIdentity = MixpanelPersistence.loadIdentity(instanceName: testMixpanel.apiToken)
-    XCTAssertTrue(
-      testMixpanel.distinctId == mixpanelIdentity.distinctID
-        && testMixpanel.people.distinctId == mixpanelIdentity.peopleDistinctID
-        && testMixpanel.anonymousId == mixpanelIdentity.anonymousId
-        && testMixpanel.userId == mixpanelIdentity.userId
-        && testMixpanel.alias == mixpanelIdentity.alias)
-    MixpanelPersistence.deleteMPUserDefaultsData(instanceName: testMixpanel.apiToken)
-    waitForTrackingQueue(testMixpanel)
-    mixpanelIdentity = MixpanelPersistence.loadIdentity(instanceName: testMixpanel.apiToken)
-    XCTAssertTrue(
-      "" == mixpanelIdentity.distinctID && nil == mixpanelIdentity.peopleDistinctID
-        && nil == mixpanelIdentity.anonymousId && nil == mixpanelIdentity.userId
-        && nil == mixpanelIdentity.alias)
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testUseUniqueDistinctId() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let testMixpanel2 = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    XCTAssertNotEqual(
-      testMixpanel.distinctId, testMixpanel2.distinctId,
-      "by default, distinctId should not be unique to the device")
-
-    let testMixpanel3 = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60, useUniqueDistinctId: false)
-    let testMixpanel4 = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60, useUniqueDistinctId: false)
-    XCTAssertNotEqual(
-      testMixpanel3.distinctId, testMixpanel4.distinctId,
-      "distinctId should not be unique to the device if useUniqueDistinctId is set to false")
-
-    let testMixpanel5 = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60, useUniqueDistinctId: true)
-    let testMixpanel6 = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60, useUniqueDistinctId: true)
-    XCTAssertEqual(
-      testMixpanel5.distinctId, testMixpanel6.distinctId,
-      "distinctId should be unique to the device if useUniqueDistinctId is set to true")
-  }
-
-  func testHadPersistedDistinctId() {
-    let testToken = randomId()
-    let testMixpanel = Mixpanel.initialize(
-      token: testToken, trackAutomaticEvents: true, flushInterval: 60)
-    XCTAssertNotNil(testMixpanel.distinctId)
-    let distinctId = testMixpanel.distinctId
-    let testMixpanel2 = Mixpanel.initialize(
-      token: testToken, trackAutomaticEvents: true, flushInterval: 60)
-    XCTAssertEqual(
-      testMixpanel2.distinctId, distinctId,
-      "mixpanel anonymous distinct id should not be changed for each init")
-
-    let userId: String = "u1"
-    testMixpanel.identify(distinctId: userId)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(devicePrefix + testMixpanel.anonymousId!, distinctId)
-    XCTAssertEqual(testMixpanel.userId, userId)
-    XCTAssertEqual(testMixpanel.distinctId, userId)
-    XCTAssertTrue(testMixpanel.hadPersistedDistinctId!)
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testTrackWithDefaultProperties() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.track(event: "Something Happened")
-    waitForTrackingQueue(testMixpanel)
-    let e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(e["event"] as? String, "Something Happened", "incorrect event name")
-    let p: InternalProperties = e["properties"] as! InternalProperties
-    XCTAssertNotNil(p["$app_build_number"], "$app_build_number not set")
-    XCTAssertNotNil(p["$app_version_string"], "$app_version_string not set")
-    XCTAssertNotNil(p["$lib_version"], "$lib_version not set")
-    XCTAssertNotNil(p["$model"], "$model not set")
-    XCTAssertNotNil(p["$os"], "$os not set")
-    XCTAssertNotNil(p["$os_version"], "$os_version not set")
-    XCTAssertNotNil(p["$screen_height"], "$screen_height not set")
-    XCTAssertNotNil(p["$screen_width"], "$screen_width not set")
-    XCTAssertNotNil(p["distinct_id"], "distinct_id not set")
-    XCTAssertNotNil(p["time"], "time not set")
-    XCTAssertEqual(p["$manufacturer"] as? String, "Apple", "incorrect $manufacturer")
-    XCTAssertEqual(p["mp_lib"] as? String, "swift", "incorrect mp_lib")
-    XCTAssertEqual(p["token"] as? String, testMixpanel.apiToken, "incorrect token")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testTrackWithCustomProperties() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let now = Date()
-    let p: Properties = [
-      "string": "yello",
-      "number": 3,
-      "date": now,
-      "$app_version": "override",
-    ]
-    testMixpanel.track(event: "Something Happened", properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let props: InternalProperties =
-      eventQueue(token: testMixpanel.apiToken).last?["properties"] as! InternalProperties
-    XCTAssertEqual(props["string"] as? String, "yello")
-    XCTAssertEqual(props["number"] as? Int, 3)
-    let dateValue = props["date"] as! String
-    compareDate(dateString: dateValue, dateDate: now)
-    XCTAssertEqual(
-      props["$app_version"] as? String, "override",
-      "reserved property override failed")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testTrackWithOptionalProperties() {
-    let optNil: Double? = nil
-    let optDouble: Double? = 1.0
-    let optArray: [Double?] = [nil, 1.0, 2.0]
-    let optDict: [String: Double?] = ["nil": nil, "double": 1.0]
-    let nested: [String: Any] = ["list": optArray, "dict": optDict]
-    let p: Properties = [
-      "nil": optNil,
-      "double": optDouble,
-      "list": optArray,
-      "dict": optDict,
-      "nested": nested,
-    ]
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.track(event: "Optional Test", properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let props: InternalProperties =
-      eventQueue(token: testMixpanel.apiToken).last?["properties"] as! InternalProperties
-    XCTAssertNil(props["nil"] as? Double)
-    XCTAssertEqual(props["double"] as? Double, 1.0)
-    XCTAssertEqual(props["list"] as? Array, [1.0, 2.0])
-    XCTAssertEqual(props["dict"] as? Dictionary, ["nil": nil, "double": 1.0])
-    let nestedProp = props["nested"] as? [String: Any]
-    XCTAssertEqual(nestedProp?["dict"] as? Dictionary, ["nil": nil, "double": 1.0])
-    XCTAssertEqual(nestedProp?["list"] as? Array, [1.0, 2.0])
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testTrackWithCustomDistinctIdAndToken() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let p: Properties = ["token": "t1", "distinct_id": "d1"]
-    testMixpanel.track(event: "e1", properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let trackToken =
-      (eventQueue(token: testMixpanel.apiToken).last?["properties"] as? InternalProperties)?[
-        "token"] as? String
-    let trackDistinctId =
-      (eventQueue(token: testMixpanel.apiToken).last?["properties"] as? InternalProperties)?[
-        "distinct_id"] as? String
-    XCTAssertEqual(trackToken, "t1", "user-defined distinct id not used in track.")
-    XCTAssertEqual(trackDistinctId, "d1", "user-defined distinct id not used in track.")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testTrackWithGroups() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    testMixpanel.trackWithGroups(
-      event: "Something Happened", properties: [groupKey: "some other value", "p1": "value"],
-      groups: [groupKey: groupID])
-    waitForTrackingQueue(testMixpanel)
-    let e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(e["event"] as? String, "Something Happened", "incorrect event name")
-    let p: InternalProperties = e["properties"] as! InternalProperties
-    XCTAssertNotNil(p["$app_build_number"], "$app_build_number not set")
-    XCTAssertNotNil(p["$app_version_string"], "$app_version_string not set")
-    XCTAssertNotNil(p["$lib_version"], "$lib_version not set")
-    XCTAssertNotNil(p["$model"], "$model not set")
-    XCTAssertNotNil(p["$os"], "$os not set")
-    XCTAssertNotNil(p["$os_version"], "$os_version not set")
-    XCTAssertNotNil(p["$screen_height"], "$screen_height not set")
-    XCTAssertNotNil(p["$screen_width"], "$screen_width not set")
-    XCTAssertNotNil(p["distinct_id"], "distinct_id not set")
-    XCTAssertNotNil(p["time"], "time not set")
-    XCTAssertEqual(p["$manufacturer"] as? String, "Apple", "incorrect $manufacturer")
-    XCTAssertEqual(p["mp_lib"] as? String, "swift", "incorrect mp_lib")
-    XCTAssertEqual(p["token"] as? String, testMixpanel.apiToken, "incorrect token")
-    XCTAssertEqual(p[groupKey] as? String, groupID, "incorrect group id")
-    XCTAssertEqual(p["p1"] as? String, "value", "incorrect group value")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testRegisterSuperProperties() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    var p: Properties = ["p1": "a", "p2": 3, "p3": Date()]
-    testMixpanel.registerSuperProperties(p)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(
-      NSDictionary(dictionary: testMixpanel.currentSuperProperties()),
-      NSDictionary(dictionary: p),
-      "register super properties failed")
-    p = ["p1": "b"]
-    testMixpanel.registerSuperProperties(p)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(
-      testMixpanel.currentSuperProperties()["p1"] as? String, "b",
-      "register super properties failed to overwrite existing value")
-    p = ["p4": "a"]
-    testMixpanel.registerSuperPropertiesOnce(p)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(
-      testMixpanel.currentSuperProperties()["p4"] as? String, "a",
-      "register super properties once failed first time")
-    p = ["p4": "b"]
-    testMixpanel.registerSuperPropertiesOnce(p)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(
-      testMixpanel.currentSuperProperties()["p4"] as? String, "a",
-      "register super properties once failed second time")
-    p = ["p4": "c"]
-    testMixpanel.registerSuperPropertiesOnce(p, defaultValue: "d")
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(
-      testMixpanel.currentSuperProperties()["p4"] as? String, "a",
-      "register super properties once with default value failed when no match")
-    testMixpanel.registerSuperPropertiesOnce(p, defaultValue: "a")
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(
-      testMixpanel.currentSuperProperties()["p4"] as? String, "c",
-      "register super properties once with default value failed when match")
-    testMixpanel.unregisterSuperProperty("a")
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertNil(
-      testMixpanel.currentSuperProperties()["a"],
-      "unregister super property failed")
-    // unregister non-existent super property should not throw
-    testMixpanel.unregisterSuperProperty("a")
-    testMixpanel.clearSuperProperties()
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      testMixpanel.currentSuperProperties().isEmpty,
-      "clear super properties failed")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testSettingSuperPropertiesWhenInit() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60,
-      superProperties: ["mp_lib": "flutter"])
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(
-      testMixpanel.currentSuperProperties()["mp_lib"] as? String, "flutter",
-      "register super properties in init failed")
-    testMixpanel.track(event: "e1")
-    waitForTrackingQueue(testMixpanel)
-    let e = eventQueue(token: testMixpanel.apiToken).last!
-    let p = e["properties"] as! InternalProperties
-    XCTAssertNotNil(p["mp_lib"], "flutter")
-  }
-
-  func testInvalidPropertiesTrack() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let p: Properties = ["data": [Data()]]
-    XCTExpectAssert("property type should not be allowed") {
-      testMixpanel.track(event: "e1", properties: p)
-    }
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testInvalidSuperProperties() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let p: Properties = ["data": [Data()]]
-    XCTExpectAssert("property type should not be allowed") {
-      testMixpanel.registerSuperProperties(p)
-    }
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testInvalidSuperProperties2() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let p: Properties = ["data": [Data()]]
-    XCTExpectAssert("property type should not be allowed") {
-      testMixpanel.registerSuperPropertiesOnce(p)
-    }
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testInvalidSuperProperties3() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let p: Properties = ["data": [Data()]]
-    XCTExpectAssert("property type should not be allowed") {
-      testMixpanel.registerSuperPropertiesOnce(p, defaultValue: "v")
-    }
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testValidPropertiesTrack() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let p: Properties = allPropertyTypes()
-    testMixpanel.track(event: "e1", properties: p)
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testValidSuperProperties() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let p: Properties = allPropertyTypes()
-    testMixpanel.registerSuperProperties(p)
-    testMixpanel.registerSuperPropertiesOnce(p)
-    testMixpanel.registerSuperPropertiesOnce(p, defaultValue: "v")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testReset() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    waitForAsyncTasks()
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.track(event: "e1")
-    waitForTrackingQueue(testMixpanel)
-    let p: Properties = ["p1": "a"]
-    testMixpanel.registerSuperProperties(p)
-    testMixpanel.people.set(properties: p)
-    testMixpanel.archive()
-    testMixpanel.reset()
-    waitForTrackingQueue(testMixpanel)
-
-    #if MIXPANEL_UNIQUE_DISTINCT_ID
-      XCTAssertEqual(
-        testMixpanel.distinctId,
-        devicePrefix + testMixpanel.defaultDeviceId(),
-        "distinct id failed to reset")
-    #endif
-    XCTAssertNil(testMixpanel.people.distinctId, "people distinct id failed to reset")
-    XCTAssertTrue(
-      testMixpanel.currentSuperProperties().isEmpty,
-      "super properties failed to reset")
-    XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).isEmpty, "events queue failed to reset")
-    XCTAssertTrue(peopleQueue(token: testMixpanel.apiToken).isEmpty, "people queue failed to reset")
-    let testMixpanel2 = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    waitForAsyncTasks()
-    waitForTrackingQueue(testMixpanel2)
-    #if MIXPANEL_UNIQUE_DISTINCT_ID
-      XCTAssertEqual(
-        testMixpanel2.distinctId, devicePrefix + testMixpanel2.defaultDeviceId(),
-        "distinct id failed to reset after archive")
-    #endif
-    XCTAssertNil(
-      testMixpanel2.people.distinctId,
-      "people distinct id failed to reset after archive")
-    XCTAssertTrue(
-      testMixpanel2.currentSuperProperties().isEmpty,
-      "super properties failed to reset after archive")
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel2.apiToken).count == 1,
-      "events queue failed to reset after archive")
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel2.apiToken).isEmpty,
-      "people queue failed to reset after archive")
-    removeDBfile(testMixpanel.apiToken)
-    removeDBfile(testMixpanel2.apiToken)
-  }
-
-  func testArchiveNSNumberBoolIntProperty() {
-    let testToken = randomId()
-    let testMixpanel = Mixpanel.initialize(
-      token: testToken, trackAutomaticEvents: true, flushInterval: 60)
-    waitForAsyncTasks()
-    testMixpanel.serverURL = kFakeServerUrl
-    let aBoolNumber: Bool = true
-    let aBoolNSNumber = NSNumber(value: aBoolNumber)
-
-    let aIntNumber: Int = 1
-    let aIntNSNumber = NSNumber(value: aIntNumber)
-
-    testMixpanel.track(event: "e1", properties: ["p1": aBoolNSNumber, "p2": aIntNSNumber])
-    testMixpanel.archive()
-    waitForTrackingQueue(testMixpanel)
-
-    let testMixpanel2 = Mixpanel.initialize(
-      token: testToken, trackAutomaticEvents: true, flushInterval: 60)
-    waitForAsyncTasks()
-    testMixpanel2.serverURL = kFakeServerUrl
-    waitForTrackingQueue(testMixpanel2)
-
-    let properties: [String: Any] =
-      eventQueue(token: testMixpanel2.apiToken)[1]["properties"] as! [String: Any]
-
-    XCTAssertTrue(
-      isBoolNumber(num: properties["p1"]! as! NSNumber),
-      "The bool value should be unarchived as bool")
-    XCTAssertFalse(
-      isBoolNumber(num: properties["p2"]! as! NSNumber),
-      "The int value should not be unarchived as bool")
-    removeDBfile(testToken)
-  }
-
-  private func isBoolNumber(num: NSNumber) -> Bool {
-    let boolID = CFBooleanGetTypeID()  // the type ID of CFBoolean
-    let numID = CFGetTypeID(num)  // the type ID of num
-    return numID == boolID
-  }
-
-  func testArchive() {
-    let testToken = randomId()
-    let testMixpanel = Mixpanel.initialize(
-      token: testToken, trackAutomaticEvents: false, flushInterval: 60)
-    testMixpanel.serverURL = kFakeServerUrl
-    #if MIXPANEL_UNIQUE_DISTINCT_ID
-      XCTAssertEqual(
-        testMixpanel.distinctId, devicePrefix + testMixpanel.defaultDeviceId(),
-        "default distinct id archive failed")
-    #endif
-    XCTAssertTrue(
-      testMixpanel.currentSuperProperties().isEmpty,
-      "default super properties archive failed")
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).isEmpty, "default events queue archive failed")
-    XCTAssertNil(testMixpanel.people.distinctId, "default people distinct id archive failed")
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel.apiToken).isEmpty, "default people queue archive failed")
-    let p: Properties = ["p1": "a"]
-    testMixpanel.identify(distinctId: "d1")
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.registerSuperProperties(p)
-    testMixpanel.track(event: "e1")
-    testMixpanel.track(event: "e2")
-    testMixpanel.track(event: "e3")
-    testMixpanel.track(event: "e4")
-    testMixpanel.track(event: "e5")
-    testMixpanel.track(event: "e6")
-    testMixpanel.track(event: "e7")
-    testMixpanel.track(event: "e8")
-    testMixpanel.track(event: "e9")
-    testMixpanel.people.set(properties: p)
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.timedEvents["e2"] = 5
-    testMixpanel.archive()
-    let testMixpanel2 = Mixpanel.initialize(
-      token: testToken, trackAutomaticEvents: false, flushInterval: 60)
-    testMixpanel2.serverURL = kFakeServerUrl
-    waitForTrackingQueue(testMixpanel2)
-    XCTAssertEqual(testMixpanel2.distinctId, "d1", "custom distinct archive failed")
-    XCTAssertTrue(
-      testMixpanel2.currentSuperProperties().count == 1,
-      "custom super properties archive failed")
-    let eventQueueValue = eventQueue(token: testMixpanel2.apiToken)
-
-    XCTAssertEqual(
-      eventQueueValue[1]["event"] as? String, "e1",
-      "event was not successfully archived/unarchived")
-    XCTAssertEqual(
-      eventQueueValue[2]["event"] as? String, "e2",
-      "event was not successfully archived/unarchived or order is incorrect")
-    XCTAssertEqual(
-      eventQueueValue[3]["event"] as? String, "e3",
-      "event was not successfully archived/unarchived or order is incorrect")
-    XCTAssertEqual(
-      eventQueueValue[4]["event"] as? String, "e4",
-      "event was not successfully archived/unarchived or order is incorrect")
-    XCTAssertEqual(
-      eventQueueValue[5]["event"] as? String, "e5",
-      "event was not successfully archived/unarchived or order is incorrect")
-    XCTAssertEqual(
-      eventQueueValue[6]["event"] as? String, "e6",
-      "event was not successfully archived/unarchived or order is incorrect")
-    XCTAssertEqual(
-      eventQueueValue[7]["event"] as? String, "e7",
-      "event was not successfully archived/unarchived or order is incorrect")
-    XCTAssertEqual(
-      eventQueueValue[8]["event"] as? String, "e8",
-      "event was not successfully archived/unarchived or order is incorrect")
-    XCTAssertEqual(
-      eventQueueValue[9]["event"] as? String, "e9",
-      "event was not successfully archived/unarchived or order is incorrect")
-    XCTAssertEqual(
-      testMixpanel2.people.distinctId, "d1",
-      "custom people distinct id archive failed")
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel2.apiToken).count >= 1, "pending people queue archive failed")
-    XCTAssertEqual(
-      testMixpanel2.timedEvents["e2"] as? Int, 5,
-      "timedEvents archive failed")
-    let testMixpanel3 = Mixpanel.initialize(
-      token: testToken, trackAutomaticEvents: false, flushInterval: 60)
-    testMixpanel3.serverURL = kFakeServerUrl
-    XCTAssertEqual(testMixpanel3.distinctId, "d1", "expecting d1 as distinct id as initialised")
-    XCTAssertTrue(
-      testMixpanel3.currentSuperProperties().count == 1,
-      "default super properties expected to have 1 item")
-    XCTAssertNotNil(eventQueue(token: testMixpanel3.apiToken), "default events queue is nil")
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel3.apiToken).count == 10,
-      "default events queue expecting 10 items ($identify call added)")
-    XCTAssertNotNil(
-      testMixpanel3.people.distinctId,
-      "default people distinct id from no file failed")
-    XCTAssertNotNil(
-      peopleQueue(token: testMixpanel3.apiToken), "default people queue from no file is nil")
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel3.apiToken).count >= 1, "default people queue expecting 1 item"
-    )
-    XCTAssertTrue(testMixpanel3.timedEvents.count == 1, "timedEvents expecting 1 item")
-    removeDBfile(testToken)
-  }
-
-  func testMixpanelDelegate() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    waitForAsyncTasks()
-    testMixpanel.delegate = self
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.track(event: "e1")
-    testMixpanel.people.set(property: "p1", to: "a")
-    waitForTrackingQueue(testMixpanel)
-    flushAndWaitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 3, "delegate should have stopped flush")
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel.apiToken).count == 2, "delegate should have stopped flush")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testEventTiming() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.track(event: "Something Happened")
-    waitForTrackingQueue(testMixpanel)
-    var e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
-    var p = e["properties"] as! InternalProperties
-    XCTAssertNil(p["$duration"], "New events should not be timed.")
-    testMixpanel.time(event: "400 Meters")
-    testMixpanel.track(event: "500 Meters")
-    waitForTrackingQueue(testMixpanel)
-    e = eventQueue(token: testMixpanel.apiToken).last!
-    p = e["properties"] as! InternalProperties
-    XCTAssertNil(p["$duration"], "The exact same event name is required for timing.")
-    testMixpanel.track(event: "400 Meters")
-    waitForTrackingQueue(testMixpanel)
-    e = eventQueue(token: testMixpanel.apiToken).last!
-    p = e["properties"] as! InternalProperties
-    XCTAssertNotNil(p["$duration"], "This event should be timed.")
-    testMixpanel.track(event: "400 Meters")
-    waitForTrackingQueue(testMixpanel)
-    e = eventQueue(token: testMixpanel.apiToken).last!
-    p = e["properties"] as! InternalProperties
-    XCTAssertNil(
-      p["$duration"],
-      "Tracking the same event should require a second call to timeEvent.")
-    testMixpanel.time(event: "Time Event A")
-    testMixpanel.time(event: "Time Event B")
-    testMixpanel.time(event: "Time Event C")
-    waitForTrackingQueue(testMixpanel)
-    var testTimedEvents = MixpanelPersistence.loadTimedEvents(instanceName: testMixpanel.apiToken)
-    XCTAssertTrue(
-      testTimedEvents.count == 3, "Each call to time() should add an event to timedEvents")
-    XCTAssertNotNil(testTimedEvents["Time Event A"], "Keys in timedEvents should be event names")
-    testMixpanel.clearTimedEvent(event: "Time Event A")
-    waitForTrackingQueue(testMixpanel)
-    testTimedEvents = MixpanelPersistence.loadTimedEvents(instanceName: testMixpanel.apiToken)
-    XCTAssertNil(testTimedEvents["Time Event A"], "clearTimedEvent should remove key/value pair")
-    XCTAssertTrue(
-      testTimedEvents.count == 2, "clearTimedEvent shoud remove only one key/value pair")
-    testMixpanel.clearTimedEvents()
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      MixpanelPersistence.loadTimedEvents(instanceName: testMixpanel.apiToken).count == 0,
-      "clearTimedEvents should remove all key/value pairs")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testReadWriteLock() {
-    var array = [Int]()
-    let lock = ReadWriteLock(label: "test")
-    let queue = DispatchQueue(label: "concurrent", qos: .utility, attributes: .concurrent)
-    for _ in 0..<10 {
-      queue.async {
-        lock.write {
-          for i in 0..<100 {
-            array.append(i)
-          }
-        }
-      }
-
-      queue.async {
-        lock.read {
-          XCTAssertTrue(array.count % 100 == 0, "supposed to happen after write")
-        }
-      }
-    }
-  }
-
-  func testSetGroup() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    let groupKey = "test_key"
-    let groupValue = "test_value"
-    testMixpanel.setGroup(groupKey: groupKey, groupIDs: [groupValue])
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue])
-    let q = peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
-    XCTAssertEqual(q[groupKey] as? [String], [groupValue], "group value people property not queued")
-    assertDefaultPeopleProperties(q)
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testAddGroup() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    let groupKey = "test_key"
-    let groupValue = "test_value"
-
-    testMixpanel.addGroup(groupKey: groupKey, groupID: groupValue)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue])
-    waitForTrackingQueue(testMixpanel)
-    let q = peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
-    XCTAssertEqual(q[groupKey] as? [String], [groupValue], "addGroup people update not queued")
-    assertDefaultPeopleProperties(q)
-    testMixpanel.addGroup(groupKey: groupKey, groupID: groupValue)
-
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue])
-    waitForTrackingQueue(testMixpanel)
-    let q2 = peopleQueue(token: testMixpanel.apiToken).last!["$union"] as! InternalProperties
-    XCTAssertEqual(q2[groupKey] as? [String], [groupValue], "addGroup people update not queued")
-
-    let newVal = "new_group"
-    testMixpanel.addGroup(groupKey: groupKey, groupID: newVal)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(
-      testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue, newVal])
-    waitForTrackingQueue(testMixpanel)
-    waitForTrackingQueue(testMixpanel)
-    let q3 = peopleQueue(token: testMixpanel.apiToken).last!["$union"] as! InternalProperties
-    XCTAssertEqual(q3[groupKey] as? [String], [newVal], "addGroup people update not queued")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testRemoveGroup() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    let groupKey = "test_key"
-    let groupValue = "test_value"
-    let newVal = "new_group"
-
-    testMixpanel.setGroup(groupKey: groupKey, groupIDs: [groupValue, newVal])
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(
-      testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue, newVal])
-
-    testMixpanel.removeGroup(groupKey: groupKey, groupID: groupValue)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertEqual(testMixpanel.currentSuperProperties()[groupKey] as? [String], [newVal])
-    waitForTrackingQueue(testMixpanel)
-    let q2 = peopleQueue(token: testMixpanel.apiToken).last!["$remove"] as! InternalProperties
-    XCTAssertEqual(q2[groupKey] as? String, groupValue, "removeGroup people update not queued")
-
-    testMixpanel.removeGroup(groupKey: groupKey, groupID: groupValue)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertNil(testMixpanel.currentSuperProperties()[groupKey])
-    waitForTrackingQueue(testMixpanel)
-    let q3 = peopleQueue(token: testMixpanel.apiToken).last!["$unset"] as! [String]
-    XCTAssertEqual(q3, [groupKey], "removeGroup people update not queued")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testMultipleInstancesWithSameToken() {
-    let testToken = randomId()
-    let concurentQueue = DispatchQueue(label: "multithread", attributes: .concurrent)
-
-    var testMixpanel: MixpanelInstance?
-    for _ in 1...10 {
-      concurentQueue.async {
-        testMixpanel = Mixpanel.initialize(
-          token: testToken, trackAutomaticEvents: true, flushInterval: 60)
-        testMixpanel?.loggingEnabled = true
-        testMixpanel?.track(event: "test")
-      }
-    }
-
-    var testMixpanel2: MixpanelInstance?
-    for _ in 1...10 {
-      concurentQueue.async {
-        testMixpanel2 = Mixpanel.initialize(
-          token: testToken, trackAutomaticEvents: true, flushInterval: 60)
-        testMixpanel2?.loggingEnabled = true
-        testMixpanel2?.track(event: "test")
-      }
-    }
-    sleep(5)
-    testMixpanel = Mixpanel.initialize(
-      token: testToken, trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel2 = Mixpanel.initialize(
-      token: testToken, trackAutomaticEvents: true, flushInterval: 60)
-    XCTAssertTrue(
-      testMixpanel === testMixpanel2,
-      "instance with same token should be reused and no sqlite db locked error should be populated")
-  }
-
-  func testMultipleInstancesWithSameTokenButDifferentInstanceNameShouldNotCrash() {
-    let testToken = randomId()
-    let concurentQueue = DispatchQueue(label: "multithread", attributes: .concurrent)
-
-    for i in 1...10 {
-      concurentQueue.async {
+    func test5XXResponse() {
         let testMixpanel = Mixpanel.initialize(
-          token: testToken, trackAutomaticEvents: true, flushInterval: 60,
-          instanceName: "instance\(i)")
-        testMixpanel.loggingEnabled = true
-        testMixpanel.track(event: "test")
-      }
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        waitForAsyncTasks()
+        testMixpanel.serverURL = kFakeServerUrl
+        testMixpanel.track(event: "Fake Event")
+        flushAndWaitForTrackingQueue(testMixpanel)
+        // Failure count should be 3
+        let waitTime =
+            testMixpanel.flushInstance.flushRequest.networkRequestsAllowedAfterTime
+            - Date().timeIntervalSince1970
+        print("Delta wait time is \(waitTime)")
+        XCTAssert(waitTime >= 110, "Network backoff time is less than 2 minutes.")
+        XCTAssert(
+            testMixpanel.flushInstance.flushRequest.networkConsecutiveFailures == 2,
+            "Network failures did not equal 2")
+
+        XCTAssert(
+            eventQueue(token: testMixpanel.apiToken).count == 2,
+            "Removed an event from the queue that was not sent")
+        removeDBfile(testMixpanel.apiToken)
     }
 
-    sleep(5)
-    XCTAssertTrue(true, "no sqlite db locked error should be populated")
-    for j in 1...10 {
-      removeDBfile("instance\(j)")
-    }
-  }
-
-  func testMultipleInstancesWithSameTokenButDifferentInstanceName() {
-    let testToken = randomId()
-    let instanceName1 = randomId()
-    let instanceName2 = randomId()
-    let instance1 = Mixpanel.initialize(
-      token: testToken, trackAutomaticEvents: true, flushInterval: 60, instanceName: instanceName1)
-    let instance2 = Mixpanel.initialize(
-      token: testToken, trackAutomaticEvents: true, flushInterval: 60, instanceName: instanceName2)
-
-    XCTAssertNotEqual(instance1.distinctId, instance2.distinctId)
-    instance1.identify(distinctId: "user1")
-    instance1.track(event: "test")
-    waitForTrackingQueue(instance1)
-    waitForTrackingQueue(instance2)
-
-    XCTAssertEqual(instance1.distinctId, "user1")
-    XCTAssertEqual(instance1.userId, "user1")
-    let events = eventQueue(token: instanceName1)
-    let properties = events.last?["properties"] as? InternalProperties
-    XCTAssertEqual(properties?["distinct_id"] as? String, "user1")
-
-    instance1.people.set(property: "p1", to: "a")
-    waitForTrackingQueue(instance1)
-    waitForTrackingQueue(instance2)
-
-    let peopleQueue_value = peopleQueue(token: instanceName1)
-    let setValue = peopleQueue_value.last!["$set"] as! InternalProperties
-    XCTAssertEqual(setValue["p1"] as? String, "a", "custom people property not queued")
-
-    XCTAssertEqual(
-      peopleQueue_value.last?["$distinct_id"] as? String,
-      "user1", "distinct id not set properly on the people record")
-
-    instance2.identify(distinctId: "user2")
-    instance2.track(event: "test2")
-    waitForTrackingQueue(instance1)
-    waitForTrackingQueue(instance2)
-    XCTAssertEqual(instance2.distinctId, "user2")
-    XCTAssertEqual(instance2.userId, "user2")
-    let events2 = eventQueue(token: instanceName2)
-    let properties2 = events2.last?["properties"] as? InternalProperties
-    // event property should have the current distinct id
-    XCTAssertEqual(properties2?["distinct_id"] as? String, "user2")
-
-    instance2.people.set(property: "p2", to: "b")
-    waitForTrackingQueue(instance1)
-    waitForTrackingQueue(instance2)
-
-    let peopleQueue2_value = peopleQueue(token: instanceName2)
-    XCTAssertEqual(
-      peopleQueue2_value.last?["$distinct_id"] as? String,
-      "user2", "distinct id not set properly on the people record")
-
-    let setValue2 = peopleQueue2_value.last!["$set"] as! InternalProperties
-    XCTAssertEqual(setValue2["p2"] as? String, "b", "custom people property not queued")
-
-    removeDBfile(instanceName1)
-    removeDBfile(instanceName2)
-  }
-
-  func testReadWriteMultiThreadShouldNotCrash() {
-    let concurentQueue = DispatchQueue(label: "multithread", attributes: .concurrent)
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-
-    for n in 1...10 {
-      concurentQueue.async {
-        testMixpanel.track(event: "event\(n)")
-      }
-      concurentQueue.async {
-        testMixpanel.flush()
-      }
-      concurentQueue.async {
-        testMixpanel.archive()
-      }
-      concurentQueue.async {
-        testMixpanel.reset()
-      }
-      concurentQueue.async {
-        testMixpanel.createAlias("aaa11", distinctId: testMixpanel.distinctId)
-        testMixpanel.identify(distinctId: "test")
-      }
-      concurentQueue.async {
-        testMixpanel.registerSuperProperties(["Plan": "Mega"])
-      }
-      concurentQueue.async {
-        let _ = testMixpanel.currentSuperProperties()
-      }
-      concurentQueue.async {
-        testMixpanel.people.set(property: "aaa", to: "SwiftSDK Cocoapods")
-        testMixpanel.getGroup(groupKey: "test", groupID: 123).set(properties: ["test": 123])
-        testMixpanel.removeGroup(groupKey: "test", groupID: 123)
-      }
-      concurentQueue.async {
-        testMixpanel.track(event: "test")
-        testMixpanel.time(event: "test")
-        testMixpanel.clearTimedEvents()
-      }
-    }
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testMPDB() {
-    // we test with this crazy string because the "token" here can be the instanceName
-    // which can be any string the user likes, MPDB should strip the non-alphanumeric characters to prevent SQL errors
-    let mpdb = MPDB.init(token: "Re@lly  Bad.T0ken+\(randomId())--*🤪/0️⃣\\_? ")
-    mpdb.open()
-
-    let numRows = 50
-    let halfRows = numRows / 2
-    let eventName = "Test Event"
-
-    for pType in PersistenceType.allCases {
-      let emptyArray: [InternalProperties] = mpdb.readRows(pType, numRows: numRows)
-      XCTAssertTrue(emptyArray.isEmpty, "Table should be empty")
-      for i in 0...numRows - 1 {
-        let eventObj: InternalProperties = ["event": eventName, "properties": ["index": i]]
-        let eventData = JSONHandler.serializeJSONObject(eventObj)!
-        mpdb.insertRow(pType, data: eventData)
-      }
-      let dataArray: [InternalProperties] = mpdb.readRows(pType, numRows: halfRows)
-      XCTAssertEqual(dataArray.count, halfRows, "Should have read only half of the rows")
-      var ids: [Int32] = []
-      for (n, entity) in dataArray.enumerated() {
-        guard let id = entity["id"] as? Int32 else {
-          continue
+    func testFlushEvents() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        for i in 0..<50 {
+            testMixpanel.track(event: "event \(i)")
         }
-        ids.append(id)
-        XCTAssertEqual(entity["event"] as! String, eventName, "Event name should be unchanged")
-        // index should be oldest events, 0 - 24
-        XCTAssertEqual(
-          entity["properties"] as! [String: Int], ["index": n], "Should read oldest events first")
-      }
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).isEmpty,
+            "events should have been flushed")
 
-      mpdb.deleteRows(pType, ids: ids)
-      let dataArray2: [InternalProperties] = mpdb.readRows(pType, numRows: numRows)
-      // even though we requested numRows, there should only be halfRows left
-      XCTAssertEqual(dataArray2.count, halfRows, "Should have deleted half the rows")
-      for (n, entity) in dataArray2.enumerated() {
-        XCTAssertEqual(entity["event"] as! String, eventName, "Event name should be unchanged")
-        // old events (0-24) should have been deleted so index should be recent events 25-49
-        XCTAssertEqual(
-          entity["properties"] as! [String: Int], ["index": n + halfRows],
-          "Should have deleted oldest events first")
-      }
+        for i in 0..<60 {
+            testMixpanel.track(event: "event \(i)")
+        }
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).isEmpty,
+            "events should have been flushed")
+        removeDBfile(testMixpanel.apiToken)
     }
 
-    mpdb.close()
-    removeDBfile(mpdb.apiToken)
-  }
-
-  func testMigration() {
-    let token = "testToken"
-    // clean up
-    removeDBfile(token)
-    // copy the legacy archived file for the migration test
-    let legacyFiles = [
-      "mixpanel-testToken-events", "mixpanel-testToken-properties", "mixpanel-testToken-groups",
-      "mixpanel-testToken-people", "mixpanel-testToken-optOutStatus",
-    ]
-    prepareForMigrationFiles(legacyFiles)
-    // initialize mixpanel will do the migration automatically if found legacy archive files.
-    let testMixpanel = Mixpanel.initialize(
-      token: token, trackAutomaticEvents: true, flushInterval: 60)
-    let fileManager = FileManager.default
-    let libraryUrls = fileManager.urls(
-      for: .libraryDirectory,
-      in: .userDomainMask)
-    XCTAssertFalse(
-      fileManager.fileExists(
-        atPath: (libraryUrls.first?.appendingPathComponent("mixpanel-testToken-events"))!.path),
-      "after migration, the legacy archive files should be removed")
-    XCTAssertFalse(
-      fileManager.fileExists(
-        atPath: (libraryUrls.first?.appendingPathComponent("mixpanel-testToken-properties"))!.path),
-      "after migration, the legacy archive files should be removed")
-    XCTAssertFalse(
-      fileManager.fileExists(
-        atPath: (libraryUrls.first?.appendingPathComponent("mixpanel-testToken-groups"))!.path),
-      "after migration, the legacy archive files should be removed")
-    XCTAssertFalse(
-      fileManager.fileExists(
-        atPath: (libraryUrls.first?.appendingPathComponent("mixpanel-testToken-people"))!.path),
-      "after migration, the legacy archive files should be removed")
-
-    let events = eventQueue(token: testMixpanel.apiToken)
-    XCTAssertEqual(events.count, 306)
-
-    XCTAssertEqual(events[0]["event"] as? String, "$identify")
-    XCTAssertEqual(events[1]["event"] as? String, "Logged in")
-    XCTAssertEqual(events[2]["event"] as? String, "$ae_first_open")
-    XCTAssertEqual(events[3]["event"] as? String, "Tracked event 1")
-    let properties = events.last?["properties"] as? InternalProperties
-    XCTAssertEqual(properties?["Cool Property"] as? [Int], [12345, 301])
-    XCTAssertEqual(properties?["Super Property 2"] as? String, "p2")
-
-    let people = peopleQueue(token: testMixpanel.apiToken)
-    XCTAssertEqual(people.count, 6)
-    XCTAssertEqual(people[0]["$distinct_id"] as? String, "demo_user")
-    XCTAssertEqual(people[0]["$token"] as? String, "testToken")
-    let appendProperties = people[5]["$append"] as! InternalProperties
-    XCTAssertEqual(appendProperties["d"] as? String, "goodbye")
-
-    let group = groupQueue(token: testMixpanel.apiToken)
-    XCTAssertEqual(group.count, 2)
-    XCTAssertEqual(group[0]["$group_key"] as? String, "Cool Property")
-    let setProperties = group[0]["$set"] as! InternalProperties
-    XCTAssertEqual(setProperties["g"] as? String, "yo")
-    let setProperties2 = group[1]["$set"] as! InternalProperties
-    XCTAssertEqual(setProperties2["a"] as? Int, 1)
-    XCTAssertTrue(MixpanelPersistence.loadOptOutStatusFlag(instanceName: token)!)
-
-    //timedEvents
-    let testTimedEvents = MixpanelPersistence.loadTimedEvents(instanceName: token)
-    XCTAssertEqual(testTimedEvents.count, 3)
-    XCTAssertNotNil(testTimedEvents["Time Event A"])
-    XCTAssertNotNil(testTimedEvents["Time Event B"])
-    XCTAssertNotNil(testTimedEvents["Time Event C"])
-    let identity = MixpanelPersistence.loadIdentity(instanceName: token)
-    XCTAssertEqual(identity.distinctID, "demo_user")
-    XCTAssertEqual(identity.peopleDistinctID, "demo_user")
-    XCTAssertNotNil(identity.anonymousId)
-    XCTAssertEqual(identity.userId, "demo_user")
-    XCTAssertEqual(identity.alias, "New Alias")
-    XCTAssertEqual(identity.hadPersistedDistinctId, false)
-
-    let superProperties = MixpanelPersistence.loadSuperProperties(instanceName: token)
-    XCTAssertEqual(superProperties.count, 7)
-    XCTAssertEqual(superProperties["Super Property 1"] as? Int, 1)
-    XCTAssertEqual(superProperties["Super Property 7"] as? NSNull, NSNull())
-    removeDBfile("testToken")
-  }
-
-  func prepareForMigrationFiles(_ fileNames: [String]) {
-    for fileName in fileNames {
-      let fileManager = FileManager.default
-      let filepath = Bundle(for: type(of: self)).url(forResource: fileName, withExtension: nil)!
-      let libraryUrls = fileManager.urls(
-        for: .libraryDirectory,
-        in: .userDomainMask)
-      let destURL = libraryUrls.first?.appendingPathComponent(fileName)
-      do {
-        try FileManager.default.copyItem(at: filepath, to: destURL!)
-      } catch let error {
-        print(error)
-      }
+    func testFlushProperties() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        XCTAssertTrue(testMixpanel.flushBatchSize == 50, "the default flush batch size is set to 50")
+        XCTAssertTrue(testMixpanel.flushInterval == 60, "flush interval is set correctly")
+        testMixpanel.flushBatchSize = 10
+        XCTAssertTrue(testMixpanel.flushBatchSize == 10, "flush batch size is set correctly")
+        testMixpanel.flushBatchSize = 60
+        XCTAssertTrue(testMixpanel.flushBatchSize == 50, "flush batch size is max at 50")
+        testMixpanel.flushInterval = 30
+        XCTAssertTrue(testMixpanel.flushInterval == 30, "flush interval is set correctly")
     }
-  }
 
-  func testGzipCompressionInit() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: false, useGzipCompression: true)
-    XCTAssertTrue(testMixpanel.useGzipCompression == true, "the init of GzipCompression failed")
-  }
+    func testFlushPeople() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        for i in 0..<50 {
+            testMixpanel.people.set(property: "p1", to: "\(i)")
+        }
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel.apiToken).isEmpty, "people should have been flushed")
+        for i in 0..<60 {
+            testMixpanel.people.set(property: "p1", to: "\(i)")
+        }
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel.apiToken).isEmpty, "people should have been flushed")
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-  func testGzipCompressionDefault() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: false)
-    XCTAssertTrue(
-      testMixpanel.useGzipCompression == false, "the default gzip option disabled failed")
-  }
+    func testFlushGroups() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        let groupKey = "test_key"
+        let groupValue = "test_value"
+        for i in 0..<50 {
+            testMixpanel.getGroup(groupKey: groupKey, groupID: groupValue).set(property: "p1", to: "\(i)")
+        }
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            groupQueue(token: testMixpanel.apiToken).isEmpty, "groups should have been flushed")
+        for i in 0..<60 {
+            testMixpanel.getGroup(groupKey: groupKey, groupID: groupValue).set(property: "p1", to: "\(i)")
+        }
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel.apiToken).isEmpty, "groups should have been flushed")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testFlushNetworkFailure() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        waitForAsyncTasks()
+        testMixpanel.serverURL = kFakeServerUrl
+        for i in 0..<50 {
+            testMixpanel.track(event: "event \(UInt(i))")
+        }
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 51, "51 events should be queued up")
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 51,
+            "events should still be in the queue if flush fails")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testFlushQueueContainsCorruptedEvent() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.trackingQueue.async {
+            testMixpanel.mixpanelPersistence.saveEntity(
+                ["event": "bad event1", "properties": ["BadProp": Double.nan]], type: .events)
+            testMixpanel.mixpanelPersistence.saveEntity(
+                ["event": "bad event2", "properties": ["BadProp": Float.nan]], type: .events)
+            testMixpanel.mixpanelPersistence.saveEntity(
+                ["event": "bad event3", "properties": ["BadProp": Double.infinity]], type: .events)
+            testMixpanel.mixpanelPersistence.saveEntity(
+                ["event": "bad event4", "properties": ["BadProp": Float.infinity]], type: .events)
+        }
+
+        for i in 0..<10 {
+            testMixpanel.track(event: "event \(UInt(i))")
+        }
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 0, "good events should still be flushed")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testAddEventContainsInvalidJsonObjectDoubleNaN() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.track(event: "bad event", properties: ["BadProp": Double.nan])
+        }
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testAddEventContainsInvalidJsonObjectFloatNaN() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.track(event: "bad event", properties: ["BadProp": Float.nan])
+        }
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testAddEventContainsInvalidJsonObjectDoubleInfinity() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.track(event: "bad event", properties: ["BadProp": Double.infinity])
+        }
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testAddEventContainsInvalidJsonObjectFloatInfinity() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.track(event: "bad event", properties: ["BadProp": Float.infinity])
+        }
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testAddingEventsAfterFlush() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        waitForAsyncTasks()
+        for i in 0..<10 {
+            testMixpanel.track(event: "event \(UInt(i))")
+        }
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 11, "11 events should be queued up")
+        flushAndWaitForTrackingQueue(testMixpanel)
+        for i in 0..<5 {
+            testMixpanel.track(event: "event \(UInt(i))")
+        }
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 5, "5 more events should be queued up")
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).isEmpty, "events should have been flushed")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    // Mock implementation of MixpanelFlags to track loadFlags calls
+    class MockMixpanelFlags: MixpanelFlags {
+        var delegate: MixpanelFlagDelegate?
+        var loadFlagsCallCount = 0
+
+        func loadFlags() {
+            loadFlagsCallCount += 1
+        }
+
+        func setContext(_ context: [String: Any], completion: @escaping () -> Void) {
+            completion()
+        }
+
+        func loadFlags(completion: ((Bool) -> Void)?) {
+            loadFlagsCallCount += 1
+            completion?(true)
+        }
+
+        func areFlagsReady() -> Bool {
+            return true
+        }
+
+        func getVariantSync(_ flagName: String, fallback: MixpanelFlagVariant) -> MixpanelFlagVariant {
+            return fallback
+        }
+
+        func getVariant(
+            _ flagName: String, fallback: MixpanelFlagVariant,
+            completion: @escaping (MixpanelFlagVariant) -> Void
+        ) {
+            completion(fallback)
+        }
+
+        func getVariantValueSync(_ flagName: String, fallbackValue: Any?) -> Any? {
+            return fallbackValue
+        }
+
+        func getVariantValue(
+            _ flagName: String, fallbackValue: Any?, completion: @escaping (Any?) -> Void
+        ) {
+            completion(fallbackValue)
+        }
+
+        func isEnabledSync(_ flagName: String, fallbackValue: Bool) -> Bool {
+            return fallbackValue
+        }
+
+        func isEnabled(_ flagName: String, fallbackValue: Bool, completion: @escaping (Bool) -> Void) {
+            completion(fallbackValue)
+        }
+
+        func getAllVariantsSync() -> [String: MixpanelFlagVariant] {
+            return [:]
+        }
+
+        func getAllVariants(completion: @escaping ([String: MixpanelFlagVariant]) -> Void) {
+            completion([:])
+        }
+    }
+
+    func testIdentify() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+
+        // Inject our mock flags object
+        let mockFlags = MockMixpanelFlags()
+        testMixpanel.flags = mockFlags
+
+        for _ in 0..<2 {
+            // run this twice to test reset works correctly wrt to distinct ids
+            let distinctId: String = "d1"
+            // try this for ODIN and nil
+            #if MIXPANEL_UNIQUE_DISTINCT_ID
+            XCTAssertEqual(
+                testMixpanel.distinctId,
+                devicePrefix + testMixpanel.defaultDeviceId(),
+                "mixpanel identify failed to set default distinct id")
+            XCTAssertEqual(
+                testMixpanel.anonymousId,
+                testMixpanel.defaultDeviceId(),
+                "mixpanel failed to set default anonymous id")
+            #endif
+            XCTAssertNil(
+                testMixpanel.people.distinctId,
+                "mixpanel people distinct id should default to nil")
+            XCTAssertNil(
+                testMixpanel.people.distinctId,
+                "mixpanel user id should default to nil")
+            testMixpanel.track(event: "e1")
+            waitForTrackingQueue(testMixpanel)
+            let eventsQueue = eventQueue(token: testMixpanel.apiToken)
+            XCTAssertTrue(
+                eventsQueue.count == 2 || eventsQueue.count == 1,  // first app open should not be tracked for the second run,
+                "events should be sent right away with default distinct id")
+            #if MIXPANEL_UNIQUE_DISTINCT_ID
+            XCTAssertEqual(
+                (eventsQueue.last?["properties"] as? InternalProperties)?["distinct_id"] as? String,
+                devicePrefix + mixpanel.defaultDeviceId(),
+                "events should use default distinct id if none set")
+            #endif
+            XCTAssertEqual(
+                (eventsQueue.last?["properties"] as? InternalProperties)?["$lib_version"] as? String,
+                AutomaticProperties.libVersion(),
+                "events should has lib version in internal properties")
+            testMixpanel.people.set(property: "p1", to: "a")
+            waitForTrackingQueue(testMixpanel)
+            var peopleQueue_value = peopleQueue(token: testMixpanel.apiToken)
+            var unidentifiedQueue = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)
+            XCTAssertTrue(
+                peopleQueue_value.isEmpty,
+                "people records should go to unidentified queue before identify:")
+            XCTAssertTrue(
+                unidentifiedQueue.count == 2 || eventsQueue.count == 1,  // first app open should not be tracked for the second run,
+                "unidentified people records not queued")
+            XCTAssertEqual(
+                unidentifiedQueue.last?["$token"] as? String,
+                testMixpanel.apiToken,
+                "incorrect project token in people record")
+            // Record the loadFlags call count before identify
+            let loadFlagsCallCountBefore = mockFlags.loadFlagsCallCount
+
+            testMixpanel.identify(distinctId: distinctId)
+            waitForTrackingQueue(testMixpanel)
+
+            // Assert that loadFlags was called when distinctId changed
+            XCTAssertEqual(
+                mockFlags.loadFlagsCallCount, loadFlagsCallCountBefore + 1,
+                "loadFlags should be called when distinctId changes during identify")
+
+            let anonymousId = testMixpanel.anonymousId
+            peopleQueue_value = peopleQueue(token: testMixpanel.apiToken)
+            unidentifiedQueue = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)
+            XCTAssertEqual(
+                peopleQueue_value.last?["$distinct_id"] as? String,
+                distinctId, "distinct id not set properly on unidentified people record")
+            XCTAssertEqual(
+                testMixpanel.distinctId, distinctId,
+                "mixpanel identify failed to set distinct id")
+            XCTAssertEqual(
+                testMixpanel.userId, distinctId,
+                "mixpanel identify failed to set user id")
+            XCTAssertEqual(
+                testMixpanel.anonymousId, anonymousId,
+                "mixpanel identify shouldn't change anonymousId")
+            XCTAssertEqual(
+                testMixpanel.people.distinctId, distinctId,
+                "mixpanel identify failed to set people distinct id")
+            XCTAssertTrue(
+                unidentifiedQueue.isEmpty,
+                "identify: should move records from unidentified queue")
+            XCTAssertTrue(
+                peopleQueue_value.count > 0,
+                "identify: should move records to main people queue")
+            XCTAssertEqual(
+                peopleQueue_value.last?["$token"] as? String,
+                testMixpanel.apiToken, "incorrect project token in people record")
+            let p: InternalProperties = peopleQueue_value.last?["$set"] as! InternalProperties
+            XCTAssertEqual(p["p1"] as? String, "a", "custom people property not queued")
+            assertDefaultPeopleProperties(p)
+            peopleQueue_value = peopleQueue(token: testMixpanel.apiToken)
+
+            testMixpanel.people.set(property: "p1", to: "a")
+            waitForTrackingQueue(testMixpanel)
+
+            peopleQueue_value = peopleQueue(token: testMixpanel.apiToken)
+            unidentifiedQueue = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)
+            XCTAssertEqual(
+                peopleQueue_value.last?["$distinct_id"] as? String,
+                distinctId, "distinct id not set properly on unidentified people record")
+            XCTAssertTrue(
+                unidentifiedQueue.isEmpty,
+                "once idenitfy: is called, unidentified queue should be skipped")
+            XCTAssertTrue(
+                peopleQueue_value.count > 0,
+                "once identify: is called, records should go straight to main queue")
+            testMixpanel.track(event: "e2")
+            waitForTrackingQueue(testMixpanel)
+            let newDistinctId =
+                (eventQueue(token: testMixpanel.apiToken).last?["properties"] as? InternalProperties)?[
+                    "distinct_id"] as? String
+            XCTAssertEqual(
+                newDistinctId, distinctId,
+                "events should use new distinct id after identify:")
+
+            // Test that calling identify with the same distinctId does NOT trigger loadFlags
+            let loadFlagsCountBeforeSameId = mockFlags.loadFlagsCallCount
+            testMixpanel.identify(distinctId: distinctId)  // Same distinctId
+            waitForTrackingQueue(testMixpanel)
+            XCTAssertEqual(
+                mockFlags.loadFlagsCallCount, loadFlagsCountBeforeSameId,
+                "loadFlags should NOT be called when distinctId doesn't change")
+
+            testMixpanel.reset()
+            waitForTrackingQueue(testMixpanel)
+        }
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testIdentifyTrack() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let distinctIdBeforeIdentify: String? = testMixpanel.distinctId
+        let distinctId = "testIdentifyTrack"
+
+        testMixpanel.identify(distinctId: distinctId)
+        waitForTrackingQueue(testMixpanel)
+        let e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(e["event"] as? String, "$identify", "incorrect event name")
+        let p: InternalProperties = e["properties"] as! InternalProperties
+        XCTAssertEqual(p["distinct_id"] as? String, distinctId, "wrong distinct_id")
+        XCTAssertEqual(
+            p["$anon_distinct_id"] as? String, distinctIdBeforeIdentify, "wrong $anon_distinct_id")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testIdentifyResetTrack() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let originalDistinctId: String? = testMixpanel.distinctId
+        let distinctId = "testIdentifyTrack"
+        testMixpanel.reset()
+        waitForTrackingQueue(testMixpanel)
+
+        for i in 1...3 {
+            let prevDistinctId: String? = testMixpanel.distinctId
+            let newDistinctId = distinctId + String(i)
+            testMixpanel.identify(distinctId: newDistinctId)
+            waitForTrackingQueue(testMixpanel)
+
+            let e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
+            XCTAssertEqual(e["event"] as? String, "$identify", "incorrect event name")
+            let p: InternalProperties = e["properties"] as! InternalProperties
+            XCTAssertEqual(p["distinct_id"] as? String, newDistinctId, "wrong distinct_id")
+            XCTAssertEqual(p["$anon_distinct_id"] as? String, prevDistinctId, "wrong $anon_distinct_id")
+            XCTAssertNotEqual(
+                prevDistinctId, originalDistinctId, "After reset, UUID will be used - never the same")
+            #if MIXPANEL_UNIQUE_DISTINCT_ID
+            XCTAssertEqual(
+                prevDistinctId, originalDistinctId, "After reset, IFV will be used - always the same")
+            #endif
+            testMixpanel.reset()
+            waitForTrackingQueue(testMixpanel)
+        }
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testCreateAlias() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.people.set(properties: ["p1": "a"])
+        waitForTrackingQueue(testMixpanel)
+        var unidentifiedQueue = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)
+        // the user profile update has been queued up in unidentifiedQueue until identify is called
+        XCTAssertTrue(!unidentifiedQueue.isEmpty)
+
+        let distinctId = testMixpanel.distinctId
+        let alias: String = "a1"
+        testMixpanel.createAlias(alias, distinctId: testMixpanel.distinctId)
+        waitForTrackingQueue(testMixpanel)
+
+        let mixpanelIdentity = MixpanelPersistence.loadIdentity(instanceName: testMixpanel.apiToken)
+        XCTAssertTrue(
+            distinctId == mixpanelIdentity.distinctID && distinctId == mixpanelIdentity.peopleDistinctID
+                && distinctId == mixpanelIdentity.userId && alias == mixpanelIdentity.alias)
+        removeDBfile(testMixpanel.apiToken)
+        unidentifiedQueue = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)
+        // unidentifiedQueue has been flushed
+        XCTAssertTrue(unidentifiedQueue.isEmpty)
+
+        let testMixpanel2 = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel2.people.set(properties: ["p1": "a"])
+        waitForTrackingQueue(testMixpanel2)
+
+        let distinctId2 = testMixpanel2.distinctId
+        testMixpanel2.createAlias(alias, distinctId: testMixpanel.distinctId, andIdentify: false)
+        waitForTrackingQueue(testMixpanel2)
+
+        let unidentifiedQueue2 = unIdentifiedPeopleQueue(token: testMixpanel2.apiToken)
+        // The user profile updates should still be held in unidentifiedQueue cause no identify is called
+        XCTAssertTrue(!unidentifiedQueue2.isEmpty)
+        let mixpanelIdentity2 = MixpanelPersistence.loadIdentity(instanceName: testMixpanel2.apiToken)
+        XCTAssertTrue(
+            distinctId2 == mixpanelIdentity2.distinctID && nil == mixpanelIdentity2.peopleDistinctID
+                && nil == mixpanelIdentity2.userId && alias == mixpanelIdentity2.alias)
+        removeDBfile(testMixpanel2.apiToken)
+    }
+
+    func testPersistentIdentity() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let distinctId: String = "d1"
+        let alias: String = "a1"
+        testMixpanel.identify(distinctId: distinctId)
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.createAlias(alias, distinctId: testMixpanel.distinctId)
+        waitForTrackingQueue(testMixpanel)
+        var mixpanelIdentity = MixpanelPersistence.loadIdentity(instanceName: testMixpanel.apiToken)
+        XCTAssertTrue(
+            distinctId == mixpanelIdentity.distinctID && distinctId == mixpanelIdentity.peopleDistinctID
+                && distinctId == mixpanelIdentity.userId && alias == mixpanelIdentity.alias)
+        testMixpanel.archive()
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.unarchive()
+        waitForTrackingQueue(testMixpanel)
+        mixpanelIdentity = MixpanelPersistence.loadIdentity(instanceName: testMixpanel.apiToken)
+        XCTAssertTrue(
+            testMixpanel.distinctId == mixpanelIdentity.distinctID
+                && testMixpanel.people.distinctId == mixpanelIdentity.peopleDistinctID
+                && testMixpanel.anonymousId == mixpanelIdentity.anonymousId
+                && testMixpanel.userId == mixpanelIdentity.userId
+                && testMixpanel.alias == mixpanelIdentity.alias)
+        MixpanelPersistence.deleteMPUserDefaultsData(instanceName: testMixpanel.apiToken)
+        waitForTrackingQueue(testMixpanel)
+        mixpanelIdentity = MixpanelPersistence.loadIdentity(instanceName: testMixpanel.apiToken)
+        XCTAssertTrue(
+            "" == mixpanelIdentity.distinctID && nil == mixpanelIdentity.peopleDistinctID
+                && nil == mixpanelIdentity.anonymousId && nil == mixpanelIdentity.userId
+                && nil == mixpanelIdentity.alias)
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testUseUniqueDistinctId() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let testMixpanel2 = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        XCTAssertNotEqual(
+            testMixpanel.distinctId, testMixpanel2.distinctId,
+            "by default, distinctId should not be unique to the device")
+
+        let testMixpanel3 = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60, useUniqueDistinctId: false)
+        let testMixpanel4 = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60, useUniqueDistinctId: false)
+        XCTAssertNotEqual(
+            testMixpanel3.distinctId, testMixpanel4.distinctId,
+            "distinctId should not be unique to the device if useUniqueDistinctId is set to false")
+
+        let testMixpanel5 = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60, useUniqueDistinctId: true)
+        let testMixpanel6 = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60, useUniqueDistinctId: true)
+        XCTAssertEqual(
+            testMixpanel5.distinctId, testMixpanel6.distinctId,
+            "distinctId should be unique to the device if useUniqueDistinctId is set to true")
+    }
+
+    func testHadPersistedDistinctId() {
+        let testToken = randomId()
+        let testMixpanel = Mixpanel.initialize(
+            token: testToken, trackAutomaticEvents: true, flushInterval: 60)
+        XCTAssertNotNil(testMixpanel.distinctId)
+        let distinctId = testMixpanel.distinctId
+        let testMixpanel2 = Mixpanel.initialize(
+            token: testToken, trackAutomaticEvents: true, flushInterval: 60)
+        XCTAssertEqual(
+            testMixpanel2.distinctId, distinctId,
+            "mixpanel anonymous distinct id should not be changed for each init")
+
+        let userId: String = "u1"
+        testMixpanel.identify(distinctId: userId)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(devicePrefix + testMixpanel.anonymousId!, distinctId)
+        XCTAssertEqual(testMixpanel.userId, userId)
+        XCTAssertEqual(testMixpanel.distinctId, userId)
+        XCTAssertTrue(testMixpanel.hadPersistedDistinctId!)
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testTrackWithDefaultProperties() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.track(event: "Something Happened")
+        waitForTrackingQueue(testMixpanel)
+        let e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(e["event"] as? String, "Something Happened", "incorrect event name")
+        let p: InternalProperties = e["properties"] as! InternalProperties
+        XCTAssertNotNil(p["$app_build_number"], "$app_build_number not set")
+        XCTAssertNotNil(p["$app_version_string"], "$app_version_string not set")
+        XCTAssertNotNil(p["$lib_version"], "$lib_version not set")
+        XCTAssertNotNil(p["$model"], "$model not set")
+        XCTAssertNotNil(p["$os"], "$os not set")
+        XCTAssertNotNil(p["$os_version"], "$os_version not set")
+        XCTAssertNotNil(p["$screen_height"], "$screen_height not set")
+        XCTAssertNotNil(p["$screen_width"], "$screen_width not set")
+        XCTAssertNotNil(p["distinct_id"], "distinct_id not set")
+        XCTAssertNotNil(p["time"], "time not set")
+        XCTAssertEqual(p["$manufacturer"] as? String, "Apple", "incorrect $manufacturer")
+        XCTAssertEqual(p["mp_lib"] as? String, "swift", "incorrect mp_lib")
+        XCTAssertEqual(p["token"] as? String, testMixpanel.apiToken, "incorrect token")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testTrackWithCustomProperties() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let now = Date()
+        let p: Properties = [
+            "string": "yello",
+            "number": 3,
+            "date": now,
+            "$app_version": "override",
+        ]
+        testMixpanel.track(event: "Something Happened", properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let props: InternalProperties =
+            eventQueue(token: testMixpanel.apiToken).last?["properties"] as! InternalProperties
+        XCTAssertEqual(props["string"] as? String, "yello")
+        XCTAssertEqual(props["number"] as? Int, 3)
+        let dateValue = props["date"] as! String
+        compareDate(dateString: dateValue, dateDate: now)
+        XCTAssertEqual(
+            props["$app_version"] as? String, "override",
+            "reserved property override failed")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testTrackWithOptionalProperties() {
+        let optNil: Double? = nil
+        let optDouble: Double? = 1.0
+        let optArray: [Double?] = [nil, 1.0, 2.0]
+        let optDict: [String: Double?] = ["nil": nil, "double": 1.0]
+        let nested: [String: Any] = ["list": optArray, "dict": optDict]
+        let p: Properties = [
+            "nil": optNil,
+            "double": optDouble,
+            "list": optArray,
+            "dict": optDict,
+            "nested": nested,
+        ]
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.track(event: "Optional Test", properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let props: InternalProperties =
+            eventQueue(token: testMixpanel.apiToken).last?["properties"] as! InternalProperties
+        XCTAssertNil(props["nil"] as? Double)
+        XCTAssertEqual(props["double"] as? Double, 1.0)
+        XCTAssertEqual(props["list"] as? Array, [1.0, 2.0])
+        XCTAssertEqual(props["dict"] as? Dictionary, ["nil": nil, "double": 1.0])
+        let nestedProp = props["nested"] as? [String: Any]
+        XCTAssertEqual(nestedProp?["dict"] as? Dictionary, ["nil": nil, "double": 1.0])
+        XCTAssertEqual(nestedProp?["list"] as? Array, [1.0, 2.0])
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testTrackWithCustomDistinctIdAndToken() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let p: Properties = ["token": "t1", "distinct_id": "d1"]
+        testMixpanel.track(event: "e1", properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let trackToken =
+            (eventQueue(token: testMixpanel.apiToken).last?["properties"] as? InternalProperties)?[
+                "token"] as? String
+        let trackDistinctId =
+            (eventQueue(token: testMixpanel.apiToken).last?["properties"] as? InternalProperties)?[
+                "distinct_id"] as? String
+        XCTAssertEqual(trackToken, "t1", "user-defined distinct id not used in track.")
+        XCTAssertEqual(trackDistinctId, "d1", "user-defined distinct id not used in track.")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testTrackWithGroups() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        testMixpanel.trackWithGroups(
+            event: "Something Happened", properties: [groupKey: "some other value", "p1": "value"],
+            groups: [groupKey: groupID])
+        waitForTrackingQueue(testMixpanel)
+        let e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(e["event"] as? String, "Something Happened", "incorrect event name")
+        let p: InternalProperties = e["properties"] as! InternalProperties
+        XCTAssertNotNil(p["$app_build_number"], "$app_build_number not set")
+        XCTAssertNotNil(p["$app_version_string"], "$app_version_string not set")
+        XCTAssertNotNil(p["$lib_version"], "$lib_version not set")
+        XCTAssertNotNil(p["$model"], "$model not set")
+        XCTAssertNotNil(p["$os"], "$os not set")
+        XCTAssertNotNil(p["$os_version"], "$os_version not set")
+        XCTAssertNotNil(p["$screen_height"], "$screen_height not set")
+        XCTAssertNotNil(p["$screen_width"], "$screen_width not set")
+        XCTAssertNotNil(p["distinct_id"], "distinct_id not set")
+        XCTAssertNotNil(p["time"], "time not set")
+        XCTAssertEqual(p["$manufacturer"] as? String, "Apple", "incorrect $manufacturer")
+        XCTAssertEqual(p["mp_lib"] as? String, "swift", "incorrect mp_lib")
+        XCTAssertEqual(p["token"] as? String, testMixpanel.apiToken, "incorrect token")
+        XCTAssertEqual(p[groupKey] as? String, groupID, "incorrect group id")
+        XCTAssertEqual(p["p1"] as? String, "value", "incorrect group value")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testRegisterSuperProperties() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        var p: Properties = ["p1": "a", "p2": 3, "p3": Date()]
+        testMixpanel.registerSuperProperties(p)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(
+            NSDictionary(dictionary: testMixpanel.currentSuperProperties()),
+            NSDictionary(dictionary: p),
+            "register super properties failed")
+        p = ["p1": "b"]
+        testMixpanel.registerSuperProperties(p)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(
+            testMixpanel.currentSuperProperties()["p1"] as? String, "b",
+            "register super properties failed to overwrite existing value")
+        p = ["p4": "a"]
+        testMixpanel.registerSuperPropertiesOnce(p)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(
+            testMixpanel.currentSuperProperties()["p4"] as? String, "a",
+            "register super properties once failed first time")
+        p = ["p4": "b"]
+        testMixpanel.registerSuperPropertiesOnce(p)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(
+            testMixpanel.currentSuperProperties()["p4"] as? String, "a",
+            "register super properties once failed second time")
+        p = ["p4": "c"]
+        testMixpanel.registerSuperPropertiesOnce(p, defaultValue: "d")
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(
+            testMixpanel.currentSuperProperties()["p4"] as? String, "a",
+            "register super properties once with default value failed when no match")
+        testMixpanel.registerSuperPropertiesOnce(p, defaultValue: "a")
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(
+            testMixpanel.currentSuperProperties()["p4"] as? String, "c",
+            "register super properties once with default value failed when match")
+        testMixpanel.unregisterSuperProperty("a")
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertNil(
+            testMixpanel.currentSuperProperties()["a"],
+            "unregister super property failed")
+        // unregister non-existent super property should not throw
+        testMixpanel.unregisterSuperProperty("a")
+        testMixpanel.clearSuperProperties()
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            testMixpanel.currentSuperProperties().isEmpty,
+            "clear super properties failed")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testSettingSuperPropertiesWhenInit() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60,
+            superProperties: ["mp_lib": "flutter"])
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(
+            testMixpanel.currentSuperProperties()["mp_lib"] as? String, "flutter",
+            "register super properties in init failed")
+        testMixpanel.track(event: "e1")
+        waitForTrackingQueue(testMixpanel)
+        let e = eventQueue(token: testMixpanel.apiToken).last!
+        let p = e["properties"] as! InternalProperties
+        XCTAssertNotNil(p["mp_lib"], "flutter")
+    }
+
+    func testInvalidPropertiesTrack() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let p: Properties = ["data": [Data()]]
+        XCTExpectAssert("property type should not be allowed") {
+            testMixpanel.track(event: "e1", properties: p)
+        }
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testInvalidSuperProperties() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let p: Properties = ["data": [Data()]]
+        XCTExpectAssert("property type should not be allowed") {
+            testMixpanel.registerSuperProperties(p)
+        }
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testInvalidSuperProperties2() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let p: Properties = ["data": [Data()]]
+        XCTExpectAssert("property type should not be allowed") {
+            testMixpanel.registerSuperPropertiesOnce(p)
+        }
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testInvalidSuperProperties3() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let p: Properties = ["data": [Data()]]
+        XCTExpectAssert("property type should not be allowed") {
+            testMixpanel.registerSuperPropertiesOnce(p, defaultValue: "v")
+        }
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testValidPropertiesTrack() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let p: Properties = allPropertyTypes()
+        testMixpanel.track(event: "e1", properties: p)
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testValidSuperProperties() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let p: Properties = allPropertyTypes()
+        testMixpanel.registerSuperProperties(p)
+        testMixpanel.registerSuperPropertiesOnce(p)
+        testMixpanel.registerSuperPropertiesOnce(p, defaultValue: "v")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testReset() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        waitForAsyncTasks()
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.track(event: "e1")
+        waitForTrackingQueue(testMixpanel)
+        let p: Properties = ["p1": "a"]
+        testMixpanel.registerSuperProperties(p)
+        testMixpanel.people.set(properties: p)
+        testMixpanel.archive()
+        testMixpanel.reset()
+        waitForTrackingQueue(testMixpanel)
+
+        #if MIXPANEL_UNIQUE_DISTINCT_ID
+        XCTAssertEqual(
+            testMixpanel.distinctId,
+            devicePrefix + testMixpanel.defaultDeviceId(),
+            "distinct id failed to reset")
+        #endif
+        XCTAssertNil(testMixpanel.people.distinctId, "people distinct id failed to reset")
+        XCTAssertTrue(
+            testMixpanel.currentSuperProperties().isEmpty,
+            "super properties failed to reset")
+        XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).isEmpty, "events queue failed to reset")
+        XCTAssertTrue(peopleQueue(token: testMixpanel.apiToken).isEmpty, "people queue failed to reset")
+        let testMixpanel2 = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        waitForAsyncTasks()
+        waitForTrackingQueue(testMixpanel2)
+        #if MIXPANEL_UNIQUE_DISTINCT_ID
+        XCTAssertEqual(
+            testMixpanel2.distinctId, devicePrefix + testMixpanel2.defaultDeviceId(),
+            "distinct id failed to reset after archive")
+        #endif
+        XCTAssertNil(
+            testMixpanel2.people.distinctId,
+            "people distinct id failed to reset after archive")
+        XCTAssertTrue(
+            testMixpanel2.currentSuperProperties().isEmpty,
+            "super properties failed to reset after archive")
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel2.apiToken).count == 1,
+            "events queue failed to reset after archive")
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel2.apiToken).isEmpty,
+            "people queue failed to reset after archive")
+        removeDBfile(testMixpanel.apiToken)
+        removeDBfile(testMixpanel2.apiToken)
+    }
+
+    func testArchiveNSNumberBoolIntProperty() {
+        let testToken = randomId()
+        let testMixpanel = Mixpanel.initialize(
+            token: testToken, trackAutomaticEvents: true, flushInterval: 60)
+        waitForAsyncTasks()
+        testMixpanel.serverURL = kFakeServerUrl
+        let aBoolNumber: Bool = true
+        let aBoolNSNumber = NSNumber(value: aBoolNumber)
+
+        let aIntNumber: Int = 1
+        let aIntNSNumber = NSNumber(value: aIntNumber)
+
+        testMixpanel.track(event: "e1", properties: ["p1": aBoolNSNumber, "p2": aIntNSNumber])
+        testMixpanel.archive()
+        waitForTrackingQueue(testMixpanel)
+
+        let testMixpanel2 = Mixpanel.initialize(
+            token: testToken, trackAutomaticEvents: true, flushInterval: 60)
+        waitForAsyncTasks()
+        testMixpanel2.serverURL = kFakeServerUrl
+        waitForTrackingQueue(testMixpanel2)
+
+        let properties: [String: Any] =
+            eventQueue(token: testMixpanel2.apiToken)[1]["properties"] as! [String: Any]
+
+        XCTAssertTrue(
+            isBoolNumber(num: properties["p1"]! as! NSNumber),
+            "The bool value should be unarchived as bool")
+        XCTAssertFalse(
+            isBoolNumber(num: properties["p2"]! as! NSNumber),
+            "The int value should not be unarchived as bool")
+        removeDBfile(testToken)
+    }
+
+    private func isBoolNumber(num: NSNumber) -> Bool {
+        let boolID = CFBooleanGetTypeID()  // the type ID of CFBoolean
+        let numID = CFGetTypeID(num)  // the type ID of num
+        return numID == boolID
+    }
+
+    func testArchive() {
+        let testToken = randomId()
+        let testMixpanel = Mixpanel.initialize(
+            token: testToken, trackAutomaticEvents: false, flushInterval: 60)
+        testMixpanel.serverURL = kFakeServerUrl
+        #if MIXPANEL_UNIQUE_DISTINCT_ID
+        XCTAssertEqual(
+            testMixpanel.distinctId, devicePrefix + testMixpanel.defaultDeviceId(),
+            "default distinct id archive failed")
+        #endif
+        XCTAssertTrue(
+            testMixpanel.currentSuperProperties().isEmpty,
+            "default super properties archive failed")
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).isEmpty, "default events queue archive failed")
+        XCTAssertNil(testMixpanel.people.distinctId, "default people distinct id archive failed")
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel.apiToken).isEmpty, "default people queue archive failed")
+        let p: Properties = ["p1": "a"]
+        testMixpanel.identify(distinctId: "d1")
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.registerSuperProperties(p)
+        testMixpanel.track(event: "e1")
+        testMixpanel.track(event: "e2")
+        testMixpanel.track(event: "e3")
+        testMixpanel.track(event: "e4")
+        testMixpanel.track(event: "e5")
+        testMixpanel.track(event: "e6")
+        testMixpanel.track(event: "e7")
+        testMixpanel.track(event: "e8")
+        testMixpanel.track(event: "e9")
+        testMixpanel.people.set(properties: p)
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.timedEvents["e2"] = 5
+        testMixpanel.archive()
+        let testMixpanel2 = Mixpanel.initialize(
+            token: testToken, trackAutomaticEvents: false, flushInterval: 60)
+        testMixpanel2.serverURL = kFakeServerUrl
+        waitForTrackingQueue(testMixpanel2)
+        XCTAssertEqual(testMixpanel2.distinctId, "d1", "custom distinct archive failed")
+        XCTAssertTrue(
+            testMixpanel2.currentSuperProperties().count == 1,
+            "custom super properties archive failed")
+        let eventQueueValue = eventQueue(token: testMixpanel2.apiToken)
+
+        XCTAssertEqual(
+            eventQueueValue[1]["event"] as? String, "e1",
+            "event was not successfully archived/unarchived")
+        XCTAssertEqual(
+            eventQueueValue[2]["event"] as? String, "e2",
+            "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(
+            eventQueueValue[3]["event"] as? String, "e3",
+            "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(
+            eventQueueValue[4]["event"] as? String, "e4",
+            "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(
+            eventQueueValue[5]["event"] as? String, "e5",
+            "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(
+            eventQueueValue[6]["event"] as? String, "e6",
+            "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(
+            eventQueueValue[7]["event"] as? String, "e7",
+            "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(
+            eventQueueValue[8]["event"] as? String, "e8",
+            "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(
+            eventQueueValue[9]["event"] as? String, "e9",
+            "event was not successfully archived/unarchived or order is incorrect")
+        XCTAssertEqual(
+            testMixpanel2.people.distinctId, "d1",
+            "custom people distinct id archive failed")
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel2.apiToken).count >= 1, "pending people queue archive failed")
+        XCTAssertEqual(
+            testMixpanel2.timedEvents["e2"] as? Int, 5,
+            "timedEvents archive failed")
+        let testMixpanel3 = Mixpanel.initialize(
+            token: testToken, trackAutomaticEvents: false, flushInterval: 60)
+        testMixpanel3.serverURL = kFakeServerUrl
+        XCTAssertEqual(testMixpanel3.distinctId, "d1", "expecting d1 as distinct id as initialised")
+        XCTAssertTrue(
+            testMixpanel3.currentSuperProperties().count == 1,
+            "default super properties expected to have 1 item")
+        XCTAssertNotNil(eventQueue(token: testMixpanel3.apiToken), "default events queue is nil")
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel3.apiToken).count == 10,
+            "default events queue expecting 10 items ($identify call added)")
+        XCTAssertNotNil(
+            testMixpanel3.people.distinctId,
+            "default people distinct id from no file failed")
+        XCTAssertNotNil(
+            peopleQueue(token: testMixpanel3.apiToken), "default people queue from no file is nil")
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel3.apiToken).count >= 1, "default people queue expecting 1 item"
+        )
+        XCTAssertTrue(testMixpanel3.timedEvents.count == 1, "timedEvents expecting 1 item")
+        removeDBfile(testToken)
+    }
+
+    func testMixpanelDelegate() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        waitForAsyncTasks()
+        testMixpanel.delegate = self
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.track(event: "e1")
+        testMixpanel.people.set(property: "p1", to: "a")
+        waitForTrackingQueue(testMixpanel)
+        flushAndWaitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 3, "delegate should have stopped flush")
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel.apiToken).count == 2, "delegate should have stopped flush")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testEventTiming() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.track(event: "Something Happened")
+        waitForTrackingQueue(testMixpanel)
+        var e: InternalProperties = eventQueue(token: testMixpanel.apiToken).last!
+        var p = e["properties"] as! InternalProperties
+        XCTAssertNil(p["$duration"], "New events should not be timed.")
+        testMixpanel.time(event: "400 Meters")
+        testMixpanel.track(event: "500 Meters")
+        waitForTrackingQueue(testMixpanel)
+        e = eventQueue(token: testMixpanel.apiToken).last!
+        p = e["properties"] as! InternalProperties
+        XCTAssertNil(p["$duration"], "The exact same event name is required for timing.")
+        testMixpanel.track(event: "400 Meters")
+        waitForTrackingQueue(testMixpanel)
+        e = eventQueue(token: testMixpanel.apiToken).last!
+        p = e["properties"] as! InternalProperties
+        XCTAssertNotNil(p["$duration"], "This event should be timed.")
+        testMixpanel.track(event: "400 Meters")
+        waitForTrackingQueue(testMixpanel)
+        e = eventQueue(token: testMixpanel.apiToken).last!
+        p = e["properties"] as! InternalProperties
+        XCTAssertNil(
+            p["$duration"],
+            "Tracking the same event should require a second call to timeEvent.")
+        testMixpanel.time(event: "Time Event A")
+        testMixpanel.time(event: "Time Event B")
+        testMixpanel.time(event: "Time Event C")
+        waitForTrackingQueue(testMixpanel)
+        var testTimedEvents = MixpanelPersistence.loadTimedEvents(instanceName: testMixpanel.apiToken)
+        XCTAssertTrue(
+            testTimedEvents.count == 3, "Each call to time() should add an event to timedEvents")
+        XCTAssertNotNil(testTimedEvents["Time Event A"], "Keys in timedEvents should be event names")
+        testMixpanel.clearTimedEvent(event: "Time Event A")
+        waitForTrackingQueue(testMixpanel)
+        testTimedEvents = MixpanelPersistence.loadTimedEvents(instanceName: testMixpanel.apiToken)
+        XCTAssertNil(testTimedEvents["Time Event A"], "clearTimedEvent should remove key/value pair")
+        XCTAssertTrue(
+            testTimedEvents.count == 2, "clearTimedEvent shoud remove only one key/value pair")
+        testMixpanel.clearTimedEvents()
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            MixpanelPersistence.loadTimedEvents(instanceName: testMixpanel.apiToken).count == 0,
+            "clearTimedEvents should remove all key/value pairs")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testReadWriteLock() {
+        var array = [Int]()
+        let lock = ReadWriteLock(label: "test")
+        let queue = DispatchQueue(label: "concurrent", qos: .utility, attributes: .concurrent)
+        for _ in 0..<10 {
+            queue.async {
+                lock.write {
+                    for i in 0..<100 {
+                        array.append(i)
+                    }
+                }
+            }
+
+            queue.async {
+                lock.read {
+                    XCTAssertTrue(array.count % 100 == 0, "supposed to happen after write")
+                }
+            }
+        }
+    }
+
+    func testSetGroup() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        let groupKey = "test_key"
+        let groupValue = "test_value"
+        testMixpanel.setGroup(groupKey: groupKey, groupIDs: [groupValue])
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue])
+        let q = peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
+        XCTAssertEqual(q[groupKey] as? [String], [groupValue], "group value people property not queued")
+        assertDefaultPeopleProperties(q)
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testAddGroup() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        let groupKey = "test_key"
+        let groupValue = "test_value"
+
+        testMixpanel.addGroup(groupKey: groupKey, groupID: groupValue)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue])
+        waitForTrackingQueue(testMixpanel)
+        let q = peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
+        XCTAssertEqual(q[groupKey] as? [String], [groupValue], "addGroup people update not queued")
+        assertDefaultPeopleProperties(q)
+        testMixpanel.addGroup(groupKey: groupKey, groupID: groupValue)
+
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue])
+        waitForTrackingQueue(testMixpanel)
+        let q2 = peopleQueue(token: testMixpanel.apiToken).last!["$union"] as! InternalProperties
+        XCTAssertEqual(q2[groupKey] as? [String], [groupValue], "addGroup people update not queued")
+
+        let newVal = "new_group"
+        testMixpanel.addGroup(groupKey: groupKey, groupID: newVal)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(
+            testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue, newVal])
+        waitForTrackingQueue(testMixpanel)
+        waitForTrackingQueue(testMixpanel)
+        let q3 = peopleQueue(token: testMixpanel.apiToken).last!["$union"] as! InternalProperties
+        XCTAssertEqual(q3[groupKey] as? [String], [newVal], "addGroup people update not queued")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testRemoveGroup() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        let groupKey = "test_key"
+        let groupValue = "test_value"
+        let newVal = "new_group"
+
+        testMixpanel.setGroup(groupKey: groupKey, groupIDs: [groupValue, newVal])
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(
+            testMixpanel.currentSuperProperties()[groupKey] as? [String], [groupValue, newVal])
+
+        testMixpanel.removeGroup(groupKey: groupKey, groupID: groupValue)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertEqual(testMixpanel.currentSuperProperties()[groupKey] as? [String], [newVal])
+        waitForTrackingQueue(testMixpanel)
+        let q2 = peopleQueue(token: testMixpanel.apiToken).last!["$remove"] as! InternalProperties
+        XCTAssertEqual(q2[groupKey] as? String, groupValue, "removeGroup people update not queued")
+
+        testMixpanel.removeGroup(groupKey: groupKey, groupID: groupValue)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertNil(testMixpanel.currentSuperProperties()[groupKey])
+        waitForTrackingQueue(testMixpanel)
+        let q3 = peopleQueue(token: testMixpanel.apiToken).last!["$unset"] as! [String]
+        XCTAssertEqual(q3, [groupKey], "removeGroup people update not queued")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testMultipleInstancesWithSameToken() {
+        let testToken = randomId()
+        let concurentQueue = DispatchQueue(label: "multithread", attributes: .concurrent)
+
+        var testMixpanel: MixpanelInstance?
+        for _ in 1...10 {
+            concurentQueue.async {
+                testMixpanel = Mixpanel.initialize(
+                    token: testToken, trackAutomaticEvents: true, flushInterval: 60)
+                testMixpanel?.loggingEnabled = true
+                testMixpanel?.track(event: "test")
+            }
+        }
+
+        var testMixpanel2: MixpanelInstance?
+        for _ in 1...10 {
+            concurentQueue.async {
+                testMixpanel2 = Mixpanel.initialize(
+                    token: testToken, trackAutomaticEvents: true, flushInterval: 60)
+                testMixpanel2?.loggingEnabled = true
+                testMixpanel2?.track(event: "test")
+            }
+        }
+        sleep(5)
+        testMixpanel = Mixpanel.initialize(
+            token: testToken, trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel2 = Mixpanel.initialize(
+            token: testToken, trackAutomaticEvents: true, flushInterval: 60)
+        XCTAssertTrue(
+            testMixpanel === testMixpanel2,
+            "instance with same token should be reused and no sqlite db locked error should be populated")
+    }
+
+    func testMultipleInstancesWithSameTokenButDifferentInstanceNameShouldNotCrash() {
+        let testToken = randomId()
+        let concurentQueue = DispatchQueue(label: "multithread", attributes: .concurrent)
+
+        for i in 1...10 {
+            concurentQueue.async {
+                let testMixpanel = Mixpanel.initialize(
+                    token: testToken, trackAutomaticEvents: true, flushInterval: 60,
+                    instanceName: "instance\(i)")
+                testMixpanel.loggingEnabled = true
+                testMixpanel.track(event: "test")
+            }
+        }
+
+        sleep(5)
+        XCTAssertTrue(true, "no sqlite db locked error should be populated")
+        for j in 1...10 {
+            removeDBfile("instance\(j)")
+        }
+    }
+
+    func testMultipleInstancesWithSameTokenButDifferentInstanceName() {
+        let testToken = randomId()
+        let instanceName1 = randomId()
+        let instanceName2 = randomId()
+        let instance1 = Mixpanel.initialize(
+            token: testToken, trackAutomaticEvents: true, flushInterval: 60, instanceName: instanceName1)
+        let instance2 = Mixpanel.initialize(
+            token: testToken, trackAutomaticEvents: true, flushInterval: 60, instanceName: instanceName2)
+
+        XCTAssertNotEqual(instance1.distinctId, instance2.distinctId)
+        instance1.identify(distinctId: "user1")
+        instance1.track(event: "test")
+        waitForTrackingQueue(instance1)
+        waitForTrackingQueue(instance2)
+
+        XCTAssertEqual(instance1.distinctId, "user1")
+        XCTAssertEqual(instance1.userId, "user1")
+        let events = eventQueue(token: instanceName1)
+        let properties = events.last?["properties"] as? InternalProperties
+        XCTAssertEqual(properties?["distinct_id"] as? String, "user1")
+
+        instance1.people.set(property: "p1", to: "a")
+        waitForTrackingQueue(instance1)
+        waitForTrackingQueue(instance2)
+
+        let peopleQueue_value = peopleQueue(token: instanceName1)
+        let setValue = peopleQueue_value.last!["$set"] as! InternalProperties
+        XCTAssertEqual(setValue["p1"] as? String, "a", "custom people property not queued")
+
+        XCTAssertEqual(
+            peopleQueue_value.last?["$distinct_id"] as? String,
+            "user1", "distinct id not set properly on the people record")
+
+        instance2.identify(distinctId: "user2")
+        instance2.track(event: "test2")
+        waitForTrackingQueue(instance1)
+        waitForTrackingQueue(instance2)
+        XCTAssertEqual(instance2.distinctId, "user2")
+        XCTAssertEqual(instance2.userId, "user2")
+        let events2 = eventQueue(token: instanceName2)
+        let properties2 = events2.last?["properties"] as? InternalProperties
+        // event property should have the current distinct id
+        XCTAssertEqual(properties2?["distinct_id"] as? String, "user2")
+
+        instance2.people.set(property: "p2", to: "b")
+        waitForTrackingQueue(instance1)
+        waitForTrackingQueue(instance2)
+
+        let peopleQueue2_value = peopleQueue(token: instanceName2)
+        XCTAssertEqual(
+            peopleQueue2_value.last?["$distinct_id"] as? String,
+            "user2", "distinct id not set properly on the people record")
+
+        let setValue2 = peopleQueue2_value.last!["$set"] as! InternalProperties
+        XCTAssertEqual(setValue2["p2"] as? String, "b", "custom people property not queued")
+
+        removeDBfile(instanceName1)
+        removeDBfile(instanceName2)
+    }
+
+    func testReadWriteMultiThreadShouldNotCrash() {
+        let concurentQueue = DispatchQueue(label: "multithread", attributes: .concurrent)
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+
+        for n in 1...10 {
+            concurentQueue.async {
+                testMixpanel.track(event: "event\(n)")
+            }
+            concurentQueue.async {
+                testMixpanel.flush()
+            }
+            concurentQueue.async {
+                testMixpanel.archive()
+            }
+            concurentQueue.async {
+                testMixpanel.reset()
+            }
+            concurentQueue.async {
+                testMixpanel.createAlias("aaa11", distinctId: testMixpanel.distinctId)
+                testMixpanel.identify(distinctId: "test")
+            }
+            concurentQueue.async {
+                testMixpanel.registerSuperProperties(["Plan": "Mega"])
+            }
+            concurentQueue.async {
+                let _ = testMixpanel.currentSuperProperties()
+            }
+            concurentQueue.async {
+                testMixpanel.people.set(property: "aaa", to: "SwiftSDK Cocoapods")
+                testMixpanel.getGroup(groupKey: "test", groupID: 123).set(properties: ["test": 123])
+                testMixpanel.removeGroup(groupKey: "test", groupID: 123)
+            }
+            concurentQueue.async {
+                testMixpanel.track(event: "test")
+                testMixpanel.time(event: "test")
+                testMixpanel.clearTimedEvents()
+            }
+        }
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testMPDB() {
+        // we test with this crazy string because the "token" here can be the instanceName
+        // which can be any string the user likes, MPDB should strip the non-alphanumeric characters to prevent SQL errors
+        let mpdb = MPDB.init(token: "Re@lly  Bad.T0ken+\(randomId())--*🤪/0️⃣\\_? ")
+        mpdb.open()
+
+        let numRows = 50
+        let halfRows = numRows / 2
+        let eventName = "Test Event"
+
+        for pType in PersistenceType.allCases {
+            let emptyArray: [InternalProperties] = mpdb.readRows(pType, numRows: numRows)
+            XCTAssertTrue(emptyArray.isEmpty, "Table should be empty")
+            for i in 0...numRows - 1 {
+                let eventObj: InternalProperties = ["event": eventName, "properties": ["index": i]]
+                let eventData = JSONHandler.serializeJSONObject(eventObj)!
+                mpdb.insertRow(pType, data: eventData)
+            }
+            let dataArray: [InternalProperties] = mpdb.readRows(pType, numRows: halfRows)
+            XCTAssertEqual(dataArray.count, halfRows, "Should have read only half of the rows")
+            var ids: [Int32] = []
+            for (n, entity) in dataArray.enumerated() {
+                guard let id = entity["id"] as? Int32 else {
+                    continue
+                }
+                ids.append(id)
+                XCTAssertEqual(entity["event"] as! String, eventName, "Event name should be unchanged")
+                // index should be oldest events, 0 - 24
+                XCTAssertEqual(
+                    entity["properties"] as! [String: Int], ["index": n], "Should read oldest events first")
+            }
+
+            mpdb.deleteRows(pType, ids: ids)
+            let dataArray2: [InternalProperties] = mpdb.readRows(pType, numRows: numRows)
+            // even though we requested numRows, there should only be halfRows left
+            XCTAssertEqual(dataArray2.count, halfRows, "Should have deleted half the rows")
+            for (n, entity) in dataArray2.enumerated() {
+                XCTAssertEqual(entity["event"] as! String, eventName, "Event name should be unchanged")
+                // old events (0-24) should have been deleted so index should be recent events 25-49
+                XCTAssertEqual(
+                    entity["properties"] as! [String: Int], ["index": n + halfRows],
+                    "Should have deleted oldest events first")
+            }
+        }
+
+        mpdb.close()
+        removeDBfile(mpdb.apiToken)
+    }
+
+    func testMigration() {
+        let token = "testToken"
+        // clean up
+        removeDBfile(token)
+        // copy the legacy archived file for the migration test
+        let legacyFiles = [
+            "mixpanel-testToken-events", "mixpanel-testToken-properties", "mixpanel-testToken-groups",
+            "mixpanel-testToken-people", "mixpanel-testToken-optOutStatus",
+        ]
+        prepareForMigrationFiles(legacyFiles)
+        // initialize mixpanel will do the migration automatically if found legacy archive files.
+        let testMixpanel = Mixpanel.initialize(
+            token: token, trackAutomaticEvents: true, flushInterval: 60)
+        let fileManager = FileManager.default
+        let libraryUrls = fileManager.urls(
+            for: .libraryDirectory,
+            in: .userDomainMask)
+        XCTAssertFalse(
+            fileManager.fileExists(
+                atPath: (libraryUrls.first?.appendingPathComponent("mixpanel-testToken-events"))!.path),
+            "after migration, the legacy archive files should be removed")
+        XCTAssertFalse(
+            fileManager.fileExists(
+                atPath: (libraryUrls.first?.appendingPathComponent("mixpanel-testToken-properties"))!.path),
+            "after migration, the legacy archive files should be removed")
+        XCTAssertFalse(
+            fileManager.fileExists(
+                atPath: (libraryUrls.first?.appendingPathComponent("mixpanel-testToken-groups"))!.path),
+            "after migration, the legacy archive files should be removed")
+        XCTAssertFalse(
+            fileManager.fileExists(
+                atPath: (libraryUrls.first?.appendingPathComponent("mixpanel-testToken-people"))!.path),
+            "after migration, the legacy archive files should be removed")
+
+        let events = eventQueue(token: testMixpanel.apiToken)
+        XCTAssertEqual(events.count, 306)
+
+        XCTAssertEqual(events[0]["event"] as? String, "$identify")
+        XCTAssertEqual(events[1]["event"] as? String, "Logged in")
+        XCTAssertEqual(events[2]["event"] as? String, "$ae_first_open")
+        XCTAssertEqual(events[3]["event"] as? String, "Tracked event 1")
+        let properties = events.last?["properties"] as? InternalProperties
+        XCTAssertEqual(properties?["Cool Property"] as? [Int], [12345, 301])
+        XCTAssertEqual(properties?["Super Property 2"] as? String, "p2")
+
+        let people = peopleQueue(token: testMixpanel.apiToken)
+        XCTAssertEqual(people.count, 6)
+        XCTAssertEqual(people[0]["$distinct_id"] as? String, "demo_user")
+        XCTAssertEqual(people[0]["$token"] as? String, "testToken")
+        let appendProperties = people[5]["$append"] as! InternalProperties
+        XCTAssertEqual(appendProperties["d"] as? String, "goodbye")
+
+        let group = groupQueue(token: testMixpanel.apiToken)
+        XCTAssertEqual(group.count, 2)
+        XCTAssertEqual(group[0]["$group_key"] as? String, "Cool Property")
+        let setProperties = group[0]["$set"] as! InternalProperties
+        XCTAssertEqual(setProperties["g"] as? String, "yo")
+        let setProperties2 = group[1]["$set"] as! InternalProperties
+        XCTAssertEqual(setProperties2["a"] as? Int, 1)
+        XCTAssertTrue(MixpanelPersistence.loadOptOutStatusFlag(instanceName: token)!)
+
+        //timedEvents
+        let testTimedEvents = MixpanelPersistence.loadTimedEvents(instanceName: token)
+        XCTAssertEqual(testTimedEvents.count, 3)
+        XCTAssertNotNil(testTimedEvents["Time Event A"])
+        XCTAssertNotNil(testTimedEvents["Time Event B"])
+        XCTAssertNotNil(testTimedEvents["Time Event C"])
+        let identity = MixpanelPersistence.loadIdentity(instanceName: token)
+        XCTAssertEqual(identity.distinctID, "demo_user")
+        XCTAssertEqual(identity.peopleDistinctID, "demo_user")
+        XCTAssertNotNil(identity.anonymousId)
+        XCTAssertEqual(identity.userId, "demo_user")
+        XCTAssertEqual(identity.alias, "New Alias")
+        XCTAssertEqual(identity.hadPersistedDistinctId, false)
+
+        let superProperties = MixpanelPersistence.loadSuperProperties(instanceName: token)
+        XCTAssertEqual(superProperties.count, 7)
+        XCTAssertEqual(superProperties["Super Property 1"] as? Int, 1)
+        XCTAssertEqual(superProperties["Super Property 7"] as? NSNull, NSNull())
+        removeDBfile("testToken")
+    }
+
+    func prepareForMigrationFiles(_ fileNames: [String]) {
+        for fileName in fileNames {
+            let fileManager = FileManager.default
+            let filepath = Bundle(for: type(of: self)).url(forResource: fileName, withExtension: nil)!
+            let libraryUrls = fileManager.urls(
+                for: .libraryDirectory,
+                in: .userDomainMask)
+            let destURL = libraryUrls.first?.appendingPathComponent(fileName)
+            do {
+                try FileManager.default.copyItem(at: filepath, to: destURL!)
+            } catch let error {
+                print(error)
+            }
+        }
+    }
+
+    func testGzipCompressionInit() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: false, useGzipCompression: true)
+        XCTAssertTrue(testMixpanel.useGzipCompression == true, "the init of GzipCompression failed")
+    }
+
+    func testGzipCompressionDefault() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: false)
+        XCTAssertTrue(
+            testMixpanel.useGzipCompression == false, "the default gzip option disabled failed")
+    }
 }

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelDeviceIdProviderTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelDeviceIdProviderTests.swift
@@ -12,435 +12,435 @@ import XCTest
 
 class MixpanelDeviceIdProviderTests: MixpanelBaseTests {
 
-  // MARK: - Test Group 1: Basic Provider Functionality
-
-  /// Test 1.1: Verify provider is called during initialization and value is used
-  func testDeviceIdProviderIsCalledOnInitialization() {
-    var providerCalled = false
-    let customDeviceId = "custom-device-id-12345"
-
-    let options = MixpanelOptions(
-      token: randomId(),
-      deviceIdProvider: {
-        providerCalled = true
-        return customDeviceId
-      }
-    )
-
-    let testMixpanel = Mixpanel.initialize(options: options)
-    waitForTrackingQueue(testMixpanel)
-
-    XCTAssertTrue(providerCalled, "deviceIdProvider should be called during initialization")
-    XCTAssertEqual(
-      testMixpanel.anonymousId, customDeviceId,
-      "anonymousId should be set from provider")
-    XCTAssertEqual(
-      testMixpanel.distinctId, "$device:\(customDeviceId)",
-      "distinctId should use provider value with prefix")
-
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  /// Test 1.2: Verify backward compatibility when no provider is set
-  func testNilProviderUsesDefaultBehavior() {
-    let options = MixpanelOptions(
-      token: randomId(),
-      deviceIdProvider: nil
-    )
-
-    let testMixpanel = Mixpanel.initialize(options: options)
-    waitForTrackingQueue(testMixpanel)
-
-    // Should use UUID or IDFV depending on configuration
-    XCTAssertNotNil(testMixpanel.anonymousId, "anonymousId should be generated")
-    XCTAssertFalse(testMixpanel.anonymousId?.isEmpty ?? true, "anonymousId should not be empty")
-    XCTAssertTrue(
-      testMixpanel.distinctId.hasPrefix("$device:"), "distinctId should have device prefix")
-
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  /// Test 1.3: Verify that tracked events use the provider-generated device ID
-  func testDeviceIdProviderValueUsedInEvents() {
-    let customDeviceId = "my-custom-device-123"
-    let options = MixpanelOptions(
-      token: randomId(),
-      deviceIdProvider: { customDeviceId }
-    )
-
-    let testMixpanel = Mixpanel.initialize(options: options)
-    testMixpanel.track(event: "Test Event")
-    waitForTrackingQueue(testMixpanel)
-
-    let events = eventQueue(token: testMixpanel.apiToken)
-    XCTAssertFalse(events.isEmpty, "Should have tracked event")
-
-    let lastEvent = events.last!
-    let properties = lastEvent["properties"] as! InternalProperties
-
-    XCTAssertEqual(
-      properties["distinct_id"] as? String, "$device:\(customDeviceId)",
-      "Event distinct_id should use provider value")
-    XCTAssertEqual(
-      properties["$device_id"] as? String, customDeviceId,
-      "Event $device_id should be the raw provider value")
-
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  // MARK: - Test Group 2: Reset Behavior
-
-  /// Test 2.1: Verify that reset() calls the provider to get a new device ID
-  func testResetCallsDeviceIdProvider() {
-    var callCount = 0
-
-    let options = MixpanelOptions(
-      token: randomId(),
-      deviceIdProvider: {
-        callCount += 1
-        return "device-id-\(callCount)"
-      }
-    )
-
-    let testMixpanel = Mixpanel.initialize(options: options)
-    waitForTrackingQueue(testMixpanel)
-
-    let initialCallCount = callCount
-    let initialDeviceId = testMixpanel.anonymousId
-
-    testMixpanel.reset()
-    waitForTrackingQueue(testMixpanel)
-
-    XCTAssertGreaterThan(callCount, initialCallCount, "Provider should be called again on reset")
-    XCTAssertNotEqual(
-      testMixpanel.anonymousId, initialDeviceId, "Device ID should change after reset")
+    // MARK: - Test Group 1: Basic Provider Functionality
+
+    /// Test 1.1: Verify provider is called during initialization and value is used
+    func testDeviceIdProviderIsCalledOnInitialization() {
+        var providerCalled = false
+        let customDeviceId = "custom-device-id-12345"
+
+        let options = MixpanelOptions(
+            token: randomId(),
+            deviceIdProvider: {
+                providerCalled = true
+                return customDeviceId
+            }
+        )
+
+        let testMixpanel = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel)
+
+        XCTAssertTrue(providerCalled, "deviceIdProvider should be called during initialization")
+        XCTAssertEqual(
+            testMixpanel.anonymousId, customDeviceId,
+            "anonymousId should be set from provider")
+        XCTAssertEqual(
+            testMixpanel.distinctId, "$device:\(customDeviceId)",
+            "distinctId should use provider value with prefix")
+
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    /// Test 1.2: Verify backward compatibility when no provider is set
+    func testNilProviderUsesDefaultBehavior() {
+        let options = MixpanelOptions(
+            token: randomId(),
+            deviceIdProvider: nil
+        )
+
+        let testMixpanel = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel)
+
+        // Should use UUID or IDFV depending on configuration
+        XCTAssertNotNil(testMixpanel.anonymousId, "anonymousId should be generated")
+        XCTAssertFalse(testMixpanel.anonymousId?.isEmpty ?? true, "anonymousId should not be empty")
+        XCTAssertTrue(
+            testMixpanel.distinctId.hasPrefix("$device:"), "distinctId should have device prefix")
+
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    /// Test 1.3: Verify that tracked events use the provider-generated device ID
+    func testDeviceIdProviderValueUsedInEvents() {
+        let customDeviceId = "my-custom-device-123"
+        let options = MixpanelOptions(
+            token: randomId(),
+            deviceIdProvider: { customDeviceId }
+        )
+
+        let testMixpanel = Mixpanel.initialize(options: options)
+        testMixpanel.track(event: "Test Event")
+        waitForTrackingQueue(testMixpanel)
+
+        let events = eventQueue(token: testMixpanel.apiToken)
+        XCTAssertFalse(events.isEmpty, "Should have tracked event")
+
+        let lastEvent = events.last!
+        let properties = lastEvent["properties"] as! InternalProperties
+
+        XCTAssertEqual(
+            properties["distinct_id"] as? String, "$device:\(customDeviceId)",
+            "Event distinct_id should use provider value")
+        XCTAssertEqual(
+            properties["$device_id"] as? String, customDeviceId,
+            "Event $device_id should be the raw provider value")
+
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    // MARK: - Test Group 2: Reset Behavior
+
+    /// Test 2.1: Verify that reset() calls the provider to get a new device ID
+    func testResetCallsDeviceIdProvider() {
+        var callCount = 0
+
+        let options = MixpanelOptions(
+            token: randomId(),
+            deviceIdProvider: {
+                callCount += 1
+                return "device-id-\(callCount)"
+            }
+        )
+
+        let testMixpanel = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel)
+
+        let initialCallCount = callCount
+        let initialDeviceId = testMixpanel.anonymousId
+
+        testMixpanel.reset()
+        waitForTrackingQueue(testMixpanel)
+
+        XCTAssertGreaterThan(callCount, initialCallCount, "Provider should be called again on reset")
+        XCTAssertNotEqual(
+            testMixpanel.anonymousId, initialDeviceId, "Device ID should change after reset")
 
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  /// Test 2.2: Demonstrate that returning the same value = "never reset"
-  func testProviderReturningSameValuePersistsAcrossReset() {
-    let persistentDeviceId = "persistent-device-id"
-    var callCount = 0
-
-    let options = MixpanelOptions(
-      token: randomId(),
-      deviceIdProvider: {
-        callCount += 1
-        return persistentDeviceId  // Always return same value
-      }
-    )
-
-    let testMixpanel = Mixpanel.initialize(options: options)
-    waitForTrackingQueue(testMixpanel)
-
-    let callCountAfterInit = callCount
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    /// Test 2.2: Demonstrate that returning the same value = "never reset"
+    func testProviderReturningSameValuePersistsAcrossReset() {
+        let persistentDeviceId = "persistent-device-id"
+        var callCount = 0
+
+        let options = MixpanelOptions(
+            token: randomId(),
+            deviceIdProvider: {
+                callCount += 1
+                return persistentDeviceId  // Always return same value
+            }
+        )
+
+        let testMixpanel = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel)
+
+        let callCountAfterInit = callCount
 
-    testMixpanel.reset()
-    waitForTrackingQueue(testMixpanel)
-
-    testMixpanel.reset()
-    waitForTrackingQueue(testMixpanel)
-
-    // Provider is called on each reset
-    XCTAssertGreaterThan(callCount, callCountAfterInit, "Provider called on each reset")
-    XCTAssertEqual(
-      testMixpanel.anonymousId, persistentDeviceId,
-      "Device ID persists when provider returns same value")
-
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  /// Test 2.3: Demonstrate that returning different values = "reset behavior"
-  func testProviderReturningDifferentValueResetsDeviceId() {
-    var callCount = 0
-
-    let options = MixpanelOptions(
-      token: randomId(),
-      deviceIdProvider: {
-        callCount += 1
-        return "device-id-\(callCount)"  // Different value each time
-      }
-    )
-
-    let testMixpanel = Mixpanel.initialize(options: options)
-    waitForTrackingQueue(testMixpanel)
-
-    let initialDeviceId = testMixpanel.anonymousId
-    XCTAssertNotNil(initialDeviceId, "Should have initial device ID")
-
-    testMixpanel.reset()
-    waitForTrackingQueue(testMixpanel)
-
-    XCTAssertNotEqual(
-      testMixpanel.anonymousId, initialDeviceId,
-      "Device ID changes when provider returns new value")
-
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  // MARK: - Test Group 3: OptOutTracking Behavior
-
-  /// Test 3.1: Verify that optOutTracking() uses the provider
-  func testOptOutTrackingCallsDeviceIdProvider() {
-    var callCount = 0
-
-    let options = MixpanelOptions(
-      token: randomId(),
-      trackAutomaticEvents: false,
-      deviceIdProvider: {
-        callCount += 1
-        return "opt-out-device-\(callCount)"
-      }
-    )
-
-    let testMixpanel = Mixpanel.initialize(options: options)
-    waitForTrackingQueue(testMixpanel)
-
-    let callCountAfterInit = callCount
-    let initialDeviceId = testMixpanel.anonymousId
-
-    testMixpanel.optOutTracking()
-    waitForTrackingQueue(testMixpanel)
-
-    XCTAssertGreaterThan(callCount, callCountAfterInit, "Provider called on optOutTracking")
-    XCTAssertNotEqual(
-      testMixpanel.anonymousId, initialDeviceId,
-      "Device ID changes after opt-out when provider returns different value")
+        testMixpanel.reset()
+        waitForTrackingQueue(testMixpanel)
+
+        testMixpanel.reset()
+        waitForTrackingQueue(testMixpanel)
+
+        // Provider is called on each reset
+        XCTAssertGreaterThan(callCount, callCountAfterInit, "Provider called on each reset")
+        XCTAssertEqual(
+            testMixpanel.anonymousId, persistentDeviceId,
+            "Device ID persists when provider returns same value")
+
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    /// Test 2.3: Demonstrate that returning different values = "reset behavior"
+    func testProviderReturningDifferentValueResetsDeviceId() {
+        var callCount = 0
+
+        let options = MixpanelOptions(
+            token: randomId(),
+            deviceIdProvider: {
+                callCount += 1
+                return "device-id-\(callCount)"  // Different value each time
+            }
+        )
+
+        let testMixpanel = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel)
+
+        let initialDeviceId = testMixpanel.anonymousId
+        XCTAssertNotNil(initialDeviceId, "Should have initial device ID")
+
+        testMixpanel.reset()
+        waitForTrackingQueue(testMixpanel)
+
+        XCTAssertNotEqual(
+            testMixpanel.anonymousId, initialDeviceId,
+            "Device ID changes when provider returns new value")
+
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    // MARK: - Test Group 3: OptOutTracking Behavior
+
+    /// Test 3.1: Verify that optOutTracking() uses the provider
+    func testOptOutTrackingCallsDeviceIdProvider() {
+        var callCount = 0
+
+        let options = MixpanelOptions(
+            token: randomId(),
+            trackAutomaticEvents: false,
+            deviceIdProvider: {
+                callCount += 1
+                return "opt-out-device-\(callCount)"
+            }
+        )
+
+        let testMixpanel = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel)
+
+        let callCountAfterInit = callCount
+        let initialDeviceId = testMixpanel.anonymousId
+
+        testMixpanel.optOutTracking()
+        waitForTrackingQueue(testMixpanel)
+
+        XCTAssertGreaterThan(callCount, callCountAfterInit, "Provider called on optOutTracking")
+        XCTAssertNotEqual(
+            testMixpanel.anonymousId, initialDeviceId,
+            "Device ID changes after opt-out when provider returns different value")
 
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  // MARK: - Test Group 4: Migration/Warning Behavior
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    // MARK: - Test Group 4: Migration/Warning Behavior
 
-  /// Test 4.1: Verify warning is logged when provider replaces existing ID
-  /// Note: This test validates the warning behavior by checking that initialization
-  /// completes without issues when provider differs from persisted value
-  func testWarningWhenProviderReplacesExistingAnonymousId() {
-    let testToken = randomId()
-
-    // First, create an instance WITHOUT a provider to establish persisted identity
-    let testMixpanel1 = Mixpanel.initialize(
-      token: testToken,
-      trackAutomaticEvents: false
-    )
-    waitForTrackingQueue(testMixpanel1)
-
-    let originalAnonymousId = testMixpanel1.anonymousId
-    XCTAssertNotNil(originalAnonymousId, "Should have original anonymous ID")
+    /// Test 4.1: Verify warning is logged when provider replaces existing ID
+    /// Note: This test validates the warning behavior by checking that initialization
+    /// completes without issues when provider differs from persisted value
+    func testWarningWhenProviderReplacesExistingAnonymousId() {
+        let testToken = randomId()
+
+        // First, create an instance WITHOUT a provider to establish persisted identity
+        let testMixpanel1 = Mixpanel.initialize(
+            token: testToken,
+            trackAutomaticEvents: false
+        )
+        waitForTrackingQueue(testMixpanel1)
+
+        let originalAnonymousId = testMixpanel1.anonymousId
+        XCTAssertNotNil(originalAnonymousId, "Should have original anonymous ID")
 
-    // Force archive to persist
-    flushAndWaitForTrackingQueue(testMixpanel1)
-
-    // Remove instance to simulate app restart
-    Mixpanel.removeInstance(name: testToken)
-
-    // Reinitialize WITH a provider that returns a DIFFERENT value
-    let options = MixpanelOptions(
-      token: testToken,
-      deviceIdProvider: { "completely-different-device-id" }
-    )
-
-    let testMixpanel2 = Mixpanel.initialize(options: options)
-    waitForTrackingQueue(testMixpanel2)
-
-    // The persisted value should be used (not the provider value)
-    // because we don't want to break identity continuity
-    // The warning should be logged (we can't easily assert on logs in tests)
-    XCTAssertEqual(
-      testMixpanel2.anonymousId, originalAnonymousId,
-      "Should use persisted anonymousId, not provider value, to preserve identity")
-
-    removeDBfile(testToken)
-  }
-
-  /// Test 4.2: Verify no warning when provider matches existing ID
-  func testNoWarningWhenProviderMatchesExistingAnonymousId() {
-    let persistentId = "always-the-same-id"
-    let testToken = randomId()
-
-    let options = MixpanelOptions(
-      token: testToken,
-      deviceIdProvider: { persistentId }
-    )
-
-    // First init
-    let testMixpanel1 = Mixpanel.initialize(options: options)
-    waitForTrackingQueue(testMixpanel1)
-
-    XCTAssertEqual(testMixpanel1.anonymousId, persistentId)
-    flushAndWaitForTrackingQueue(testMixpanel1)
-
-    // Remove and reinitialize
-    Mixpanel.removeInstance(name: testToken)
-
-    // Second init with same provider returning same value
-    let testMixpanel2 = Mixpanel.initialize(options: options)
-    waitForTrackingQueue(testMixpanel2)
-
-    // Should work without issues, no warning expected
-    XCTAssertEqual(
-      testMixpanel2.anonymousId, persistentId,
-      "Should use same ID without warnings")
-
-    removeDBfile(testToken)
-  }
-
-  // MARK: - Test Group 5: Persistence Behavior
-
-  /// Test 5.1: Persisted identity value is used even if provider returns different value
-  func testPersistedIdentityUsedOverProviderValue() {
-    let testToken = randomId()
-    let persistentId = "persistent-device-id"
-
-    let options = MixpanelOptions(
-      token: testToken,
-      deviceIdProvider: { persistentId }
-    )
-
-    // First initialization - provider should be called
-    let testMixpanel1 = Mixpanel.initialize(options: options)
-    waitForTrackingQueue(testMixpanel1)
-
-    XCTAssertEqual(testMixpanel1.anonymousId, persistentId)
-
-    flushAndWaitForTrackingQueue(testMixpanel1)
-    Mixpanel.removeInstance(name: testToken)
-
-    // Second initialization with same provider - persisted value should be used
-    let testMixpanel2 = Mixpanel.initialize(options: options)
-    waitForTrackingQueue(testMixpanel2)
-
-    // Persisted value should be preserved
-    XCTAssertEqual(
-      testMixpanel2.anonymousId, persistentId,
-      "Persisted value should be used")
-
-    removeDBfile(testToken)
-  }
-
-  /// Test 5.2: Provider IS called when there's no persisted identity
-  func testProviderCalledWhenNoPersistedIdentity() {
-    let testToken = randomId()
-    var callCount = 0
-
-    // Ensure no persisted data
-    removeDBfile(testToken)
-    MixpanelPersistence.deleteMPUserDefaultsData(instanceName: testToken)
-
-    let options = MixpanelOptions(
-      token: testToken,
-      deviceIdProvider: {
-        callCount += 1
-        return "fresh-device-id"
-      }
-    )
-
-    let testMixpanel = Mixpanel.initialize(options: options)
-    waitForTrackingQueue(testMixpanel)
-
-    XCTAssertGreaterThanOrEqual(
-      callCount, 1, "Provider should be called when no persisted identity")
-    XCTAssertEqual(testMixpanel.anonymousId, "fresh-device-id")
-
-    removeDBfile(testToken)
-  }
-
-  // MARK: - Test Group 6: Edge Cases
-
-  /// Test 6.1a: Provider returning nil should fall back to default
-  func testProviderReturningNilFallsBackToDefault() {
-    let options = MixpanelOptions(
-      token: randomId(),
-      deviceIdProvider: { nil }  // Return nil
-    )
-
-    let testMixpanel = Mixpanel.initialize(options: options)
-    waitForTrackingQueue(testMixpanel)
-
-    // Should fall back to default behavior (UUID or IDFV)
-    XCTAssertNotNil(testMixpanel.anonymousId, "Should have anonymousId")
-    XCTAssertFalse(
-      testMixpanel.anonymousId?.isEmpty ?? true,
-      "Should not have empty anonymousId - should fall back to default")
-
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  /// Test 6.1b: Provider returning empty string should fall back to default
-  func testProviderReturningEmptyStringFallsBackToDefault() {
-    let options = MixpanelOptions(
-      token: randomId(),
-      deviceIdProvider: { "" }  // Empty string
-    )
-
-    let testMixpanel = Mixpanel.initialize(options: options)
-    waitForTrackingQueue(testMixpanel)
-
-    // Should fall back to default behavior (UUID or IDFV)
-    XCTAssertNotNil(testMixpanel.anonymousId, "Should have anonymousId")
-    XCTAssertFalse(
-      testMixpanel.anonymousId?.isEmpty ?? true,
-      "Should not have empty anonymousId - should fall back to default")
-
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  /// Test 6.2: Verify identify() works correctly with provider-generated device ID
-  func testIdentifyWithDeviceIdProvider() {
-    let customDeviceId = "provider-device-id"
-    let options = MixpanelOptions(
-      token: randomId(),
-      deviceIdProvider: { customDeviceId }
-    )
-
-    let testMixpanel = Mixpanel.initialize(options: options)
-    waitForTrackingQueue(testMixpanel)
-
-    // Before identify
-    XCTAssertEqual(
-      testMixpanel.distinctId, "$device:\(customDeviceId)",
-      "distinctId should use provider value before identify")
-
-    // After identify
-    let userId = "user@example.com"
-    testMixpanel.identify(distinctId: userId)
-    waitForTrackingQueue(testMixpanel)
-
-    XCTAssertEqual(testMixpanel.distinctId, userId, "distinctId should be userId after identify")
-    XCTAssertEqual(testMixpanel.userId, userId, "userId should be set after identify")
-    XCTAssertEqual(
-      testMixpanel.anonymousId, customDeviceId,
-      "anonymousId should still be provider value after identify")
-
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  /// Test 6.3: Multiple instances can have different providers
-  func testMultipleInstancesWithDifferentProviders() {
-    let options1 = MixpanelOptions(
-      token: randomId(),
-      deviceIdProvider: { "instance-1-device" }
-    )
-
-    let options2 = MixpanelOptions(
-      token: randomId(),
-      deviceIdProvider: { "instance-2-device" }
-    )
-
-    let instance1 = Mixpanel.initialize(options: options1)
-    let instance2 = Mixpanel.initialize(options: options2)
-
-    waitForTrackingQueue(instance1)
-    waitForTrackingQueue(instance2)
-
-    XCTAssertEqual(instance1.anonymousId, "instance-1-device", "Instance 1 should use its provider")
-    XCTAssertEqual(instance2.anonymousId, "instance-2-device", "Instance 2 should use its provider")
-    XCTAssertNotEqual(
-      instance1.anonymousId, instance2.anonymousId,
-      "Instances should have different device IDs")
-
-    removeDBfile(instance1.apiToken)
-    removeDBfile(instance2.apiToken)
-  }
+        // Force archive to persist
+        flushAndWaitForTrackingQueue(testMixpanel1)
+
+        // Remove instance to simulate app restart
+        Mixpanel.removeInstance(name: testToken)
+
+        // Reinitialize WITH a provider that returns a DIFFERENT value
+        let options = MixpanelOptions(
+            token: testToken,
+            deviceIdProvider: { "completely-different-device-id" }
+        )
+
+        let testMixpanel2 = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel2)
+
+        // The persisted value should be used (not the provider value)
+        // because we don't want to break identity continuity
+        // The warning should be logged (we can't easily assert on logs in tests)
+        XCTAssertEqual(
+            testMixpanel2.anonymousId, originalAnonymousId,
+            "Should use persisted anonymousId, not provider value, to preserve identity")
+
+        removeDBfile(testToken)
+    }
+
+    /// Test 4.2: Verify no warning when provider matches existing ID
+    func testNoWarningWhenProviderMatchesExistingAnonymousId() {
+        let persistentId = "always-the-same-id"
+        let testToken = randomId()
+
+        let options = MixpanelOptions(
+            token: testToken,
+            deviceIdProvider: { persistentId }
+        )
+
+        // First init
+        let testMixpanel1 = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel1)
+
+        XCTAssertEqual(testMixpanel1.anonymousId, persistentId)
+        flushAndWaitForTrackingQueue(testMixpanel1)
+
+        // Remove and reinitialize
+        Mixpanel.removeInstance(name: testToken)
+
+        // Second init with same provider returning same value
+        let testMixpanel2 = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel2)
+
+        // Should work without issues, no warning expected
+        XCTAssertEqual(
+            testMixpanel2.anonymousId, persistentId,
+            "Should use same ID without warnings")
+
+        removeDBfile(testToken)
+    }
+
+    // MARK: - Test Group 5: Persistence Behavior
+
+    /// Test 5.1: Persisted identity value is used even if provider returns different value
+    func testPersistedIdentityUsedOverProviderValue() {
+        let testToken = randomId()
+        let persistentId = "persistent-device-id"
+
+        let options = MixpanelOptions(
+            token: testToken,
+            deviceIdProvider: { persistentId }
+        )
+
+        // First initialization - provider should be called
+        let testMixpanel1 = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel1)
+
+        XCTAssertEqual(testMixpanel1.anonymousId, persistentId)
+
+        flushAndWaitForTrackingQueue(testMixpanel1)
+        Mixpanel.removeInstance(name: testToken)
+
+        // Second initialization with same provider - persisted value should be used
+        let testMixpanel2 = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel2)
+
+        // Persisted value should be preserved
+        XCTAssertEqual(
+            testMixpanel2.anonymousId, persistentId,
+            "Persisted value should be used")
+
+        removeDBfile(testToken)
+    }
+
+    /// Test 5.2: Provider IS called when there's no persisted identity
+    func testProviderCalledWhenNoPersistedIdentity() {
+        let testToken = randomId()
+        var callCount = 0
+
+        // Ensure no persisted data
+        removeDBfile(testToken)
+        MixpanelPersistence.deleteMPUserDefaultsData(instanceName: testToken)
+
+        let options = MixpanelOptions(
+            token: testToken,
+            deviceIdProvider: {
+                callCount += 1
+                return "fresh-device-id"
+            }
+        )
+
+        let testMixpanel = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel)
+
+        XCTAssertGreaterThanOrEqual(
+            callCount, 1, "Provider should be called when no persisted identity")
+        XCTAssertEqual(testMixpanel.anonymousId, "fresh-device-id")
+
+        removeDBfile(testToken)
+    }
+
+    // MARK: - Test Group 6: Edge Cases
+
+    /// Test 6.1a: Provider returning nil should fall back to default
+    func testProviderReturningNilFallsBackToDefault() {
+        let options = MixpanelOptions(
+            token: randomId(),
+            deviceIdProvider: { nil }  // Return nil
+        )
+
+        let testMixpanel = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel)
+
+        // Should fall back to default behavior (UUID or IDFV)
+        XCTAssertNotNil(testMixpanel.anonymousId, "Should have anonymousId")
+        XCTAssertFalse(
+            testMixpanel.anonymousId?.isEmpty ?? true,
+            "Should not have empty anonymousId - should fall back to default")
+
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    /// Test 6.1b: Provider returning empty string should fall back to default
+    func testProviderReturningEmptyStringFallsBackToDefault() {
+        let options = MixpanelOptions(
+            token: randomId(),
+            deviceIdProvider: { "" }  // Empty string
+        )
+
+        let testMixpanel = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel)
+
+        // Should fall back to default behavior (UUID or IDFV)
+        XCTAssertNotNil(testMixpanel.anonymousId, "Should have anonymousId")
+        XCTAssertFalse(
+            testMixpanel.anonymousId?.isEmpty ?? true,
+            "Should not have empty anonymousId - should fall back to default")
+
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    /// Test 6.2: Verify identify() works correctly with provider-generated device ID
+    func testIdentifyWithDeviceIdProvider() {
+        let customDeviceId = "provider-device-id"
+        let options = MixpanelOptions(
+            token: randomId(),
+            deviceIdProvider: { customDeviceId }
+        )
+
+        let testMixpanel = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel)
+
+        // Before identify
+        XCTAssertEqual(
+            testMixpanel.distinctId, "$device:\(customDeviceId)",
+            "distinctId should use provider value before identify")
+
+        // After identify
+        let userId = "user@example.com"
+        testMixpanel.identify(distinctId: userId)
+        waitForTrackingQueue(testMixpanel)
+
+        XCTAssertEqual(testMixpanel.distinctId, userId, "distinctId should be userId after identify")
+        XCTAssertEqual(testMixpanel.userId, userId, "userId should be set after identify")
+        XCTAssertEqual(
+            testMixpanel.anonymousId, customDeviceId,
+            "anonymousId should still be provider value after identify")
+
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    /// Test 6.3: Multiple instances can have different providers
+    func testMultipleInstancesWithDifferentProviders() {
+        let options1 = MixpanelOptions(
+            token: randomId(),
+            deviceIdProvider: { "instance-1-device" }
+        )
+
+        let options2 = MixpanelOptions(
+            token: randomId(),
+            deviceIdProvider: { "instance-2-device" }
+        )
+
+        let instance1 = Mixpanel.initialize(options: options1)
+        let instance2 = Mixpanel.initialize(options: options2)
+
+        waitForTrackingQueue(instance1)
+        waitForTrackingQueue(instance2)
+
+        XCTAssertEqual(instance1.anonymousId, "instance-1-device", "Instance 1 should use its provider")
+        XCTAssertEqual(instance2.anonymousId, "instance-2-device", "Instance 2 should use its provider")
+        XCTAssertNotEqual(
+            instance1.anonymousId, instance2.anonymousId,
+            "Instances should have different device IDs")
+
+        removeDBfile(instance1.apiToken)
+        removeDBfile(instance2.apiToken)
+    }
 }

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelEventBridgeTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelEventBridgeTests.swift
@@ -6,91 +6,91 @@
 //  Copyright © 2026 Mixpanel. All rights reserved.
 //
 
-import XCTest
 import MixpanelSwiftCommon
+import XCTest
 
 @testable import Mixpanel
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 class MixpanelEventBridgeTests: MixpanelBaseTests {
 
-  // MARK: - Event Bridge Notified on Track
+    // MARK: - Event Bridge Notified on Track
 
-  func testEventBridgeNotifiedOnTrack() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: false)
-    let eventName = "BridgeTestEvent_\(randomId())"
-    let expectation = XCTestExpectation(description: "Event bridge is notified when event is tracked")
+    func testEventBridgeNotifiedOnTrack() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: false)
+        let eventName = "BridgeTestEvent_\(randomId())"
+        let expectation = XCTestExpectation(description: "Event bridge is notified when event is tracked")
 
-    let stream = MixpanelEventBridge.shared.eventStream()
-    let task = Task {
-      for await event in stream {
-        if event.eventName == eventName {
-          expectation.fulfill()
-          break
+        let stream = MixpanelEventBridge.shared.eventStream()
+        let task = Task {
+            for await event in stream {
+                if event.eventName == eventName {
+                    expectation.fulfill()
+                    break
+                }
+            }
         }
-      }
+
+        testMixpanel.track(event: eventName)
+        waitForTrackingQueue(testMixpanel)
+
+        wait(for: [expectation], timeout: 2.0)
+        task.cancel()
+        removeDBfile(testMixpanel.apiToken)
     }
 
-    testMixpanel.track(event: eventName)
-    waitForTrackingQueue(testMixpanel)
+    // MARK: - Event Bridge Receives Properties
 
-    wait(for: [expectation], timeout: 2.0)
-    task.cancel()
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testEventBridgeReceivesEventProperties() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: false)
+        let eventName = "BridgePropsTest_\(randomId())"
+        let expectation = XCTestExpectation(
+            description: "Event bridge receives event with correct properties")
 
-  // MARK: - Event Bridge Receives Properties
-
-  func testEventBridgeReceivesEventProperties() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: false)
-    let eventName = "BridgePropsTest_\(randomId())"
-    let expectation = XCTestExpectation(
-      description: "Event bridge receives event with correct properties")
-
-    let stream = MixpanelEventBridge.shared.eventStream()
-    let task = Task {
-      for await event in stream {
-        if event.eventName == eventName {
-          XCTAssertEqual(event.properties["testKey"] as? String, "testValue")
-          expectation.fulfill()
-          break
+        let stream = MixpanelEventBridge.shared.eventStream()
+        let task = Task {
+            for await event in stream {
+                if event.eventName == eventName {
+                    XCTAssertEqual(event.properties["testKey"] as? String, "testValue")
+                    expectation.fulfill()
+                    break
+                }
+            }
         }
-      }
+
+        testMixpanel.track(event: eventName, properties: ["testKey": "testValue"])
+        waitForTrackingQueue(testMixpanel)
+
+        wait(for: [expectation], timeout: 2.0)
+        task.cancel()
+        removeDBfile(testMixpanel.apiToken)
     }
 
-    testMixpanel.track(event: eventName, properties: ["testKey": "testValue"])
-    waitForTrackingQueue(testMixpanel)
+    // MARK: - Event Bridge Not Notified When Opted Out
 
-    wait(for: [expectation], timeout: 2.0)
-    task.cancel()
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testEventBridgeNotNotifiedWhenOptedOut() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: false, optOutTrackingByDefault: true)
+        let eventName = "BridgeOptOutTest_\(randomId())"
+        let noEventExpectation = XCTestExpectation(
+            description: "Event bridge should not be notified when tracking is opted out")
+        noEventExpectation.isInverted = true
 
-  // MARK: - Event Bridge Not Notified When Opted Out
-
-  func testEventBridgeNotNotifiedWhenOptedOut() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: false, optOutTrackingByDefault: true)
-    let eventName = "BridgeOptOutTest_\(randomId())"
-    let noEventExpectation = XCTestExpectation(
-      description: "Event bridge should not be notified when tracking is opted out")
-    noEventExpectation.isInverted = true
-
-    let stream = MixpanelEventBridge.shared.eventStream()
-    let task = Task {
-      for await event in stream {
-        if event.eventName == eventName {
-          noEventExpectation.fulfill()
+        let stream = MixpanelEventBridge.shared.eventStream()
+        let task = Task {
+            for await event in stream {
+                if event.eventName == eventName {
+                    noEventExpectation.fulfill()
+                }
+            }
         }
-      }
+
+        testMixpanel.track(event: eventName)
+        waitForTrackingQueue(testMixpanel)
+
+        wait(for: [noEventExpectation], timeout: 1.0)
+        task.cancel()
+        removeDBfile(testMixpanel.apiToken)
     }
-
-    testMixpanel.track(event: eventName)
-    waitForTrackingQueue(testMixpanel)
-
-    wait(for: [noEventExpectation], timeout: 1.0)
-    task.cancel()
-    removeDBfile(testMixpanel.apiToken)
-  }
 
 }

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelExcludePropertiesTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelExcludePropertiesTests.swift
@@ -9,277 +9,277 @@ import XCTest
 
 class MixpanelExcludePropertiesTests: MixpanelBaseTests {
 
-  // MARK: - Direct helper tests (mirror Android ExcludePropertiesTest)
+    // MARK: - Direct helper tests (mirror Android ExcludePropertiesTest)
 
-  /// Mirrors a representative subset of what the SDK puts in the properties bag for an event:
-  /// reserved identity/routing keys, auto-properties, and a custom user property.
-  private func buildSampleEventProps() -> InternalProperties {
-    return [
-      "token": "test-token",
-      "time": 1_700_000_000_000.0,
-      "distinct_id": "abc-123",
-      "$device_id": "device-xyz",
-      "$user_id": "user-42",
-      "$had_persisted_distinct_id": true,
-      "$insert_id": "insert-1",
-      "mp_lib": "swift",
-      "$lib_version": "5.0.0",
-      "$os": "iOS",
-      "$screen_height": 1920,
-      "$screen_width": 1080,
-      "$carrier": "Verizon",
-      "custom_user_prop": "value",
-    ]
-  }
-
-  func testEmptyExcludeSetIsNoOp() {
-    var props = buildSampleEventProps()
-    let before = props.count
-    Track.applyExcludeProperties(&props, exclude: [])
-    XCTAssertEqual(props.count, before)
-  }
-
-  func testStripsAutoProperty() {
-    var props = buildSampleEventProps()
-    Track.applyExcludeProperties(&props, exclude: ["$screen_height"])
-    XCTAssertNil(props["$screen_height"])
-    // Adjacent auto-props remain untouched.
-    XCTAssertNotNil(props["$screen_width"])
-    XCTAssertNotNil(props["$lib_version"])
-  }
-
-  func testStripsCustomUserProperty() {
-    var props = buildSampleEventProps()
-    Track.applyExcludeProperties(&props, exclude: ["custom_user_prop"])
-    XCTAssertNil(props["custom_user_prop"])
-  }
-
-  func testReservedKeysAreNeverStripped() {
-    var props = buildSampleEventProps()
-    // Drive the test from the canonical reserved set so adding a new reserved key
-    // here automatically tightens this test rather than leaving it stale.
-    let exclude = MixpanelOptions.reservedPropertyKeys
-
-    // Sanity check: every reserved key we're about to try to exclude is actually
-    // present in the sample, otherwise the test would silently pass for missing keys.
-    for key in MixpanelOptions.reservedPropertyKeys {
-      XCTAssertNotNil(props[key], "Sample event props is missing reserved key \(key)")
+    /// Mirrors a representative subset of what the SDK puts in the properties bag for an event:
+    /// reserved identity/routing keys, auto-properties, and a custom user property.
+    private func buildSampleEventProps() -> InternalProperties {
+        return [
+            "token": "test-token",
+            "time": 1_700_000_000_000.0,
+            "distinct_id": "abc-123",
+            "$device_id": "device-xyz",
+            "$user_id": "user-42",
+            "$had_persisted_distinct_id": true,
+            "$insert_id": "insert-1",
+            "mp_lib": "swift",
+            "$lib_version": "5.0.0",
+            "$os": "iOS",
+            "$screen_height": 1920,
+            "$screen_width": 1080,
+            "$carrier": "Verizon",
+            "custom_user_prop": "value",
+        ]
     }
 
-    Track.applyExcludeProperties(&props, exclude: exclude)
-
-    for key in MixpanelOptions.reservedPropertyKeys {
-      XCTAssertNotNil(props[key], "Reserved key was stripped: \(key)")
+    func testEmptyExcludeSetIsNoOp() {
+        var props = buildSampleEventProps()
+        let before = props.count
+        Track.applyExcludeProperties(&props, exclude: [])
+        XCTAssertEqual(props.count, before)
     }
-  }
 
-  /// `$insert_id` is in the Mixpanel ingestion vocabulary but this SDK never writes it
-  /// (we use `$mp_event_id` inside `$mp_metadata` for dedup, which lives outside the
-  /// properties bag). If a customer lists `$insert_id` in their exclude set we should
-  /// honor it — there's nothing to protect.
-  func testInsertIdIsNotReserved() {
-    var props = buildSampleEventProps()
-    Track.applyExcludeProperties(&props, exclude: ["$insert_id"])
-    XCTAssertNil(props["$insert_id"])
-  }
+    func testStripsAutoProperty() {
+        var props = buildSampleEventProps()
+        Track.applyExcludeProperties(&props, exclude: ["$screen_height"])
+        XCTAssertNil(props["$screen_height"])
+        // Adjacent auto-props remain untouched.
+        XCTAssertNotNil(props["$screen_width"])
+        XCTAssertNotNil(props["$lib_version"])
+    }
 
-  func testMultiplePropertiesStripped() {
-    var props = buildSampleEventProps()
-    let exclude: Set<String> = [
-      "$screen_height", "$screen_width", "$carrier", "custom_user_prop",
-    ]
+    func testStripsCustomUserProperty() {
+        var props = buildSampleEventProps()
+        Track.applyExcludeProperties(&props, exclude: ["custom_user_prop"])
+        XCTAssertNil(props["custom_user_prop"])
+    }
 
-    Track.applyExcludeProperties(&props, exclude: exclude)
+    func testReservedKeysAreNeverStripped() {
+        var props = buildSampleEventProps()
+        // Drive the test from the canonical reserved set so adding a new reserved key
+        // here automatically tightens this test rather than leaving it stale.
+        let exclude = MixpanelOptions.reservedPropertyKeys
 
-    XCTAssertNil(props["$screen_height"])
-    XCTAssertNil(props["$screen_width"])
-    XCTAssertNil(props["$carrier"])
-    XCTAssertNil(props["custom_user_prop"])
-    // Untouched samples
-    XCTAssertNotNil(props["$os"])
-    XCTAssertNotNil(props["$lib_version"])
-  }
+        // Sanity check: every reserved key we're about to try to exclude is actually
+        // present in the sample, otherwise the test would silently pass for missing keys.
+        for key in MixpanelOptions.reservedPropertyKeys {
+            XCTAssertNotNil(props[key], "Sample event props is missing reserved key \(key)")
+        }
 
-  func testExcludedKeyNotPresentIsNoOp() {
-    var props = buildSampleEventProps()
-    let before = props.count
-    Track.applyExcludeProperties(&props, exclude: ["never_added"])
-    XCTAssertEqual(props.count, before)
-  }
+        Track.applyExcludeProperties(&props, exclude: exclude)
 
-  // MARK: - End-to-end integration tests
+        for key in MixpanelOptions.reservedPropertyKeys {
+            XCTAssertNotNil(props[key], "Reserved key was stripped: \(key)")
+        }
+    }
 
-  /// Pick the event by name — `identify` (and other auto-events) can land on the queue
-  /// alongside the event under test, so `.last!` is unreliable.
-  private func findEvent(
-    in mixpanel: MixpanelInstance, named eventName: String
-  ) -> InternalProperties? {
-    return eventQueue(token: mixpanel.apiToken).first(where: {
-      ($0["event"] as? String) == eventName
-    })
-  }
+    /// `$insert_id` is in the Mixpanel ingestion vocabulary but this SDK never writes it
+    /// (we use `$mp_event_id` inside `$mp_metadata` for dedup, which lives outside the
+    /// properties bag). If a customer lists `$insert_id` in their exclude set we should
+    /// honor it — there's nothing to protect.
+    func testInsertIdIsNotReserved() {
+        var props = buildSampleEventProps()
+        Track.applyExcludeProperties(&props, exclude: ["$insert_id"])
+        XCTAssertNil(props["$insert_id"])
+    }
 
-  func testExcludePropertiesStripsAutoAndCustomFromQueuedEvent() {
-    let token = randomId()
-    let options = MixpanelOptions(
-      token: token,
-      flushInterval: 60,
-      excludeProperties: ["$lib_version", "custom_prop"])
-    let testMixpanel = Mixpanel.initialize(options: options)
-    testMixpanel.track(event: "test_event", properties: ["custom_prop": "v", "keep_me": "yes"])
-    waitForTrackingQueue(testMixpanel)
+    func testMultiplePropertiesStripped() {
+        var props = buildSampleEventProps()
+        let exclude: Set<String> = [
+            "$screen_height", "$screen_width", "$carrier", "custom_user_prop",
+        ]
 
-    let event = findEvent(in: testMixpanel, named: "test_event")!
-    let props = event["properties"] as! InternalProperties
+        Track.applyExcludeProperties(&props, exclude: exclude)
 
-    // Excluded keys are gone.
-    XCTAssertNil(props["$lib_version"])
-    XCTAssertNil(props["custom_prop"])
-    // Non-excluded custom property survives.
-    XCTAssertEqual(props["keep_me"] as? String, "yes")
-    // Reserved keys still present.
-    XCTAssertNotNil(props["token"])
-    XCTAssertNotNil(props["time"])
-    XCTAssertNotNil(props["distinct_id"])
-    // $mp_metadata lives at the envelope level, not inside properties — confirm it
-    // survives at the envelope (the filter's scope ends at `properties`).
-    XCTAssertNotNil(event["$mp_metadata"])
+        XCTAssertNil(props["$screen_height"])
+        XCTAssertNil(props["$screen_width"])
+        XCTAssertNil(props["$carrier"])
+        XCTAssertNil(props["custom_user_prop"])
+        // Untouched samples
+        XCTAssertNotNil(props["$os"])
+        XCTAssertNotNil(props["$lib_version"])
+    }
 
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testExcludedKeyNotPresentIsNoOp() {
+        var props = buildSampleEventProps()
+        let before = props.count
+        Track.applyExcludeProperties(&props, exclude: ["never_added"])
+        XCTAssertEqual(props.count, before)
+    }
 
-  func testExcludePropertiesCannotStripReservedKeysEndToEnd() {
-    let token = randomId()
-    let options = MixpanelOptions(
-      token: token,
-      flushInterval: 60,
-      // Customer mistakenly lists a reserved key — must still be sent.
-      excludeProperties: ["distinct_id", "token"])
-    let testMixpanel = Mixpanel.initialize(options: options)
-    testMixpanel.track(event: "test_event")
-    waitForTrackingQueue(testMixpanel)
+    // MARK: - End-to-end integration tests
 
-    let event = findEvent(in: testMixpanel, named: "test_event")!
-    let props = event["properties"] as! InternalProperties
-    XCTAssertNotNil(props["distinct_id"], "reserved key distinct_id was stripped")
-    XCTAssertNotNil(props["token"], "reserved key token was stripped")
+    /// Pick the event by name — `identify` (and other auto-events) can land on the queue
+    /// alongside the event under test, so `.last!` is unreliable.
+    private func findEvent(
+        in mixpanel: MixpanelInstance, named eventName: String
+    ) -> InternalProperties? {
+        return eventQueue(token: mixpanel.apiToken).first(where: {
+            ($0["event"] as? String) == eventName
+        })
+    }
 
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testExcludePropertiesStripsAutoAndCustomFromQueuedEvent() {
+        let token = randomId()
+        let options = MixpanelOptions(
+            token: token,
+            flushInterval: 60,
+            excludeProperties: ["$lib_version", "custom_prop"])
+        let testMixpanel = Mixpanel.initialize(options: options)
+        testMixpanel.track(event: "test_event", properties: ["custom_prop": "v", "keep_me": "yes"])
+        waitForTrackingQueue(testMixpanel)
 
-  func testDefaultOptionsStripNothing() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: false, flushInterval: 60)
-    testMixpanel.track(event: "test_event", properties: ["custom_prop": "v"])
-    waitForTrackingQueue(testMixpanel)
+        let event = findEvent(in: testMixpanel, named: "test_event")!
+        let props = event["properties"] as! InternalProperties
 
-    let event = findEvent(in: testMixpanel, named: "test_event")!
-    let props = event["properties"] as! InternalProperties
-    XCTAssertEqual(props["custom_prop"] as? String, "v")
-    XCTAssertNotNil(props["$lib_version"])
+        // Excluded keys are gone.
+        XCTAssertNil(props["$lib_version"])
+        XCTAssertNil(props["custom_prop"])
+        // Non-excluded custom property survives.
+        XCTAssertEqual(props["keep_me"] as? String, "yes")
+        // Reserved keys still present.
+        XCTAssertNotNil(props["token"])
+        XCTAssertNotNil(props["time"])
+        XCTAssertNotNil(props["distinct_id"])
+        // $mp_metadata lives at the envelope level, not inside properties — confirm it
+        // survives at the envelope (the filter's scope ends at `properties`).
+        XCTAssertNotNil(event["$mp_metadata"])
 
-    removeDBfile(testMixpanel.apiToken)
-  }
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-  // MARK: - People exclude tests
+    func testExcludePropertiesCannotStripReservedKeysEndToEnd() {
+        let token = randomId()
+        let options = MixpanelOptions(
+            token: token,
+            flushInterval: 60,
+            // Customer mistakenly lists a reserved key — must still be sent.
+            excludeProperties: ["distinct_id", "token"])
+        let testMixpanel = Mixpanel.initialize(options: options)
+        testMixpanel.track(event: "test_event")
+        waitForTrackingQueue(testMixpanel)
 
-  /// Pick the People record by action key (`$set`, `$set_once`, `$add`, …). After
-  /// `identify` + a People call, the queue contains both the identify-driven merge
-  /// and the test's own action, so action-name matching is the reliable filter.
-  private func findPeopleRecord(
-    in mixpanel: MixpanelInstance, action: String
-  ) -> InternalProperties? {
-    return peopleQueue(token: mixpanel.apiToken).first(where: { $0[action] != nil })
-  }
+        let event = findEvent(in: testMixpanel, named: "test_event")!
+        let props = event["properties"] as! InternalProperties
+        XCTAssertNotNil(props["distinct_id"], "reserved key distinct_id was stripped")
+        XCTAssertNotNil(props["token"], "reserved key token was stripped")
 
-  func testExcludePropertiesStripsAutoAndCustomFromPeopleSet() {
-    let token = randomId()
-    let options = MixpanelOptions(
-      token: token,
-      flushInterval: 60,
-      excludeProperties: ["$ios_lib_version", "secret_prop"])
-    let testMixpanel = Mixpanel.initialize(options: options)
-    testMixpanel.identify(distinctId: "u1")
-    testMixpanel.people.set(properties: ["secret_prop": "x", "keep_me": "y"])
-    waitForTrackingQueue(testMixpanel)
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-    let record = peopleQueue(token: testMixpanel.apiToken).first(where: { $0["$set"] != nil })!
-    let bag = record["$set"] as! InternalProperties
+    func testDefaultOptionsStripNothing() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: false, flushInterval: 60)
+        testMixpanel.track(event: "test_event", properties: ["custom_prop": "v"])
+        waitForTrackingQueue(testMixpanel)
 
-    // Excluded auto-prop and custom prop are stripped.
-    XCTAssertNil(bag["$ios_lib_version"])
-    XCTAssertNil(bag["secret_prop"])
-    // Non-excluded custom prop survives.
-    XCTAssertEqual(bag["keep_me"] as? String, "y")
-    // Other auto-props are untouched.
-    XCTAssertNotNil(bag["$ios_device_model"])
-    // Envelope-level routing keys live outside the bag and are unaffected.
-    XCTAssertNotNil(record["$token"])
-    XCTAssertNotNil(record["$distinct_id"])
+        let event = findEvent(in: testMixpanel, named: "test_event")!
+        let props = event["properties"] as! InternalProperties
+        XCTAssertEqual(props["custom_prop"] as? String, "v")
+        XCTAssertNotNil(props["$lib_version"])
 
-    removeDBfile(testMixpanel.apiToken)
-  }
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-  /// Swift-specific deviation from Android: this SDK merges
-  /// `AutomaticProperties.peopleProperties` into both `$set` and `$set_once`, so the
-  /// filter runs on `$set_once` here. Android only merges into `$set` and filters
-  /// accordingly.
-  func testExcludePropertiesAppliesToPeopleSetOnce() {
-    let token = randomId()
-    let options = MixpanelOptions(
-      token: token,
-      flushInterval: 60,
-      excludeProperties: ["$ios_lib_version", "secret_prop"])
-    let testMixpanel = Mixpanel.initialize(options: options)
-    testMixpanel.identify(distinctId: "u1")
-    testMixpanel.people.setOnce(properties: ["secret_prop": "x", "keep_me": "y"])
-    waitForTrackingQueue(testMixpanel)
+    // MARK: - People exclude tests
 
-    let record = findPeopleRecord(in: testMixpanel, action: "$set_once")!
-    let bag = record["$set_once"] as! InternalProperties
+    /// Pick the People record by action key (`$set`, `$set_once`, `$add`, …). After
+    /// `identify` + a People call, the queue contains both the identify-driven merge
+    /// and the test's own action, so action-name matching is the reliable filter.
+    private func findPeopleRecord(
+        in mixpanel: MixpanelInstance, action: String
+    ) -> InternalProperties? {
+        return peopleQueue(token: mixpanel.apiToken).first(where: { $0[action] != nil })
+    }
 
-    XCTAssertNil(bag["$ios_lib_version"])
-    XCTAssertNil(bag["secret_prop"])
-    XCTAssertEqual(bag["keep_me"] as? String, "y")
-    XCTAssertNotNil(bag["$ios_device_model"])
+    func testExcludePropertiesStripsAutoAndCustomFromPeopleSet() {
+        let token = randomId()
+        let options = MixpanelOptions(
+            token: token,
+            flushInterval: 60,
+            excludeProperties: ["$ios_lib_version", "secret_prop"])
+        let testMixpanel = Mixpanel.initialize(options: options)
+        testMixpanel.identify(distinctId: "u1")
+        testMixpanel.people.set(properties: ["secret_prop": "x", "keep_me": "y"])
+        waitForTrackingQueue(testMixpanel)
 
-    removeDBfile(testMixpanel.apiToken)
-  }
+        let record = peopleQueue(token: testMixpanel.apiToken).first(where: { $0["$set"] != nil })!
+        let bag = record["$set"] as! InternalProperties
 
-  /// Mutating operators (`$add`, `$append`, `$union`, `$unset`) treat the bag as
-  /// operands rather than a property dictionary to mutate; the filter must NOT
-  /// touch them, since stripping a key from e.g. an `$unset` list would silently
-  /// change the operation's meaning.
-  func testExcludePropertiesPassThroughForMutatingPeopleOperators() {
-    let token = randomId()
-    let options = MixpanelOptions(
-      token: token,
-      flushInterval: 60,
-      excludeProperties: ["secret_prop"])
-    let testMixpanel = Mixpanel.initialize(options: options)
-    testMixpanel.identify(distinctId: "u1")
+        // Excluded auto-prop and custom prop are stripped.
+        XCTAssertNil(bag["$ios_lib_version"])
+        XCTAssertNil(bag["secret_prop"])
+        // Non-excluded custom prop survives.
+        XCTAssertEqual(bag["keep_me"] as? String, "y")
+        // Other auto-props are untouched.
+        XCTAssertNotNil(bag["$ios_device_model"])
+        // Envelope-level routing keys live outside the bag and are unaffected.
+        XCTAssertNotNil(record["$token"])
+        XCTAssertNotNil(record["$distinct_id"])
 
-    testMixpanel.people.increment(property: "secret_prop", by: 1)
-    testMixpanel.people.append(properties: ["secret_prop": "v"])
-    testMixpanel.people.union(properties: ["secret_prop": ["v"]])
-    testMixpanel.people.unset(properties: ["secret_prop"])
-    waitForTrackingQueue(testMixpanel)
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-    XCTAssertEqual(
-      (findPeopleRecord(in: testMixpanel, action: "$add")!["$add"] as! InternalProperties)[
-        "secret_prop"] as? Double, 1, "$add must not be filtered")
-    XCTAssertEqual(
-      (findPeopleRecord(in: testMixpanel, action: "$append")!["$append"] as! InternalProperties)[
-        "secret_prop"] as? String, "v", "$append must not be filtered")
-    XCTAssertNotNil(
-      (findPeopleRecord(in: testMixpanel, action: "$union")!["$union"] as! InternalProperties)[
-        "secret_prop"], "$union must not be filtered")
-    // $unset stores the property names as an array under the action key.
-    let unsetNames = findPeopleRecord(in: testMixpanel, action: "$unset")!["$unset"] as! [String]
-    XCTAssertTrue(
-      unsetNames.contains("secret_prop"),
-      "$unset operand list must not be filtered (would silently change semantics)")
+    /// Swift-specific deviation from Android: this SDK merges
+    /// `AutomaticProperties.peopleProperties` into both `$set` and `$set_once`, so the
+    /// filter runs on `$set_once` here. Android only merges into `$set` and filters
+    /// accordingly.
+    func testExcludePropertiesAppliesToPeopleSetOnce() {
+        let token = randomId()
+        let options = MixpanelOptions(
+            token: token,
+            flushInterval: 60,
+            excludeProperties: ["$ios_lib_version", "secret_prop"])
+        let testMixpanel = Mixpanel.initialize(options: options)
+        testMixpanel.identify(distinctId: "u1")
+        testMixpanel.people.setOnce(properties: ["secret_prop": "x", "keep_me": "y"])
+        waitForTrackingQueue(testMixpanel)
 
-    removeDBfile(testMixpanel.apiToken)
-  }
+        let record = findPeopleRecord(in: testMixpanel, action: "$set_once")!
+        let bag = record["$set_once"] as! InternalProperties
+
+        XCTAssertNil(bag["$ios_lib_version"])
+        XCTAssertNil(bag["secret_prop"])
+        XCTAssertEqual(bag["keep_me"] as? String, "y")
+        XCTAssertNotNil(bag["$ios_device_model"])
+
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    /// Mutating operators (`$add`, `$append`, `$union`, `$unset`) treat the bag as
+    /// operands rather than a property dictionary to mutate; the filter must NOT
+    /// touch them, since stripping a key from e.g. an `$unset` list would silently
+    /// change the operation's meaning.
+    func testExcludePropertiesPassThroughForMutatingPeopleOperators() {
+        let token = randomId()
+        let options = MixpanelOptions(
+            token: token,
+            flushInterval: 60,
+            excludeProperties: ["secret_prop"])
+        let testMixpanel = Mixpanel.initialize(options: options)
+        testMixpanel.identify(distinctId: "u1")
+
+        testMixpanel.people.increment(property: "secret_prop", by: 1)
+        testMixpanel.people.append(properties: ["secret_prop": "v"])
+        testMixpanel.people.union(properties: ["secret_prop": ["v"]])
+        testMixpanel.people.unset(properties: ["secret_prop"])
+        waitForTrackingQueue(testMixpanel)
+
+        XCTAssertEqual(
+            (findPeopleRecord(in: testMixpanel, action: "$add")!["$add"] as! InternalProperties)[
+                "secret_prop"] as? Double, 1, "$add must not be filtered")
+        XCTAssertEqual(
+            (findPeopleRecord(in: testMixpanel, action: "$append")!["$append"] as! InternalProperties)[
+                "secret_prop"] as? String, "v", "$append must not be filtered")
+        XCTAssertNotNil(
+            (findPeopleRecord(in: testMixpanel, action: "$union")!["$union"] as! InternalProperties)[
+                "secret_prop"], "$union must not be filtered")
+        // $unset stores the property names as an array under the action key.
+        let unsetNames = findPeopleRecord(in: testMixpanel, action: "$unset")!["$unset"] as! [String]
+        XCTAssertTrue(
+            unsetNames.contains("secret_prop"),
+            "$unset operand list must not be filtered (would silently change semantics)")
+
+        removeDBfile(testMixpanel.apiToken)
+    }
 }

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
@@ -26,28 +26,28 @@ import XCTest
 // these persistence tests actually exercise.
 
 private final class PersistenceTestMockDelegate: MixpanelFlagDelegate {
-  var options: MixpanelOptions
-  var distinctId: String
-  var anonymousId: String?
-  var trackedEvents: [(event: String?, properties: Properties?)] = []
-  private let trackQueue = DispatchQueue(label: "persistence.test.mock.track")
+    var options: MixpanelOptions
+    var distinctId: String
+    var anonymousId: String?
+    var trackedEvents: [(event: String?, properties: Properties?)] = []
+    private let trackQueue = DispatchQueue(label: "persistence.test.mock.track")
 
-  init(options: MixpanelOptions, distinctId: String, anonymousId: String? = nil) {
-    self.options = options
-    self.distinctId = distinctId
-    self.anonymousId = anonymousId
-  }
+    init(options: MixpanelOptions, distinctId: String, anonymousId: String? = nil) {
+        self.options = options
+        self.distinctId = distinctId
+        self.anonymousId = anonymousId
+    }
 
-  func getOptions() -> MixpanelOptions { return options }
-  func getDistinctId() -> String { return distinctId }
-  func getAnonymousId() -> String? { return anonymousId }
-  func track(event: String?, properties: Properties?) {
-    trackQueue.sync { trackedEvents.append((event: event, properties: properties)) }
-  }
+    func getOptions() -> MixpanelOptions { return options }
+    func getDistinctId() -> String { return distinctId }
+    func getAnonymousId() -> String? { return anonymousId }
+    func track(event: String?, properties: Properties?) {
+        trackQueue.sync { trackedEvents.append((event: event, properties: properties)) }
+    }
 
-  func snapshotTrackedEvents() -> [(event: String?, properties: Properties?)] {
-    return trackQueue.sync { trackedEvents }
-  }
+    func snapshotTrackedEvents() -> [(event: String?, properties: Properties?)] {
+        return trackQueue.sync { trackedEvents }
+    }
 }
 
 /// Minimal mock of FeatureFlagManager that intercepts the network call. Deliberately
@@ -55,1401 +55,1427 @@ private final class PersistenceTestMockDelegate: MixpanelFlagDelegate {
 /// `loadedBlobPersistedAt` lifecycle, completion fan-out) so async-lookup tests can
 /// verify behavior end-to-end.
 private final class PersistenceTestMockManager: FeatureFlagManager {
-  var simulatedFetchResult: (success: Bool, flags: [String: MixpanelFlagVariant]?)?
-  var simulatedNetworkDelay: TimeInterval = 0.1
-  private let fetchCountQueue = DispatchQueue(label: "ff.mock.fetchcount.\(UUID().uuidString)")
-  private var _fetchCallCount = 0
-  var fetchCallCount: Int { fetchCountQueue.sync { _fetchCallCount } }
+    var simulatedFetchResult: (success: Bool, flags: [String: MixpanelFlagVariant]?)?
+    var simulatedNetworkDelay: TimeInterval = 0.1
+    private let fetchCountQueue = DispatchQueue(label: "ff.mock.fetchcount.\(UUID().uuidString)")
+    private var _fetchCallCount = 0
+    var fetchCallCount: Int { fetchCountQueue.sync { _fetchCallCount } }
 
-  override func _performFetchRequest() {
-    fetchCountQueue.sync { _fetchCallCount += 1 }
-    let work: () -> Void = { [weak self] in
-      guard let self = self else { return }
-      guard let result = self.simulatedFetchResult else {
-        self._completeFetch(success: false)
-        return
-      }
-      if result.success, let flags = result.flags {
-        let stamped = flags.mapValues { $0.withSource(.network) }
-        self.flagsLock.write {
-          self.flags = stamped
-          // Mirror production: a successful fetch overwrites the persisted blob (so the
-          // marker clears) and resets the per-flag $experiment_started dedup window.
-          self.loadedBlobPersistedAt = nil
-          self.trackedFeatures.removeAll()
-          self.timeLastFetched = Date()
+    override func _performFetchRequest() {
+        fetchCountQueue.sync { _fetchCallCount += 1 }
+        let work: () -> Void = { [weak self] in
+            guard let self = self else { return }
+            guard let result = self.simulatedFetchResult else {
+                self._completeFetch(success: false)
+                return
+            }
+            if result.success, let flags = result.flags {
+                let stamped = flags.mapValues { $0.withSource(.network) }
+                self.flagsLock.write {
+                    self.flags = stamped
+                    // Mirror production: a successful fetch overwrites the persisted blob (so the
+                    // marker clears) and resets the per-flag $experiment_started dedup window.
+                    self.loadedBlobPersistedAt = nil
+                    self.trackedFeatures.removeAll()
+                    self.timeLastFetched = Date()
+                }
+                self._completeFetch(success: true)
+            } else {
+                // Failure: leave `flags` AND `loadedBlobPersistedAt` in place. NetworkFirst's
+                // `isNetworkFirstAwaitingFetch()` derives from the persisted-blob marker, so the
+                // gate stays true after a failure and the next async lookup retries the network.
+                self._completeFetch(success: false)
+            }
         }
-        self._completeFetch(success: true)
-      } else {
-        // Failure: leave `flags` AND `loadedBlobPersistedAt` in place. NetworkFirst's
-        // `isNetworkFirstAwaitingFetch()` derives from the persisted-blob marker, so the
-        // gate stays true after a failure and the next async lookup retries the network.
-        self._completeFetch(success: false)
-      }
+        if simulatedNetworkDelay > 0 {
+            DispatchQueue.global().asyncAfter(deadline: .now() + simulatedNetworkDelay, execute: work)
+        } else {
+            work()
+        }
     }
-    if simulatedNetworkDelay > 0 {
-      DispatchQueue.global().asyncAfter(deadline: .now() + simulatedNetworkDelay, execute: work)
-    } else {
-      work()
-    }
-  }
 
-  // No-op so we don't fire real first-time-event recording requests.
-  override func recordFirstTimeEvent(
-    flagId: String, projectId: Int, firstTimeEventHash: String, distinctId: String
-  ) {}
+    // No-op so we don't fire real first-time-event recording requests.
+    override func recordFirstTimeEvent(
+        flagId: String, projectId: Int, firstTimeEventHash: String, distinctId: String
+    ) {}
 }
 
 class FeatureFlagPersistenceTests: XCTestCase {
 
-  // Each test uses a unique instance name so UserDefaults state from one test can't bleed
-  // into another. Writes go to the shared "Mixpanel" suite, but the per-instance prefix
-  // keys keep them isolated.
-  private var instanceName: String!
+    // Each test uses a unique instance name so UserDefaults state from one test can't bleed
+    // into another. Writes go to the shared "Mixpanel" suite, but the per-instance prefix
+    // keys keep them isolated.
+    private var instanceName: String!
 
-  // FeatureFlagManager.delegate is `weak`. Tests build delegates inside helper methods, so
-  // unless the test instance holds a strong ref the delegate gets deallocated as soon as the
-  // helper returns and `delegate?.getOptions()` returns nil. Stash all created delegates
-  // here for the test's lifetime.
-  private var retainedDelegates: [MixpanelFlagDelegate] = []
+    // FeatureFlagManager.delegate is `weak`. Tests build delegates inside helper methods, so
+    // unless the test instance holds a strong ref the delegate gets deallocated as soon as the
+    // helper returns and `delegate?.getOptions()` returns nil. Stash all created delegates
+    // here for the test's lifetime.
+    private var retainedDelegates: [MixpanelFlagDelegate] = []
 
-  override func setUpWithError() throws {
-    try super.setUpWithError()
-    instanceName = "fftest-\(UUID().uuidString)"
-  }
-
-  override func tearDownWithError() throws {
-    MixpanelPersistence.deleteFlagsPersistence(instanceName: instanceName)
-    instanceName = nil
-    retainedDelegates.removeAll()
-    try super.tearDownWithError()
-  }
-
-  // MARK: - Persistence layer
-
-  func testSaveAndLoadRoundTrip() throws {
-    let blob = FlagsPersistenceBlob(
-      persistedAt: Date(timeIntervalSince1970: 1_700_000_000),
-      distinctId: "user_a",
-      response: #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
-    )
-
-    MixpanelPersistence.saveFlagsPersistence(blob, instanceName: instanceName)
-    let loaded = MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName)
-
-    let loadedBlob = try XCTUnwrap(loaded)
-    XCTAssertEqual(loadedBlob.distinctId, blob.distinctId)
-    XCTAssertEqual(loadedBlob.response, blob.response)
-    XCTAssertEqual(
-      loadedBlob.persistedAt.timeIntervalSince1970,
-      blob.persistedAt.timeIntervalSince1970, accuracy: 0.001)
-  }
-
-  func testLoadReturnsNilWhenNothingPersisted() {
-    XCTAssertNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
-  }
-
-  func testDeleteRemovesBlob() {
-    let blob = FlagsPersistenceBlob(
-      persistedAt: Date(), distinctId: "user_x", response: "{}")
-    MixpanelPersistence.saveFlagsPersistence(blob, instanceName: instanceName)
-    XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
-
-    MixpanelPersistence.deleteFlagsPersistence(instanceName: instanceName)
-    XCTAssertNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
-  }
-
-  func testMalformedBlobIsSelfHealed() {
-    // Write a non-JSON byte sequence directly to the same key the persistence layer uses.
-    let defaults = UserDefaults(suiteName: "Mixpanel")!
-    let key = "mixpanel-\(instanceName!)-MPFlagsPersistence"
-    defaults.set(Data([0xFF, 0xFE, 0xFD]), forKey: key)
-
-    // Read should return nil AND clear the blob so we don't keep failing on every load.
-    XCTAssertNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
-    XCTAssertNil(defaults.data(forKey: key))
-  }
-
-  func testWellFormedJSONWithUnexpectedShapeIsSelfHealed() {
-    // Valid JSON but wrong shape (missing required keys) should also self-heal.
-    let defaults = UserDefaults(suiteName: "Mixpanel")!
-    let key = "mixpanel-\(instanceName!)-MPFlagsPersistence"
-    let bogus = #"{"unexpected":"shape"}"#.data(using: .utf8)!
-    defaults.set(bogus, forKey: key)
-
-    XCTAssertNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
-    XCTAssertNil(defaults.data(forKey: key))
-  }
-
-  // MARK: - Source stamping
-
-  func testWithSourceStampsAndPreservesOtherFields() {
-    let original = MixpanelFlagVariant(
-      key: "k", value: "v", isExperimentActive: true, isQATester: false, experimentID: "exp_1")
-    let stamped = original.withSource(.network)
-
-    XCTAssertEqual(stamped.key, "k")
-    XCTAssertEqual(stamped.value as? String, "v")
-    XCTAssertEqual(stamped.experimentID, "exp_1")
-    XCTAssertEqual(stamped.isExperimentActive, true)
-    XCTAssertEqual(stamped.isQATester, false)
-    if case .network = stamped.source {} else { XCTFail("expected .network source") }
-
-    let persistedAt = Date(timeIntervalSince1970: 1_700_000_000)
-    let persistenceStamped = original.withSource(.persistence(persistedAt: persistedAt))
-    if case .persistence(let at) = persistenceStamped.source {
-      XCTAssertEqual(at.timeIntervalSince1970, persistedAt.timeIntervalSince1970, accuracy: 0.001)
-    } else {
-      XCTFail("expected .persistence source")
-    }
-  }
-
-  func testFallbackVariantsHaveFallbackSource() {
-    let fallback = MixpanelFlagVariant(value: "default")
-    if case .fallback = fallback.source {} else {
-      XCTFail("developer-supplied variants should carry .fallback source")
-    }
-  }
-
-  // MARK: - Default TTL
-
-  /// `VariantLookupPolicy.defaultTTL` is 24 hours, and the zero-arg static factories
-  /// `persistenceUntilNetworkSuccess()` / `networkFirst()` produce cases keyed to that default. This also
-  /// exercises the case-plus-static-func overload pattern (different parameter lists, so
-  /// `.persistenceUntilNetworkSuccess()` and `.persistenceUntilNetworkSuccess(persistenceTtl:)` resolve to different members).
-  func testDefaultTTLConvenienceConstructors() throws {
-    XCTAssertEqual(VariantLookupPolicy.defaultTTL, 24 * 60 * 60, "default TTL should be 24 hours")
-
-    let convenientPersistenceUntilNetworkSuccess = VariantLookupPolicy.persistenceUntilNetworkSuccess()
-    if case .persistenceUntilNetworkSuccess(let ttl) = convenientPersistenceUntilNetworkSuccess {
-      XCTAssertEqual(ttl, VariantLookupPolicy.defaultTTL)
-    } else {
-      XCTFail("convenience persistenceUntilNetworkSuccess() should produce .persistenceUntilNetworkSuccess case")
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        instanceName = "fftest-\(UUID().uuidString)"
     }
 
-    let convenientNetworkFirst = VariantLookupPolicy.networkFirst()
-    if case .networkFirst(let ttl) = convenientNetworkFirst {
-      XCTAssertEqual(ttl, VariantLookupPolicy.defaultTTL)
-    } else {
-      XCTFail("convenience networkFirst() should produce .networkFirst case")
-    }
-  }
-
-  /// Factories preserve exactly what was asked — they don't sanitize. The "non-positive TTL
-  /// becomes networkOnly" rule is enforced at SDK init via `VariantLookupPolicy.effective(_:)`,
-  /// not at construction time, so callers can introspect what they configured.
-  func testFactoriesPreserveExactTtl() throws {
-    if case .persistenceUntilNetworkSuccess(let t) = VariantLookupPolicy.persistenceUntilNetworkSuccess(persistenceTtl: -1) {
-      XCTAssertEqual(t, -1)
-    } else {
-      XCTFail("expected .persistenceUntilNetworkSuccess case")
-    }
-    if case .persistenceUntilNetworkSuccess(let t) = VariantLookupPolicy.persistenceUntilNetworkSuccess(persistenceTtl: 0) {
-      XCTAssertEqual(t, 0)
-    } else {
-      XCTFail("expected .persistenceUntilNetworkSuccess case")
-    }
-    if case .networkFirst(let t) = VariantLookupPolicy.networkFirst(persistenceTtl: -100) {
-      XCTAssertEqual(t, -100)
-    } else {
-      XCTFail("expected .networkFirst case")
-    }
-  }
-
-  /// Persisting policies with TTL <= 0 do no useful work (we'd write to disk on every fetch
-  /// but never serve anything from persistence) so the SDK substitutes `.networkOnly` at init.
-  func testEffectivePolicyNonPositiveTtlBecomesNetworkOnly() throws {
-    let resolvedNegativePersistence = VariantLookupPolicy.effective(.persistenceUntilNetworkSuccess(persistenceTtl: -1))
-    if case .networkOnly = resolvedNegativePersistence {} else {
-      XCTFail("negative TTL on persistenceUntilNetworkSuccess should resolve to .networkOnly")
+    override func tearDownWithError() throws {
+        MixpanelPersistence.deleteFlagsPersistence(instanceName: instanceName)
+        instanceName = nil
+        retainedDelegates.removeAll()
+        try super.tearDownWithError()
     }
 
-    let resolvedZeroPersistence = VariantLookupPolicy.effective(.persistenceUntilNetworkSuccess(persistenceTtl: 0))
-    if case .networkOnly = resolvedZeroPersistence {} else {
-      XCTFail("zero TTL on persistenceUntilNetworkSuccess should resolve to .networkOnly")
+    // MARK: - Persistence layer
+
+    func testSaveAndLoadRoundTrip() throws {
+        let blob = FlagsPersistenceBlob(
+            persistedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            distinctId: "user_a",
+            response: #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+        )
+
+        MixpanelPersistence.saveFlagsPersistence(blob, instanceName: instanceName)
+        let loaded = MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName)
+
+        let loadedBlob = try XCTUnwrap(loaded)
+        XCTAssertEqual(loadedBlob.distinctId, blob.distinctId)
+        XCTAssertEqual(loadedBlob.response, blob.response)
+        XCTAssertEqual(
+            loadedBlob.persistedAt.timeIntervalSince1970,
+            blob.persistedAt.timeIntervalSince1970, accuracy: 0.001)
     }
 
-    let resolvedNegativeNetworkFirst = VariantLookupPolicy.effective(.networkFirst(persistenceTtl: -100))
-    if case .networkOnly = resolvedNegativeNetworkFirst {} else {
-      XCTFail("negative TTL on networkFirst should resolve to .networkOnly")
+    func testLoadReturnsNilWhenNothingPersisted() {
+        XCTAssertNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
     }
 
-    let resolvedZeroNetworkFirst = VariantLookupPolicy.effective(.networkFirst(persistenceTtl: 0))
-    if case .networkOnly = resolvedZeroNetworkFirst {} else {
-      XCTFail("zero TTL on networkFirst should resolve to .networkOnly")
-    }
-  }
+    func testDeleteRemovesBlob() {
+        let blob = FlagsPersistenceBlob(
+            persistedAt: Date(), distinctId: "user_x", response: "{}")
+        MixpanelPersistence.saveFlagsPersistence(blob, instanceName: instanceName)
+        XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
-  /// Sanity: non-degenerate configurations pass through `effective(_:)` unchanged.
-  func testEffectivePolicyPositiveTtlPreserved() throws {
-    let persistence = VariantLookupPolicy.persistenceUntilNetworkSuccess(persistenceTtl: 3600)
-    if case .persistenceUntilNetworkSuccess(let t) = VariantLookupPolicy.effective(persistence) {
-      XCTAssertEqual(t, 3600)
-    } else {
-      XCTFail("positive TTL should pass through unchanged")
+        MixpanelPersistence.deleteFlagsPersistence(instanceName: instanceName)
+        XCTAssertNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
     }
 
-    let networkOnly = VariantLookupPolicy.networkOnly
-    if case .networkOnly = VariantLookupPolicy.effective(networkOnly) {} else {
-      XCTFail(".networkOnly should pass through unchanged")
-    }
-  }
+    func testMalformedBlobIsSelfHealed() {
+        // Write a non-JSON byte sequence directly to the same key the persistence layer uses.
+        let defaults = UserDefaults(suiteName: "Mixpanel")!
+        let key = "mixpanel-\(instanceName!)-MPFlagsPersistence"
+        defaults.set(Data([0xFF, 0xFE, 0xFD]), forKey: key)
 
-  /// End-to-end check: configuring the SDK with a persisting policy + non-positive TTL means
-  /// no persistence happens at runtime — the SDK behaves as if `.networkOnly` was configured.
-  func testNonPositiveTtlPersistingPolicyBehavesAsNetworkOnly() throws {
-    // Pre-stage a persisted blob on disk. Under .networkOnly init, the manager should wipe
-    // it (proves the resolved policy is .networkOnly, not the persisting policy the customer
-    // requested).
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
-    MixpanelPersistence.saveFlagsPersistence(
-      FlagsPersistenceBlob(
-        persistedAt: Date(),
-        distinctId: "user_a",
-        response: response),
-      instanceName: instanceName)
-    XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
-
-    let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 0))
-    waitForTrackingQueue(manager: manager)
-
-    XCTAssertFalse(
-      manager.areFlagsReady(),
-      "non-positive TTL should resolve to .networkOnly; nothing loaded from persistence")
-    XCTAssertNil(
-      MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
-      "resolved .networkOnly init should wipe the existing blob")
-  }
-
-  // MARK: - Init loads persisted variants and stamps them
-
-  func testInitLoadsPersistedVariantsAndStampsPersistenceSource() throws {
-    // `Date()` (rather than a fixed-far-past timestamp) so the 86_400s TTL check passes.
-    let persistedAt = Date()
-    let context = ["plan": "enterprise"]
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":42},"flag_b":{"variant_key":"v2","variant_value":"hello"}}}"#
-
-    MixpanelPersistence.saveFlagsPersistence(
-      FlagsPersistenceBlob(persistedAt: persistedAt, distinctId: "user_a", response: response),
-      instanceName: instanceName)
-
-    let manager = makeManager(
-      distinctId: "user_a", context: context, policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
-
-    waitForTrackingQueue(manager: manager)
-
-    XCTAssertTrue(manager.areFlagsReady())
-    let variants = manager.getAllVariantsSync()
-    XCTAssertEqual(variants.count, 2)
-
-    if case .persistence(let at) = variants["flag_a"]?.source {
-      XCTAssertEqual(at.timeIntervalSince1970, persistedAt.timeIntervalSince1970, accuracy: 0.001)
-    } else {
-      XCTFail("flag_a should have .persistence source")
-    }
-    XCTAssertEqual(variants["flag_a"]?.value as? Int, 42)
-    XCTAssertEqual(variants["flag_b"]?.value as? String, "hello")
-  }
-
-  /// distinctId mismatch on init is the cross-session form of "distinctId changed":
-  /// it leaves flags empty AND wipes the stale blob from disk, so the prior identity's
-  /// variants don't sit on this device after the user has moved on.
-  func testInitWipesPersistenceOnDistinctIdMismatch() throws {
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
-    MixpanelPersistence.saveFlagsPersistence(
-      FlagsPersistenceBlob(
-        persistedAt: Date(),
-        distinctId: "different_user",
-        response: response),
-      instanceName: instanceName)
-    XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
-
-    let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
-    waitForTrackingQueue(manager: manager)
-
-    XCTAssertFalse(manager.areFlagsReady(), "distinctId mismatch should leave flags empty")
-    XCTAssertTrue(manager.getAllVariantsSync().isEmpty)
-    XCTAssertNil(
-      MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
-      "distinctId mismatch on init should wipe the stale blob")
-  }
-
-  /// Documents the deliberate decision to key persistence on distinctId only — context changes
-  /// do NOT invalidate the persisted blob. A blob written under one context will load under
-  /// a different context for the same user (in-memory variants will then be stale with respect
-  /// to the new context until the next successful fetch overwrites them).
-  ///
-  /// Customers signaled this tradeoff is acceptable: context rarely flips mid-session in
-  /// practice, and the gain is keeping the persistence layer useful when customers do flip
-  /// between contexts they've used before.
-  func testInitLoadsPersistenceRegardlessOfContextDifference() throws {
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
-    MixpanelPersistence.saveFlagsPersistence(
-      FlagsPersistenceBlob(
-        persistedAt: Date(),
-        // Blob originally persisted under no context.
-        distinctId: "user_a",
-        response: response),
-      instanceName: instanceName)
-
-    // Manager comes up under a different context for the same user.
-    let manager = makeManager(
-      distinctId: "user_a",
-      context: ["plan": "enterprise"],
-      policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
-    waitForTrackingQueue(manager: manager)
-
-    XCTAssertTrue(
-      manager.areFlagsReady(),
-      "context mismatch must NOT invalidate persisted blob when keyed on distinctId only")
-    XCTAssertEqual(manager.getAllVariantsSync().count, 1)
-  }
-
-  func testInitIgnoresPersistenceWhenExpired() throws {
-    let oldDate = Date(timeIntervalSinceNow: -86_400 * 7) // 7 days ago
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
-    MixpanelPersistence.saveFlagsPersistence(
-      FlagsPersistenceBlob(
-        persistedAt: oldDate,
-        distinctId: "user_a",
-        response: response),
-      instanceName: instanceName)
-
-    let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))  // 60s TTL
-    waitForTrackingQueue(manager: manager)
-
-    XCTAssertFalse(manager.areFlagsReady(), "expired entry should be ignored")
-  }
-
-  func testInitClearsPersistedBlobWhenResponseStringIsUnparseable() throws {
-    // Structurally-valid envelope but the `response` string is garbage. Without self-heal
-    // the blob would stick on disk and fail every cold-start. The init-time persistence load
-    // should both ignore it AND wipe it.
-    let blob = FlagsPersistenceBlob(
-      persistedAt: Date(),
-      distinctId: "user_a",
-      response: "this is not json"
-    )
-    MixpanelPersistence.saveFlagsPersistence(blob, instanceName: instanceName)
-    XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
-
-    let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
-    waitForTrackingQueue(manager: manager)
-
-    XCTAssertFalse(manager.areFlagsReady(), "unparseable response should leave flags empty")
-    XCTAssertNil(
-      MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
-      "blob should be wiped so the next successful fetch gets a clean slate")
-  }
-
-  /// `.networkOnly` does two things on init when a stale blob is on disk: (a) doesn't load
-  /// it into memory, and (b) actively wipes it. This way, toggling from a persisting policy
-  /// back to `.networkOnly` cleans up the orphaned blob rather than leaving it stranded.
-  func testInitWipesAndDoesNotLoadPersistenceWhenPolicyIsNetworkOnly() throws {
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
-    MixpanelPersistence.saveFlagsPersistence(
-      FlagsPersistenceBlob(
-        persistedAt: Date(),
-        distinctId: "user_a",
-        response: response),
-      instanceName: instanceName)
-    XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
-
-    let manager = makeManager(distinctId: "user_a", context: [:], policy: .networkOnly)
-    waitForTrackingQueue(manager: manager)
-
-    XCTAssertFalse(manager.areFlagsReady(), ".networkOnly must not load from persistence")
-    XCTAssertNil(
-      MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
-      ".networkOnly init should wipe a stale blob from a previous persisting-policy session")
-  }
-
-  /// Regression test for the init-time race that motivated moving FeatureFlagManager
-  /// construction below `unarchive()` in MixpanelInstance.init.
-  ///
-  /// The async persistence-load block reads `delegate.getDistinctId()` at the moment GCD
-  /// picks it up — NOT at the moment FeatureFlagManager.init dispatched it. This test
-  /// simulates the race by:
-  ///   1. Persisting a blob keyed to "real_user".
-  ///   2. Constructing the manager with a delegate whose distinctId is "wrong_user" — the
-  ///      persistence-load block is queued on a SUSPENDED tracking queue, so it can't run yet.
-  ///   3. Mutating delegate.distinctId to "real_user" (simulating unarchive() loading the
-  ///      persisted identity AFTER FeatureFlagManager init returned).
-  ///   4. Resuming the queue and waiting.
-  /// If the persistence load read distinctId at the right time (block-execution, not
-  /// dispatch), flags load successfully. If we'd snapshotted at dispatch time, this would
-  /// fail.
-  func testPersistenceLoadReadsDistinctIdAtBlockExecutionNotDispatch() throws {
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
-    MixpanelPersistence.saveFlagsPersistence(
-      FlagsPersistenceBlob(
-        persistedAt: Date(),
-        distinctId: "real_user",
-        response: response),
-      instanceName: instanceName)
-
-    let delegate = PersistenceTestMockDelegate(
-      options: MixpanelOptions(
-        token: "test_token",
-        featureFlagOptions: FeatureFlagOptions(
-          enabled: true,
-          variantLookupPolicy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))),
-      distinctId: "wrong_user")
-    retainedDelegates.append(delegate)
-
-    // Suspend the queue BEFORE the manager init so the persistence-load dispatch sits in
-    // the queue without running. Models the worst-case race: GCD couldn't schedule the
-    // worker thread before init's caller continued past the dispatch point.
-    let queue = DispatchQueue(label: "ff.persistence.race.test.\(UUID().uuidString)")
-    queue.suspend()
-    let manager = FeatureFlagManager(
-      serverURL: "https://example.test",
-      trackingQueue: queue,
-      instanceName: instanceName,
-      delegate: delegate)
-
-    // "unarchive() finishes" — the persisted identity is now visible via the delegate.
-    delegate.distinctId = "real_user"
-
-    // Let the persistence load proceed. The waitForTrackingQueue helper posts a barrier
-    // task; because the queue is serial, the persistence load runs first.
-    queue.resume()
-    waitForTrackingQueue(manager: manager)
-
-    XCTAssertTrue(
-      manager.areFlagsReady(),
-      "persistence load should have used the post-mutation distinctId, not the construction-time one")
-    XCTAssertEqual(manager.getAllVariantsSync().count, 1)
-  }
-
-  // MARK: - TTL re-check on get
-  //
-  // The TTL is re-checked on every `getVariant`/`getAllVariants` call (not only at init load
-  // time). Once a `.persistence(persistedAt:)`-stamped variant ages past TTL while sitting in
-  // memory, lookups return the developer fallback rather than the stale value. The on-disk
-  // blob is NOT deleted — the next successful fetch will overwrite it.
-
-  /// A `.persistence(persistedAt:)`-stamped variant that's older than the configured TTL is
-  /// treated as not-present by `getVariantSync` — the developer fallback is returned instead.
-  func testGetVariantSyncReturnsFallbackForExpiredPersistedVariant() throws {
-    let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
-    waitForTrackingQueue(manager: manager)
-
-    // Inject an expired persisted variant directly into in-memory state. Bypasses the disk
-    // load path so we can test the get-time TTL check in isolation. persistedAt is 1 hour
-    // ago, well past the 60s TTL configured above.
-    let persistedAt = Date(timeIntervalSinceNow: -3600)
-    let expired = MixpanelFlagVariant(key: "v1", value: "stale_value")
-      .withSource(.persistence(persistedAt: persistedAt))
-    manager.flagsLock.write {
-      manager.flags = ["flag_a": expired]
-      manager.loadedBlobPersistedAt = persistedAt
+        // Read should return nil AND clear the blob so we don't keep failing on every load.
+        XCTAssertNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
+        XCTAssertNil(defaults.data(forKey: key))
     }
 
-    let fallback = MixpanelFlagVariant(key: "fb", value: "fallback_value")
-    let result = manager.getVariantSync("flag_a", fallback: fallback)
+    func testWellFormedJSONWithUnexpectedShapeIsSelfHealed() {
+        // Valid JSON but wrong shape (missing required keys) should also self-heal.
+        let defaults = UserDefaults(suiteName: "Mixpanel")!
+        let key = "mixpanel-\(instanceName!)-MPFlagsPersistence"
+        let bogus = #"{"unexpected":"shape"}"#.data(using: .utf8)!
+        defaults.set(bogus, forKey: key)
 
-    XCTAssertEqual(result.value as? String, "fallback_value")
-    if case .fallback = result.source {} else {
-      XCTFail("served fallback should carry .fallback source")
-    }
-  }
-
-  /// A `.persistence(persistedAt:)`-stamped variant within TTL is served as-is (with
-  /// `.persistence` source preserved).
-  func testGetVariantSyncReturnsFreshPersistedVariant() throws {
-    let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
-    waitForTrackingQueue(manager: manager)
-
-    let persistedAt = Date(timeIntervalSinceNow: -60)
-    let fresh = MixpanelFlagVariant(key: "v1", value: "fresh_value")
-      .withSource(.persistence(persistedAt: persistedAt))
-    manager.flagsLock.write {
-      manager.flags = ["flag_a": fresh]
-      manager.loadedBlobPersistedAt = persistedAt
+        XCTAssertNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
+        XCTAssertNil(defaults.data(forKey: key))
     }
 
-    let fallback = MixpanelFlagVariant(key: "fb", value: "fallback_value")
-    let result = manager.getVariantSync("flag_a", fallback: fallback)
+    // MARK: - Source stamping
 
-    XCTAssertEqual(result.value as? String, "fresh_value")
-    if case .persistence = result.source {} else {
-      XCTFail("expected .persistence source preserved")
-    }
-  }
+    func testWithSourceStampsAndPreservesOtherFields() {
+        let original = MixpanelFlagVariant(
+            key: "k", value: "v", isExperimentActive: true, isQATester: false, experimentID: "exp_1")
+        let stamped = original.withSource(.network)
 
-  /// `.network`-stamped variants are never expired regardless of how old they are — TTL only
-  /// applies to `.persistence(persistedAt:)` variants.
-  func testGetVariantSyncReturnsNetworkVariantRegardlessOfAge() throws {
-    let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
-    waitForTrackingQueue(manager: manager)
+        XCTAssertEqual(stamped.key, "k")
+        XCTAssertEqual(stamped.value as? String, "v")
+        XCTAssertEqual(stamped.experimentID, "exp_1")
+        XCTAssertEqual(stamped.isExperimentActive, true)
+        XCTAssertEqual(stamped.isQATester, false)
+        if case .network = stamped.source {} else { XCTFail("expected .network source") }
 
-    // .network variants don't carry a timestamp, so the TTL check should always return false.
-    let networkVariant = MixpanelFlagVariant(key: "v1", value: "from_network")
-      .withSource(.network)
-    manager.flagsLock.write {
-      manager.flags = ["flag_a": networkVariant]
-    }
-
-    let fallback = MixpanelFlagVariant(key: "fb", value: "fallback_value")
-    let result = manager.getVariantSync("flag_a", fallback: fallback)
-    XCTAssertEqual(result.value as? String, "from_network")
-  }
-
-  /// When the loaded persisted blob is past TTL, `getAllVariantsSync` filters out all
-  /// `.persistence` variants but keeps `.network` variants (e.g., activated first-time
-  /// events that were promoted to network source mid-session). Documents the blob-level
-  /// expiry rule: all `.persistence` variants share `persistedAt`, so they pass-or-fail
-  /// the TTL check together.
-  func testGetAllVariantsSyncFiltersPersistedVariantsWhenBlobIsStale() throws {
-    let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
-    waitForTrackingQueue(manager: manager)
-
-    let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
-    let stalePersistedA = MixpanelFlagVariant(key: "v1", value: "stale_a")
-      .withSource(.persistence(persistedAt: stalePersistedAt))
-    let stalePersistedB = MixpanelFlagVariant(key: "v2", value: "stale_b")
-      .withSource(.persistence(persistedAt: stalePersistedAt))
-    let networkSourced = MixpanelFlagVariant(key: "v3", value: "from_network")
-      .withSource(.network)
-
-    manager.flagsLock.write {
-      manager.flags = [
-        "stale_flag_a": stalePersistedA,
-        "stale_flag_b": stalePersistedB,
-        "network_flag": networkSourced,
-      ]
-      manager.loadedBlobPersistedAt = stalePersistedAt
+        let persistedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let persistenceStamped = original.withSource(.persistence(persistedAt: persistedAt))
+        if case .persistence(let at) = persistenceStamped.source {
+            XCTAssertEqual(at.timeIntervalSince1970, persistedAt.timeIntervalSince1970, accuracy: 0.001)
+        } else {
+            XCTFail("expected .persistence source")
+        }
     }
 
-    let result = manager.getAllVariantsSync()
-    XCTAssertEqual(result.count, 1)
-    XCTAssertNil(result["stale_flag_a"], "stale persisted variant should be filtered out")
-    XCTAssertNil(result["stale_flag_b"], "stale persisted variant should be filtered out")
-    XCTAssertNotNil(
-      result["network_flag"], ".network variants survive blob expiration (e.g., activated FTEs)")
-  }
-
-  /// The on-disk blob is NOT deleted when an in-memory variant expires at get-time.
-  /// Per the rule: "no harm in keeping. Will likely be overwritten shortly after."
-  func testExpiredVariantOnGetVariantDoesNotWipeDiskPersistence() throws {
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"v"}}}"#
-    let blob = FlagsPersistenceBlob(persistedAt: Date(), distinctId: "user_a", response: response)
-    MixpanelPersistence.saveFlagsPersistence(blob, instanceName: instanceName)
-
-    let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
-    waitForTrackingQueue(manager: manager)
-    XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
-
-    // Force the in-memory variant to be expired without wiping the disk blob.
-    let stalePersistedAt = Date(timeIntervalSinceNow: -90_000)  // > 86_400s TTL
-    let expired = MixpanelFlagVariant(key: "v1", value: "stale")
-      .withSource(.persistence(persistedAt: stalePersistedAt))
-    manager.flagsLock.write {
-      manager.flags = ["flag_a": expired]
-      manager.loadedBlobPersistedAt = stalePersistedAt
+    func testFallbackVariantsHaveFallbackSource() {
+        let fallback = MixpanelFlagVariant(value: "default")
+        if case .fallback = fallback.source {
+        } else {
+            XCTFail("developer-supplied variants should carry .fallback source")
+        }
     }
 
-    let fallback = MixpanelFlagVariant(key: "fb", value: "fb")
-    let result = manager.getVariantSync("flag_a", fallback: fallback)
-    XCTAssertEqual(result.value as? String, "fb")
+    // MARK: - Default TTL
 
-    // Critical: blob persists. The next successful fetch overwrites it; this lookup didn't
-    // delete it.
-    XCTAssertNotNil(
-      MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
-      "expired-on-get must NOT wipe the on-disk blob")
-  }
+    /// `VariantLookupPolicy.defaultTTL` is 24 hours, and the zero-arg static factories
+    /// `persistenceUntilNetworkSuccess()` / `networkFirst()` produce cases keyed to that default. This also
+    /// exercises the case-plus-static-func overload pattern (different parameter lists, so
+    /// `.persistenceUntilNetworkSuccess()` and `.persistenceUntilNetworkSuccess(persistenceTtl:)` resolve to different members).
+    func testDefaultTTLConvenienceConstructors() throws {
+        XCTAssertEqual(VariantLookupPolicy.defaultTTL, 24 * 60 * 60, "default TTL should be 24 hours")
 
-  // MARK: - NetworkFirst gating
+        let convenientPersistenceUntilNetworkSuccess = VariantLookupPolicy.persistenceUntilNetworkSuccess()
+        if case .persistenceUntilNetworkSuccess(let ttl) = convenientPersistenceUntilNetworkSuccess {
+            XCTAssertEqual(ttl, VariantLookupPolicy.defaultTTL)
+        } else {
+            XCTFail("convenience persistenceUntilNetworkSuccess() should produce .persistenceUntilNetworkSuccess case")
+        }
 
-  func testNetworkFirstAsyncLookupAwaitsFetchEvenWithPersistence() throws {
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"persisted_val"}}}"#
-    MixpanelPersistence.saveFlagsPersistence(
-      FlagsPersistenceBlob(
-        persistedAt: Date(),
-        distinctId: "user_a",
-        response: response),
-      instanceName: instanceName)
-
-    let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .networkFirst(persistenceTtl: 86_400))
-
-    // Configure the mock to "succeed" with new flags, but with a delay that lets us assert
-    // the async lookup waited for the network rather than serving persisted values
-    // immediately.
-    mock.simulatedFetchResult = (
-      success: true,
-      flags: [
-        "flag_a": MixpanelFlagVariant(key: "v_fresh", value: "network_val")
-      ]
-    )
-    mock.simulatedNetworkDelay = 0.1  // 100ms delay
-
-    waitForTrackingQueue(manager: mock)
-    // Persistence load should have populated `flags` with .persistence stamping. Now async
-    // lookup must NOT serve those persisted values — it has to await the network response.
-    let asyncDone = expectation(description: "async lookup completes after network")
-    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
-      // The variant served must be the network value, not the persisted one.
-      XCTAssertEqual(variant.value as? String, "network_val")
-      if case .network = variant.source {} else {
-        XCTFail("variant served by NetworkFirst should be from .network after fetch")
-      }
-      asyncDone.fulfill()
-    }
-    wait(for: [asyncDone], timeout: 2.0)
-  }
-
-  func testNetworkFirstFallsBackToPersistenceOnFetchFailure() throws {
-    let persistedAt = Date(timeIntervalSinceNow: -60)  // 60s old, well within TTL
-    let response = #"{"flags":{"flag_a":{"variant_key":"v_persisted","variant_value":"persisted_val"}}}"#
-    MixpanelPersistence.saveFlagsPersistence(
-      FlagsPersistenceBlob(
-        persistedAt: persistedAt,
-        distinctId: "user_a",
-        response: response),
-      instanceName: instanceName)
-
-    let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .networkFirst(persistenceTtl: 86_400))
-    mock.simulatedFetchResult = (success: false, flags: nil)
-
-    waitForTrackingQueue(manager: mock)
-
-    let asyncDone = expectation(description: "async lookup completes after fetch failure")
-    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
-      // Fetch failed → persisted values stay → async lookup serves the persisted variant.
-      XCTAssertEqual(variant.value as? String, "persisted_val")
-      if case .persistence = variant.source {} else {
-        XCTFail("variant served on NetworkFirst failure should keep .persistence source")
-      }
-      asyncDone.fulfill()
-    }
-    wait(for: [asyncDone], timeout: 2.0)
-  }
-
-  func testPersistenceUntilNetworkSuccessAsyncLookupServesPersistedImmediately() throws {
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"persisted_val"}}}"#
-    MixpanelPersistence.saveFlagsPersistence(
-      FlagsPersistenceBlob(
-        persistedAt: Date(),
-        distinctId: "user_a",
-        response: response),
-      instanceName: instanceName)
-
-    let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
-    // Configure a slow network so we'd notice if the lookup was waiting on it.
-    mock.simulatedFetchResult = (
-      success: true, flags: ["flag_a": MixpanelFlagVariant(key: "v2", value: "network_val")])
-    mock.simulatedNetworkDelay = 0.1
-
-    waitForTrackingQueue(manager: mock)
-
-    let asyncDone = expectation(description: "async lookup completes")
-    let start = Date()
-    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
-      let elapsed = Date().timeIntervalSince(start)
-      XCTAssertEqual(
-        variant.value as? String, "persisted_val", "persistenceUntilNetworkSuccess should serve persisted")
-      if case .persistence = variant.source {} else { XCTFail("expected .persistence source") }
-      // Generous bound — just want to confirm we didn't wait on the 100ms simulated network.
-      XCTAssertLessThan(elapsed, 0.08, "persistenceUntilNetworkSuccess should not wait for network")
-      asyncDone.fulfill()
-    }
-    wait(for: [asyncDone], timeout: 1.0)
-  }
-
-  // MARK: - Reset wipes persistence
-
-  func testResetWipesDiskPersistence() throws {
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
-    MixpanelPersistence.saveFlagsPersistence(
-      FlagsPersistenceBlob(
-        persistedAt: Date(),
-        distinctId: "user_a",
-        response: response),
-      instanceName: instanceName)
-
-    let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
-    waitForTrackingQueue(manager: manager)
-
-    XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
-
-    manager.reset()
-    waitForTrackingQueue(manager: manager)
-
-    XCTAssertNil(
-      MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
-      "reset() should wipe the on-disk persistence blob")
-    XCTAssertFalse(manager.areFlagsReady())
-  }
-
-  /// `setContext` deliberately does NOT clear in-memory variants OR the on-disk blob. The
-  /// blob is keyed on distinctId only, so it remains valid across context changes for the
-  /// same user. The next successful fetch under the new context overwrites the blob.
-  func testSetContextDoesNotWipePersistenceOrInMemoryState() throws {
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
-    MixpanelPersistence.saveFlagsPersistence(
-      FlagsPersistenceBlob(
-        persistedAt: Date(),
-        distinctId: "user_a",
-        response: response),
-      instanceName: instanceName)
-
-    let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
-    // Make the post-setContext fetch fail so we can isolate setContext's effect — without
-    // a successful overwrite, the blob's survival is solely attributable to setContext
-    // NOT wiping it. The same goes for in-memory state.
-    mock.simulatedFetchResult = (success: false, flags: nil)
-    mock.simulatedNetworkDelay = 0
-    waitForTrackingQueue(manager: mock)
-
-    XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
-    XCTAssertTrue(mock.areFlagsReady(), "persistence load on init should populate flags")
-
-    let setContextDone = expectation(description: "setContext fetch completes")
-    mock.setContext(["plan": "enterprise"]) { setContextDone.fulfill() }
-    wait(for: [setContextDone], timeout: 2.0)
-    waitForTrackingQueue(manager: mock)
-
-    XCTAssertNotNil(
-      MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
-      "setContext must NOT wipe the on-disk persistence blob")
-    XCTAssertTrue(
-      mock.areFlagsReady(),
-      "setContext must NOT clear in-memory variants")
-  }
-
-  // MARK: - Async lookups refresh when loaded blob is stale
-  //
-  // When a persisting policy is in effect and the loaded persisted blob has aged past TTL
-  // mid-session, the async getVariant / getAllVariants paths must fall through to a network
-  // fetch rather than silently serving the developer fallback or an empty dict. The blob
-  // shares a single `persistedAt`, so any one expired entry decides for the whole set.
-
-  /// `getVariant(completion:)` triggers a fetch when the in-memory persisted variant for the
-  /// requested flag has aged past TTL, and serves the post-fetch (network) value rather than
-  /// the developer fallback.
-  func testGetVariantAsyncTriggersFetchWhenLoadedBlobIsStale() throws {
-    let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
-    waitForTrackingQueue(manager: mock)
-
-    // Inject an expired persisted variant directly. Bypasses the disk-load path so we can
-    // pin the staleness without depending on init timing.
-    let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
-    let expired = MixpanelFlagVariant(key: "v_old", value: "stale_val")
-      .withSource(.persistence(persistedAt: stalePersistedAt))
-    mock.flagsLock.write {
-      mock.flags = ["flag_a": expired]
-      mock.loadedBlobPersistedAt = stalePersistedAt
+        let convenientNetworkFirst = VariantLookupPolicy.networkFirst()
+        if case .networkFirst(let ttl) = convenientNetworkFirst {
+            XCTAssertEqual(ttl, VariantLookupPolicy.defaultTTL)
+        } else {
+            XCTFail("convenience networkFirst() should produce .networkFirst case")
+        }
     }
 
-    // Mock the refresh response so we can confirm the served value came from the network.
-    mock.simulatedFetchResult = (
-      success: true,
-      flags: ["flag_a": MixpanelFlagVariant(key: "v_fresh", value: "network_val")]
-    )
-    mock.simulatedNetworkDelay = 0
-
-    let asyncDone = expectation(description: "async lookup completes after refresh")
-    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
-      XCTAssertEqual(
-        variant.value as? String, "network_val",
-        "stale persisted blob should trigger fetch and serve the network value")
-      if case .network = variant.source {} else {
-        XCTFail("post-fetch variant should carry .network source")
-      }
-      asyncDone.fulfill()
-    }
-    wait(for: [asyncDone], timeout: 2.0)
-  }
-
-  /// When the loaded blob is stale and the refresh fails, async getVariant serves the
-  /// developer fallback (the stale persisted value is filtered by `_getVariantSyncImpl`'s
-  /// per-variant TTL check). This documents the post-fix tolerance: we fetch, but we don't
-  /// resurrect stale values just because the network was unavailable.
-  func testGetVariantAsyncReturnsFallbackWhenStaleBlobAndFetchFails() throws {
-    let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
-    waitForTrackingQueue(manager: mock)
-
-    let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
-    let expired = MixpanelFlagVariant(key: "v_old", value: "stale_val")
-      .withSource(.persistence(persistedAt: stalePersistedAt))
-    mock.flagsLock.write {
-      mock.flags = ["flag_a": expired]
-      mock.loadedBlobPersistedAt = stalePersistedAt
+    /// Factories preserve exactly what was asked — they don't sanitize. The "non-positive TTL
+    /// becomes networkOnly" rule is enforced at SDK init via `VariantLookupPolicy.effective(_:)`,
+    /// not at construction time, so callers can introspect what they configured.
+    func testFactoriesPreserveExactTtl() throws {
+        if case .persistenceUntilNetworkSuccess(let t) = VariantLookupPolicy.persistenceUntilNetworkSuccess(
+            persistenceTtl: -1)
+        {
+            XCTAssertEqual(t, -1)
+        } else {
+            XCTFail("expected .persistenceUntilNetworkSuccess case")
+        }
+        if case .persistenceUntilNetworkSuccess(let t) = VariantLookupPolicy.persistenceUntilNetworkSuccess(
+            persistenceTtl: 0)
+        {
+            XCTAssertEqual(t, 0)
+        } else {
+            XCTFail("expected .persistenceUntilNetworkSuccess case")
+        }
+        if case .networkFirst(let t) = VariantLookupPolicy.networkFirst(persistenceTtl: -100) {
+            XCTAssertEqual(t, -100)
+        } else {
+            XCTFail("expected .networkFirst case")
+        }
     }
 
-    mock.simulatedFetchResult = (success: false, flags: nil)
-    mock.simulatedNetworkDelay = 0
+    /// Persisting policies with TTL <= 0 do no useful work (we'd write to disk on every fetch
+    /// but never serve anything from persistence) so the SDK substitutes `.networkOnly` at init.
+    func testEffectivePolicyNonPositiveTtlBecomesNetworkOnly() throws {
+        let resolvedNegativePersistence = VariantLookupPolicy.effective(
+            .persistenceUntilNetworkSuccess(persistenceTtl: -1))
+        if case .networkOnly = resolvedNegativePersistence {
+        } else {
+            XCTFail("negative TTL on persistenceUntilNetworkSuccess should resolve to .networkOnly")
+        }
 
-    let asyncDone = expectation(description: "async lookup completes after failed refresh")
-    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback_val")) { variant in
-      XCTAssertEqual(variant.value as? String, "fallback_val")
-      asyncDone.fulfill()
-    }
-    wait(for: [asyncDone], timeout: 2.0)
-  }
+        let resolvedZeroPersistence = VariantLookupPolicy.effective(.persistenceUntilNetworkSuccess(persistenceTtl: 0))
+        if case .networkOnly = resolvedZeroPersistence {
+        } else {
+            XCTFail("zero TTL on persistenceUntilNetworkSuccess should resolve to .networkOnly")
+        }
 
-  /// `getAllVariants(completion:)` triggers a fetch when the loaded blob is stale rather
-  /// than returning an empty (post-filter) dictionary without attempting refresh.
-  func testGetAllVariantsAsyncTriggersFetchWhenLoadedBlobIsStale() throws {
-    let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
-    waitForTrackingQueue(manager: mock)
+        let resolvedNegativeNetworkFirst = VariantLookupPolicy.effective(.networkFirst(persistenceTtl: -100))
+        if case .networkOnly = resolvedNegativeNetworkFirst {
+        } else {
+            XCTFail("negative TTL on networkFirst should resolve to .networkOnly")
+        }
 
-    let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
-    let expiredA = MixpanelFlagVariant(key: "v1", value: "stale_a")
-      .withSource(.persistence(persistedAt: stalePersistedAt))
-    let expiredB = MixpanelFlagVariant(key: "v2", value: "stale_b")
-      .withSource(.persistence(persistedAt: stalePersistedAt))
-    mock.flagsLock.write {
-      mock.flags = ["flag_a": expiredA, "flag_b": expiredB]
-      mock.loadedBlobPersistedAt = stalePersistedAt
-    }
-
-    mock.simulatedFetchResult = (
-      success: true,
-      flags: [
-        "flag_a": MixpanelFlagVariant(key: "v1f", value: "fresh_a"),
-        "flag_b": MixpanelFlagVariant(key: "v2f", value: "fresh_b"),
-      ]
-    )
-    mock.simulatedNetworkDelay = 0
-
-    let asyncDone = expectation(description: "async getAll completes after refresh")
-    mock.getAllVariants { variants in
-      XCTAssertEqual(variants.count, 2)
-      XCTAssertEqual(variants["flag_a"]?.value as? String, "fresh_a")
-      XCTAssertEqual(variants["flag_b"]?.value as? String, "fresh_b")
-      asyncDone.fulfill()
-    }
-    wait(for: [asyncDone], timeout: 2.0)
-  }
-
-  /// An empty persisted blob within TTL is treated as a valid state: serve the developer
-  /// fallback, no network refresh. The customer is opting into "use cached flags," and
-  /// the cache says "no flags configured at the time it was written" — until TTL elapses,
-  /// we trust that.
-  func testGetVariantAsyncServesFallbackOnEmptyFreshBlobWithoutRefresh() throws {
-    let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
-    waitForTrackingQueue(manager: mock)
-
-    let freshPersistedAt = Date(timeIntervalSinceNow: -60)  // well within TTL
-    mock.flagsLock.write {
-      mock.flags = [:]
-      mock.loadedBlobPersistedAt = freshPersistedAt
+        let resolvedZeroNetworkFirst = VariantLookupPolicy.effective(.networkFirst(persistenceTtl: 0))
+        if case .networkOnly = resolvedZeroNetworkFirst {
+        } else {
+            XCTFail("zero TTL on networkFirst should resolve to .networkOnly")
+        }
     }
 
-    // Configure a recognizable network response. If the staleness check wrongly triggers
-    // a fetch, the served value would be "should_not_be_served".
-    mock.simulatedFetchResult = (
-      success: true,
-      flags: ["flag_a": MixpanelFlagVariant(key: "v1", value: "should_not_be_served")]
-    )
-    mock.simulatedNetworkDelay = 0
+    /// Sanity: non-degenerate configurations pass through `effective(_:)` unchanged.
+    func testEffectivePolicyPositiveTtlPreserved() throws {
+        let persistence = VariantLookupPolicy.persistenceUntilNetworkSuccess(persistenceTtl: 3600)
+        if case .persistenceUntilNetworkSuccess(let t) = VariantLookupPolicy.effective(persistence) {
+            XCTAssertEqual(t, 3600)
+        } else {
+            XCTFail("positive TTL should pass through unchanged")
+        }
 
-    let asyncDone = expectation(description: "async lookup completes without refresh")
-    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
-      XCTAssertEqual(
-        variant.value as? String, "fallback",
-        "empty fresh blob should serve fallback without auto-refreshing")
-      asyncDone.fulfill()
-    }
-    wait(for: [asyncDone], timeout: 2.0)
-  }
-
-  /// An empty persisted blob PAST TTL still triggers a fetch — the TTL governs when to
-  /// refresh regardless of whether the blob has flags in it. This is exactly why we keep
-  /// `loadedBlobPersistedAt` separate from variant inspection: an empty blob has no
-  /// variants to check, but its persistedAt still tells us when to give up on the cache.
-  func testGetVariantAsyncTriggersFetchWhenEmptyBlobIsStale() throws {
-    let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
-    waitForTrackingQueue(manager: mock)
-
-    let stalePersistedAt = Date(timeIntervalSinceNow: -3600)  // well past 60s TTL
-    mock.flagsLock.write {
-      mock.flags = [:]
-      mock.loadedBlobPersistedAt = stalePersistedAt
+        let networkOnly = VariantLookupPolicy.networkOnly
+        if case .networkOnly = VariantLookupPolicy.effective(networkOnly) {
+        } else {
+            XCTFail(".networkOnly should pass through unchanged")
+        }
     }
 
-    mock.simulatedFetchResult = (
-      success: true,
-      flags: ["flag_a": MixpanelFlagVariant(key: "v1", value: "fresh_val")]
-    )
-    mock.simulatedNetworkDelay = 0
+    /// End-to-end check: configuring the SDK with a persisting policy + non-positive TTL means
+    /// no persistence happens at runtime — the SDK behaves as if `.networkOnly` was configured.
+    func testNonPositiveTtlPersistingPolicyBehavesAsNetworkOnly() throws {
+        // Pre-stage a persisted blob on disk. Under .networkOnly init, the manager should wipe
+        // it (proves the resolved policy is .networkOnly, not the persisting policy the customer
+        // requested).
+        let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+        MixpanelPersistence.saveFlagsPersistence(
+            FlagsPersistenceBlob(
+                persistedAt: Date(),
+                distinctId: "user_a",
+                response: response),
+            instanceName: instanceName)
+        XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
-    let asyncDone = expectation(description: "async lookup refreshes stale empty blob")
-    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
-      XCTAssertEqual(
-        variant.value as? String, "fresh_val",
-        "stale empty blob should trigger fetch and serve newly-discovered flag")
-      asyncDone.fulfill()
-    }
-    wait(for: [asyncDone], timeout: 2.0)
-  }
+        let manager = makeManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 0))
+        waitForTrackingQueue(manager: manager)
 
-  /// Sanity check the existing serve-immediately path still wins when the loaded blob is
-  /// fresh — the staleness check shouldn't push fresh persisted variants through a needless
-  /// network round-trip.
-  func testGetVariantAsyncServesFreshPersistedImmediatelyWithoutFetch() throws {
-    let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
-    waitForTrackingQueue(manager: mock)
-
-    let freshPersistedAt = Date(timeIntervalSinceNow: -60)
-    let fresh = MixpanelFlagVariant(key: "v1", value: "persisted_val")
-      .withSource(.persistence(persistedAt: freshPersistedAt))
-    mock.flagsLock.write {
-      mock.flags = ["flag_a": fresh]
-      mock.loadedBlobPersistedAt = freshPersistedAt
+        XCTAssertFalse(
+            manager.areFlagsReady(),
+            "non-positive TTL should resolve to .networkOnly; nothing loaded from persistence")
+        XCTAssertNil(
+            MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
+            "resolved .networkOnly init should wipe the existing blob")
     }
 
-    // Configure a slow + clearly-different network response. If the staleness check
-    // wrongly triggers a fetch, the test will catch the wrong value (and the slow delay
-    // would add noticeable latency).
-    mock.simulatedFetchResult = (
-      success: true,
-      flags: ["flag_a": MixpanelFlagVariant(key: "v2", value: "network_val")]
-    )
-    mock.simulatedNetworkDelay = 0.1
+    // MARK: - Init loads persisted variants and stamps them
 
-    let asyncDone = expectation(description: "async getVariant completes")
-    let start = Date()
-    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fb")) { variant in
-      let elapsed = Date().timeIntervalSince(start)
-      XCTAssertEqual(variant.value as? String, "persisted_val")
-      if case .persistence = variant.source {} else {
-        XCTFail("fresh persisted variant should be served as-is, not refreshed")
-      }
-      XCTAssertLessThan(elapsed, 0.08, "fresh blob must not wait on the network")
-      asyncDone.fulfill()
-    }
-    wait(for: [asyncDone], timeout: 1.0)
-  }
+    func testInitLoadsPersistedVariantsAndStampsPersistenceSource() throws {
+        // `Date()` (rather than a fixed-far-past timestamp) so the 86_400s TTL check passes.
+        let persistedAt = Date()
+        let context = ["plan": "enterprise"]
+        let response =
+            #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":42},"flag_b":{"variant_key":"v2","variant_value":"hello"}}}"#
 
-  // MARK: - Tracking properties for persisted variants
+        MixpanelPersistence.saveFlagsPersistence(
+            FlagsPersistenceBlob(persistedAt: persistedAt, distinctId: "user_a", response: response),
+            instanceName: instanceName)
 
-  /// When a served variant came from the persistence layer, `$experiment_started` carries
-  /// `$variant_source` = "persistence", `$persisted_at_in_ms` (raw epoch ms — no offsets,
-  /// no deltas), and `$ttl_in_ms` (the customer-configured TTL in ms). Verifies the values
-  /// against the same `persistedAt` and `ttl` we configured.
-  func testTrackingIncludesPersistencePropertiesForPersistedVariant() throws {
-    // Use a recent fixed timestamp (offset from "now") so we can assert the exact
-    // $persisted_at_in_ms while still passing the TTL check.
-    let persistedAt = Date(timeIntervalSinceNow: -60)  // 60s ago
-    let ttlSeconds: TimeInterval = 86_400  // 24 hours
-    let manager = makeManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: ttlSeconds))
-    waitForTrackingQueue(manager: manager)
-    let delegate = retainedDelegates.last as! PersistenceTestMockDelegate
+        let manager = makeManager(
+            distinctId: "user_a", context: context, policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
 
-    // Inject a .persistence-stamped variant directly. Bypasses the disk-load round-trip so
-    // we can pin `persistedAt` to an exact value for the assertion below without depending
-    // on the blob serializer's millisecond rounding.
-    let persistedVariant = MixpanelFlagVariant(key: "v1", value: "persisted_val")
-      .withSource(.persistence(persistedAt: persistedAt))
-    manager.flagsLock.write {
-      manager.flags = ["flag_a": persistedVariant]
-      manager.loadedBlobPersistedAt = persistedAt
+        waitForTrackingQueue(manager: manager)
+
+        XCTAssertTrue(manager.areFlagsReady())
+        let variants = manager.getAllVariantsSync()
+        XCTAssertEqual(variants.count, 2)
+
+        if case .persistence(let at) = variants["flag_a"]?.source {
+            XCTAssertEqual(at.timeIntervalSince1970, persistedAt.timeIntervalSince1970, accuracy: 0.001)
+        } else {
+            XCTFail("flag_a should have .persistence source")
+        }
+        XCTAssertEqual(variants["flag_a"]?.value as? Int, 42)
+        XCTAssertEqual(variants["flag_b"]?.value as? String, "hello")
     }
 
-    // Trigger tracking by reading the persisted variant (first read records the tracking
-    // event; subsequent reads are deduped via `trackedFeatures`).
-    let fallback = MixpanelFlagVariant(key: "fb", value: "fb")
-    _ = manager.getVariantSync("flag_a", fallback: fallback)
+    /// distinctId mismatch on init is the cross-session form of "distinctId changed":
+    /// it leaves flags empty AND wipes the stale blob from disk, so the prior identity's
+    /// variants don't sit on this device after the user has moved on.
+    func testInitWipesPersistenceOnDistinctIdMismatch() throws {
+        let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+        MixpanelPersistence.saveFlagsPersistence(
+            FlagsPersistenceBlob(
+                persistedAt: Date(),
+                distinctId: "different_user",
+                response: response),
+            instanceName: instanceName)
+        XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
-    // The delegate.track call is dispatched async to main; spin briefly until it lands.
-    let trackedExpectation = expectation(description: "tracking event recorded")
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-      let events = delegate.snapshotTrackedEvents()
-      if events.contains(where: { $0.event == "$experiment_started" }) {
-        trackedExpectation.fulfill()
-      }
-    }
-    wait(for: [trackedExpectation], timeout: 2.0)
+        let manager = makeManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
+        waitForTrackingQueue(manager: manager)
 
-    let events = delegate.snapshotTrackedEvents()
-    let experiment = try XCTUnwrap(events.first(where: { $0.event == "$experiment_started" }))
-    let props = try XCTUnwrap(experiment.properties)
-
-    XCTAssertEqual(props["$variant_source"] as? String, "persistence")
-    let expectedPersistedAtMs = Int(persistedAt.timeIntervalSince1970 * 1000)
-    XCTAssertEqual(props["$persisted_at_in_ms"] as? Int, expectedPersistedAtMs)
-    XCTAssertEqual(props["$ttl_in_ms"] as? Int, Int(ttlSeconds * 1000))
-  }
-
-  /// `.network`-sourced variants carry `$variant_source = "network"` (matching the JS SDK)
-  /// but NOT the persistence-layer-only properties (`$persisted_at_in_ms`, `$ttl_in_ms`).
-  /// This protects against accidentally leaking persistence properties through the
-  /// `.network` path.
-  func testTrackingIncludesVariantSourceForNetworkVariant() throws {
-    let delegate = PersistenceTestMockDelegate(
-      options: MixpanelOptions(
-        token: "test_token",
-        featureFlagOptions: FeatureFlagOptions(
-          enabled: true,
-          variantLookupPolicy: .networkOnly)),
-      distinctId: "user_a")
-    retainedDelegates.append(delegate)
-    let queue = DispatchQueue(label: "ff.network.tracking.test.\(UUID().uuidString)")
-    let manager = FeatureFlagManager(
-      serverURL: "https://example.test",
-      trackingQueue: queue,
-      instanceName: instanceName,
-      delegate: delegate)
-    waitForTrackingQueue(manager: manager)
-
-    // Inject a .network-sourced variant directly — bypasses the fetch path.
-    let networkVariant = MixpanelFlagVariant(key: "v1", value: "network_val")
-      .withSource(.network)
-    manager.flagsLock.write { manager.flags = ["flag_a": networkVariant] }
-
-    let fallback = MixpanelFlagVariant(key: "fb", value: "fb")
-    _ = manager.getVariantSync("flag_a", fallback: fallback)
-
-    let trackedExpectation = expectation(description: "tracking event recorded")
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-      let events = delegate.snapshotTrackedEvents()
-      if events.contains(where: { $0.event == "$experiment_started" }) {
-        trackedExpectation.fulfill()
-      }
-    }
-    wait(for: [trackedExpectation], timeout: 2.0)
-
-    let events = delegate.snapshotTrackedEvents()
-    let experiment = try XCTUnwrap(events.first(where: { $0.event == "$experiment_started" }))
-    let props = try XCTUnwrap(experiment.properties)
-
-    XCTAssertEqual(props["$variant_source"] as? String, "network")
-    XCTAssertNil(props["$persisted_at_in_ms"], "network variants don't carry persistedAt")
-    XCTAssertNil(props["$ttl_in_ms"], "network variants don't carry TTL")
-  }
-
-  // MARK: - NetworkFirst retries until a fetch succeeds
-
-  /// Regression test for the bug where NetworkFirst would stop attempting the network after
-  /// the first failure: `awaitingInitialNetworkResponse` was being cleared on fetch failure,
-  /// so subsequent async lookups would silently serve persistence forever even though no
-  /// successful network response had ever come back.
-  ///
-  /// Spec: NetworkFirst lookups await a successful network response. After a failed fetch,
-  /// the next async lookup must retry the network — only a successful fetch satisfies the
-  /// "we got the network value" gate. Verified end-to-end: two failed fetches in a row → two
-  /// fetch attempts (not one).
-  func testNetworkFirstRetriesNetworkAfterFailureUntilSuccess() throws {
-    let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"persisted_val"}}}"#
-    MixpanelPersistence.saveFlagsPersistence(
-      FlagsPersistenceBlob(
-        persistedAt: Date(),
-        distinctId: "user_a",
-        response: response),
-      instanceName: instanceName)
-
-    let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .networkFirst(persistenceTtl: 86_400))
-    waitForTrackingQueue(manager: mock)
-
-    // Round 1: fetch fails. Lookup falls back to persisted value.
-    mock.simulatedFetchResult = (success: false, flags: nil)
-    mock.simulatedNetworkDelay = 0
-    let firstDone = expectation(description: "first lookup")
-    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
-      XCTAssertEqual(variant.value as? String, "persisted_val",
-                     "first lookup should fall back to persisted value after failed fetch")
-      firstDone.fulfill()
-    }
-    wait(for: [firstDone], timeout: 2.0)
-    XCTAssertEqual(mock.fetchCallCount, 1, "first lookup should trigger one fetch attempt")
-
-    // Round 2: fetch fails again. Pre-fix, the lookup would skip the network entirely
-    // (`awaiting` had been cleared by round 1's failure) and serve persisted directly,
-    // leaving the count at 1. Post-fix, NetworkFirst retries until success.
-    let secondDone = expectation(description: "second lookup")
-    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
-      XCTAssertEqual(variant.value as? String, "persisted_val")
-      secondDone.fulfill()
-    }
-    wait(for: [secondDone], timeout: 2.0)
-    XCTAssertEqual(
-      mock.fetchCallCount, 2,
-      "NetworkFirst must retry the network on subsequent lookups after a failure")
-
-    // Round 3: fetch succeeds. Network value served, blob marker cleared.
-    mock.simulatedFetchResult = (
-      success: true, flags: ["flag_a": MixpanelFlagVariant(key: "v_fresh", value: "network_val")])
-    let thirdDone = expectation(description: "third lookup")
-    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
-      XCTAssertEqual(variant.value as? String, "network_val",
-                     "successful fetch should serve the network value")
-      thirdDone.fulfill()
-    }
-    wait(for: [thirdDone], timeout: 2.0)
-    XCTAssertEqual(mock.fetchCallCount, 3, "third lookup triggers the successful fetch")
-
-    // Round 4: subsequent lookup should NOT retry — the gate flipped off after success.
-    let fourthDone = expectation(description: "fourth lookup")
-    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
-      XCTAssertEqual(variant.value as? String, "network_val")
-      fourthDone.fulfill()
-    }
-    wait(for: [fourthDone], timeout: 2.0)
-    XCTAssertEqual(
-      mock.fetchCallCount, 3,
-      "after a successful fetch, NetworkFirst stops retrying — gate is satisfied")
-  }
-
-  // MARK: - PersistenceUntilNetworkSuccess background refresh
-
-  /// PUN's contract is "serve persisted now, refresh in background." The first lookup that
-  /// finds the immediate-serve path satisfied by a persisted blob (not yet overwritten by a
-  /// successful network fetch) must kick off a background fetch — without blocking the
-  /// lookup itself — so subsequent lookups eventually see fresh values. The fetch self-stops
-  /// because a successful fetch clears `loadedBlobPersistedAt`, taking us off the
-  /// background-refresh trigger.
-  func testPersistenceUntilNetworkSuccessLookupKicksOffBackgroundRefresh() throws {
-    let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
-    waitForTrackingQueue(manager: mock)
-
-    let freshPersistedAt = Date(timeIntervalSinceNow: -60)
-    let persisted = MixpanelFlagVariant(key: "v_old", value: "persisted_val")
-      .withSource(.persistence(persistedAt: freshPersistedAt))
-    mock.flagsLock.write {
-      mock.flags = ["flag_a": persisted]
-      mock.loadedBlobPersistedAt = freshPersistedAt
+        XCTAssertFalse(manager.areFlagsReady(), "distinctId mismatch should leave flags empty")
+        XCTAssertTrue(manager.getAllVariantsSync().isEmpty)
+        XCTAssertNil(
+            MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
+            "distinctId mismatch on init should wipe the stale blob")
     }
 
-    // Hang the simulated fetch so it counts as kicked-off but doesn't complete and replace
-    // `flags` mid-test. Counter increments synchronously inside `_performFetchRequest`.
-    mock.simulatedFetchResult = (success: true, flags: ["flag_a": MixpanelFlagVariant(key: "v_new", value: "network_val")])
-    mock.simulatedNetworkDelay = 60  // effectively never completes within the test
+    /// Documents the deliberate decision to key persistence on distinctId only — context changes
+    /// do NOT invalidate the persisted blob. A blob written under one context will load under
+    /// a different context for the same user (in-memory variants will then be stale with respect
+    /// to the new context until the next successful fetch overwrites them).
+    ///
+    /// Customers signaled this tradeoff is acceptable: context rarely flips mid-session in
+    /// practice, and the gain is keeping the persistence layer useful when customers do flip
+    /// between contexts they've used before.
+    func testInitLoadsPersistenceRegardlessOfContextDifference() throws {
+        let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+        MixpanelPersistence.saveFlagsPersistence(
+            FlagsPersistenceBlob(
+                persistedAt: Date(),
+                // Blob originally persisted under no context.
+                distinctId: "user_a",
+                response: response),
+            instanceName: instanceName)
 
-    XCTAssertEqual(mock.fetchCallCount, 0, "no fetch before lookup")
+        // Manager comes up under a different context for the same user.
+        let manager = makeManager(
+            distinctId: "user_a",
+            context: ["plan": "enterprise"],
+            policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
+        waitForTrackingQueue(manager: manager)
 
-    let asyncDone = expectation(description: "async lookup completes immediately")
-    let start = Date()
-    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
-      let elapsed = Date().timeIntervalSince(start)
-      XCTAssertEqual(
-        variant.value as? String, "persisted_val",
-        "lookup must serve the persisted value, not wait on the background fetch")
-      if case .persistence = variant.source {} else {
-        XCTFail("expected .persistence source")
-      }
-      XCTAssertLessThan(elapsed, 0.5, "lookup must not block on the background fetch")
-      asyncDone.fulfill()
-    }
-    wait(for: [asyncDone], timeout: 2.0)
-
-    // Drain the tracking queue to make sure the background _fetchFlagsIfNeeded has been
-    // invoked (it's posted to the same serial queue from inside the lookup block).
-    waitForTrackingQueue(manager: mock)
-    XCTAssertEqual(
-      mock.fetchCallCount, 1,
-      "PUN's first lookup serving persistence should kick off exactly one background fetch")
-  }
-
-  /// After the background fetch completes successfully, `loadedBlobPersistedAt` is cleared
-  /// (in production, by the fetch-success handler) so subsequent lookups stop triggering
-  /// the background-refresh path. Verifies the self-stopping property: PUN doesn't fire a
-  /// fetch on every single lookup forever.
-  func testPersistenceUntilNetworkSuccessBackgroundRefreshSelfStopsAfterSuccess() throws {
-    let mock = makeMockManager(
-      distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
-    waitForTrackingQueue(manager: mock)
-
-    let freshPersistedAt = Date(timeIntervalSinceNow: -60)
-    let persisted = MixpanelFlagVariant(key: "v1", value: "persisted_val")
-      .withSource(.persistence(persistedAt: freshPersistedAt))
-    mock.flagsLock.write {
-      mock.flags = ["flag_a": persisted]
-      mock.loadedBlobPersistedAt = freshPersistedAt
+        XCTAssertTrue(
+            manager.areFlagsReady(),
+            "context mismatch must NOT invalidate persisted blob when keyed on distinctId only")
+        XCTAssertEqual(manager.getAllVariantsSync().count, 1)
     }
 
-    mock.simulatedFetchResult = (
-      success: true, flags: ["flag_a": MixpanelFlagVariant(key: "v2", value: "network_val")])
-    mock.simulatedNetworkDelay = 0  // complete immediately so flags get replaced post-fetch
+    func testInitIgnoresPersistenceWhenExpired() throws {
+        let oldDate = Date(timeIntervalSinceNow: -86_400 * 7)  // 7 days ago
+        let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+        MixpanelPersistence.saveFlagsPersistence(
+            FlagsPersistenceBlob(
+                persistedAt: oldDate,
+                distinctId: "user_a",
+                response: response),
+            instanceName: instanceName)
 
-    // First lookup: kicks off the background refresh.
-    let firstDone = expectation(description: "first lookup")
-    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fb")) { _ in firstDone.fulfill() }
-    wait(for: [firstDone], timeout: 2.0)
-    waitForTrackingQueue(manager: mock)
-    XCTAssertEqual(mock.fetchCallCount, 1, "first lookup kicks off the background refresh")
+        let manager = makeManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))  // 60s TTL
+        waitForTrackingQueue(manager: manager)
 
-    // Second lookup: now `loadedBlobPersistedAt` should be nil (cleared by the successful
-    // fetch), so this lookup serves the network value without triggering another fetch.
-    let secondDone = expectation(description: "second lookup")
-    mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fb")) { variant in
-      XCTAssertEqual(
-        variant.value as? String, "network_val",
-        "second lookup should serve the freshly-fetched network value")
-      secondDone.fulfill()
+        XCTAssertFalse(manager.areFlagsReady(), "expired entry should be ignored")
     }
-    wait(for: [secondDone], timeout: 2.0)
-    waitForTrackingQueue(manager: mock)
-    XCTAssertEqual(
-      mock.fetchCallCount, 1,
-      "no additional fetch — successful refresh cleared loadedBlobPersistedAt")
-  }
 
-  // MARK: - Tracking dedup window resets after every successful fetch
+    func testInitClearsPersistedBlobWhenResponseStringIsUnparseable() throws {
+        // Structurally-valid envelope but the `response` string is garbage. Without self-heal
+        // the blob would stick on disk and fail every cold-start. The init-time persistence load
+        // should both ignore it AND wipe it.
+        let blob = FlagsPersistenceBlob(
+            persistedAt: Date(),
+            distinctId: "user_a",
+            response: "this is not json"
+        )
+        MixpanelPersistence.saveFlagsPersistence(blob, instanceName: instanceName)
+        XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
-  /// Regression test mirroring mixpanel-android's
-  /// `testTracking_getVariantSync_refireAfterSuccessfulRefetch`.
-  ///
-  /// The per-flag `trackedFeatures` set deduplicates `$experiment_started` within a fetch
-  /// round, but must clear on every successful refetch so a second fetch round gets a fresh
-  /// shot at firing tracking — even when the variant value didn't change. Without the clear,
-  /// a flag whose value flipped between fetches (persisted "control" → network "treatment")
-  /// would serve the new value but skip tracking, leaving Mixpanel analytics permanently
-  /// tied to the prior exposure.
-  func testTrackingRefiresAfterSuccessfulRefetch() throws {
-    let delegate = PersistenceTestMockDelegate(
-      options: MixpanelOptions(
-        token: "test_token",
-        featureFlagOptions: FeatureFlagOptions(
-          enabled: true,
-          variantLookupPolicy: .networkOnly)),
-      distinctId: "user_a")
-    retainedDelegates.append(delegate)
-    let queue = DispatchQueue(label: "ff.refire.test.\(UUID().uuidString)")
-    let mock = PersistenceTestMockManager(
-      serverURL: "https://example.test",
-      trackingQueue: queue,
-      instanceName: instanceName,
-      delegate: delegate)
-    waitForTrackingQueue(manager: mock)
+        let manager = makeManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
+        waitForTrackingQueue(manager: manager)
 
-    // ── Fetch round 1: server returns flag_X = variant_A. ──
-    mock.simulatedFetchResult = (
-      success: true,
-      flags: ["flag_x": MixpanelFlagVariant(key: "variant_a", value: "value_a")]
-    )
-    mock.simulatedNetworkDelay = 0
-    let firstFetchDone = expectation(description: "first fetch completes")
-    mock.loadFlags(completion: { _ in firstFetchDone.fulfill() })
-    wait(for: [firstFetchDone], timeout: 2.0)
+        XCTAssertFalse(manager.areFlagsReady(), "unparseable response should leave flags empty")
+        XCTAssertNil(
+            MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
+            "blob should be wiped so the next successful fetch gets a clean slate")
+    }
 
-    let fallback = MixpanelFlagVariant(key: "fb", value: "fb_value")
+    /// `.networkOnly` does two things on init when a stale blob is on disk: (a) doesn't load
+    /// it into memory, and (b) actively wipes it. This way, toggling from a persisting policy
+    /// back to `.networkOnly` cleans up the orphaned blob rather than leaving it stranded.
+    func testInitWipesAndDoesNotLoadPersistenceWhenPolicyIsNetworkOnly() throws {
+        let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+        MixpanelPersistence.saveFlagsPersistence(
+            FlagsPersistenceBlob(
+                persistedAt: Date(),
+                distinctId: "user_a",
+                response: response),
+            instanceName: instanceName)
+        XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
 
-    // First lookup → tracks once.
-    _ = mock.getVariantSync("flag_x", fallback: fallback)
-    waitForMainAndTracking(manager: mock)
-    XCTAssertEqual(
-      delegate.snapshotTrackedEvents().filter { $0.event == "$experiment_started" }.count, 1,
-      "first lookup should fire $experiment_started exactly once")
+        let manager = makeManager(distinctId: "user_a", context: [:], policy: .networkOnly)
+        waitForTrackingQueue(manager: manager)
 
-    // Second lookup in the same fetch round → still 1 (dedup intact).
-    _ = mock.getVariantSync("flag_x", fallback: fallback)
-    waitForMainAndTracking(manager: mock)
-    XCTAssertEqual(
-      delegate.snapshotTrackedEvents().filter { $0.event == "$experiment_started" }.count, 1,
-      "repeat lookup in the same fetch round must not re-fire (dedup window)")
+        XCTAssertFalse(manager.areFlagsReady(), ".networkOnly must not load from persistence")
+        XCTAssertNil(
+            MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
+            ".networkOnly init should wipe a stale blob from a previous persisting-policy session")
+    }
 
-    // ── Fetch round 2: server returns the SAME variant — proves we're testing the
-    //    dedup-clearing behavior, not a value-change-detection behavior. ──
-    mock.simulatedFetchResult = (
-      success: true,
-      flags: ["flag_x": MixpanelFlagVariant(key: "variant_a", value: "value_a")]
-    )
-    let secondFetchDone = expectation(description: "second fetch completes")
-    mock.loadFlags(completion: { _ in secondFetchDone.fulfill() })
-    wait(for: [secondFetchDone], timeout: 2.0)
+    /// Regression test for the init-time race that motivated moving FeatureFlagManager
+    /// construction below `unarchive()` in MixpanelInstance.init.
+    ///
+    /// The async persistence-load block reads `delegate.getDistinctId()` at the moment GCD
+    /// picks it up — NOT at the moment FeatureFlagManager.init dispatched it. This test
+    /// simulates the race by:
+    ///   1. Persisting a blob keyed to "real_user".
+    ///   2. Constructing the manager with a delegate whose distinctId is "wrong_user" — the
+    ///      persistence-load block is queued on a SUSPENDED tracking queue, so it can't run yet.
+    ///   3. Mutating delegate.distinctId to "real_user" (simulating unarchive() loading the
+    ///      persisted identity AFTER FeatureFlagManager init returned).
+    ///   4. Resuming the queue and waiting.
+    /// If the persistence load read distinctId at the right time (block-execution, not
+    /// dispatch), flags load successfully. If we'd snapshotted at dispatch time, this would
+    /// fail.
+    func testPersistenceLoadReadsDistinctIdAtBlockExecutionNotDispatch() throws {
+        let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+        MixpanelPersistence.saveFlagsPersistence(
+            FlagsPersistenceBlob(
+                persistedAt: Date(),
+                distinctId: "real_user",
+                response: response),
+            instanceName: instanceName)
 
-    // Lookup after refetch → fires again (dedup window reset).
-    _ = mock.getVariantSync("flag_x", fallback: fallback)
-    waitForMainAndTracking(manager: mock)
-    XCTAssertEqual(
-      delegate.snapshotTrackedEvents().filter { $0.event == "$experiment_started" }.count, 2,
-      "successful refetch should clear the dedup window so the next lookup re-fires")
-  }
+        let delegate = PersistenceTestMockDelegate(
+            options: MixpanelOptions(
+                token: "test_token",
+                featureFlagOptions: FeatureFlagOptions(
+                    enabled: true,
+                    variantLookupPolicy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))),
+            distinctId: "wrong_user")
+        retainedDelegates.append(delegate)
 
-  /// `waitForTrackingQueue` only drains the tracking queue. Tracking-event recording goes
-  /// through `DispatchQueue.main.async` after the tracking queue, so we need to drain main
-  /// too to observe the recorded events.
-  private func waitForMainAndTracking(manager: FeatureFlagManager) {
-    waitForTrackingQueue(manager: manager)
-    let mainDrained = expectation(description: "main queue drained")
-    DispatchQueue.main.async { mainDrained.fulfill() }
-    wait(for: [mainDrained], timeout: 1.0)
-  }
+        // Suspend the queue BEFORE the manager init so the persistence-load dispatch sits in
+        // the queue without running. Models the worst-case race: GCD couldn't schedule the
+        // worker thread before init's caller continued past the dispatch point.
+        let queue = DispatchQueue(label: "ff.persistence.race.test.\(UUID().uuidString)")
+        queue.suspend()
+        let manager = FeatureFlagManager(
+            serverURL: "https://example.test",
+            trackingQueue: queue,
+            instanceName: instanceName,
+            delegate: delegate)
 
-  // MARK: - Helpers
+        // "unarchive() finishes" — the persisted identity is now visible via the delegate.
+        delegate.distinctId = "real_user"
 
-  private func makeManager(
-    distinctId: String,
-    context: [String: Any],
-    policy: VariantLookupPolicy
-  ) -> FeatureFlagManager {
-    let delegate = PersistenceTestMockDelegate(
-      options: MixpanelOptions(
-        token: "test_token",
-        featureFlagOptions: FeatureFlagOptions(
-          enabled: true,
-          context: context,
-          variantLookupPolicy: policy)),
-      distinctId: distinctId)
-    retainedDelegates.append(delegate)
-    let queue = DispatchQueue(label: "ff.persistence.test.\(UUID().uuidString)")
-    return FeatureFlagManager(
-      serverURL: "https://example.test",
-      trackingQueue: queue,
-      instanceName: instanceName,
-      delegate: delegate)
-  }
+        // Let the persistence load proceed. The waitForTrackingQueue helper posts a barrier
+        // task; because the queue is serial, the persistence load runs first.
+        queue.resume()
+        waitForTrackingQueue(manager: manager)
 
-  private func makeMockManager(
-    distinctId: String,
-    context: [String: Any],
-    policy: VariantLookupPolicy
-  ) -> PersistenceTestMockManager {
-    let delegate = PersistenceTestMockDelegate(
-      options: MixpanelOptions(
-        token: "test_token",
-        featureFlagOptions: FeatureFlagOptions(
-          enabled: true,
-          context: context,
-          variantLookupPolicy: policy)),
-      distinctId: distinctId)
-    retainedDelegates.append(delegate)
-    let queue = DispatchQueue(label: "ff.persistence.mock.test.\(UUID().uuidString)")
-    return PersistenceTestMockManager(
-      serverURL: "https://example.test",
-      trackingQueue: queue,
-      instanceName: instanceName,
-      delegate: delegate)
-  }
+        XCTAssertTrue(
+            manager.areFlagsReady(),
+            "persistence load should have used the post-mutation distinctId, not the construction-time one")
+        XCTAssertEqual(manager.getAllVariantsSync().count, 1)
+    }
 
-  /// Wait for any pending work on the manager's tracking queue (notably the async
-  /// persistence load posted from init) to complete by posting a barrier task and blocking
-  /// on it.
-  private func waitForTrackingQueue(
-    manager: FeatureFlagManager,
-    timeout: TimeInterval = 1.0,
-    file: StaticString = #file,
-    line: UInt = #line
-  ) {
-    let done = expectation(description: "tracking queue drained")
-    manager.trackingQueue.async { done.fulfill() }
-    wait(for: [done], timeout: timeout)
-  }
+    // MARK: - TTL re-check on get
+    //
+    // The TTL is re-checked on every `getVariant`/`getAllVariants` call (not only at init load
+    // time). Once a `.persistence(persistedAt:)`-stamped variant ages past TTL while sitting in
+    // memory, lookups return the developer fallback rather than the stale value. The on-disk
+    // blob is NOT deleted — the next successful fetch will overwrite it.
+
+    /// A `.persistence(persistedAt:)`-stamped variant that's older than the configured TTL is
+    /// treated as not-present by `getVariantSync` — the developer fallback is returned instead.
+    func testGetVariantSyncReturnsFallbackForExpiredPersistedVariant() throws {
+        let manager = makeManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
+        waitForTrackingQueue(manager: manager)
+
+        // Inject an expired persisted variant directly into in-memory state. Bypasses the disk
+        // load path so we can test the get-time TTL check in isolation. persistedAt is 1 hour
+        // ago, well past the 60s TTL configured above.
+        let persistedAt = Date(timeIntervalSinceNow: -3600)
+        let expired = MixpanelFlagVariant(key: "v1", value: "stale_value")
+            .withSource(.persistence(persistedAt: persistedAt))
+        manager.flagsLock.write {
+            manager.flags = ["flag_a": expired]
+            manager.loadedBlobPersistedAt = persistedAt
+        }
+
+        let fallback = MixpanelFlagVariant(key: "fb", value: "fallback_value")
+        let result = manager.getVariantSync("flag_a", fallback: fallback)
+
+        XCTAssertEqual(result.value as? String, "fallback_value")
+        if case .fallback = result.source {
+        } else {
+            XCTFail("served fallback should carry .fallback source")
+        }
+    }
+
+    /// A `.persistence(persistedAt:)`-stamped variant within TTL is served as-is (with
+    /// `.persistence` source preserved).
+    func testGetVariantSyncReturnsFreshPersistedVariant() throws {
+        let manager = makeManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
+        waitForTrackingQueue(manager: manager)
+
+        let persistedAt = Date(timeIntervalSinceNow: -60)
+        let fresh = MixpanelFlagVariant(key: "v1", value: "fresh_value")
+            .withSource(.persistence(persistedAt: persistedAt))
+        manager.flagsLock.write {
+            manager.flags = ["flag_a": fresh]
+            manager.loadedBlobPersistedAt = persistedAt
+        }
+
+        let fallback = MixpanelFlagVariant(key: "fb", value: "fallback_value")
+        let result = manager.getVariantSync("flag_a", fallback: fallback)
+
+        XCTAssertEqual(result.value as? String, "fresh_value")
+        if case .persistence = result.source {
+        } else {
+            XCTFail("expected .persistence source preserved")
+        }
+    }
+
+    /// `.network`-stamped variants are never expired regardless of how old they are — TTL only
+    /// applies to `.persistence(persistedAt:)` variants.
+    func testGetVariantSyncReturnsNetworkVariantRegardlessOfAge() throws {
+        let manager = makeManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
+        waitForTrackingQueue(manager: manager)
+
+        // .network variants don't carry a timestamp, so the TTL check should always return false.
+        let networkVariant = MixpanelFlagVariant(key: "v1", value: "from_network")
+            .withSource(.network)
+        manager.flagsLock.write {
+            manager.flags = ["flag_a": networkVariant]
+        }
+
+        let fallback = MixpanelFlagVariant(key: "fb", value: "fallback_value")
+        let result = manager.getVariantSync("flag_a", fallback: fallback)
+        XCTAssertEqual(result.value as? String, "from_network")
+    }
+
+    /// When the loaded persisted blob is past TTL, `getAllVariantsSync` filters out all
+    /// `.persistence` variants but keeps `.network` variants (e.g., activated first-time
+    /// events that were promoted to network source mid-session). Documents the blob-level
+    /// expiry rule: all `.persistence` variants share `persistedAt`, so they pass-or-fail
+    /// the TTL check together.
+    func testGetAllVariantsSyncFiltersPersistedVariantsWhenBlobIsStale() throws {
+        let manager = makeManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
+        waitForTrackingQueue(manager: manager)
+
+        let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
+        let stalePersistedA = MixpanelFlagVariant(key: "v1", value: "stale_a")
+            .withSource(.persistence(persistedAt: stalePersistedAt))
+        let stalePersistedB = MixpanelFlagVariant(key: "v2", value: "stale_b")
+            .withSource(.persistence(persistedAt: stalePersistedAt))
+        let networkSourced = MixpanelFlagVariant(key: "v3", value: "from_network")
+            .withSource(.network)
+
+        manager.flagsLock.write {
+            manager.flags = [
+                "stale_flag_a": stalePersistedA,
+                "stale_flag_b": stalePersistedB,
+                "network_flag": networkSourced,
+            ]
+            manager.loadedBlobPersistedAt = stalePersistedAt
+        }
+
+        let result = manager.getAllVariantsSync()
+        XCTAssertEqual(result.count, 1)
+        XCTAssertNil(result["stale_flag_a"], "stale persisted variant should be filtered out")
+        XCTAssertNil(result["stale_flag_b"], "stale persisted variant should be filtered out")
+        XCTAssertNotNil(
+            result["network_flag"], ".network variants survive blob expiration (e.g., activated FTEs)")
+    }
+
+    /// The on-disk blob is NOT deleted when an in-memory variant expires at get-time.
+    /// Per the rule: "no harm in keeping. Will likely be overwritten shortly after."
+    func testExpiredVariantOnGetVariantDoesNotWipeDiskPersistence() throws {
+        let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"v"}}}"#
+        let blob = FlagsPersistenceBlob(persistedAt: Date(), distinctId: "user_a", response: response)
+        MixpanelPersistence.saveFlagsPersistence(blob, instanceName: instanceName)
+
+        let manager = makeManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
+        waitForTrackingQueue(manager: manager)
+        XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
+
+        // Force the in-memory variant to be expired without wiping the disk blob.
+        let stalePersistedAt = Date(timeIntervalSinceNow: -90_000)  // > 86_400s TTL
+        let expired = MixpanelFlagVariant(key: "v1", value: "stale")
+            .withSource(.persistence(persistedAt: stalePersistedAt))
+        manager.flagsLock.write {
+            manager.flags = ["flag_a": expired]
+            manager.loadedBlobPersistedAt = stalePersistedAt
+        }
+
+        let fallback = MixpanelFlagVariant(key: "fb", value: "fb")
+        let result = manager.getVariantSync("flag_a", fallback: fallback)
+        XCTAssertEqual(result.value as? String, "fb")
+
+        // Critical: blob persists. The next successful fetch overwrites it; this lookup didn't
+        // delete it.
+        XCTAssertNotNil(
+            MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
+            "expired-on-get must NOT wipe the on-disk blob")
+    }
+
+    // MARK: - NetworkFirst gating
+
+    func testNetworkFirstAsyncLookupAwaitsFetchEvenWithPersistence() throws {
+        let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"persisted_val"}}}"#
+        MixpanelPersistence.saveFlagsPersistence(
+            FlagsPersistenceBlob(
+                persistedAt: Date(),
+                distinctId: "user_a",
+                response: response),
+            instanceName: instanceName)
+
+        let mock = makeMockManager(
+            distinctId: "user_a", context: [:], policy: .networkFirst(persistenceTtl: 86_400))
+
+        // Configure the mock to "succeed" with new flags, but with a delay that lets us assert
+        // the async lookup waited for the network rather than serving persisted values
+        // immediately.
+        mock.simulatedFetchResult = (
+            success: true,
+            flags: [
+                "flag_a": MixpanelFlagVariant(key: "v_fresh", value: "network_val")
+            ]
+        )
+        mock.simulatedNetworkDelay = 0.1  // 100ms delay
+
+        waitForTrackingQueue(manager: mock)
+        // Persistence load should have populated `flags` with .persistence stamping. Now async
+        // lookup must NOT serve those persisted values — it has to await the network response.
+        let asyncDone = expectation(description: "async lookup completes after network")
+        mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+            // The variant served must be the network value, not the persisted one.
+            XCTAssertEqual(variant.value as? String, "network_val")
+            if case .network = variant.source {
+            } else {
+                XCTFail("variant served by NetworkFirst should be from .network after fetch")
+            }
+            asyncDone.fulfill()
+        }
+        wait(for: [asyncDone], timeout: 2.0)
+    }
+
+    func testNetworkFirstFallsBackToPersistenceOnFetchFailure() throws {
+        let persistedAt = Date(timeIntervalSinceNow: -60)  // 60s old, well within TTL
+        let response = #"{"flags":{"flag_a":{"variant_key":"v_persisted","variant_value":"persisted_val"}}}"#
+        MixpanelPersistence.saveFlagsPersistence(
+            FlagsPersistenceBlob(
+                persistedAt: persistedAt,
+                distinctId: "user_a",
+                response: response),
+            instanceName: instanceName)
+
+        let mock = makeMockManager(
+            distinctId: "user_a", context: [:], policy: .networkFirst(persistenceTtl: 86_400))
+        mock.simulatedFetchResult = (success: false, flags: nil)
+
+        waitForTrackingQueue(manager: mock)
+
+        let asyncDone = expectation(description: "async lookup completes after fetch failure")
+        mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+            // Fetch failed → persisted values stay → async lookup serves the persisted variant.
+            XCTAssertEqual(variant.value as? String, "persisted_val")
+            if case .persistence = variant.source {
+            } else {
+                XCTFail("variant served on NetworkFirst failure should keep .persistence source")
+            }
+            asyncDone.fulfill()
+        }
+        wait(for: [asyncDone], timeout: 2.0)
+    }
+
+    func testPersistenceUntilNetworkSuccessAsyncLookupServesPersistedImmediately() throws {
+        let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"persisted_val"}}}"#
+        MixpanelPersistence.saveFlagsPersistence(
+            FlagsPersistenceBlob(
+                persistedAt: Date(),
+                distinctId: "user_a",
+                response: response),
+            instanceName: instanceName)
+
+        let mock = makeMockManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
+        // Configure a slow network so we'd notice if the lookup was waiting on it.
+        mock.simulatedFetchResult = (
+            success: true, flags: ["flag_a": MixpanelFlagVariant(key: "v2", value: "network_val")]
+        )
+        mock.simulatedNetworkDelay = 0.1
+
+        waitForTrackingQueue(manager: mock)
+
+        let asyncDone = expectation(description: "async lookup completes")
+        let start = Date()
+        mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+            let elapsed = Date().timeIntervalSince(start)
+            XCTAssertEqual(
+                variant.value as? String, "persisted_val", "persistenceUntilNetworkSuccess should serve persisted")
+            if case .persistence = variant.source {} else { XCTFail("expected .persistence source") }
+            // Generous bound — just want to confirm we didn't wait on the 100ms simulated network.
+            XCTAssertLessThan(elapsed, 0.08, "persistenceUntilNetworkSuccess should not wait for network")
+            asyncDone.fulfill()
+        }
+        wait(for: [asyncDone], timeout: 1.0)
+    }
+
+    // MARK: - Reset wipes persistence
+
+    func testResetWipesDiskPersistence() throws {
+        let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+        MixpanelPersistence.saveFlagsPersistence(
+            FlagsPersistenceBlob(
+                persistedAt: Date(),
+                distinctId: "user_a",
+                response: response),
+            instanceName: instanceName)
+
+        let manager = makeManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
+        waitForTrackingQueue(manager: manager)
+
+        XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
+
+        manager.reset()
+        waitForTrackingQueue(manager: manager)
+
+        XCTAssertNil(
+            MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
+            "reset() should wipe the on-disk persistence blob")
+        XCTAssertFalse(manager.areFlagsReady())
+    }
+
+    /// `setContext` deliberately does NOT clear in-memory variants OR the on-disk blob. The
+    /// blob is keyed on distinctId only, so it remains valid across context changes for the
+    /// same user. The next successful fetch under the new context overwrites the blob.
+    func testSetContextDoesNotWipePersistenceOrInMemoryState() throws {
+        let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":true}}}"#
+        MixpanelPersistence.saveFlagsPersistence(
+            FlagsPersistenceBlob(
+                persistedAt: Date(),
+                distinctId: "user_a",
+                response: response),
+            instanceName: instanceName)
+
+        let mock = makeMockManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
+        // Make the post-setContext fetch fail so we can isolate setContext's effect — without
+        // a successful overwrite, the blob's survival is solely attributable to setContext
+        // NOT wiping it. The same goes for in-memory state.
+        mock.simulatedFetchResult = (success: false, flags: nil)
+        mock.simulatedNetworkDelay = 0
+        waitForTrackingQueue(manager: mock)
+
+        XCTAssertNotNil(MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName))
+        XCTAssertTrue(mock.areFlagsReady(), "persistence load on init should populate flags")
+
+        let setContextDone = expectation(description: "setContext fetch completes")
+        mock.setContext(["plan": "enterprise"]) { setContextDone.fulfill() }
+        wait(for: [setContextDone], timeout: 2.0)
+        waitForTrackingQueue(manager: mock)
+
+        XCTAssertNotNil(
+            MixpanelPersistence.loadFlagsPersistence(instanceName: instanceName),
+            "setContext must NOT wipe the on-disk persistence blob")
+        XCTAssertTrue(
+            mock.areFlagsReady(),
+            "setContext must NOT clear in-memory variants")
+    }
+
+    // MARK: - Async lookups refresh when loaded blob is stale
+    //
+    // When a persisting policy is in effect and the loaded persisted blob has aged past TTL
+    // mid-session, the async getVariant / getAllVariants paths must fall through to a network
+    // fetch rather than silently serving the developer fallback or an empty dict. The blob
+    // shares a single `persistedAt`, so any one expired entry decides for the whole set.
+
+    /// `getVariant(completion:)` triggers a fetch when the in-memory persisted variant for the
+    /// requested flag has aged past TTL, and serves the post-fetch (network) value rather than
+    /// the developer fallback.
+    func testGetVariantAsyncTriggersFetchWhenLoadedBlobIsStale() throws {
+        let mock = makeMockManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
+        waitForTrackingQueue(manager: mock)
+
+        // Inject an expired persisted variant directly. Bypasses the disk-load path so we can
+        // pin the staleness without depending on init timing.
+        let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
+        let expired = MixpanelFlagVariant(key: "v_old", value: "stale_val")
+            .withSource(.persistence(persistedAt: stalePersistedAt))
+        mock.flagsLock.write {
+            mock.flags = ["flag_a": expired]
+            mock.loadedBlobPersistedAt = stalePersistedAt
+        }
+
+        // Mock the refresh response so we can confirm the served value came from the network.
+        mock.simulatedFetchResult = (
+            success: true,
+            flags: ["flag_a": MixpanelFlagVariant(key: "v_fresh", value: "network_val")]
+        )
+        mock.simulatedNetworkDelay = 0
+
+        let asyncDone = expectation(description: "async lookup completes after refresh")
+        mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+            XCTAssertEqual(
+                variant.value as? String, "network_val",
+                "stale persisted blob should trigger fetch and serve the network value")
+            if case .network = variant.source {
+            } else {
+                XCTFail("post-fetch variant should carry .network source")
+            }
+            asyncDone.fulfill()
+        }
+        wait(for: [asyncDone], timeout: 2.0)
+    }
+
+    /// When the loaded blob is stale and the refresh fails, async getVariant serves the
+    /// developer fallback (the stale persisted value is filtered by `_getVariantSyncImpl`'s
+    /// per-variant TTL check). This documents the post-fix tolerance: we fetch, but we don't
+    /// resurrect stale values just because the network was unavailable.
+    func testGetVariantAsyncReturnsFallbackWhenStaleBlobAndFetchFails() throws {
+        let mock = makeMockManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
+        waitForTrackingQueue(manager: mock)
+
+        let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
+        let expired = MixpanelFlagVariant(key: "v_old", value: "stale_val")
+            .withSource(.persistence(persistedAt: stalePersistedAt))
+        mock.flagsLock.write {
+            mock.flags = ["flag_a": expired]
+            mock.loadedBlobPersistedAt = stalePersistedAt
+        }
+
+        mock.simulatedFetchResult = (success: false, flags: nil)
+        mock.simulatedNetworkDelay = 0
+
+        let asyncDone = expectation(description: "async lookup completes after failed refresh")
+        mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback_val")) { variant in
+            XCTAssertEqual(variant.value as? String, "fallback_val")
+            asyncDone.fulfill()
+        }
+        wait(for: [asyncDone], timeout: 2.0)
+    }
+
+    /// `getAllVariants(completion:)` triggers a fetch when the loaded blob is stale rather
+    /// than returning an empty (post-filter) dictionary without attempting refresh.
+    func testGetAllVariantsAsyncTriggersFetchWhenLoadedBlobIsStale() throws {
+        let mock = makeMockManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
+        waitForTrackingQueue(manager: mock)
+
+        let stalePersistedAt = Date(timeIntervalSinceNow: -3600)
+        let expiredA = MixpanelFlagVariant(key: "v1", value: "stale_a")
+            .withSource(.persistence(persistedAt: stalePersistedAt))
+        let expiredB = MixpanelFlagVariant(key: "v2", value: "stale_b")
+            .withSource(.persistence(persistedAt: stalePersistedAt))
+        mock.flagsLock.write {
+            mock.flags = ["flag_a": expiredA, "flag_b": expiredB]
+            mock.loadedBlobPersistedAt = stalePersistedAt
+        }
+
+        mock.simulatedFetchResult = (
+            success: true,
+            flags: [
+                "flag_a": MixpanelFlagVariant(key: "v1f", value: "fresh_a"),
+                "flag_b": MixpanelFlagVariant(key: "v2f", value: "fresh_b"),
+            ]
+        )
+        mock.simulatedNetworkDelay = 0
+
+        let asyncDone = expectation(description: "async getAll completes after refresh")
+        mock.getAllVariants { variants in
+            XCTAssertEqual(variants.count, 2)
+            XCTAssertEqual(variants["flag_a"]?.value as? String, "fresh_a")
+            XCTAssertEqual(variants["flag_b"]?.value as? String, "fresh_b")
+            asyncDone.fulfill()
+        }
+        wait(for: [asyncDone], timeout: 2.0)
+    }
+
+    /// An empty persisted blob within TTL is treated as a valid state: serve the developer
+    /// fallback, no network refresh. The customer is opting into "use cached flags," and
+    /// the cache says "no flags configured at the time it was written" — until TTL elapses,
+    /// we trust that.
+    func testGetVariantAsyncServesFallbackOnEmptyFreshBlobWithoutRefresh() throws {
+        let mock = makeMockManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
+        waitForTrackingQueue(manager: mock)
+
+        let freshPersistedAt = Date(timeIntervalSinceNow: -60)  // well within TTL
+        mock.flagsLock.write {
+            mock.flags = [:]
+            mock.loadedBlobPersistedAt = freshPersistedAt
+        }
+
+        // Configure a recognizable network response. If the staleness check wrongly triggers
+        // a fetch, the served value would be "should_not_be_served".
+        mock.simulatedFetchResult = (
+            success: true,
+            flags: ["flag_a": MixpanelFlagVariant(key: "v1", value: "should_not_be_served")]
+        )
+        mock.simulatedNetworkDelay = 0
+
+        let asyncDone = expectation(description: "async lookup completes without refresh")
+        mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+            XCTAssertEqual(
+                variant.value as? String, "fallback",
+                "empty fresh blob should serve fallback without auto-refreshing")
+            asyncDone.fulfill()
+        }
+        wait(for: [asyncDone], timeout: 2.0)
+    }
+
+    /// An empty persisted blob PAST TTL still triggers a fetch — the TTL governs when to
+    /// refresh regardless of whether the blob has flags in it. This is exactly why we keep
+    /// `loadedBlobPersistedAt` separate from variant inspection: an empty blob has no
+    /// variants to check, but its persistedAt still tells us when to give up on the cache.
+    func testGetVariantAsyncTriggersFetchWhenEmptyBlobIsStale() throws {
+        let mock = makeMockManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 60))
+        waitForTrackingQueue(manager: mock)
+
+        let stalePersistedAt = Date(timeIntervalSinceNow: -3600)  // well past 60s TTL
+        mock.flagsLock.write {
+            mock.flags = [:]
+            mock.loadedBlobPersistedAt = stalePersistedAt
+        }
+
+        mock.simulatedFetchResult = (
+            success: true,
+            flags: ["flag_a": MixpanelFlagVariant(key: "v1", value: "fresh_val")]
+        )
+        mock.simulatedNetworkDelay = 0
+
+        let asyncDone = expectation(description: "async lookup refreshes stale empty blob")
+        mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+            XCTAssertEqual(
+                variant.value as? String, "fresh_val",
+                "stale empty blob should trigger fetch and serve newly-discovered flag")
+            asyncDone.fulfill()
+        }
+        wait(for: [asyncDone], timeout: 2.0)
+    }
+
+    /// Sanity check the existing serve-immediately path still wins when the loaded blob is
+    /// fresh — the staleness check shouldn't push fresh persisted variants through a needless
+    /// network round-trip.
+    func testGetVariantAsyncServesFreshPersistedImmediatelyWithoutFetch() throws {
+        let mock = makeMockManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
+        waitForTrackingQueue(manager: mock)
+
+        let freshPersistedAt = Date(timeIntervalSinceNow: -60)
+        let fresh = MixpanelFlagVariant(key: "v1", value: "persisted_val")
+            .withSource(.persistence(persistedAt: freshPersistedAt))
+        mock.flagsLock.write {
+            mock.flags = ["flag_a": fresh]
+            mock.loadedBlobPersistedAt = freshPersistedAt
+        }
+
+        // Configure a slow + clearly-different network response. If the staleness check
+        // wrongly triggers a fetch, the test will catch the wrong value (and the slow delay
+        // would add noticeable latency).
+        mock.simulatedFetchResult = (
+            success: true,
+            flags: ["flag_a": MixpanelFlagVariant(key: "v2", value: "network_val")]
+        )
+        mock.simulatedNetworkDelay = 0.1
+
+        let asyncDone = expectation(description: "async getVariant completes")
+        let start = Date()
+        mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fb")) { variant in
+            let elapsed = Date().timeIntervalSince(start)
+            XCTAssertEqual(variant.value as? String, "persisted_val")
+            if case .persistence = variant.source {
+            } else {
+                XCTFail("fresh persisted variant should be served as-is, not refreshed")
+            }
+            XCTAssertLessThan(elapsed, 0.08, "fresh blob must not wait on the network")
+            asyncDone.fulfill()
+        }
+        wait(for: [asyncDone], timeout: 1.0)
+    }
+
+    // MARK: - Tracking properties for persisted variants
+
+    /// When a served variant came from the persistence layer, `$experiment_started` carries
+    /// `$variant_source` = "persistence", `$persisted_at_in_ms` (raw epoch ms — no offsets,
+    /// no deltas), and `$ttl_in_ms` (the customer-configured TTL in ms). Verifies the values
+    /// against the same `persistedAt` and `ttl` we configured.
+    func testTrackingIncludesPersistencePropertiesForPersistedVariant() throws {
+        // Use a recent fixed timestamp (offset from "now") so we can assert the exact
+        // $persisted_at_in_ms while still passing the TTL check.
+        let persistedAt = Date(timeIntervalSinceNow: -60)  // 60s ago
+        let ttlSeconds: TimeInterval = 86_400  // 24 hours
+        let manager = makeManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: ttlSeconds))
+        waitForTrackingQueue(manager: manager)
+        let delegate = retainedDelegates.last as! PersistenceTestMockDelegate
+
+        // Inject a .persistence-stamped variant directly. Bypasses the disk-load round-trip so
+        // we can pin `persistedAt` to an exact value for the assertion below without depending
+        // on the blob serializer's millisecond rounding.
+        let persistedVariant = MixpanelFlagVariant(key: "v1", value: "persisted_val")
+            .withSource(.persistence(persistedAt: persistedAt))
+        manager.flagsLock.write {
+            manager.flags = ["flag_a": persistedVariant]
+            manager.loadedBlobPersistedAt = persistedAt
+        }
+
+        // Trigger tracking by reading the persisted variant (first read records the tracking
+        // event; subsequent reads are deduped via `trackedFeatures`).
+        let fallback = MixpanelFlagVariant(key: "fb", value: "fb")
+        _ = manager.getVariantSync("flag_a", fallback: fallback)
+
+        // The delegate.track call is dispatched async to main; spin briefly until it lands.
+        let trackedExpectation = expectation(description: "tracking event recorded")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            let events = delegate.snapshotTrackedEvents()
+            if events.contains(where: { $0.event == "$experiment_started" }) {
+                trackedExpectation.fulfill()
+            }
+        }
+        wait(for: [trackedExpectation], timeout: 2.0)
+
+        let events = delegate.snapshotTrackedEvents()
+        let experiment = try XCTUnwrap(events.first(where: { $0.event == "$experiment_started" }))
+        let props = try XCTUnwrap(experiment.properties)
+
+        XCTAssertEqual(props["$variant_source"] as? String, "persistence")
+        let expectedPersistedAtMs = Int(persistedAt.timeIntervalSince1970 * 1000)
+        XCTAssertEqual(props["$persisted_at_in_ms"] as? Int, expectedPersistedAtMs)
+        XCTAssertEqual(props["$ttl_in_ms"] as? Int, Int(ttlSeconds * 1000))
+    }
+
+    /// `.network`-sourced variants carry `$variant_source = "network"` (matching the JS SDK)
+    /// but NOT the persistence-layer-only properties (`$persisted_at_in_ms`, `$ttl_in_ms`).
+    /// This protects against accidentally leaking persistence properties through the
+    /// `.network` path.
+    func testTrackingIncludesVariantSourceForNetworkVariant() throws {
+        let delegate = PersistenceTestMockDelegate(
+            options: MixpanelOptions(
+                token: "test_token",
+                featureFlagOptions: FeatureFlagOptions(
+                    enabled: true,
+                    variantLookupPolicy: .networkOnly)),
+            distinctId: "user_a")
+        retainedDelegates.append(delegate)
+        let queue = DispatchQueue(label: "ff.network.tracking.test.\(UUID().uuidString)")
+        let manager = FeatureFlagManager(
+            serverURL: "https://example.test",
+            trackingQueue: queue,
+            instanceName: instanceName,
+            delegate: delegate)
+        waitForTrackingQueue(manager: manager)
+
+        // Inject a .network-sourced variant directly — bypasses the fetch path.
+        let networkVariant = MixpanelFlagVariant(key: "v1", value: "network_val")
+            .withSource(.network)
+        manager.flagsLock.write { manager.flags = ["flag_a": networkVariant] }
+
+        let fallback = MixpanelFlagVariant(key: "fb", value: "fb")
+        _ = manager.getVariantSync("flag_a", fallback: fallback)
+
+        let trackedExpectation = expectation(description: "tracking event recorded")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            let events = delegate.snapshotTrackedEvents()
+            if events.contains(where: { $0.event == "$experiment_started" }) {
+                trackedExpectation.fulfill()
+            }
+        }
+        wait(for: [trackedExpectation], timeout: 2.0)
+
+        let events = delegate.snapshotTrackedEvents()
+        let experiment = try XCTUnwrap(events.first(where: { $0.event == "$experiment_started" }))
+        let props = try XCTUnwrap(experiment.properties)
+
+        XCTAssertEqual(props["$variant_source"] as? String, "network")
+        XCTAssertNil(props["$persisted_at_in_ms"], "network variants don't carry persistedAt")
+        XCTAssertNil(props["$ttl_in_ms"], "network variants don't carry TTL")
+    }
+
+    // MARK: - NetworkFirst retries until a fetch succeeds
+
+    /// Regression test for the bug where NetworkFirst would stop attempting the network after
+    /// the first failure: `awaitingInitialNetworkResponse` was being cleared on fetch failure,
+    /// so subsequent async lookups would silently serve persistence forever even though no
+    /// successful network response had ever come back.
+    ///
+    /// Spec: NetworkFirst lookups await a successful network response. After a failed fetch,
+    /// the next async lookup must retry the network — only a successful fetch satisfies the
+    /// "we got the network value" gate. Verified end-to-end: two failed fetches in a row → two
+    /// fetch attempts (not one).
+    func testNetworkFirstRetriesNetworkAfterFailureUntilSuccess() throws {
+        let response = #"{"flags":{"flag_a":{"variant_key":"v1","variant_value":"persisted_val"}}}"#
+        MixpanelPersistence.saveFlagsPersistence(
+            FlagsPersistenceBlob(
+                persistedAt: Date(),
+                distinctId: "user_a",
+                response: response),
+            instanceName: instanceName)
+
+        let mock = makeMockManager(
+            distinctId: "user_a", context: [:], policy: .networkFirst(persistenceTtl: 86_400))
+        waitForTrackingQueue(manager: mock)
+
+        // Round 1: fetch fails. Lookup falls back to persisted value.
+        mock.simulatedFetchResult = (success: false, flags: nil)
+        mock.simulatedNetworkDelay = 0
+        let firstDone = expectation(description: "first lookup")
+        mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+            XCTAssertEqual(
+                variant.value as? String, "persisted_val",
+                "first lookup should fall back to persisted value after failed fetch")
+            firstDone.fulfill()
+        }
+        wait(for: [firstDone], timeout: 2.0)
+        XCTAssertEqual(mock.fetchCallCount, 1, "first lookup should trigger one fetch attempt")
+
+        // Round 2: fetch fails again. Pre-fix, the lookup would skip the network entirely
+        // (`awaiting` had been cleared by round 1's failure) and serve persisted directly,
+        // leaving the count at 1. Post-fix, NetworkFirst retries until success.
+        let secondDone = expectation(description: "second lookup")
+        mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+            XCTAssertEqual(variant.value as? String, "persisted_val")
+            secondDone.fulfill()
+        }
+        wait(for: [secondDone], timeout: 2.0)
+        XCTAssertEqual(
+            mock.fetchCallCount, 2,
+            "NetworkFirst must retry the network on subsequent lookups after a failure")
+
+        // Round 3: fetch succeeds. Network value served, blob marker cleared.
+        mock.simulatedFetchResult = (
+            success: true, flags: ["flag_a": MixpanelFlagVariant(key: "v_fresh", value: "network_val")]
+        )
+        let thirdDone = expectation(description: "third lookup")
+        mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+            XCTAssertEqual(
+                variant.value as? String, "network_val",
+                "successful fetch should serve the network value")
+            thirdDone.fulfill()
+        }
+        wait(for: [thirdDone], timeout: 2.0)
+        XCTAssertEqual(mock.fetchCallCount, 3, "third lookup triggers the successful fetch")
+
+        // Round 4: subsequent lookup should NOT retry — the gate flipped off after success.
+        let fourthDone = expectation(description: "fourth lookup")
+        mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+            XCTAssertEqual(variant.value as? String, "network_val")
+            fourthDone.fulfill()
+        }
+        wait(for: [fourthDone], timeout: 2.0)
+        XCTAssertEqual(
+            mock.fetchCallCount, 3,
+            "after a successful fetch, NetworkFirst stops retrying — gate is satisfied")
+    }
+
+    // MARK: - PersistenceUntilNetworkSuccess background refresh
+
+    /// PUN's contract is "serve persisted now, refresh in background." The first lookup that
+    /// finds the immediate-serve path satisfied by a persisted blob (not yet overwritten by a
+    /// successful network fetch) must kick off a background fetch — without blocking the
+    /// lookup itself — so subsequent lookups eventually see fresh values. The fetch self-stops
+    /// because a successful fetch clears `loadedBlobPersistedAt`, taking us off the
+    /// background-refresh trigger.
+    func testPersistenceUntilNetworkSuccessLookupKicksOffBackgroundRefresh() throws {
+        let mock = makeMockManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
+        waitForTrackingQueue(manager: mock)
+
+        let freshPersistedAt = Date(timeIntervalSinceNow: -60)
+        let persisted = MixpanelFlagVariant(key: "v_old", value: "persisted_val")
+            .withSource(.persistence(persistedAt: freshPersistedAt))
+        mock.flagsLock.write {
+            mock.flags = ["flag_a": persisted]
+            mock.loadedBlobPersistedAt = freshPersistedAt
+        }
+
+        // Hang the simulated fetch so it counts as kicked-off but doesn't complete and replace
+        // `flags` mid-test. Counter increments synchronously inside `_performFetchRequest`.
+        mock.simulatedFetchResult = (
+            success: true, flags: ["flag_a": MixpanelFlagVariant(key: "v_new", value: "network_val")]
+        )
+        mock.simulatedNetworkDelay = 60  // effectively never completes within the test
+
+        XCTAssertEqual(mock.fetchCallCount, 0, "no fetch before lookup")
+
+        let asyncDone = expectation(description: "async lookup completes immediately")
+        let start = Date()
+        mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fallback")) { variant in
+            let elapsed = Date().timeIntervalSince(start)
+            XCTAssertEqual(
+                variant.value as? String, "persisted_val",
+                "lookup must serve the persisted value, not wait on the background fetch")
+            if case .persistence = variant.source {
+            } else {
+                XCTFail("expected .persistence source")
+            }
+            XCTAssertLessThan(elapsed, 0.5, "lookup must not block on the background fetch")
+            asyncDone.fulfill()
+        }
+        wait(for: [asyncDone], timeout: 2.0)
+
+        // Drain the tracking queue to make sure the background _fetchFlagsIfNeeded has been
+        // invoked (it's posted to the same serial queue from inside the lookup block).
+        waitForTrackingQueue(manager: mock)
+        XCTAssertEqual(
+            mock.fetchCallCount, 1,
+            "PUN's first lookup serving persistence should kick off exactly one background fetch")
+    }
+
+    /// After the background fetch completes successfully, `loadedBlobPersistedAt` is cleared
+    /// (in production, by the fetch-success handler) so subsequent lookups stop triggering
+    /// the background-refresh path. Verifies the self-stopping property: PUN doesn't fire a
+    /// fetch on every single lookup forever.
+    func testPersistenceUntilNetworkSuccessBackgroundRefreshSelfStopsAfterSuccess() throws {
+        let mock = makeMockManager(
+            distinctId: "user_a", context: [:], policy: .persistenceUntilNetworkSuccess(persistenceTtl: 86_400))
+        waitForTrackingQueue(manager: mock)
+
+        let freshPersistedAt = Date(timeIntervalSinceNow: -60)
+        let persisted = MixpanelFlagVariant(key: "v1", value: "persisted_val")
+            .withSource(.persistence(persistedAt: freshPersistedAt))
+        mock.flagsLock.write {
+            mock.flags = ["flag_a": persisted]
+            mock.loadedBlobPersistedAt = freshPersistedAt
+        }
+
+        mock.simulatedFetchResult = (
+            success: true, flags: ["flag_a": MixpanelFlagVariant(key: "v2", value: "network_val")]
+        )
+        mock.simulatedNetworkDelay = 0  // complete immediately so flags get replaced post-fetch
+
+        // First lookup: kicks off the background refresh.
+        let firstDone = expectation(description: "first lookup")
+        mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fb")) { _ in firstDone.fulfill() }
+        wait(for: [firstDone], timeout: 2.0)
+        waitForTrackingQueue(manager: mock)
+        XCTAssertEqual(mock.fetchCallCount, 1, "first lookup kicks off the background refresh")
+
+        // Second lookup: now `loadedBlobPersistedAt` should be nil (cleared by the successful
+        // fetch), so this lookup serves the network value without triggering another fetch.
+        let secondDone = expectation(description: "second lookup")
+        mock.getVariant("flag_a", fallback: MixpanelFlagVariant(value: "fb")) { variant in
+            XCTAssertEqual(
+                variant.value as? String, "network_val",
+                "second lookup should serve the freshly-fetched network value")
+            secondDone.fulfill()
+        }
+        wait(for: [secondDone], timeout: 2.0)
+        waitForTrackingQueue(manager: mock)
+        XCTAssertEqual(
+            mock.fetchCallCount, 1,
+            "no additional fetch — successful refresh cleared loadedBlobPersistedAt")
+    }
+
+    // MARK: - Tracking dedup window resets after every successful fetch
+
+    /// Regression test mirroring mixpanel-android's
+    /// `testTracking_getVariantSync_refireAfterSuccessfulRefetch`.
+    ///
+    /// The per-flag `trackedFeatures` set deduplicates `$experiment_started` within a fetch
+    /// round, but must clear on every successful refetch so a second fetch round gets a fresh
+    /// shot at firing tracking — even when the variant value didn't change. Without the clear,
+    /// a flag whose value flipped between fetches (persisted "control" → network "treatment")
+    /// would serve the new value but skip tracking, leaving Mixpanel analytics permanently
+    /// tied to the prior exposure.
+    func testTrackingRefiresAfterSuccessfulRefetch() throws {
+        let delegate = PersistenceTestMockDelegate(
+            options: MixpanelOptions(
+                token: "test_token",
+                featureFlagOptions: FeatureFlagOptions(
+                    enabled: true,
+                    variantLookupPolicy: .networkOnly)),
+            distinctId: "user_a")
+        retainedDelegates.append(delegate)
+        let queue = DispatchQueue(label: "ff.refire.test.\(UUID().uuidString)")
+        let mock = PersistenceTestMockManager(
+            serverURL: "https://example.test",
+            trackingQueue: queue,
+            instanceName: instanceName,
+            delegate: delegate)
+        waitForTrackingQueue(manager: mock)
+
+        // ── Fetch round 1: server returns flag_X = variant_A. ──
+        mock.simulatedFetchResult = (
+            success: true,
+            flags: ["flag_x": MixpanelFlagVariant(key: "variant_a", value: "value_a")]
+        )
+        mock.simulatedNetworkDelay = 0
+        let firstFetchDone = expectation(description: "first fetch completes")
+        mock.loadFlags(completion: { _ in firstFetchDone.fulfill() })
+        wait(for: [firstFetchDone], timeout: 2.0)
+
+        let fallback = MixpanelFlagVariant(key: "fb", value: "fb_value")
+
+        // First lookup → tracks once.
+        _ = mock.getVariantSync("flag_x", fallback: fallback)
+        waitForMainAndTracking(manager: mock)
+        XCTAssertEqual(
+            delegate.snapshotTrackedEvents().filter { $0.event == "$experiment_started" }.count, 1,
+            "first lookup should fire $experiment_started exactly once")
+
+        // Second lookup in the same fetch round → still 1 (dedup intact).
+        _ = mock.getVariantSync("flag_x", fallback: fallback)
+        waitForMainAndTracking(manager: mock)
+        XCTAssertEqual(
+            delegate.snapshotTrackedEvents().filter { $0.event == "$experiment_started" }.count, 1,
+            "repeat lookup in the same fetch round must not re-fire (dedup window)")
+
+        // ── Fetch round 2: server returns the SAME variant — proves we're testing the
+        //    dedup-clearing behavior, not a value-change-detection behavior. ──
+        mock.simulatedFetchResult = (
+            success: true,
+            flags: ["flag_x": MixpanelFlagVariant(key: "variant_a", value: "value_a")]
+        )
+        let secondFetchDone = expectation(description: "second fetch completes")
+        mock.loadFlags(completion: { _ in secondFetchDone.fulfill() })
+        wait(for: [secondFetchDone], timeout: 2.0)
+
+        // Lookup after refetch → fires again (dedup window reset).
+        _ = mock.getVariantSync("flag_x", fallback: fallback)
+        waitForMainAndTracking(manager: mock)
+        XCTAssertEqual(
+            delegate.snapshotTrackedEvents().filter { $0.event == "$experiment_started" }.count, 2,
+            "successful refetch should clear the dedup window so the next lookup re-fires")
+    }
+
+    /// `waitForTrackingQueue` only drains the tracking queue. Tracking-event recording goes
+    /// through `DispatchQueue.main.async` after the tracking queue, so we need to drain main
+    /// too to observe the recorded events.
+    private func waitForMainAndTracking(manager: FeatureFlagManager) {
+        waitForTrackingQueue(manager: manager)
+        let mainDrained = expectation(description: "main queue drained")
+        DispatchQueue.main.async { mainDrained.fulfill() }
+        wait(for: [mainDrained], timeout: 1.0)
+    }
+
+    // MARK: - Helpers
+
+    private func makeManager(
+        distinctId: String,
+        context: [String: Any],
+        policy: VariantLookupPolicy
+    ) -> FeatureFlagManager {
+        let delegate = PersistenceTestMockDelegate(
+            options: MixpanelOptions(
+                token: "test_token",
+                featureFlagOptions: FeatureFlagOptions(
+                    enabled: true,
+                    context: context,
+                    variantLookupPolicy: policy)),
+            distinctId: distinctId)
+        retainedDelegates.append(delegate)
+        let queue = DispatchQueue(label: "ff.persistence.test.\(UUID().uuidString)")
+        return FeatureFlagManager(
+            serverURL: "https://example.test",
+            trackingQueue: queue,
+            instanceName: instanceName,
+            delegate: delegate)
+    }
+
+    private func makeMockManager(
+        distinctId: String,
+        context: [String: Any],
+        policy: VariantLookupPolicy
+    ) -> PersistenceTestMockManager {
+        let delegate = PersistenceTestMockDelegate(
+            options: MixpanelOptions(
+                token: "test_token",
+                featureFlagOptions: FeatureFlagOptions(
+                    enabled: true,
+                    context: context,
+                    variantLookupPolicy: policy)),
+            distinctId: distinctId)
+        retainedDelegates.append(delegate)
+        let queue = DispatchQueue(label: "ff.persistence.mock.test.\(UUID().uuidString)")
+        return PersistenceTestMockManager(
+            serverURL: "https://example.test",
+            trackingQueue: queue,
+            instanceName: instanceName,
+            delegate: delegate)
+    }
+
+    /// Wait for any pending work on the manager's tracking queue (notably the async
+    /// persistence load posted from init) to complete by posting a barrier task and blocking
+    /// on it.
+    private func waitForTrackingQueue(
+        manager: FeatureFlagManager,
+        timeout: TimeInterval = 1.0,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let done = expectation(description: "tracking queue drained")
+        manager.trackingQueue.async { done.fulfill() }
+        wait(for: [done], timeout: timeout)
+    }
 }

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagTests.swift
@@ -14,2746 +14,2808 @@ import XCTest
 
 class MockFeatureFlagDelegate: MixpanelFlagDelegate {
 
-  var options: MixpanelOptions
-  var distinctId: String
-  var anonymousId: String?
-  var trackedEvents: [(event: String?, properties: Properties?)] = []
-  var trackExpectation: XCTestExpectation?
-  var getOptionsCallCount = 0
-  var getDistinctIdCallCount = 0
-  var getAnonymousIdCallCount = 0
+    var options: MixpanelOptions
+    var distinctId: String
+    var anonymousId: String?
+    var trackedEvents: [(event: String?, properties: Properties?)] = []
+    var trackExpectation: XCTestExpectation?
+    var getOptionsCallCount = 0
+    var getDistinctIdCallCount = 0
+    var getAnonymousIdCallCount = 0
 
-  // Custom track handler to allow overriding behavior
-  var customTrackHandler: ((String?, Properties?) -> Void)?
+    // Custom track handler to allow overriding behavior
+    var customTrackHandler: ((String?, Properties?) -> Void)?
 
-  init(
-    options: MixpanelOptions = MixpanelOptions(token: "test", featureFlagOptions: FeatureFlagOptions(enabled: true)),
-    distinctId: String = "test_distinct_id",
-    anonymousId: String? = "test_anonymous_id"
-  ) {
-    self.options = options
-    self.distinctId = distinctId
-    self.anonymousId = anonymousId
-  }
-
-  func getOptions() -> MixpanelOptions {
-    getOptionsCallCount += 1
-    return options
-  }
-
-  func getDistinctId() -> String {
-    getDistinctIdCallCount += 1
-    return distinctId
-  }
-
-  func getAnonymousId() -> String? {
-    getAnonymousIdCallCount += 1
-    return anonymousId
-  }
-
-  private let trackQueue = DispatchQueue(label: "mock.track.sync")
-
-  func track(event: String?, properties: Properties?) {
-    print("MOCK Delegate: Track called - Event: \(event ?? "nil"), Props: \(properties ?? [:])")
-    trackQueue.sync {
-      trackedEvents.append((event: event, properties: properties))
+    init(
+        options: MixpanelOptions = MixpanelOptions(
+            token: "test", featureFlagOptions: FeatureFlagOptions(enabled: true)),
+        distinctId: String = "test_distinct_id",
+        anonymousId: String? = "test_anonymous_id"
+    ) {
+        self.options = options
+        self.distinctId = distinctId
+        self.anonymousId = anonymousId
     }
-    trackExpectation?.fulfill()
 
-    // Call custom handler if set
-    customTrackHandler?(event, properties)
-  }
+    func getOptions() -> MixpanelOptions {
+        getOptionsCallCount += 1
+        return options
+    }
+
+    func getDistinctId() -> String {
+        getDistinctIdCallCount += 1
+        return distinctId
+    }
+
+    func getAnonymousId() -> String? {
+        getAnonymousIdCallCount += 1
+        return anonymousId
+    }
+
+    private let trackQueue = DispatchQueue(label: "mock.track.sync")
+
+    func track(event: String?, properties: Properties?) {
+        print("MOCK Delegate: Track called - Event: \(event ?? "nil"), Props: \(properties ?? [:])")
+        trackQueue.sync {
+            trackedEvents.append((event: event, properties: properties))
+        }
+        trackExpectation?.fulfill()
+
+        // Call custom handler if set
+        customTrackHandler?(event, properties)
+    }
 }
 
 // AssertEqual helper (Unchanged from previous working version)
 func AssertEqual(_ value1: Any?, _ value2: Any?, file: StaticString = #file, line: UInt = #line) {
-  // ... (Use the version that fixed the Any?? issues) ...
-  switch (value1, value2) {
-  case (nil, nil):
-    break  // Equal
-  case (let v1 as Bool, let v2 as Bool):
-    XCTAssertEqual(v1, v2, file: file, line: line)
-  case (let v1 as String, let v2 as String):
-    XCTAssertEqual(v1, v2, file: file, line: line)
-  case (let v1 as Int, let v2 as Int):
-    XCTAssertEqual(v1, v2, file: file, line: line)
-  case (let v1 as Double, let v2 as Double):
-    // Handle potential precision issues if necessary
-    XCTAssertEqual(v1, v2, accuracy: 0.00001, file: file, line: line)
-  case (let v1 as [Any?], let v2 as [Any?]):
-    XCTAssertEqual(v1.count, v2.count, "Array counts differ", file: file, line: line)
-    for (index, item1) in v1.enumerated() {
-      guard index < v2.count else {
-        XCTFail("Index \(index) out of bounds for second array", file: file, line: line)
-        return
-      }
-      AssertEqual(item1, v2[index], file: file, line: line)
+    // ... (Use the version that fixed the Any?? issues) ...
+    switch (value1, value2) {
+        case (nil, nil):
+            break  // Equal
+        case (let v1 as Bool, let v2 as Bool):
+            XCTAssertEqual(v1, v2, file: file, line: line)
+        case (let v1 as String, let v2 as String):
+            XCTAssertEqual(v1, v2, file: file, line: line)
+        case (let v1 as Int, let v2 as Int):
+            XCTAssertEqual(v1, v2, file: file, line: line)
+        case (let v1 as Double, let v2 as Double):
+            // Handle potential precision issues if necessary
+            XCTAssertEqual(v1, v2, accuracy: 0.00001, file: file, line: line)
+        case (let v1 as [Any?], let v2 as [Any?]):
+            XCTAssertEqual(v1.count, v2.count, "Array counts differ", file: file, line: line)
+            for (index, item1) in v1.enumerated() {
+                guard index < v2.count else {
+                    XCTFail("Index \(index) out of bounds for second array", file: file, line: line)
+                    return
+                }
+                AssertEqual(item1, v2[index], file: file, line: line)
+            }
+        case (let v1 as [String: Any?], let v2 as [String: Any?]):
+            XCTAssertEqual(
+                v1.count, v2.count, "Dictionary counts differ (\(v1.keys.sorted()) vs \(v2.keys.sorted()))",
+                file: file, line: line)
+            for (key, item1) in v1 {
+                guard v2.keys.contains(key) else {
+                    XCTFail("Key '\(key)' missing in second dictionary", file: file, line: line)
+                    continue
+                }
+                let item2DoubleOptional = v2[key]
+                AssertEqual(item1, item2DoubleOptional ?? nil, file: file, line: line)
+            }
+        default:
+            if let n1 = value1 as? NSNumber, let n2 = value2 as? NSNumber {
+                XCTAssertEqual(n1, n2, "NSNumber values differ: \(n1) vs \(n2)", file: file, line: line)
+            } else {
+                XCTFail(
+                    "Values are not equal or of comparable types: \(String(describing: value1)) vs \(String(describing: value2))",
+                    file: file, line: line)
+            }
     }
-  case (let v1 as [String: Any?], let v2 as [String: Any?]):
-    XCTAssertEqual(
-      v1.count, v2.count, "Dictionary counts differ (\(v1.keys.sorted()) vs \(v2.keys.sorted()))",
-      file: file, line: line)
-    for (key, item1) in v1 {
-      guard v2.keys.contains(key) else {
-        XCTFail("Key '\(key)' missing in second dictionary", file: file, line: line)
-        continue
-      }
-      let item2DoubleOptional = v2[key]
-      AssertEqual(item1, item2DoubleOptional ?? nil, file: file, line: line)
-    }
-  default:
-    if let n1 = value1 as? NSNumber, let n2 = value2 as? NSNumber {
-      XCTAssertEqual(n1, n2, "NSNumber values differ: \(n1) vs \(n2)", file: file, line: line)
-    } else {
-      XCTFail(
-        "Values are not equal or of comparable types: \(String(describing: value1)) vs \(String(describing: value2))",
-        file: file, line: line)
-    }
-  }
 }
 
 // MARK: - Mock FeatureFlagManager for Network Isolation
 
 class MockFeatureFlagManager: FeatureFlagManager {
-  var shouldSimulateNetworkDelay = false
-  var simulatedFetchResult: (success: Bool, flags: [String: MixpanelFlagVariant]?)?
-  var fetchRequestCount = 0
-  private var fetchStartTime: Date?
+    var shouldSimulateNetworkDelay = false
+    var simulatedFetchResult: (success: Bool, flags: [String: MixpanelFlagVariant]?)?
+    var fetchRequestCount = 0
+    private var fetchStartTime: Date?
 
-  // Request validation properties
-  var requestValidationEnabled = false
-  var lastRequestMethod: RequestMethod?
-  var lastRequestHeaders: [String: String]?
-  var lastRequestBody: Data?
-  var lastQueryItems: [URLQueryItem]?
-  var requestValidationError: String?
+    // Request validation properties
+    var requestValidationEnabled = false
+    var lastRequestMethod: RequestMethod?
+    var lastRequestHeaders: [String: String]?
+    var lastRequestBody: Data?
+    var lastQueryItems: [URLQueryItem]?
+    var requestValidationError: String?
 
-  // First-time event recording tracking
-  var recordFirstTimeEventCallCount = 0
-  var lastRecordedFlagId: String?
-  var lastRecordedProjectId: Int?
-  var lastRecordedFirstTimeEventHash: String?
-  var simulateRecordFirstTimeEventFailure = false
-  var recordFirstTimeEventExpectation: XCTestExpectation?
+    // First-time event recording tracking
+    var recordFirstTimeEventCallCount = 0
+    var lastRecordedFlagId: String?
+    var lastRecordedProjectId: Int?
+    var lastRecordedFirstTimeEventHash: String?
+    var simulateRecordFirstTimeEventFailure = false
+    var recordFirstTimeEventExpectation: XCTestExpectation?
 
-  // Override the now-internal method to prevent real network calls
-  override func _performFetchRequest() {
-    fetchRequestCount += 1
-    print("MockFeatureFlagManager: Intercepted fetch request #\(fetchRequestCount)")
+    // Override the now-internal method to prevent real network calls
+    override func _performFetchRequest() {
+        fetchRequestCount += 1
+        print("MockFeatureFlagManager: Intercepted fetch request #\(fetchRequestCount)")
 
-    // Record fetch start time like the real implementation
-    let startTime = Date()
-    flagsLock.write {
-      self.fetchStartTime = startTime
-    }
-
-    // If request validation is enabled, intercept and validate the request construction
-    if requestValidationEnabled {
-      validateRequestConstruction()
-    }
-
-    // Instead of real network call, use simulated result
-    if let result = simulatedFetchResult {
-      if shouldSimulateNetworkDelay {
-        // Simulate network delay
-        DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) { [weak self] in
-          self?.completeSimulatedFetch(
-            success: result.success, flags: result.flags, startTime: startTime)
+        // Record fetch start time like the real implementation
+        let startTime = Date()
+        flagsLock.write {
+            self.fetchStartTime = startTime
         }
-      } else {
-        // Complete immediately
-        self.completeSimulatedFetch(
-          success: result.success, flags: result.flags, startTime: startTime)
-      }
-    } else {
-      // No simulation configured - fail immediately
-      print("MockFeatureFlagManager: No simulation configured, failing fetch")
-      self._completeFetch(success: false)
-    }
-  }
 
-  private func validateRequestConstruction() {
-    // Clear previous validation error
-    requestValidationError = nil
+        // If request validation is enabled, intercept and validate the request construction
+        if requestValidationEnabled {
+            validateRequestConstruction()
+        }
 
-    // Replicate the request construction logic from the real implementation to capture parameters
-    guard let delegate = self.delegate else {
-      requestValidationError = "Delegate missing"
-      return
-    }
-    let options = delegate.getOptions()
-
-    let distinctId = delegate.getDistinctId()
-    let anonymousId = delegate.getAnonymousId()
-
-    var context = options.featureFlagOptions.context
-    context["distinct_id"] = distinctId
-    if let anonymousId = anonymousId {
-      context["device_id"] = anonymousId
+        // Instead of real network call, use simulated result
+        if let result = simulatedFetchResult {
+            if shouldSimulateNetworkDelay {
+                // Simulate network delay
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                    self?.completeSimulatedFetch(
+                        success: result.success, flags: result.flags, startTime: startTime)
+                }
+            } else {
+                // Complete immediately
+                self.completeSimulatedFetch(
+                    success: result.success, flags: result.flags, startTime: startTime)
+            }
+        } else {
+            // No simulation configured - fail immediately
+            print("MockFeatureFlagManager: No simulation configured, failing fetch")
+            self._completeFetch(success: false)
+        }
     }
 
-    guard
-      let contextData = try? JSONSerialization.data(
-        withJSONObject: context, options: []),
-      let contextString = String(data: contextData, encoding: .utf8)
-    else {
-      requestValidationError = "Failed to serialize context"
-      return
+    private func validateRequestConstruction() {
+        // Clear previous validation error
+        requestValidationError = nil
+
+        // Replicate the request construction logic from the real implementation to capture parameters
+        guard let delegate = self.delegate else {
+            requestValidationError = "Delegate missing"
+            return
+        }
+        let options = delegate.getOptions()
+
+        let distinctId = delegate.getDistinctId()
+        let anonymousId = delegate.getAnonymousId()
+
+        var context = options.featureFlagOptions.context
+        context["distinct_id"] = distinctId
+        if let anonymousId = anonymousId {
+            context["device_id"] = anonymousId
+        }
+
+        guard
+            let contextData = try? JSONSerialization.data(
+                withJSONObject: context, options: []),
+            let contextString = String(data: contextData, encoding: .utf8)
+        else {
+            requestValidationError = "Failed to serialize context"
+            return
+        }
+
+        guard let authData = "\(options.token):".data(using: .utf8) else {
+            requestValidationError = "Failed to create auth data"
+            return
+        }
+        let base64Auth = authData.base64EncodedString()
+        let headers = ["Authorization": "Basic \(base64Auth)"]
+
+        let queryItems = [
+            URLQueryItem(name: "context", value: contextString),
+            URLQueryItem(name: "token", value: options.token),
+            URLQueryItem(name: "mp_lib", value: "swift"),
+            URLQueryItem(name: "$lib_version", value: AutomaticProperties.libVersion()),
+        ]
+
+        // Capture the constructed request parameters for validation
+        lastRequestMethod = .get
+        lastRequestHeaders = headers
+        lastRequestBody = nil  // GET request should have no body
+        lastQueryItems = queryItems
     }
 
-    guard let authData = "\(options.token):".data(using: .utf8) else {
-      requestValidationError = "Failed to create auth data"
-      return
+    private func completeSimulatedFetch(
+        success: Bool, flags: [String: MixpanelFlagVariant]?, startTime: Date
+    ) {
+        let fetchEndTime = Date()
+
+        if success {
+            print("MockFeatureFlagManager: Simulating successful fetch with \(flags?.count ?? 0) flags")
+
+            // Mimic the real implementation's behavior - use mergeFlags like the real impl
+            let (mergedFlags, mergedPendingEvents, mergedPendingEventNames) = self.mergeFlags(
+                responseFlags: flags,
+                responsePendingEvents: nil
+            )
+
+            self.flagsLock.write {
+                self.flags = mergedFlags
+                self.pendingFirstTimeEvents = mergedPendingEvents
+                self.pendingFirstTimeEventNames = mergedPendingEventNames
+
+                // Calculate timing metrics like the real implementation
+                let latencyMs = Int(fetchEndTime.timeIntervalSince(startTime) * 1000)
+                self.fetchLatencyMs = latencyMs
+                self.timeLastFetched = fetchEndTime
+
+                print("Flags updated: \(self.flags ?? [:])")
+            }
+
+            self._completeFetch(success: true)
+        } else {
+            print("MockFeatureFlagManager: Simulating failed fetch")
+            self._completeFetch(success: false)
+        }
     }
-    let base64Auth = authData.base64EncodedString()
-    let headers = ["Authorization": "Basic \(base64Auth)"]
 
-    let queryItems = [
-      URLQueryItem(name: "context", value: contextString),
-      URLQueryItem(name: "token", value: options.token),
-      URLQueryItem(name: "mp_lib", value: "swift"),
-      URLQueryItem(name: "$lib_version", value: AutomaticProperties.libVersion())
-    ]
+    // Override recordFirstTimeEvent to prevent real network calls and track invocations
+    override func recordFirstTimeEvent(flagId: String, projectId: Int, firstTimeEventHash: String, distinctId: String) {
+        recordFirstTimeEventCallCount += 1
+        lastRecordedFlagId = flagId
+        lastRecordedProjectId = projectId
+        lastRecordedFirstTimeEventHash = firstTimeEventHash
 
-    // Capture the constructed request parameters for validation
-    lastRequestMethod = .get
-    lastRequestHeaders = headers
-    lastRequestBody = nil  // GET request should have no body
-    lastQueryItems = queryItems
-  }
+        print(
+            "MockFeatureFlagManager: Intercepted recordFirstTimeEvent call #\(recordFirstTimeEventCallCount) for flag: \(flagId)"
+        )
+        recordFirstTimeEventExpectation?.fulfill()
 
-  private func completeSimulatedFetch(
-    success: Bool, flags: [String: MixpanelFlagVariant]?, startTime: Date
-  ) {
-    let fetchEndTime = Date()
-
-    if success {
-      print("MockFeatureFlagManager: Simulating successful fetch with \(flags?.count ?? 0) flags")
-
-      // Mimic the real implementation's behavior - use mergeFlags like the real impl
-      let (mergedFlags, mergedPendingEvents, mergedPendingEventNames) = self.mergeFlags(
-        responseFlags: flags,
-        responsePendingEvents: nil
-      )
-
-      self.flagsLock.write {
-        self.flags = mergedFlags
-        self.pendingFirstTimeEvents = mergedPendingEvents
-        self.pendingFirstTimeEventNames = mergedPendingEventNames
-
-        // Calculate timing metrics like the real implementation
-        let latencyMs = Int(fetchEndTime.timeIntervalSince(startTime) * 1000)
-        self.fetchLatencyMs = latencyMs
-        self.timeLastFetched = fetchEndTime
-
-        print("Flags updated: \(self.flags ?? [:])")
-      }
-
-      self._completeFetch(success: true)
-    } else {
-      print("MockFeatureFlagManager: Simulating failed fetch")
-      self._completeFetch(success: false)
+        // DO NOT call super - prevents actual network calls
     }
-  }
-
-  // Override recordFirstTimeEvent to prevent real network calls and track invocations
-  override func recordFirstTimeEvent(flagId: String, projectId: Int, firstTimeEventHash: String, distinctId: String) {
-    recordFirstTimeEventCallCount += 1
-    lastRecordedFlagId = flagId
-    lastRecordedProjectId = projectId
-    lastRecordedFirstTimeEventHash = firstTimeEventHash
-
-    print("MockFeatureFlagManager: Intercepted recordFirstTimeEvent call #\(recordFirstTimeEventCallCount) for flag: \(flagId)")
-    recordFirstTimeEventExpectation?.fulfill()
-
-    // DO NOT call super - prevents actual network calls
-  }
 }
 
 // MARK: - Refactored FeatureFlagManager Tests
 
 class FeatureFlagManagerTests: XCTestCase {
 
-  var mockDelegate: MockFeatureFlagDelegate!
-  var manager: FeatureFlagManager!
-  // Sample flag data for simulating fetch results
-  let sampleFlags: [String: MixpanelFlagVariant] = [
-    "feature_bool_true": MixpanelFlagVariant(key: "v_true", value: true),
-    "feature_bool_false": MixpanelFlagVariant(key: "v_false", value: false),
-    "feature_string": MixpanelFlagVariant(key: "v_str", value: "test_string"),
-    "feature_int": MixpanelFlagVariant(key: "v_int", value: 101),
-    "feature_double": MixpanelFlagVariant(key: "v_double", value: 99.9),
-    "feature_null": MixpanelFlagVariant(key: "v_null", value: nil),
-  ]
-  let defaultFallback = MixpanelFlagVariant(value: nil)  // Default fallback for convenience
-
-  override func setUpWithError() throws {
-    try super.setUpWithError()
-    mockDelegate = MockFeatureFlagDelegate()
-
-    // Use MockFeatureFlagManager to prevent real network calls
-      let mockManager = MockFeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: mockDelegate)
-    // Configure default simulation - successful fetch with sample flags
-    mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
-    mockManager.shouldSimulateNetworkDelay = true
-
-    manager = mockManager
-  }
-
-  override func tearDownWithError() throws {
-    mockDelegate = nil
-    manager = nil
-    try super.tearDownWithError()
-  }
-
-  // --- Simulation Helpers ---
-  // These now directly modify state and call the *internal* _completeFetch
-  // Requires _completeFetch to be accessible (e.g., internal or @testable import)
-
-  private func simulateFetchSuccess(flags: [String: MixpanelFlagVariant]? = nil) {
-    let flagsToSet = flags ?? sampleFlags
-
-    // If using MockFeatureFlagManager, just set the flags directly
-    if let mockManager = manager as? MockFeatureFlagManager {
-      // For mock, we can directly set the flags without going through fetch
-      mockManager.flagsLock.write {
-        mockManager.flags = flagsToSet
-        mockManager.timeLastFetched = Date()
-        mockManager.fetchLatencyMs = 150
-        // Don't call _completeFetch - just set the state
-      }
-      // Give a moment for the async operation to complete
-      Thread.sleep(forTimeInterval: 0.01)
-    } else {
-      // Original implementation for non-mock manager
-      let currentTime = Date()
-      // Set flags directly *before* calling completeFetch
-      manager.flagsLock.write {
-        manager.flags = flagsToSet
-        // Set timing properties to simulate a successful fetch
-        manager.timeLastFetched = currentTime
-        manager.fetchLatencyMs = 150  // Simulate 150ms fetch time
-        // Important: Set isFetching = true *before* calling _completeFetch,
-        // as _completeFetch assumes a fetch was in progress.
-        manager.isFetching = true
-      }
-      // Call internal completion logic
-      manager._completeFetch(success: true)
-    }
-  }
-
-  private func simulateFetchFailure() {
-    // If using MockFeatureFlagManager, just clear the flags
-    if let mockManager = manager as? MockFeatureFlagManager {
-      mockManager.flagsLock.write {
-        mockManager.flags = nil
-        // Don't call _completeFetch - just set the state
-      }
-      // Give a moment for the async operation to complete
-      Thread.sleep(forTimeInterval: 0.01)
-    } else {
-      // Original implementation for non-mock manager
-      // Set isFetching = true before calling _completeFetch
-      manager.flagsLock.write {
-        manager.isFetching = true
-        // Ensure flags are nil or unchanged on failure simulation if desired
-        manager.flags = nil  // Or keep existing flags based on desired failure behavior
-      }
-      // Call internal completion logic
-      manager._completeFetch(success: false)
-    }
-  }
-
-  // MARK: - Test Helpers
-
-  // Expectation & Waiting Helpers
-
-  private func waitBriefly(timeout: TimeInterval = 0.5, file: StaticString = #file, line: UInt = #line) {
-    let expectation = XCTestExpectation(description: "Brief wait")
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { expectation.fulfill() }
-    wait(for: [expectation], timeout: timeout)
-  }
-
-  private func waitForAsyncOperation<T>(
-    timeout: TimeInterval = 2.0,
-    description: String,
-    operation: (@escaping (T) -> Void) -> Void,
-    validation: (T) -> Void
-  ) {
-    let expectation = XCTestExpectation(description: description)
-    var result: T?
-
-    operation { value in
-      result = value
-      expectation.fulfill()
-    }
-
-    wait(for: [expectation], timeout: timeout)
-
-    if let result = result {
-      validation(result)
-    } else {
-      XCTFail("Operation did not complete in time")
-    }
-  }
-
-  // Tracking Helpers
-
-  private func expectTracking(
-    expectedCount: Int = 1,
-    description: String = "Track called",
-    timeout: TimeInterval = 1.0,
-    operation: () -> Void
-  ) {
-    mockDelegate.trackedEvents.removeAll()
-    mockDelegate.trackExpectation = XCTestExpectation(description: description)
-    mockDelegate.trackExpectation?.expectedFulfillmentCount = expectedCount
-
-    operation()
-
-    wait(for: [mockDelegate.trackExpectation!], timeout: timeout)
-    XCTAssertEqual(mockDelegate.trackedEvents.count, expectedCount)
-  }
-
-  private func verifyTrackingProperties(
-    _ properties: [String: Any?],
-    experimentName: String,
-    variantName: String,
-    file: StaticString = #file,
-    line: UInt = #line
-  ) {
-    AssertEqual(properties["Experiment name"] ?? nil, experimentName, file: file, line: line)
-    AssertEqual(properties["Variant name"] ?? nil, variantName, file: file, line: line)
-    AssertEqual(properties["$experiment_type"] ?? nil, "feature_flag", file: file, line: line)
-  }
-
-  private func verifyTimingProperties(
-    _ properties: [String: Any?],
-    expectedLatency: Int? = nil,
-    file: StaticString = #file,
-    line: UInt = #line
-  ) {
-    XCTAssertTrue(properties.keys.contains("timeLastFetched"), "Should include timeLastFetched", file: file, line: line)
-    XCTAssertTrue(properties.keys.contains("fetchLatencyMs"), "Should include fetchLatencyMs", file: file, line: line)
-
-    if let expected = expectedLatency,
-       let actual = properties["fetchLatencyMs"] as? Int {
-      XCTAssertEqual(actual, expected, file: file, line: line)
-    }
-  }
-
-  // Event Verification Helper
-
-  private func verifyTrackedEvent(
-    at index: Int = 0,
-    expectedEvent: String = "$experiment_started",
-    experimentName: String,
-    variantName: String,
-    checkTimingProperties: Bool = false,
-    expectedLatency: Int? = nil,
-    additionalChecks: ((Properties) -> Void)? = nil,
-    file: StaticString = #file,
-    line: UInt = #line
-  ) {
-    guard index < mockDelegate.trackedEvents.count else {
-      XCTFail("No tracked event at index \(index)", file: file, line: line)
-      return
-    }
-
-    let tracked = mockDelegate.trackedEvents[index]
-    XCTAssertEqual(tracked.event, expectedEvent, file: file, line: line)
-    XCTAssertNotNil(tracked.properties, file: file, line: line)
-
-    guard let props = tracked.properties else { return }
-
-    verifyTrackingProperties(props, experimentName: experimentName,
-                            variantName: variantName, file: file, line: line)
-
-    if checkTimingProperties {
-      verifyTimingProperties(props, expectedLatency: expectedLatency,
-                           file: file, line: line)
-    }
-
-    additionalChecks?(props)
-  }
-
-  // Async Operation Helper
-
-  @discardableResult
-  private func getVariantAsync(
-    _ flagName: String,
-    fallback: MixpanelFlagVariant? = nil,
-    timeout: TimeInterval = 2.0,
-    description: String? = nil,
-    verifyMainThread: Bool = true,
-    file: StaticString = #file,
-    line: UInt = #line
-  ) -> MixpanelFlagVariant? {
-    let expectation = XCTestExpectation(
-      description: description ?? "Get variant async for \(flagName)"
-    )
-    var receivedData: MixpanelFlagVariant?
-
-    manager.getVariant(flagName, fallback: fallback ?? defaultFallback) { data in
-      if verifyMainThread {
-        XCTAssertTrue(Thread.isMainThread,
-                     "Completion should be on main thread",
-                     file: file, line: line)
-      }
-      receivedData = data
-      expectation.fulfill()
-    }
-
-    wait(for: [expectation], timeout: timeout)
-    return receivedData
-  }
-
-  // Fetch Setup Helpers
-
-  private func setupReadyFlags(flags: [String: MixpanelFlagVariant]? = nil) {
-    simulateFetchSuccess(flags: flags)
-    waitBriefly()
-  }
-
-  private func setupReadyFlagsAndVerify(flags: [String: MixpanelFlagVariant]? = nil) {
-    setupReadyFlags(flags: flags)
-    XCTAssertTrue(manager.areFlagsReady(), "Flags should be ready after setup")
-  }
-
-  // JSON Parsing Helpers
-
-  private func decodeJSON<T: Decodable>(
-    _ jsonString: String,
-    as type: T.Type,
-    file: StaticString = #file,
-    line: UInt = #line
-  ) -> T? {
-    guard let data = jsonString.data(using: .utf8) else {
-      XCTFail("Failed to convert JSON string to data", file: file, line: line)
-      return nil
-    }
-
-    do {
-      return try JSONDecoder().decode(type, from: data)
-    } catch {
-      XCTFail("Failed to decode JSON: \(error)", file: file, line: line)
-      return nil
-    }
-  }
-
-  private func assertJSONDecodes<T: Decodable>(
-    _ jsonString: String,
-    as type: T.Type,
-    file: StaticString = #file,
-    line: UInt = #line,
-    validation: (T) -> Void
-  ) {
-    if let result = decodeJSON(jsonString, as: type, file: file, line: line) {
-      validation(result)
-    }
-  }
-
-  // Mock Configuration Helpers
-
-  private var mockManager: MockFeatureFlagManager? {
-    return manager as? MockFeatureFlagManager
-  }
-
-  private func configureMockFetch(
-    success: Bool,
-    flags: [String: MixpanelFlagVariant]? = nil,
-    withDelay: Bool = true
-  ) {
-    guard let mock = mockManager else {
-      XCTFail("Manager is not a MockFeatureFlagManager")
-      return
-    }
-    mock.simulatedFetchResult = (success: success, flags: flags ?? sampleFlags)
-    mock.shouldSimulateNetworkDelay = withDelay
-  }
-
-  private func resetMockToSuccess() {
-    configureMockFetch(success: true, flags: sampleFlags, withDelay: true)
-  }
-
-  // Context Verification Helper
-
-  private func verifyRequestContext(
-    expectedDistinctId: String,
-    expectedDeviceId: String? = nil,
-    additionalChecks: (([String: Any]) -> Void)? = nil,
-    file: StaticString = #file,
-    line: UInt = #line
-  ) {
-    guard let mockMgr = mockManager,
-          let queryItems = mockMgr.lastQueryItems else {
-      XCTFail("No query items captured", file: file, line: line)
-      return
-    }
-
-    let queryDict = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
-
-    guard let contextString = queryDict["context"],
-          let contextData = contextString?.data(using: .utf8),
-          let context = try? JSONSerialization.jsonObject(with: contextData) as? [String: Any] else {
-      XCTFail("Failed to parse context", file: file, line: line)
-      return
-    }
-
-    XCTAssertEqual(context["distinct_id"] as? String, expectedDistinctId, file: file, line: line)
-
-    if let expectedDeviceId = expectedDeviceId {
-      XCTAssertEqual(context["device_id"] as? String, expectedDeviceId, file: file, line: line)
-    } else {
-      XCTAssertNil(context["device_id"], file: file, line: line)
-    }
-
-    additionalChecks?(context)
-  }
-
-  // Variant Creation Helpers
-
-  private func createExperimentVariant(
-    key: String,
-    value: Any?,
-    experimentID: String = "test-exp-id",
-    isActive: Bool = true,
-    isQATester: Bool = false
-  ) -> MixpanelFlagVariant {
-    return MixpanelFlagVariant(
-      key: key,
-      value: value,
-      isExperimentActive: isActive,
-      isQATester: isQATester,
-      experimentID: experimentID
-    )
-  }
-
-  private func createControlVariant(key: String = "control", value: Any? = false) -> MixpanelFlagVariant {
-    return MixpanelFlagVariant(key: key, value: value)
-  }
-
-  // First-Time Event Helper
-
-  private func setupAndTriggerFirstTimeEvent(
-    flagKey: String,
-    eventName: String,
-    triggeredEventName: String? = nil,
-    eventProperties: [String: Any] = [:],
-    filters: [String: Any]? = nil,
-    pendingVariant: MixpanelFlagVariant,
-    initialVariant: MixpanelFlagVariant? = nil,
-    firstTimeEventHash: String = "hash123",
-    expectActivation: Bool = true,
-    validation: ((MockFeatureFlagManager) -> Void)? = nil
-  ) {
-    guard let mockMgr = mockManager else {
-      XCTFail("Manager is not a MockFeatureFlagManager")
-      return
-    }
-
-    let pendingEvent = createPendingEvent(
-      flagKey: flagKey,
-      eventName: eventName,
-      filters: filters,
-      pendingVariant: pendingVariant,
-      firstTimeEventHash: firstTimeEventHash
-    )
-
-    let eventKey = "\(flagKey):\(firstTimeEventHash)"
-
-    mockMgr.flagsLock.write {
-      let initial = initialVariant ?? createControlVariant()
-      mockMgr.flags = [flagKey: initial]
-      mockMgr.pendingFirstTimeEvents = [eventKey: pendingEvent]
-      mockMgr.pendingFirstTimeEventNames = [pendingEvent.eventName]
-    }
-
-    let nameToTrigger = triggeredEventName ?? eventName
-    mockMgr.checkFirstTimeEvents(eventName: nameToTrigger, properties: eventProperties)
-
-    if expectActivation {
-      // Wait for the async checkFirstTimeEvents to complete using predicate
-      let activated = NSPredicate { _, _ in
-        var done = false
-        mockMgr.flagsLock.read { done = mockMgr.activatedFirstTimeEvents.contains(eventKey) }
-        return done
-      }
-      wait(for: [XCTNSPredicateExpectation(predicate: activated, object: nil)], timeout: 10.0)
-    } else {
-      // For negative tests, just wait briefly for async dispatch to complete
-      waitBriefly(timeout: 2.0)
-    }
-
-    mockMgr.flagsLock.read {
-      validation?(mockMgr)
-    }
-  }
-
-  // Manager State Helpers
-
-  private func resetManagerFlags(_ flags: [String: MixpanelFlagVariant]? = nil) {
-    mockManager?.flagsLock.write {
-      mockManager?.flags = flags
-    }
-    Thread.sleep(forTimeInterval: 0.01)
-  }
-
-  private func clearManagerFlags() {
-    resetManagerFlags(nil)
-  }
-
-  private func setManagerFlags(_ flags: [String: MixpanelFlagVariant]) {
-    resetManagerFlags(flags)
-  }
-
-  // --- State and Configuration Tests ---
-
-  func testAreFeaturesReady_InitialState() {
-    XCTAssertFalse(manager.areFlagsReady(), "Features should not be ready initially")
-  }
-
-  func testAreFeaturesReady_AfterSuccessfulFetchSimulation() {
-    setupReadyFlagsAndVerify()
-  }
-
-  func testAreFeaturesReady_AfterFailedFetchSimulation() {
-    simulateFetchFailure()
-    waitBriefly()
-    XCTAssertFalse(
-      manager.areFlagsReady(), "Features should not be ready after failed fetch simulation")
-  }
-
-  // --- Load Flags Tests ---
-
-  func testLoadFlags_WhenDisabledInConfig() {
-    mockDelegate.options = MixpanelOptions(token: "test", featureFlagOptions: FeatureFlagOptions(enabled: false))  // Explicitly disable
-    manager.loadFlags()  // Call public API
-
-    waitBriefly()
-
-    XCTAssertFalse(manager.areFlagsReady(), "Flags should not become ready if disabled")
-    // We can't easily check if _fetchFlagsIfNeeded was *not* called without more testability hooks
-  }
-
-  // Note: Testing that loadFlags *starts* a fetch is harder now without exposing internal state.
-  // We test the outcome via the async getFeature tests below.
-
-  // --- Sync Flag Retrieval Tests ---
-
-  func testGetVariantSync_FlagsReady_ExistingFlag() {
-    setupReadyFlags()
-    let flagVariant = manager.getVariantSync("feature_string", fallback: defaultFallback)
-    AssertEqual(flagVariant.key, "v_str")
-    AssertEqual(flagVariant.value, "test_string")
-    // Tracking check happens later
-  }
-
-  func testGetVariantSync_FlagsReady_MissingFlag_UsesFallback() {
-    setupReadyFlags()
-    let fallback = MixpanelFlagVariant(key: "fb_key", value: "fb_value")
-    let flagVariant = manager.getVariantSync("missing_feature", fallback: fallback)
-    AssertEqual(flagVariant.key, fallback.key)
-    AssertEqual(flagVariant.value, fallback.value)
-    XCTAssertEqual(mockDelegate.trackedEvents.count, 0, "Should not track for fallback")
-  }
-
-  func testGetVariantSync_FlagsNotReady_UsesFallback() {
-    XCTAssertFalse(manager.areFlagsReady())  // Precondition
-    let fallback = MixpanelFlagVariant(key: "fb_key", value: 999)
-    let flagVariant = manager.getVariantSync("feature_bool_true", fallback: fallback)
-    AssertEqual(flagVariant.key, fallback.key)
-    AssertEqual(flagVariant.value, fallback.value)
-    XCTAssertEqual(mockDelegate.trackedEvents.count, 0, "Should not track if flags not ready")
-  }
-
-  func testGetVariantValueSync_FlagsReady() {
-    setupReadyFlags()
-    let value = manager.getVariantValueSync("feature_int", fallbackValue: -1)
-    AssertEqual(value, 101)
-  }
-
-  func testGetVariantValueSync_FlagsReady_MissingFlag() {
-    setupReadyFlags()
-    let value = manager.getVariantValueSync("missing_feature", fallbackValue: "default")
-    AssertEqual(value, "default")
-  }
-
-  func testGetVariantValueSync_FlagsNotReady() {
-    XCTAssertFalse(manager.areFlagsReady())
-    let value = manager.getVariantValueSync("feature_int", fallbackValue: -1)
-    AssertEqual(value, -1)
-  }
-
-  func testIsFlagEnabledSync_FlagsReady_True() {
-    setupReadyFlags()
-    XCTAssertTrue(manager.isEnabledSync("feature_bool_true"))
-  }
-
-  func testIsFlagEnabledSync_FlagsReady_False() {
-    setupReadyFlags()
-    XCTAssertFalse(manager.isEnabledSync("feature_bool_false"))
-  }
-
-  func testIsFlagEnabledSync_FlagsReady_MissingFlag_UsesFallback() {
-    setupReadyFlags()
-    XCTAssertTrue(manager.isEnabledSync("missing", fallbackValue: true))
-    XCTAssertFalse(manager.isEnabledSync("missing", fallbackValue: false))
-  }
-
-  func testIsFlagEnabledSync_FlagsReady_NonBoolValue_UsesFallback() {
-    setupReadyFlags()
-    XCTAssertTrue(manager.isEnabledSync("feature_string", fallbackValue: true))  // String value
-    XCTAssertFalse(manager.isEnabledSync("feature_int", fallbackValue: false))  // Int value
-    XCTAssertTrue(manager.isEnabledSync("feature_null", fallbackValue: true))  // Null value
-  }
-
-  func testIsFlagEnabledSync_FlagsNotReady_UsesFallback() {
-    XCTAssertFalse(manager.areFlagsReady())
-    XCTAssertTrue(manager.isEnabledSync("feature_bool_true", fallbackValue: true))
-    XCTAssertFalse(manager.isEnabledSync("feature_bool_true", fallbackValue: false))
-  }
-
-  // --- Async Flag Retrieval Tests ---
-
-  func testGetVariant_Async_FlagsReady_ExistingFlag_XCTWaiter() {
-    setupReadyFlags()
-    let receivedData = getVariantAsync("feature_double")
-    XCTAssertNotNil(receivedData, "Received data should be non-nil after successful wait")
-    AssertEqual(receivedData?.key, "v_double")
-    AssertEqual(receivedData?.value, 99.9)
-  }
-
-  func testGetVariant_Async_FlagsReady_MissingFlag_UsesFallback() {
-    setupReadyFlags()
-    let fallback = MixpanelFlagVariant(key: "fb_async", value: -1)
-    let receivedData = getVariantAsync("missing_feature", fallback: fallback)
-    XCTAssertNotNil(receivedData)
-    AssertEqual(receivedData?.key, fallback.key)
-    AssertEqual(receivedData?.value, fallback.value)
-    XCTAssertEqual(mockDelegate.trackedEvents.count, 0, "Should not track fallback")
-  }
-
-  // Test fetch triggering and completion via getFeature when not ready
-  func testGetVariant_Async_FlagsNotReady_FetchSuccess() {
-    XCTAssertFalse(manager.areFlagsReady())
-
-    // Setup tracking expectation *before* calling getFeature
-    mockDelegate.trackExpectation = XCTestExpectation(description: "Tracking call for fetch success")
-
-    let receivedData = getVariantAsync("feature_int", timeout: 10.0)
-
-    // Wait for tracking to complete
-    wait(for: [mockDelegate.trackExpectation!], timeout: 10.0)
-
-    XCTAssertNotNil(receivedData)
-    AssertEqual(receivedData?.key, "v_int")
-    AssertEqual(receivedData?.value, 101)
-    XCTAssertTrue(manager.areFlagsReady(), "Flags should be ready after successful fetch")
-    XCTAssertEqual(mockDelegate.trackedEvents.count, 1, "Tracking event should have been recorded")
-  }
-
-  func testGetVariant_Async_FlagsNotReady_FetchFailure() {
-    // Configure mock to simulate failure without network delay
-    configureMockFetch(success: false, flags: nil, withDelay: false)
-
-    XCTAssertFalse(manager.areFlagsReady())
-    let fallback = MixpanelFlagVariant(key: "fb_fail", value: "failed_fetch")
-    let receivedData = getVariantAsync("feature_string", fallback: fallback, timeout: 10.0)
-
-    XCTAssertNotNil(receivedData)
-    AssertEqual(receivedData?.key, fallback.key)  // Should receive fallback
-    AssertEqual(receivedData?.value, fallback.value)
-    XCTAssertFalse(manager.areFlagsReady(), "Flags should still not be ready after failed fetch")
-    XCTAssertEqual(
-      mockDelegate.trackedEvents.count, 0, "Should not track on fetch failure/fallback")
-
-    // Reset mock configuration back to success for other tests
-    resetMockToSuccess()
-  }
-
-  // --- Bulk Flag Retrieval Tests (getAllVariants) ---
-
-  func testGetAllVariantsSync_FlagsReady() {
-    simulateFetchSuccess()
-    let allVariants = manager.getAllVariantsSync()
-    XCTAssertEqual(allVariants.count, sampleFlags.count, "Should return all flags")
-    // Verify specific flags exist
-    XCTAssertNotNil(allVariants["feature_bool_true"], "Should contain feature_bool_true")
-    XCTAssertNotNil(allVariants["feature_string"], "Should contain feature_string")
-    XCTAssertNotNil(allVariants["feature_int"], "Should contain feature_int")
-    // Verify values
-    AssertEqual(allVariants["feature_bool_true"]?.key, "v_true")
-    AssertEqual(allVariants["feature_bool_true"]?.value, true)
-    AssertEqual(allVariants["feature_string"]?.value, "test_string")
-  }
-
-  func testGetAllVariantsSync_FlagsNotReady() {
-    XCTAssertFalse(manager.areFlagsReady(), "Precondition: flags should not be ready")
-    let allVariants = manager.getAllVariantsSync()
-    XCTAssertTrue(allVariants.isEmpty, "Should return empty dictionary when flags not ready")
-  }
-
-  func testGetAllVariantsSync_NoTracking() {
-    simulateFetchSuccess()
-    _ = manager.getAllVariantsSync()
-    // Wait briefly to ensure no unexpected tracking call
-    let expectation = XCTestExpectation(description: "Wait briefly for no track")
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { expectation.fulfill() }
-    wait(for: [expectation], timeout: 0.5)
-    XCTAssertTrue(mockDelegate.trackedEvents.isEmpty, "getAllVariantsSync should not trigger tracking")
-  }
-
-  func testGetAllVariants_Async_FlagsReady() {
-    simulateFetchSuccess()
-    let expectation = XCTestExpectation(description: "getAllVariants completion")
-    var receivedVariants: [String: MixpanelFlagVariant]?
-    var assertionError: String?
-
-    manager.getAllVariants { variants in
-      if !Thread.isMainThread {
-        assertionError = "Completion not on main thread"
-      }
-      receivedVariants = variants
-      expectation.fulfill()
-    }
-
-    wait(for: [expectation], timeout: 2.0)
-
-    if let error = assertionError {
-      XCTFail(error)
-    }
-    XCTAssertNotNil(receivedVariants, "Should receive variants")
-    XCTAssertEqual(receivedVariants?.count, sampleFlags.count, "Should return all flags")
-    AssertEqual(receivedVariants?["feature_double"]?.key, "v_double")
-    AssertEqual(receivedVariants?["feature_double"]?.value, 99.9)
-  }
-
-  func testGetAllVariants_Async_FlagsNotReady_FetchSucceeds() {
-    XCTAssertFalse(manager.areFlagsReady(), "Precondition: flags should not be ready")
-    let expectation = XCTestExpectation(description: "getAllVariants triggers fetch and succeeds")
-    var receivedVariants: [String: MixpanelFlagVariant]?
-
-    manager.getAllVariants { variants in
-      XCTAssertTrue(Thread.isMainThread, "Completion should be on main thread")
-      receivedVariants = variants
-      expectation.fulfill()
-    }
-
-    // MockFeatureFlagManager will automatically handle the fetch simulation
-    wait(for: [expectation], timeout: 10.0)
-
-    XCTAssertNotNil(receivedVariants, "Should receive variants after fetch")
-    XCTAssertEqual(receivedVariants?.count, sampleFlags.count, "Should return all flags after fetch")
-    XCTAssertTrue(manager.areFlagsReady(), "Flags should be ready after successful fetch")
-  }
-
-  func testGetAllVariants_Async_FlagsNotReady_FetchFails() {
-    // Configure mock to simulate failure
-    if let mockManager = manager as? MockFeatureFlagManager {
-      mockManager.simulatedFetchResult = (success: false, flags: nil)
-    }
-
-    XCTAssertFalse(manager.areFlagsReady(), "Precondition: flags should not be ready")
-    let expectation = XCTestExpectation(description: "getAllVariants triggers fetch and fails")
-    var receivedVariants: [String: MixpanelFlagVariant]?
-
-    manager.getAllVariants { variants in
-      XCTAssertTrue(Thread.isMainThread, "Completion should be on main thread")
-      receivedVariants = variants
-      expectation.fulfill()
-    }
-
-    wait(for: [expectation], timeout: 10.0)
-
-    XCTAssertNotNil(receivedVariants, "Should receive result even on failure")
-    XCTAssertTrue(receivedVariants?.isEmpty ?? false, "Should return empty dictionary on fetch failure")
-    XCTAssertFalse(manager.areFlagsReady(), "Flags should not be ready after failed fetch")
-  }
-
-  func testGetAllVariants_Async_NoTracking() {
-    simulateFetchSuccess()
-    let expectation = XCTestExpectation(description: "getAllVariants completion for tracking test")
-
-    manager.getAllVariants { _ in
-      expectation.fulfill()
-    }
-
-    wait(for: [expectation], timeout: 2.0)
-
-    // Wait briefly to ensure no unexpected tracking call
-    let waitExpectation = XCTestExpectation(description: "Wait briefly for no track")
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { waitExpectation.fulfill() }
-    wait(for: [waitExpectation], timeout: 0.5)
-
-    XCTAssertTrue(mockDelegate.trackedEvents.isEmpty, "getAllVariants should not trigger tracking")
-  }
-
-  // --- Tracking Tests ---
-
-  func testTracking_CalledOncePerFeature() {
-    simulateFetchSuccess()  // Flags ready
-
-    mockDelegate.trackExpectation = XCTestExpectation(
-      description: "Track called once for feature_bool_true")
-    mockDelegate.trackExpectation?.expectedFulfillmentCount = 1  // Expect exactly one call
-
-    // Call sync methods multiple times
-    _ = manager.getVariantSync("feature_bool_true", fallback: defaultFallback)
-    _ = manager.getVariantValueSync("feature_bool_true", fallbackValue: nil)
-    _ = manager.isEnabledSync("feature_bool_true")
-
-    // Call async method
-    let asyncExpectation = XCTestExpectation(
-      description: "Async getFeature completes for tracking test")
-    manager.getVariant("feature_bool_true", fallback: defaultFallback) { _ in
-      asyncExpectation.fulfill()
-    }
-
-    // Wait for async call AND the track expectation
-    wait(for: [asyncExpectation, mockDelegate.trackExpectation!], timeout: 10.0)
-
-    // Verify track delegate method was called exactly once
-    let trueEvents = mockDelegate.trackedEvents.filter {
-      $0.properties?["Experiment name"] as? String == "feature_bool_true"
-    }
-    XCTAssertEqual(trueEvents.count, 1, "Track should only be called once for the same feature")
-
-    // --- Call for a *different* feature ---
-    mockDelegate.trackExpectation = XCTestExpectation(
-      description: "Track called for feature_string")
-    _ = manager.getVariantSync("feature_string", fallback: defaultFallback)
-    wait(for: [mockDelegate.trackExpectation!], timeout: 10.0)
-
-    let stringEvents = mockDelegate.trackedEvents.filter {
-      $0.properties?["Experiment name"] as? String == "feature_string"
-    }
-    XCTAssertEqual(stringEvents.count, 1, "Track should be called again for a different feature")
-
-    // Verify total calls
-    XCTAssertEqual(mockDelegate.trackedEvents.count, 2, "Total track calls should be 2")
-  }
-
-  func testTracking_SendsCorrectProperties() {
-    setupReadyFlags()
-    expectTracking {
-      _ = manager.getVariantSync("feature_int", fallback: defaultFallback)
-    }
-    verifyTrackedEvent(experimentName: "feature_int", variantName: "v_int", checkTimingProperties: true)
-  }
-
-  func testTracking_IncludesTimingProperties() {
-    setupReadyFlags()
-    expectTracking {
-      _ = manager.getVariantSync("feature_string", fallback: defaultFallback)
-    }
-    verifyTrackedEvent(experimentName: "feature_string", variantName: "v_str", checkTimingProperties: true, expectedLatency: 150)
-  }
-
-  func testTracking_DoesNotTrackForFallback_Sync() {
-    setupReadyFlags()
-    _ = manager.getVariantSync("missing_feature", fallback: MixpanelFlagVariant(key: "fb", value: "v"))
-    waitBriefly()
-    XCTAssertEqual(
-      mockDelegate.trackedEvents.count, 0,
-      "Track should not be called when a fallback is used (sync)")
-  }
-
-  func testTracking_DoesNotTrackForFallback_Async() {
-    setupReadyFlags()
-    getVariantAsync("missing_feature", fallback: MixpanelFlagVariant(key: "fb", value: "v"))
-    XCTAssertEqual(
-      mockDelegate.trackedEvents.count, 0,
-      "Track should not be called when a fallback is used (async)")
-  }
-
-  // --- Concurrency Tests ---
-
-  // Test concurrent fetch attempts (via getFeature when not ready)
-  func testConcurrentGetFeature_WhenNotReady_OnlyOneFetch() {
-    // Disable network delay since timing isn't what we're testing
-    configureMockFetch(success: true, flags: nil, withDelay: false)
-    XCTAssertFalse(manager.areFlagsReady())
-
-    let numConcurrentCalls = 5
-    var expectations: [XCTestExpectation] = []
-    var completionResults: [MixpanelFlagVariant?] = Array(repeating: nil, count: numConcurrentCalls)
-
-    // Use a more descriptive fallback to help with debugging
-    let testFallback = MixpanelFlagVariant(key: "fallback_key", value: "fallback_value")
-
-    // Expect tracking only ONCE for the actual feature if fetch succeeds
-    mockDelegate.trackExpectation = XCTestExpectation(description: "Track call (should be once)")
-    mockDelegate.trackExpectation?.expectedFulfillmentCount = 1
-
-    print("Starting \(numConcurrentCalls) concurrent getFeature calls...")
-
-    for i in 0..<numConcurrentCalls {
-      let exp = XCTestExpectation(description: "Async getFeature \(i) completes")
-      expectations.append(exp)
-      DispatchQueue.global().async {  // Simulate calls from different threads
-        self.manager.getVariant("feature_bool_true", fallback: testFallback) { data in
-          print("Completion handler \(i) called with data: \(String(describing: data))")
-          completionResults[i] = data
-          exp.fulfill()
-        }
-      }
-    }
-    print("Concurrent calls dispatched.")
-
-    // MockFeatureFlagManager will automatically handle the fetch simulation
-    // No need for manual simulateFetchSuccess() - the mock handles it
-
-    // Wait for all getFeature completions AND the single tracking call
-    wait(for: expectations + [mockDelegate.trackExpectation!], timeout: 10.0)  // Much longer timeout for CI
-
-    // Verify all completions received the correct data
-    for i in 0..<numConcurrentCalls {
-      XCTAssertNotNil(completionResults[i], "Completion \(i) did not receive data")
-      // Check if we got the actual flag data, not the fallback
-      if completionResults[i]?.key == testFallback.key {
-        XCTFail("Completion \(i) received fallback instead of actual flag data")
-      }
-      AssertEqual(completionResults[i]?.key, "v_true")
-      AssertEqual(completionResults[i]?.value, true)
-    }
-
-    // Verify flags are ready and tracking occurred only once
-    XCTAssertTrue(manager.areFlagsReady())
-    let trackEvents = mockDelegate.trackedEvents.filter {
-      $0.properties?["Experiment name"] as? String == "feature_bool_true"
-    }
-    XCTAssertEqual(
-      trackEvents.count, 1, "Tracking should have occurred exactly once despite concurrent calls")
-
-    // Verify only one network fetch was triggered
-    if let mockManager = manager as? MockFeatureFlagManager {
-      XCTAssertEqual(
-        mockManager.fetchRequestCount, 1,
-        "Should have made exactly one fetch request despite concurrent calls")
-    }
-  }
-
-  // --- Response Parser Tests ---
-
-  func testResponseParserFunction() {
-    // Test the response parser functionality by simulating various JSON responses
-    // We'll create test data and parse it directly using JSONDecoder
-
-    // Helper function to parse JSON data like the actual implementation does
-    let parseResponse: (Data) -> FlagsResponse? = { data in
-      do {
-        return try JSONDecoder().decode(FlagsResponse.self, from: data)
-      } catch {
-        print("Error parsing flags JSON: \(error)")
-        return nil
-      }
-    }
-
-    // Create various test data scenarios
-    let validJSON = """
-      {
-          "flags": {
-              "test_flag": {
-                  "variant_key": "test_variant",
-                  "variant_value": "test_value"
-              }
-          }
-      }
-      """.data(using: .utf8)!
-
-    let emptyFlagsJSON = """
-      {
-          "flags": {}
-      }
-      """.data(using: .utf8)!
-
-    let nullFlagsJSON = """
-      {
-          "flags": null
-      }
-      """.data(using: .utf8)!
-
-    let malformedJSON = "not json".data(using: .utf8)!
-
-    // Test valid JSON with flags
-    let validResult = parseResponse(validJSON)
-    XCTAssertNotNil(validResult, "Parser should handle valid JSON")
-    XCTAssertNotNil(validResult?.flags, "Flags should be non-nil")
-    XCTAssertEqual(validResult?.flags?.count, 1, "Should have one flag")
-    XCTAssertEqual(validResult?.flags?["test_flag"]?.key, "test_variant")
-    XCTAssertEqual(validResult?.flags?["test_flag"]?.value as? String, "test_value")
-
-    // Test empty flags object
-    let emptyResult = parseResponse(emptyFlagsJSON)
-    XCTAssertNotNil(emptyResult, "Parser should handle empty flags object")
-    XCTAssertNotNil(emptyResult?.flags, "Flags should be non-nil")
-    XCTAssertEqual(emptyResult?.flags?.count, 0, "Flags should be empty")
-
-    // Test null flags field
-    let nullResult = parseResponse(nullFlagsJSON)
-    XCTAssertNotNil(nullResult, "Parser should handle null flags")
-    XCTAssertNil(nullResult?.flags, "Flags should be nil when null in JSON")
-
-    // Test malformed JSON
-    let malformedResult = parseResponse(malformedJSON)
-    XCTAssertNil(malformedResult, "Parser should return nil for malformed JSON")
-
-    // Test with multiple flags
-    let multipleFlagsJSON = """
-      {
-          "flags": {
-              "feature_a": {
-                  "variant_key": "variant_a",
-                  "variant_value": true
-              },
-              "feature_b": {
-                  "variant_key": "variant_b",
-                  "variant_value": 42
-              },
-              "feature_c": {
-                  "variant_key": "variant_c",
-                  "variant_value": null
-              }
-          }
-      }
-      """.data(using: .utf8)!
-
-    let multiResult = parseResponse(multipleFlagsJSON)
-    XCTAssertNotNil(multiResult, "Parser should handle multiple flags")
-    XCTAssertEqual(multiResult?.flags?.count, 3, "Should have three flags")
-    XCTAssertEqual(multiResult?.flags?["feature_a"]?.value as? Bool, true)
-    XCTAssertEqual(multiResult?.flags?["feature_b"]?.value as? Int, 42)
-    XCTAssertNil(multiResult?.flags?["feature_c"]?.value, "Null value should be preserved")
-
-    // Test with missing required fields
-    let missingFieldJSON = """
-      {
-          "not_flags": {}
-      }
-      """.data(using: .utf8)!
-
-    let missingFieldResult = parseResponse(missingFieldJSON)
-    XCTAssertNotNil(missingFieldResult, "Parser should handle missing flags field")
-    XCTAssertNil(missingFieldResult?.flags, "Flags should be nil when field is missing")
-
-    let optionalExperimentPropertiesJSON = """
-      {
-          "flags": {
-              "active_experiment_flag": {
-                  "variant_key": "A",
-                  "variant_value": "A",
-                  "experiment_id": "447db52b-ec4a-4186-8d89-f9ba7bc7d7dd",
-                  "is_experiment_active": true,
-                  "is_qa_tester": false
-              },
-              "experiment_flag_for_qa_user": {
-                  "variant_key": "B",
-                  "variant_value": "B",
-                  "experiment_id": "447db52b-ec4a-4186-8d89-f9ba7bc7d7dd",
-                  "is_experiment_active": false,
-                  "is_qa_tester": true
-              },
-              "flag_with_no_optionals": {
-                  "variant_key": "C",
-                  "variant_value": "C"
-              }
-          }
-      }
-      """.data(using: .utf8)!
-
-    let experimentResult = parseResponse(optionalExperimentPropertiesJSON)
-    XCTAssertNotNil(experimentResult)
-    XCTAssertEqual(experimentResult?.flags?.count, 3)
-
-    let activeFlag = experimentResult?.flags?["active_experiment_flag"]
-    XCTAssertEqual(activeFlag?.key, "A")
-    XCTAssertEqual(activeFlag?.value as? String, "A")
-    XCTAssertEqual(activeFlag?.experimentID, "447db52b-ec4a-4186-8d89-f9ba7bc7d7dd")
-    XCTAssertEqual(activeFlag?.isExperimentActive, true)
-    XCTAssertEqual(activeFlag?.isQATester, false)
-
-    let qaFlag = experimentResult?.flags?["experiment_flag_for_qa_user"]
-    XCTAssertEqual(qaFlag?.key, "B")
-    XCTAssertEqual(qaFlag?.value as? String, "B")
-    XCTAssertEqual(qaFlag?.experimentID, "447db52b-ec4a-4186-8d89-f9ba7bc7d7dd")
-    XCTAssertEqual(qaFlag?.isExperimentActive, false)
-    XCTAssertEqual(qaFlag?.isQATester, true)
-
-    let minimalFlag = experimentResult?.flags?["flag_with_no_optionals"]
-    XCTAssertEqual(minimalFlag?.key, "C")
-    XCTAssertEqual(minimalFlag?.value as? String, "C")
-    XCTAssertNil(minimalFlag?.experimentID)
-    XCTAssertNil(minimalFlag?.isExperimentActive)
-    XCTAssertNil(minimalFlag?.isQATester)
-  }
-
-  // --- Delegate Error Handling Tests ---
-
-  func testDelegateNilHandling() {
-    // Set up with flags ready, but then remove delegate
-    simulateFetchSuccess()
-    manager.delegate = nil
-
-    // Test all operations with nil delegate
-
-    // Synchronous operations
-    let syncData = manager.getVariantSync("feature_bool_true", fallback: defaultFallback)
-    XCTAssertEqual(syncData.key, "v_true")
-    XCTAssertEqual(syncData.value as? Bool, true)
-
-    // Async operations
-    let expectation = XCTestExpectation(description: "Async with nil delegate")
-    manager.getVariant("feature_int", fallback: defaultFallback) { data in
-      XCTAssertEqual(data.key, "v_int")
-      XCTAssertEqual(data.value as? Int, 101)
-      expectation.fulfill()
-    }
-    wait(for: [expectation], timeout: 1.0)
-
-    // No tracking calls should succeed, but operations should still work
-    // This is "success" as the code doesn't crash when delegate is nil
-  }
-
-  func testFetchWithNoDelegate() {
-    // Create manager with no delegate
-      let noDelegate = FeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: nil)
-
-    // Try to load flags
-    noDelegate.loadFlags()
-
-    // Verify no crash; attempt a flag fetch after a short delay
-    let expectation = XCTestExpectation(description: "Check after attempted fetch")
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-      XCTAssertFalse(noDelegate.areFlagsReady(), "Flags should not be ready without delegate")
-      expectation.fulfill()
-    }
-    wait(for: [expectation], timeout: 1.0)
-  }
-
-  func testDelegateConfigDisabledHandling() {
-    // Set delegate options to disabled
-    mockDelegate.options = MixpanelOptions(token: "test", featureFlagOptions: FeatureFlagOptions(enabled: false))
-
-    // Try to load flags
-    manager.loadFlags()
-
-    // Verify no fetch is triggered
-    let expectation = XCTestExpectation(description: "Check disabled options behavior")
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-      XCTAssertFalse(
-        self.manager.areFlagsReady(), "Flags should not be ready when options disabled")
-      expectation.fulfill()
-    }
-    wait(for: [expectation], timeout: 1.0)
-  }
-
-  // --- AnyCodable Edge Cases ---
-
-  func testAnyCodableWithComplexTypes() {
-    // Use reflection to test AnyCodable directly
-
-    // Test with nested array
-    let nestedArrayJSON = """
-      {
-          "variant_key": "complex_array",
-          "variant_value": [1, "string", true, [2, 3], {"key": "value"}]
-      }
-      """.data(using: .utf8)!
-
-    do {
-      let decoder = JSONDecoder()
-      let flagData = try decoder.decode(MixpanelFlagVariant.self, from: nestedArrayJSON)
-
-      XCTAssertEqual(flagData.key, "complex_array")
-      XCTAssertNotNil(flagData.value, "Value should not be nil")
-
-      // Verify array structure
-      guard let array = flagData.value as? [Any?] else {
-        XCTFail("Value should be an array")
-        return
-      }
-
-      XCTAssertEqual(array.count, 5, "Array should have 5 elements")
-      XCTAssertEqual(array[0] as? Int, 1)
-      XCTAssertEqual(array[1] as? String, "string")
-      XCTAssertEqual(array[2] as? Bool, true)
-
-      // Nested array check
-      guard let nestedArray = array[3] as? [Any?] else {
-        XCTFail("Element 3 should be an array")
-        return
-      }
-      XCTAssertEqual(nestedArray.count, 2)
-      XCTAssertEqual(nestedArray[0] as? Int, 2)
-      XCTAssertEqual(nestedArray[1] as? Int, 3)
-
-      // Nested dictionary check
-      guard let nestedDict = array[4] as? [String: Any?] else {
-        XCTFail("Element 4 should be a dictionary")
-        return
-      }
-      XCTAssertEqual(nestedDict.count, 1)
-      XCTAssertEqual(nestedDict["key"] as? String, "value")
-
-    } catch {
-      XCTFail("Failed to decode nested array JSON: \(error)")
-    }
-
-    // Test with deeply nested object
-    let nestedObjectJSON = """
-      {
-          "variant_key": "complex_object",
-          "variant_value": {
-              "str": "value",
-              "num": 42,
-              "bool": true,
-              "null": null,
-              "array": [1, 2],
-              "nested": {
-                  "deeper": {
-                      "deepest": "bottom"
-                  }
-              }
-          }
-      }
-      """.data(using: .utf8)!
-
-    do {
-      let decoder = JSONDecoder()
-      let flagData = try decoder.decode(MixpanelFlagVariant.self, from: nestedObjectJSON)
-
-      XCTAssertEqual(flagData.key, "complex_object")
-      XCTAssertNotNil(flagData.value, "Value should not be nil")
-
-      // Verify dictionary structure
-      guard let dict = flagData.value as? [String: Any?] else {
-        XCTFail("Value should be a dictionary")
-        return
-      }
-
-      XCTAssertEqual(dict.count, 6, "Dictionary should have 6 keys")
-      XCTAssertEqual(dict["str"] as? String, "value")
-      XCTAssertEqual(dict["num"] as? Int, 42)
-      XCTAssertEqual(dict["bool"] as? Bool, true)
-      XCTAssertTrue(dict.keys.contains("null"), "Key 'null' should exist")
-      if let nullEntry = dict["null"] {
-        // Key exists with a value of nil (as wanted)
-        XCTAssertNil(nullEntry, "Value for null key should be nil")
-      } else {
-        // Key doesn't exist (which would be wrong)
-        XCTFail("'null' key should exist in dictionary")
-      }
-
-      // Check nested array
-      guard let array = dict["array"] as? [Any?] else {
-        XCTFail("Array key should contain an array")
-        return
-      }
-      XCTAssertEqual(array.count, 2)
-
-      // Check deeply nested structure
-      guard let nested = dict["nested"] as? [String: Any?] else {
-        XCTFail("Nested key should contain dictionary")
-        return
-      }
-
-      guard let deeper = nested["deeper"] as? [String: Any?] else {
-        XCTFail("Deeper key should contain dictionary")
-        return
-      }
-
-      XCTAssertEqual(deeper["deepest"] as? String, "bottom")
-
-    } catch {
-      XCTFail("Failed to decode nested object JSON: \(error)")
-    }
-  }
-
-  func testAnyCodableWithInvalidTypes() {
-    // Test case where variant_value has an unsupported type
-    // Note: This is harder to test directly since JSON doesn't have many "invalid" types
-    // We can test error handling by constructing invalid JSON manually
-
-    let unsupportedTypeJSON = """
-      {
-          "variant_key": "invalid_type",
-          "variant_value": "infinity"
-      }
-      """.data(using: .utf8)!
-
-    // This is a valid test since the string will decode properly
-    do {
-      let decoder = JSONDecoder()
-      let flagData = try decoder.decode(MixpanelFlagVariant.self, from: unsupportedTypeJSON)
-      XCTAssertEqual(flagData.key, "invalid_type")
-      XCTAssertEqual(flagData.value as? String, "infinity")
-    } catch {
-      XCTFail("Should not fail with simple string value: \(error)")
-    }
-
-    // Test handling of missing variant_value
-    let missingValueJSON = """
-      {
-          "variant_key": "missing_value"
-      }
-      """.data(using: .utf8)!
-
-    do {
-      let decoder = JSONDecoder()
-      let _ = try decoder.decode(MixpanelFlagVariant.self, from: missingValueJSON)
-      XCTFail("Decoding should fail with missing variant_value")
-    } catch {
-      // This is expected to fail, so the test passes
-      XCTAssertTrue(error is DecodingError, "Error should be a DecodingError")
-    }
-  }
-
-  func testFeatureFlagContextIncludesDeviceId() {
-    // Test that device_id is included in the feature flags context
-    let testAnonymousId = "test_device_id_12345"
-    let testDistinctId = "test_distinct_id_67890"
-
-    let mockDelegate = MockFeatureFlagDelegate(
-      options: MixpanelOptions(token: "test", featureFlagOptions: FeatureFlagOptions(enabled: true)),
-      distinctId: testDistinctId,
-      anonymousId: testAnonymousId
-    )
-
-      let manager = FeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: mockDelegate)
-
-    // Verify the delegate methods return expected values
-    XCTAssertEqual(mockDelegate.getDistinctId(), testDistinctId)
-    XCTAssertEqual(mockDelegate.getAnonymousId(), testAnonymousId)
-
-    // Verify call counts
-    XCTAssertEqual(mockDelegate.getDistinctIdCallCount, 1)
-    XCTAssertEqual(mockDelegate.getAnonymousIdCallCount, 1)
-  }
-
-  func testFeatureFlagContextWithNilAnonymousId() {
-    // Test that device_id is not included when anonymous ID is nil
-    let testDistinctId = "test_distinct_id_67890"
-
-    let mockDelegate = MockFeatureFlagDelegate(
-      options: MixpanelOptions(token: "test", featureFlagOptions: FeatureFlagOptions(enabled: true)),
-      distinctId: testDistinctId,
-      anonymousId: nil
-    )
-
-      let manager = FeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: mockDelegate)
-
-    // Verify the delegate methods return expected values
-    XCTAssertEqual(mockDelegate.getDistinctId(), testDistinctId)
-    XCTAssertNil(mockDelegate.getAnonymousId())
-
-    // Verify call counts
-    XCTAssertEqual(mockDelegate.getDistinctIdCallCount, 1)
-    XCTAssertEqual(mockDelegate.getAnonymousIdCallCount, 1)
-  }
-
-  func testAccessQueueKeyFunctionality() {
-    // Test that _performTrackingDelegateCall correctly determines if it's on the accessQueue
-    simulateFetchSuccess()
-
-    // First scenario: Call from accessQueue (should read timing properties directly)
-    let syncExpectation = XCTestExpectation(description: "Sync tracking completes")
-
-    // Reset tracked events
-    mockDelegate.trackedEvents.removeAll()
-    mockDelegate.trackExpectation = syncExpectation
-
-    // Call getVariantSync which should trigger tracking from within the accessQueue
-    _ = manager.getVariantSync("feature_double", fallback: defaultFallback)
-
-    wait(for: [syncExpectation], timeout: 5.0)
-
-    // Verify tracking occurred with timing properties
-    XCTAssertEqual(mockDelegate.trackedEvents.count, 1, "Should have tracked once")
-    let syncTrackedEvent = mockDelegate.trackedEvents[0]
-    XCTAssertEqual(syncTrackedEvent.event, "$experiment_started")
-
-    // Verify timing properties are present
-    let syncProps = syncTrackedEvent.properties!
-    XCTAssertNotNil(syncProps["timeLastFetched"], "Should have timeLastFetched")
-    XCTAssertNotNil(syncProps["fetchLatencyMs"], "Should have fetchLatencyMs")
-    XCTAssertEqual(syncProps["fetchLatencyMs"] as? Int, 150, "Should have expected latency")
-
-    // Second scenario: Call from outside accessQueue (should sync to read properties)
-    let asyncExpectation = XCTestExpectation(description: "Async tracking completes")
-
-    // Reset tracked events and set up new tracking expectation
-    mockDelegate.trackedEvents.removeAll()
-    mockDelegate.trackExpectation = asyncExpectation
-
-    // Use async getVariant which may trigger tracking from different queue contexts
-    manager.getVariant("feature_null", fallback: defaultFallback) { _ in
-      // This completion runs on main queue
-    }
-
-    wait(for: [asyncExpectation], timeout: 5.0)
-
-    // Verify tracking occurred with timing properties
-    XCTAssertEqual(mockDelegate.trackedEvents.count, 1, "Should have tracked once")
-    let asyncTrackedEvent = mockDelegate.trackedEvents[0]
-    XCTAssertEqual(asyncTrackedEvent.event, "$experiment_started")
-
-    // Verify timing properties are present (should be the same regardless of queue)
-    let asyncProps = asyncTrackedEvent.properties!
-    XCTAssertNotNil(asyncProps["timeLastFetched"], "Should have timeLastFetched")
-    XCTAssertNotNil(asyncProps["fetchLatencyMs"], "Should have fetchLatencyMs")
-    XCTAssertEqual(asyncProps["fetchLatencyMs"] as? Int, 150, "Should have expected latency")
-  }
-
-  func testTrackingFromDifferentQueueContexts() {
-    // Test that tracking works correctly when called from various queue contexts
-    simulateFetchSuccess()
-
-    let testQueue = DispatchQueue(label: "test.queue")
-    let concurrentQueue = DispatchQueue(label: "test.concurrent", attributes: .concurrent)
-
-    // Track expectations for multiple calls
-    let expectationCount = 3
-    var expectations: [XCTestExpectation] = []
-    for i in 0..<expectationCount {
-      expectations.append(XCTestExpectation(description: "Track call \(i)"))
-    }
-
-    mockDelegate.trackedEvents.removeAll()
-    var trackIndex = 0
-
-    // Set custom track handler to fulfill expectations in order
-    let syncQueue = DispatchQueue(label: "test.sync")
-    mockDelegate.customTrackHandler = { event, properties in
-      syncQueue.sync {
-        if trackIndex < expectations.count {
-          expectations[trackIndex].fulfill()
-          trackIndex += 1
-        }
-      }
-    }
-
-    // Test 1: From custom serial queue
-    testQueue.async {
-      _ = self.manager.getVariantSync("feature_bool_true", fallback: self.defaultFallback)
-    }
-
-    // Test 2: From concurrent queue
-    concurrentQueue.async {
-      _ = self.manager.getVariantSync("feature_bool_false", fallback: self.defaultFallback)
-    }
-
-    // Test 3: From main queue
-    DispatchQueue.main.async {
-      _ = self.manager.getVariantSync("feature_string", fallback: self.defaultFallback)
-    }
-
-    // Wait for all tracking to complete
-    wait(for: expectations, timeout: 5.0)
-
-    // Verify all tracking calls included timing properties
-    XCTAssertEqual(mockDelegate.trackedEvents.count, expectationCount)
-
-    for (index, event) in mockDelegate.trackedEvents.enumerated() {
-      XCTAssertEqual(
-        event.event, "$experiment_started", "Event \(index) should be $experiment_started")
-      let props = event.properties!
-      XCTAssertNotNil(props["timeLastFetched"], "Event \(index) should have timeLastFetched")
-      XCTAssertNotNil(props["fetchLatencyMs"], "Event \(index) should have fetchLatencyMs")
-      XCTAssertEqual(
-        props["fetchLatencyMs"] as? Int, 150, "Event \(index) should have expected latency")
-    }
-  }
-
-  func testTrackingIncludesOptionalProperties() {
-    // Set up flags with experiment properties
-    let flagsWithExperiment: [String: MixpanelFlagVariant] = [
-      "experiment_flag": MixpanelFlagVariant(key: "variant_a", value: true, isExperimentActive: true, isQATester: false, experimentID: "exp_123")
+    var mockDelegate: MockFeatureFlagDelegate!
+    var manager: FeatureFlagManager!
+    // Sample flag data for simulating fetch results
+    let sampleFlags: [String: MixpanelFlagVariant] = [
+        "feature_bool_true": MixpanelFlagVariant(key: "v_true", value: true),
+        "feature_bool_false": MixpanelFlagVariant(key: "v_false", value: false),
+        "feature_string": MixpanelFlagVariant(key: "v_str", value: "test_string"),
+        "feature_int": MixpanelFlagVariant(key: "v_int", value: 101),
+        "feature_double": MixpanelFlagVariant(key: "v_double", value: 99.9),
+        "feature_null": MixpanelFlagVariant(key: "v_null", value: nil),
     ]
-    simulateFetchSuccess(flags: flagsWithExperiment)
+    let defaultFallback = MixpanelFlagVariant(value: nil)  // Default fallback for convenience
 
-    mockDelegate.trackExpectation = XCTestExpectation(description: "Track with experiment properties")
-    _ = manager.getVariantSync("experiment_flag", fallback: defaultFallback)
-    wait(for: [mockDelegate.trackExpectation!], timeout: 1.0)
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        mockDelegate = MockFeatureFlagDelegate()
 
-    let props = mockDelegate.trackedEvents[0].properties!
-    XCTAssertEqual(props["$experiment_id"] as? String, "exp_123")
-    XCTAssertEqual(props["$is_experiment_active"] as? Bool, true)
-    XCTAssertEqual(props["$is_qa_tester"] as? Bool, false)
-  }
+        // Use MockFeatureFlagManager to prevent real network calls
+        let mockManager = MockFeatureFlagManager(
+            serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated),
+            instanceName: "test", delegate: mockDelegate)
+        // Configure default simulation - successful fetch with sample flags
+        mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
+        mockManager.shouldSimulateNetworkDelay = true
 
-  // MARK: - Timing Properties Sanity Tests
-
-  func testTimingPropertiesSanity() {
-    // 1. Test Initial State - Properties should be nil before any fetch
-    XCTAssertNil(manager.timeLastFetched, "timeLastFetched should be nil initially")
-    XCTAssertNil(manager.fetchLatencyMs, "fetchLatencyMs should be nil initially")
-
-    // 2. Test Accurate Timing Calculation with Real Delay
-    if let mockManager = manager as? MockFeatureFlagManager {
-      // Configure mock to simulate a realistic network delay
-      let expectedDelayMs = 250  // 250ms simulated network delay
-      mockManager.shouldSimulateNetworkDelay = true
-
-      // Create a custom expectation to measure actual time
-      let fetchExpectation = XCTestExpectation(description: "Fetch completes with timing")
-      let fetchStartTime = Date()
-
-      // Trigger async fetch
-      manager.getVariant("feature_bool_true", fallback: defaultFallback) { _ in
-        fetchExpectation.fulfill()
-      }
-
-      wait(for: [fetchExpectation], timeout: 10.0)
-
-      // Verify timing properties are set and reasonable
-      XCTAssertNotNil(
-        manager.timeLastFetched, "timeLastFetched should be set after successful fetch")
-      XCTAssertNotNil(manager.fetchLatencyMs, "fetchLatencyMs should be set after successful fetch")
-
-      // 3. Test Reasonable Bounds
-      if let latencyMs = manager.fetchLatencyMs {
-        XCTAssertGreaterThan(latencyMs, 0, "fetchLatencyMs should be positive")
-        XCTAssertLessThan(latencyMs, 30000, "fetchLatencyMs should be less than 30 seconds")
-
-        // Sanity check that the SDK's reported latency is in the same ballpark as the
-        // wall-clock duration of the call. We don't assert tight bounds: `fetchStartTime`
-        // is captured before `getVariant` returns control to the trackingQueue, so on a
-        // contested CI runner the dispatch delay before the mock fetch even starts can
-        // dwarf the simulated 100ms delay. The SDK timer (latencyMs) measures only the
-        // fetch itself, so it can legitimately be much smaller than actualElapsedMs.
-        // Using a 30s tolerance — same as the upper bound on latencyMs above — keeps
-        // this an order-of-magnitude check rather than a tight equivalence one.
-        let actualElapsedMs = Int(Date().timeIntervalSince(fetchStartTime) * 1000)
-        let tolerance = 30000
-        XCTAssertLessThanOrEqual(
-          abs(latencyMs - actualElapsedMs), tolerance,
-          "fetchLatencyMs (\(latencyMs)ms) should be close to actual elapsed time (\(actualElapsedMs)ms)"
-        )
-      }
-
-      if let timeLastFetched = manager.timeLastFetched {
-        let timestamp = Int(timeLastFetched.timeIntervalSince1970)
-        let year2020Timestamp = 1_577_836_800  // Jan 1, 2020
-        let year2100Timestamp = 4_102_444_800  // Jan 1, 2100
-
-        XCTAssertGreaterThan(
-          timestamp, year2020Timestamp, "timeLastFetched should be after year 2020")
-        XCTAssertLessThan(
-          timestamp, year2100Timestamp, "timeLastFetched should be before year 2100")
-
-        // Verify timestamp is not in the future
-        XCTAssertLessThanOrEqual(
-          timeLastFetched.timeIntervalSinceNow, 1.0,
-          "timeLastFetched should not be in the future (allowing 1s tolerance)"
-        )
-      }
+        manager = mockManager
     }
 
-    // 4. Test Update on Subsequent Fetches
-    if let mockManager = manager as? MockFeatureFlagManager {
-      // Store first fetch values
-      let firstFetchTime = manager.timeLastFetched
-      let firstLatency = manager.fetchLatencyMs
-
-      // Wait a bit to ensure time difference
-      Thread.sleep(forTimeInterval: 0.1)
-
-      // Reset flags to trigger new fetch
-      mockManager.flagsLock.write {
-        mockManager.flags = nil
-      }
-
-      // Configure different delay for second fetch
-      mockManager.shouldSimulateNetworkDelay = true
-      mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
-
-      let secondFetchExpectation = XCTestExpectation(description: "Second fetch completes")
-
-      manager.getVariant("feature_string", fallback: defaultFallback) { _ in
-        secondFetchExpectation.fulfill()
-      }
-
-      wait(for: [secondFetchExpectation], timeout: 10.0)
-
-      // Verify timing properties updated
-      XCTAssertNotNil(manager.timeLastFetched, "timeLastFetched should be set after second fetch")
-      XCTAssertNotNil(manager.fetchLatencyMs, "fetchLatencyMs should be set after second fetch")
-
-      if let firstTime = firstFetchTime, let secondTime = manager.timeLastFetched {
-        XCTAssertGreaterThan(
-          secondTime.timeIntervalSince1970, firstTime.timeIntervalSince1970,
-          "Second fetch time should be later than first fetch time"
-        )
-      }
-
-      // Latency might be similar but should be independently calculated
-      XCTAssertNotNil(
-        manager.fetchLatencyMs, "fetchLatencyMs should still be set after second fetch")
+    override func tearDownWithError() throws {
+        mockDelegate = nil
+        manager = nil
+        try super.tearDownWithError()
     }
 
-    // 5. Test Failed Fetch Behavior
-    if let mockManager = manager as? MockFeatureFlagManager {
-      // Store current valid timing values
-      let validTimeLastFetched = manager.timeLastFetched
-      let validFetchLatency = manager.fetchLatencyMs
+    // --- Simulation Helpers ---
+    // These now directly modify state and call the *internal* _completeFetch
+    // Requires _completeFetch to be accessible (e.g., internal or @testable import)
 
-      // Reset flags and configure for failure
-      mockManager.flagsLock.write {
-        mockManager.flags = nil
-      }
-      mockManager.simulatedFetchResult = (success: false, flags: nil)
+    private func simulateFetchSuccess(flags: [String: MixpanelFlagVariant]? = nil) {
+        let flagsToSet = flags ?? sampleFlags
 
-      let failedFetchExpectation = XCTestExpectation(description: "Failed fetch completes")
-
-      manager.getVariant("feature_int", fallback: defaultFallback) { variant in
-        // Should get fallback on failure
-        XCTAssertEqual(
-          variant.key, self.defaultFallback.key, "Should receive fallback on fetch failure")
-        failedFetchExpectation.fulfill()
-      }
-
-      wait(for: [failedFetchExpectation], timeout: 10.0)
-
-      // Verify timing properties aren't corrupted by failed fetch
-      // They should either remain unchanged or be cleared, but not set to invalid values
-      if manager.timeLastFetched != nil {
-        // If still set, should be the previous valid value
-        XCTAssertEqual(
-          manager.timeLastFetched?.timeIntervalSince1970,
-          validTimeLastFetched?.timeIntervalSince1970,
-          "timeLastFetched should not be updated on failed fetch"
-        )
-      }
-
-      if manager.fetchLatencyMs != nil {
-        // If still set, should be the previous valid value
-        XCTAssertEqual(
-          manager.fetchLatencyMs, validFetchLatency,
-          "fetchLatencyMs should not be updated on failed fetch"
-        )
-      }
-
-      // Reset to success for cleanup
-      mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
-    }
-
-    // 6. Test Consistency Between Timing Properties
-    if let mockManager = manager as? MockFeatureFlagManager {
-      // Ensure we have a successful fetch
-      mockManager.flagsLock.write {
-        mockManager.flags = nil
-      }
-
-      let consistencyExpectation = XCTestExpectation(description: "Fetch for consistency check")
-
-      manager.getVariant("feature_double", fallback: defaultFallback) { _ in
-        consistencyExpectation.fulfill()
-      }
-
-      wait(for: [consistencyExpectation], timeout: 10.0)
-
-      // Both should be set or both should be nil
-      if manager.fetchLatencyMs != nil {
-        XCTAssertNotNil(
-          manager.timeLastFetched,
-          "If fetchLatencyMs is set, timeLastFetched should also be set"
-        )
-      }
-
-      if manager.timeLastFetched != nil {
-        XCTAssertNotNil(
-          manager.fetchLatencyMs,
-          "If timeLastFetched is set, fetchLatencyMs should also be set"
-        )
-      }
-    }
-
-    // 7. Test Timing Properties in Tracking Events
-    // Reset tracked events to test fresh tracking
-    mockDelegate.trackedEvents.removeAll()
-
-    // Use a unique flag name that hasn't been tracked yet to ensure fresh tracking
-    let uniqueFlagName = "test_timing_flag_\(UUID().uuidString.prefix(8))"
-
-    // Create a test flag for this unique name
-    if let mockManager = manager as? MockFeatureFlagManager {
-      var testFlags = sampleFlags
-      testFlags[uniqueFlagName] = MixpanelFlagVariant(key: "timing_test", value: true)
-      mockManager.flagsLock.write {
-        mockManager.flags = testFlags
-      }
-    }
-
-    let trackingExpectation = XCTestExpectation(description: "Tracking includes timing properties")
-    mockDelegate.trackExpectation = trackingExpectation
-
-    // Trigger tracking by accessing the unique flag
-    _ = manager.getVariantSync(uniqueFlagName, fallback: defaultFallback)
-
-    wait(for: [trackingExpectation], timeout: 1.0)
-
-    XCTAssertEqual(mockDelegate.trackedEvents.count, 1, "Should have tracked one event")
-    let trackedEvent = mockDelegate.trackedEvents[0]
-    let props = trackedEvent.properties!
-
-    // Verify timing properties are included in tracking
-    if manager.timeLastFetched != nil {
-      XCTAssertNotNil(props["timeLastFetched"], "Tracking should include timeLastFetched")
-      if let trackedTimestamp = props["timeLastFetched"] as? Int {
-        let expectedTimestamp = Int(manager.timeLastFetched!.timeIntervalSince1970)
-        XCTAssertEqual(
-          trackedTimestamp, expectedTimestamp,
-          "Tracked timeLastFetched should match manager's value"
-        )
-      }
-    }
-
-    if manager.fetchLatencyMs != nil {
-      XCTAssertNotNil(props["fetchLatencyMs"], "Tracking should include fetchLatencyMs")
-      if let trackedLatency = props["fetchLatencyMs"] as? Int {
-        XCTAssertEqual(
-          trackedLatency, manager.fetchLatencyMs!,
-          "Tracked fetchLatencyMs should match manager's value"
-        )
-      }
-    }
-  }
-
-  func testGETRequestFormat() {
-    // Use a fresh MockFeatureFlagManager with request validation enabled
-      let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: mockDelegate)
-    mockManager.requestValidationEnabled = true
-    mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
-
-    // Trigger a request
-    mockManager.loadFlags()
-
-    // Wait for request to be processed (use predicate to handle slow CI dispatch queues)
-    let validatedPredicate = NSPredicate { _, _ in mockManager.lastRequestMethod != nil }
-    let expectation = XCTNSPredicateExpectation(predicate: validatedPredicate, object: nil)
-    wait(for: [expectation], timeout: 10.0)
-
-    // Verify no validation errors
-    XCTAssertNil(mockManager.requestValidationError, "Request validation should not have errors: \(mockManager.requestValidationError ?? "")")
-
-    // Verify GET method
-    XCTAssertEqual(mockManager.lastRequestMethod, .get, "Should use GET method")
-
-    // Verify headers
-    XCTAssertNotNil(mockManager.lastRequestHeaders, "Headers should be captured")
-    if let headers = mockManager.lastRequestHeaders {
-      XCTAssertTrue(headers.keys.contains("Authorization"), "Should include Authorization header")
-      XCTAssertTrue(headers["Authorization"]?.starts(with: "Basic ") == true, "Should use Basic auth")
-      XCTAssertFalse(headers.keys.contains("Content-Type"), "Should not include Content-Type header for GET")
-    }
-
-    // Verify no request body
-    XCTAssertNil(mockManager.lastRequestBody, "GET request should not have a body")
-
-    // Verify query parameters
-    XCTAssertNotNil(mockManager.lastQueryItems, "Query items should be captured")
-    if let queryItems = mockManager.lastQueryItems {
-      let queryDict = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
-
-      // Check required parameters
-      XCTAssertNotNil(queryDict["context"], "Should include context parameter")
-      XCTAssertEqual(queryDict["token"], "test", "Should include token parameter")
-      XCTAssertEqual(queryDict["mp_lib"], "swift", "Should include mp_lib parameter")
-      XCTAssertEqual(queryDict["$lib_version"], AutomaticProperties.libVersion(), "Should include $lib_version parameter")
-
-      // Verify context JSON structure
-      if let contextString = queryDict["context"],
-        let contextData = contextString?.data(using: .utf8),
-        let context = try? JSONSerialization.jsonObject(with: contextData) as? [String: Any] {
-        XCTAssertEqual(context["distinct_id"] as? String, "test_distinct_id", "Context should include distinct_id")
-        XCTAssertEqual(context["device_id"] as? String, "test_anonymous_id", "Context should include device_id")
-      } else {
-        XCTFail("Context should be valid JSON")
-      }
-    }
-  }
-
-  func testGETRequestWithCustomContext() {
-    // Set up custom context
-    let customOptions = MixpanelOptions(token: "custom-token", featureFlagOptions: FeatureFlagOptions(enabled: true, context: [
-      "user_id": "test-user-123",
-      "group_id": "test-group-456"
-    ]))
-
-    let customDelegate = MockFeatureFlagDelegate(
-      options: customOptions,
-      distinctId: "custom-distinct-id",
-      anonymousId: "custom-device-id"
-    )
-
-      let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: customDelegate)
-    mockManager.requestValidationEnabled = true
-    mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
-
-    // Trigger a request
-    mockManager.loadFlags()
-
-    // Wait for request to be processed (use predicate to handle slow CI dispatch queues)
-    let validatedPredicate = NSPredicate { _, _ in mockManager.lastRequestMethod != nil }
-    let expectation = XCTNSPredicateExpectation(predicate: validatedPredicate, object: nil)
-    wait(for: [expectation], timeout: 10.0)
-
-    // Verify no validation errors
-    XCTAssertNil(mockManager.requestValidationError, "Request validation should not have errors")
-
-    // Verify query parameters with custom context
-    XCTAssertNotNil(mockManager.lastQueryItems, "Query items should be captured")
-    if let queryItems = mockManager.lastQueryItems {
-      let queryDict = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
-      XCTAssertEqual(queryDict["token"], "custom-token", "Should include custom token")
-      // Verify context includes both standard and custom fields
-      if let contextString = queryDict["context"],
-        let contextData = contextString?.data(using: .utf8),
-        let context = try? JSONSerialization.jsonObject(with: contextData) as? [String: Any] {
-
-        XCTAssertEqual(context["distinct_id"] as? String, "custom-distinct-id", "Context should include distinct_id")
-        XCTAssertEqual(context["device_id"] as? String, "custom-device-id", "Context should include device_id")
-        XCTAssertEqual(context["user_id"] as? String, "test-user-123", "Context should include custom user_id")
-        XCTAssertEqual(context["group_id"] as? String, "test-group-456", "Context should include custom group_id")
-      } else {
-        XCTFail("Context should be valid JSON with custom fields")
-      }
-    }
-  }
-
-  func testGETRequestWithNilAnonymousId() {
-    // Set up with nil anonymous ID
-    let nilAnonymousDelegate = MockFeatureFlagDelegate(
-      options: MixpanelOptions(token: "test-token", featureFlagOptions: FeatureFlagOptions(enabled: true)),
-      distinctId: "test-distinct-id",
-      anonymousId: nil
-    )
-
-      let mockManager = MockFeatureFlagManager(serverURL: "https://api.mixpanel.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: nilAnonymousDelegate)
-    mockManager.requestValidationEnabled = true
-    mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
-
-    // Trigger a request
-    mockManager.loadFlags()
-
-    // Wait for request to be processed (use predicate to handle slow CI dispatch queues)
-    let validatedPredicate = NSPredicate { _, _ in mockManager.lastRequestMethod != nil }
-    let expectation = XCTNSPredicateExpectation(predicate: validatedPredicate, object: nil)
-    wait(for: [expectation], timeout: 10.0)
-
-    // Verify no validation errors
-    XCTAssertNil(mockManager.requestValidationError, "Request validation should not have errors with nil anonymous ID")
-
-    // Verify context excludes device_id when anonymous ID is nil
-    if let queryItems = mockManager.lastQueryItems {
-      let queryDict = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
-
-        if let contextString = queryDict["context"],
-          let contextData = contextString?.data(using: .utf8),
-          let context = try? JSONSerialization.jsonObject(with: contextData) as? [String: Any] {
-
-          XCTAssertEqual(context["distinct_id"] as? String, "test-distinct-id", "Context should include distinct_id")
-          XCTAssertNil(context["device_id"], "Context should not include device_id when anonymous ID is nil")
-
-          // Should only contain distinct_id (no additional context configured)
-          XCTAssertEqual(context.keys.count, 1, "Context should only contain distinct_id when no device_id or additional context")
-      } else {
-        XCTFail("Context should be valid JSON")
-      }
-    }
-  }
-
-  // MARK: - First-Time Event Targeting Tests
-
-  // MARK: Response Parsing Tests
-
-  func testParsePendingFirstTimeEvents() {
-    let json = """
-    {
-      "flags": {
-        "test-flag": {
-          "variant_key": "control",
-          "variant_value": false
+        // If using MockFeatureFlagManager, just set the flags directly
+        if let mockManager = manager as? MockFeatureFlagManager {
+            // For mock, we can directly set the flags without going through fetch
+            mockManager.flagsLock.write {
+                mockManager.flags = flagsToSet
+                mockManager.timeLastFetched = Date()
+                mockManager.fetchLatencyMs = 150
+                // Don't call _completeFetch - just set the state
+            }
+            // Give a moment for the async operation to complete
+            Thread.sleep(forTimeInterval: 0.01)
+        } else {
+            // Original implementation for non-mock manager
+            let currentTime = Date()
+            // Set flags directly *before* calling completeFetch
+            manager.flagsLock.write {
+                manager.flags = flagsToSet
+                // Set timing properties to simulate a successful fetch
+                manager.timeLastFetched = currentTime
+                manager.fetchLatencyMs = 150  // Simulate 150ms fetch time
+                // Important: Set isFetching = true *before* calling _completeFetch,
+                // as _completeFetch assumes a fetch was in progress.
+                manager.isFetching = true
+            }
+            // Call internal completion logic
+            manager._completeFetch(success: true)
         }
-      },
-      "pending_first_time_events": [
+    }
+
+    private func simulateFetchFailure() {
+        // If using MockFeatureFlagManager, just clear the flags
+        if let mockManager = manager as? MockFeatureFlagManager {
+            mockManager.flagsLock.write {
+                mockManager.flags = nil
+                // Don't call _completeFetch - just set the state
+            }
+            // Give a moment for the async operation to complete
+            Thread.sleep(forTimeInterval: 0.01)
+        } else {
+            // Original implementation for non-mock manager
+            // Set isFetching = true before calling _completeFetch
+            manager.flagsLock.write {
+                manager.isFetching = true
+                // Ensure flags are nil or unchanged on failure simulation if desired
+                manager.flags = nil  // Or keep existing flags based on desired failure behavior
+            }
+            // Call internal completion logic
+            manager._completeFetch(success: false)
+        }
+    }
+
+    // MARK: - Test Helpers
+
+    // Expectation & Waiting Helpers
+
+    private func waitBriefly(timeout: TimeInterval = 0.5, file: StaticString = #file, line: UInt = #line) {
+        let expectation = XCTestExpectation(description: "Brief wait")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { expectation.fulfill() }
+        wait(for: [expectation], timeout: timeout)
+    }
+
+    private func waitForAsyncOperation<T>(
+        timeout: TimeInterval = 2.0,
+        description: String,
+        operation: (@escaping (T) -> Void) -> Void,
+        validation: (T) -> Void
+    ) {
+        let expectation = XCTestExpectation(description: description)
+        var result: T?
+
+        operation { value in
+            result = value
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: timeout)
+
+        if let result = result {
+            validation(result)
+        } else {
+            XCTFail("Operation did not complete in time")
+        }
+    }
+
+    // Tracking Helpers
+
+    private func expectTracking(
+        expectedCount: Int = 1,
+        description: String = "Track called",
+        timeout: TimeInterval = 1.0,
+        operation: () -> Void
+    ) {
+        mockDelegate.trackedEvents.removeAll()
+        mockDelegate.trackExpectation = XCTestExpectation(description: description)
+        mockDelegate.trackExpectation?.expectedFulfillmentCount = expectedCount
+
+        operation()
+
+        wait(for: [mockDelegate.trackExpectation!], timeout: timeout)
+        XCTAssertEqual(mockDelegate.trackedEvents.count, expectedCount)
+    }
+
+    private func verifyTrackingProperties(
+        _ properties: [String: Any?],
+        experimentName: String,
+        variantName: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        AssertEqual(properties["Experiment name"] ?? nil, experimentName, file: file, line: line)
+        AssertEqual(properties["Variant name"] ?? nil, variantName, file: file, line: line)
+        AssertEqual(properties["$experiment_type"] ?? nil, "feature_flag", file: file, line: line)
+    }
+
+    private func verifyTimingProperties(
+        _ properties: [String: Any?],
+        expectedLatency: Int? = nil,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(
+            properties.keys.contains("timeLastFetched"), "Should include timeLastFetched", file: file, line: line)
+        XCTAssertTrue(
+            properties.keys.contains("fetchLatencyMs"), "Should include fetchLatencyMs", file: file, line: line)
+
+        if let expected = expectedLatency,
+            let actual = properties["fetchLatencyMs"] as? Int
         {
-          "flag_key": "test-flag",
-          "flag_id": "flag-123",
-          "project_id": 3,
-          "first_time_event_hash": "abc123",
-          "event_name": "Purchase Complete",
-          "property_filters": {
-            ">": [{"var": "amount"}, 100]
-          },
-          "pending_variant": {
-            "variant_key": "treatment",
-            "variant_value": true,
-            "experiment_id": "exp-456",
-            "is_experiment_active": true
-          }
+            XCTAssertEqual(actual, expected, file: file, line: line)
         }
-      ]
-    }
-    """.data(using: .utf8)!
-
-    do {
-      let response = try JSONDecoder().decode(FlagsResponse.self, from: json)
-      XCTAssertNotNil(response.flags)
-      XCTAssertNotNil(response.pendingFirstTimeEvents)
-      XCTAssertEqual(response.pendingFirstTimeEvents?.count, 1)
-
-      let pendingEvent = response.pendingFirstTimeEvents![0]
-      XCTAssertEqual(pendingEvent.flagKey, "test-flag")
-      XCTAssertEqual(pendingEvent.flagId, "flag-123")
-      XCTAssertEqual(pendingEvent.projectId, 3)
-      XCTAssertEqual(pendingEvent.firstTimeEventHash, "abc123")
-      XCTAssertEqual(pendingEvent.eventName, "Purchase Complete")
-      XCTAssertNotNil(pendingEvent.propertyFilters)
-      XCTAssertEqual(pendingEvent.pendingVariant.key, "treatment")
-      XCTAssertEqual(pendingEvent.pendingVariant.value as? Bool, true)
-    } catch {
-      XCTFail("Failed to parse response: \(error)")
-    }
-  }
-
-  func testParseEmptyPendingFirstTimeEvents() {
-    let json = """
-    {
-      "flags": {},
-      "pending_first_time_events": []
-    }
-    """.data(using: .utf8)!
-
-    do {
-      let response = try JSONDecoder().decode(FlagsResponse.self, from: json)
-      XCTAssertNotNil(response.pendingFirstTimeEvents)
-      XCTAssertEqual(response.pendingFirstTimeEvents?.count, 0)
-    } catch {
-      XCTFail("Failed to parse response: \(error)")
-    }
-  }
-
-  // MARK: First-Time Event Matching Tests
-
-  func testFirstTimeEventMatching_ExactNameMatch() {
-    let pendingVariant = createExperimentVariant(key: "activated", value: true, experimentID: "exp-123")
-    let initialVariant = createControlVariant(value: false)
-
-    setupAndTriggerFirstTimeEvent(
-      flagKey: "welcome-modal",
-      eventName: "Dashboard Viewed",
-      pendingVariant: pendingVariant,
-      initialVariant: initialVariant
-    ) { mockMgr in
-      let flag = mockMgr.flags?["welcome-modal"]
-      XCTAssertEqual(flag?.key, "activated")
-      XCTAssertEqual(flag?.value as? Bool, true)
-      XCTAssertTrue(mockMgr.activatedFirstTimeEvents.contains("welcome-modal:hash123"))
-    }
-  }
-
-  func testFirstTimeEventMatching_WithPropertyFilters() {
-    let pendingVariant = createExperimentVariant(key: "premium", value: ["discount": 20], experimentID: "exp-456")
-    let initialVariant = createControlVariant(value: nil)
-    let filters: [String: Any] = [">": [["var": "amount"], 100]]
-
-    setupAndTriggerFirstTimeEvent(
-      flagKey: "premium-welcome",
-      eventName: "Purchase Complete",
-      eventProperties: ["amount": 150],
-      filters: filters,
-      pendingVariant: pendingVariant,
-      initialVariant: initialVariant,
-      firstTimeEventHash: "hash456"
-    ) { mockMgr in
-      let flag = mockMgr.flags?["premium-welcome"]
-      XCTAssertEqual(flag?.key, "premium")
-      XCTAssertTrue(mockMgr.activatedFirstTimeEvents.contains("premium-welcome:hash456"))
-    }
-  }
-
-  func testFirstTimeEventMatching_PropertyFilterNoMatch() {
-    let pendingVariant = MixpanelFlagVariant(key: "premium", value: true)
-    let initialVariant = createControlVariant(value: false)
-    let filters: [String: Any] = [">": [["var": "amount"], 100]]
-
-    // Trigger event with amount < 100 (should NOT match)
-    setupAndTriggerFirstTimeEvent(
-      flagKey: "premium-welcome",
-      eventName: "Purchase Complete",
-      eventProperties: ["amount": 50],
-      filters: filters,
-      pendingVariant: pendingVariant,
-      initialVariant: initialVariant,
-      firstTimeEventHash: "hash456",
-      expectActivation: false
-    ) { mockMgr in
-      let flag = mockMgr.flags?["premium-welcome"]
-      XCTAssertEqual(flag?.key, "control")
-      XCTAssertFalse(mockMgr.activatedFirstTimeEvents.contains("premium-welcome:hash456"))
-    }
-  }
-
-  // MARK: Activation State Tests
-
-  func testFirstTimeEventActivatesOnlyOnce() {
-    if let mockManager = manager as? MockFeatureFlagManager {
-      let pendingVariant = MixpanelFlagVariant(key: "activated", value: true)
-
-      let pendingEvent = createPendingEvent(
-        flagKey: "once-only",
-        eventName: "Test Event",
-        filters: nil,
-        pendingVariant: pendingVariant
-      )
-
-      mockManager.flagsLock.write {
-        mockManager.flags = ["once-only": MixpanelFlagVariant(key: "control", value: false)]
-        mockManager.pendingFirstTimeEvents = ["once-only:hash999": pendingEvent]
-        mockManager.pendingFirstTimeEventNames = [pendingEvent.eventName]
-        // Reset tracking state
-        mockManager.recordFirstTimeEventCallCount = 0
-      }
-
-      // Set up expectation before triggering events
-      let expectation = XCTestExpectation(description: "recordFirstTimeEvent called")
-      mockManager.recordFirstTimeEventExpectation = expectation
-
-      // Trigger event multiple times
-      mockManager.checkFirstTimeEvents(eventName: "Test Event", properties: [:])
-      mockManager.checkFirstTimeEvents(eventName: "Test Event", properties: [:])
-      mockManager.checkFirstTimeEvents(eventName: "Test Event", properties: [:])
-
-      wait(for: [expectation], timeout: 5.0)
-
-      // Verify activation occurred and is tracked
-      mockManager.flagsLock.read {
-        XCTAssertTrue(mockManager.activatedFirstTimeEvents.contains("once-only:hash999"))
-
-        // Verify recordFirstTimeEvent was called exactly once
-        XCTAssertEqual(mockManager.recordFirstTimeEventCallCount, 1,
-          "recordFirstTimeEvent should be called exactly once, not \(mockManager.recordFirstTimeEventCallCount) times")
-
-        // Verify the correct parameters were recorded
-        XCTAssertEqual(mockManager.lastRecordedFlagId, "test-flag-id")
-        XCTAssertEqual(mockManager.lastRecordedProjectId, 1)
-        XCTAssertEqual(mockManager.lastRecordedFirstTimeEventHash, "hash123")
-      }
-    }
-  }
-
-  // MARK: Flag Refresh Edge Cases
-
-  func testFlagRefresh_PreservesActivatedVariants() {
-    if let mockManager = manager as? MockFeatureFlagManager {
-      // Set up initial state with activated variant
-      mockManager.flagsLock.write {
-        mockManager.flags = ["test-flag": MixpanelFlagVariant(key: "activated", value: true)]
-        mockManager.activatedFirstTimeEvents.insert("test-flag:hash123")
-      }
-
-      // Simulate fetch response with different variant for same flag
-      let newFlags = ["test-flag": MixpanelFlagVariant(key: "control", value: false)]
-      mockManager.simulatedFetchResult = (success: true, flags: newFlags)
-
-      // Trigger fetch
-      mockManager.loadFlags()
-
-      let expectation = XCTestExpectation(description: "Fetch completes")
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { expectation.fulfill() }
-      wait(for: [expectation], timeout: 5.0)
-
-      // Verify activated variant was preserved
-      mockManager.flagsLock.read {
-        let flag = mockManager.flags?["test-flag"]
-        XCTAssertEqual(flag?.key, "activated", "Activated variant should be preserved")
-        XCTAssertEqual(flag?.value as? Bool, true)
-      }
-    }
-  }
-
-  func testFlagRefresh_KeepsOrphanedActivatedFlags() {
-    if let mockManager = manager as? MockFeatureFlagManager {
-      // Set up initial state with activated variant
-      mockManager.flagsLock.write {
-        mockManager.flags = ["orphaned-flag": MixpanelFlagVariant(key: "activated", value: true)]
-        mockManager.activatedFirstTimeEvents.insert("orphaned-flag:hash123")
-      }
-
-      // Simulate fetch response WITHOUT the orphaned flag
-      let newFlags = ["other-flag": MixpanelFlagVariant(key: "control", value: false)]
-      mockManager.simulatedFetchResult = (success: true, flags: newFlags)
-
-      // Trigger fetch
-      mockManager.loadFlags()
-
-      let expectation = XCTestExpectation(description: "Fetch completes")
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { expectation.fulfill() }
-      wait(for: [expectation], timeout: 5.0)
-
-      // Verify orphaned flag was kept
-      mockManager.flagsLock.read {
-        let flag = mockManager.flags?["orphaned-flag"]
-        XCTAssertNotNil(flag, "Orphaned activated flag should be kept")
-        XCTAssertEqual(flag?.key, "activated")
-      }
-    }
-  }
-
-  // MARK: Additional Coverage Tests
-
-  func testFirstTimeEventMatching_EventNameMismatch() {
-    // Test that event name matching is case-sensitive
-    let pendingVariant = MixpanelFlagVariant(key: "activated", value: true)
-    let initialVariant = createControlVariant(value: false)
-
-    setupAndTriggerFirstTimeEvent(
-      flagKey: "event-name-test",
-      eventName: "Purchase Complete",  // Configured event name
-      triggeredEventName: "Purchase Completed",  // Call with different name (mismatch)
-      eventProperties: [:],
-      filters: nil,
-      pendingVariant: pendingVariant,
-      initialVariant: initialVariant,
-      firstTimeEventHash: "hash-mismatch",
-      expectActivation: false
-    ) { mockMgr in
-      // Verify flag stayed at control due to name mismatch
-      let initialFlag = mockMgr.flags?["event-name-test"]
-      XCTAssertEqual(initialFlag?.key, "control", "Flag should remain at control variant")
-      XCTAssertEqual(initialFlag?.value as? Bool, false)
     }
 
-    // Now try with different case - should also NOT match (case-sensitive)
-    if let mockMgr = mockManager as? MockFeatureFlagManager {
-      mockMgr.checkFirstTimeEvents(eventName: "purchase complete", properties: [:])  // lowercase
-      waitBriefly(timeout: 1.0)
+    // Event Verification Helper
 
-      mockMgr.flagsLock.read {
-        let flag = mockMgr.flags?["event-name-test"]
-        XCTAssertEqual(flag?.key, "control", "Event name matching should be case-sensitive")
-        XCTAssertFalse(mockMgr.activatedFirstTimeEvents.contains("event-name-test:hash-mismatch"))
-      }
+    private func verifyTrackedEvent(
+        at index: Int = 0,
+        expectedEvent: String = "$experiment_started",
+        experimentName: String,
+        variantName: String,
+        checkTimingProperties: Bool = false,
+        expectedLatency: Int? = nil,
+        additionalChecks: ((Properties) -> Void)? = nil,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        guard index < mockDelegate.trackedEvents.count else {
+            XCTFail("No tracked event at index \(index)", file: file, line: line)
+            return
+        }
+
+        let tracked = mockDelegate.trackedEvents[index]
+        XCTAssertEqual(tracked.event, expectedEvent, file: file, line: line)
+        XCTAssertNotNil(tracked.properties, file: file, line: line)
+
+        guard let props = tracked.properties else { return }
+
+        verifyTrackingProperties(
+            props, experimentName: experimentName,
+            variantName: variantName, file: file, line: line)
+
+        if checkTimingProperties {
+            verifyTimingProperties(
+                props, expectedLatency: expectedLatency,
+                file: file, line: line)
+        }
+
+        additionalChecks?(props)
     }
-  }
 
-  func testMultiplePendingEventsOnSameFlag() {
-    // Test that multiple pending events on the same flag work correctly
-    if let mockMgr = mockManager as? MockFeatureFlagManager {
-      let controlVariant = createControlVariant(value: false)
-      let variant1 = MixpanelFlagVariant(key: "variant1", value: "first")
-      let variant2 = MixpanelFlagVariant(key: "variant2", value: "second")
+    // Async Operation Helper
 
-      let event1 = createPendingEvent(
-        flagKey: "multi-event-flag",
-        eventName: "Event A",
-        filters: nil,
-        pendingVariant: variant1,
-        firstTimeEventHash: "hash1"
-      )
+    @discardableResult
+    private func getVariantAsync(
+        _ flagName: String,
+        fallback: MixpanelFlagVariant? = nil,
+        timeout: TimeInterval = 2.0,
+        description: String? = nil,
+        verifyMainThread: Bool = true,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> MixpanelFlagVariant? {
+        let expectation = XCTestExpectation(
+            description: description ?? "Get variant async for \(flagName)"
+        )
+        var receivedData: MixpanelFlagVariant?
 
-      let event2 = createPendingEvent(
-        flagKey: "multi-event-flag",
-        eventName: "Event B",
-        filters: nil,
-        pendingVariant: variant2,
-        firstTimeEventHash: "hash2"
-      )
+        manager.getVariant(flagName, fallback: fallback ?? defaultFallback) { data in
+            if verifyMainThread {
+                XCTAssertTrue(
+                    Thread.isMainThread,
+                    "Completion should be on main thread",
+                    file: file, line: line)
+            }
+            receivedData = data
+            expectation.fulfill()
+        }
 
-      mockMgr.flagsLock.write {
-        mockMgr.flags = ["multi-event-flag": controlVariant]
-        mockMgr.pendingFirstTimeEvents = [
-          "multi-event-flag:hash1": event1,
-          "multi-event-flag:hash2": event2
+        wait(for: [expectation], timeout: timeout)
+        return receivedData
+    }
+
+    // Fetch Setup Helpers
+
+    private func setupReadyFlags(flags: [String: MixpanelFlagVariant]? = nil) {
+        simulateFetchSuccess(flags: flags)
+        waitBriefly()
+    }
+
+    private func setupReadyFlagsAndVerify(flags: [String: MixpanelFlagVariant]? = nil) {
+        setupReadyFlags(flags: flags)
+        XCTAssertTrue(manager.areFlagsReady(), "Flags should be ready after setup")
+    }
+
+    // JSON Parsing Helpers
+
+    private func decodeJSON<T: Decodable>(
+        _ jsonString: String,
+        as type: T.Type,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> T? {
+        guard let data = jsonString.data(using: .utf8) else {
+            XCTFail("Failed to convert JSON string to data", file: file, line: line)
+            return nil
+        }
+
+        do {
+            return try JSONDecoder().decode(type, from: data)
+        } catch {
+            XCTFail("Failed to decode JSON: \(error)", file: file, line: line)
+            return nil
+        }
+    }
+
+    private func assertJSONDecodes<T: Decodable>(
+        _ jsonString: String,
+        as type: T.Type,
+        file: StaticString = #file,
+        line: UInt = #line,
+        validation: (T) -> Void
+    ) {
+        if let result = decodeJSON(jsonString, as: type, file: file, line: line) {
+            validation(result)
+        }
+    }
+
+    // Mock Configuration Helpers
+
+    private var mockManager: MockFeatureFlagManager? {
+        return manager as? MockFeatureFlagManager
+    }
+
+    private func configureMockFetch(
+        success: Bool,
+        flags: [String: MixpanelFlagVariant]? = nil,
+        withDelay: Bool = true
+    ) {
+        guard let mock = mockManager else {
+            XCTFail("Manager is not a MockFeatureFlagManager")
+            return
+        }
+        mock.simulatedFetchResult = (success: success, flags: flags ?? sampleFlags)
+        mock.shouldSimulateNetworkDelay = withDelay
+    }
+
+    private func resetMockToSuccess() {
+        configureMockFetch(success: true, flags: sampleFlags, withDelay: true)
+    }
+
+    // Context Verification Helper
+
+    private func verifyRequestContext(
+        expectedDistinctId: String,
+        expectedDeviceId: String? = nil,
+        additionalChecks: (([String: Any]) -> Void)? = nil,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        guard let mockMgr = mockManager,
+            let queryItems = mockMgr.lastQueryItems
+        else {
+            XCTFail("No query items captured", file: file, line: line)
+            return
+        }
+
+        let queryDict = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
+
+        guard let contextString = queryDict["context"],
+            let contextData = contextString?.data(using: .utf8),
+            let context = try? JSONSerialization.jsonObject(with: contextData) as? [String: Any]
+        else {
+            XCTFail("Failed to parse context", file: file, line: line)
+            return
+        }
+
+        XCTAssertEqual(context["distinct_id"] as? String, expectedDistinctId, file: file, line: line)
+
+        if let expectedDeviceId = expectedDeviceId {
+            XCTAssertEqual(context["device_id"] as? String, expectedDeviceId, file: file, line: line)
+        } else {
+            XCTAssertNil(context["device_id"], file: file, line: line)
+        }
+
+        additionalChecks?(context)
+    }
+
+    // Variant Creation Helpers
+
+    private func createExperimentVariant(
+        key: String,
+        value: Any?,
+        experimentID: String = "test-exp-id",
+        isActive: Bool = true,
+        isQATester: Bool = false
+    ) -> MixpanelFlagVariant {
+        return MixpanelFlagVariant(
+            key: key,
+            value: value,
+            isExperimentActive: isActive,
+            isQATester: isQATester,
+            experimentID: experimentID
+        )
+    }
+
+    private func createControlVariant(key: String = "control", value: Any? = false) -> MixpanelFlagVariant {
+        return MixpanelFlagVariant(key: key, value: value)
+    }
+
+    // First-Time Event Helper
+
+    private func setupAndTriggerFirstTimeEvent(
+        flagKey: String,
+        eventName: String,
+        triggeredEventName: String? = nil,
+        eventProperties: [String: Any] = [:],
+        filters: [String: Any]? = nil,
+        pendingVariant: MixpanelFlagVariant,
+        initialVariant: MixpanelFlagVariant? = nil,
+        firstTimeEventHash: String = "hash123",
+        expectActivation: Bool = true,
+        validation: ((MockFeatureFlagManager) -> Void)? = nil
+    ) {
+        guard let mockMgr = mockManager else {
+            XCTFail("Manager is not a MockFeatureFlagManager")
+            return
+        }
+
+        let pendingEvent = createPendingEvent(
+            flagKey: flagKey,
+            eventName: eventName,
+            filters: filters,
+            pendingVariant: pendingVariant,
+            firstTimeEventHash: firstTimeEventHash
+        )
+
+        let eventKey = "\(flagKey):\(firstTimeEventHash)"
+
+        mockMgr.flagsLock.write {
+            let initial = initialVariant ?? createControlVariant()
+            mockMgr.flags = [flagKey: initial]
+            mockMgr.pendingFirstTimeEvents = [eventKey: pendingEvent]
+            mockMgr.pendingFirstTimeEventNames = [pendingEvent.eventName]
+        }
+
+        let nameToTrigger = triggeredEventName ?? eventName
+        mockMgr.checkFirstTimeEvents(eventName: nameToTrigger, properties: eventProperties)
+
+        if expectActivation {
+            // Wait for the async checkFirstTimeEvents to complete using predicate
+            let activated = NSPredicate { _, _ in
+                var done = false
+                mockMgr.flagsLock.read { done = mockMgr.activatedFirstTimeEvents.contains(eventKey) }
+                return done
+            }
+            wait(for: [XCTNSPredicateExpectation(predicate: activated, object: nil)], timeout: 10.0)
+        } else {
+            // For negative tests, just wait briefly for async dispatch to complete
+            waitBriefly(timeout: 2.0)
+        }
+
+        mockMgr.flagsLock.read {
+            validation?(mockMgr)
+        }
+    }
+
+    // Manager State Helpers
+
+    private func resetManagerFlags(_ flags: [String: MixpanelFlagVariant]? = nil) {
+        mockManager?.flagsLock.write {
+            mockManager?.flags = flags
+        }
+        Thread.sleep(forTimeInterval: 0.01)
+    }
+
+    private func clearManagerFlags() {
+        resetManagerFlags(nil)
+    }
+
+    private func setManagerFlags(_ flags: [String: MixpanelFlagVariant]) {
+        resetManagerFlags(flags)
+    }
+
+    // --- State and Configuration Tests ---
+
+    func testAreFeaturesReady_InitialState() {
+        XCTAssertFalse(manager.areFlagsReady(), "Features should not be ready initially")
+    }
+
+    func testAreFeaturesReady_AfterSuccessfulFetchSimulation() {
+        setupReadyFlagsAndVerify()
+    }
+
+    func testAreFeaturesReady_AfterFailedFetchSimulation() {
+        simulateFetchFailure()
+        waitBriefly()
+        XCTAssertFalse(
+            manager.areFlagsReady(), "Features should not be ready after failed fetch simulation")
+    }
+
+    // --- Load Flags Tests ---
+
+    func testLoadFlags_WhenDisabledInConfig() {
+        mockDelegate.options = MixpanelOptions(token: "test", featureFlagOptions: FeatureFlagOptions(enabled: false))  // Explicitly disable
+        manager.loadFlags()  // Call public API
+
+        waitBriefly()
+
+        XCTAssertFalse(manager.areFlagsReady(), "Flags should not become ready if disabled")
+        // We can't easily check if _fetchFlagsIfNeeded was *not* called without more testability hooks
+    }
+
+    // Note: Testing that loadFlags *starts* a fetch is harder now without exposing internal state.
+    // We test the outcome via the async getFeature tests below.
+
+    // --- Sync Flag Retrieval Tests ---
+
+    func testGetVariantSync_FlagsReady_ExistingFlag() {
+        setupReadyFlags()
+        let flagVariant = manager.getVariantSync("feature_string", fallback: defaultFallback)
+        AssertEqual(flagVariant.key, "v_str")
+        AssertEqual(flagVariant.value, "test_string")
+        // Tracking check happens later
+    }
+
+    func testGetVariantSync_FlagsReady_MissingFlag_UsesFallback() {
+        setupReadyFlags()
+        let fallback = MixpanelFlagVariant(key: "fb_key", value: "fb_value")
+        let flagVariant = manager.getVariantSync("missing_feature", fallback: fallback)
+        AssertEqual(flagVariant.key, fallback.key)
+        AssertEqual(flagVariant.value, fallback.value)
+        XCTAssertEqual(mockDelegate.trackedEvents.count, 0, "Should not track for fallback")
+    }
+
+    func testGetVariantSync_FlagsNotReady_UsesFallback() {
+        XCTAssertFalse(manager.areFlagsReady())  // Precondition
+        let fallback = MixpanelFlagVariant(key: "fb_key", value: 999)
+        let flagVariant = manager.getVariantSync("feature_bool_true", fallback: fallback)
+        AssertEqual(flagVariant.key, fallback.key)
+        AssertEqual(flagVariant.value, fallback.value)
+        XCTAssertEqual(mockDelegate.trackedEvents.count, 0, "Should not track if flags not ready")
+    }
+
+    func testGetVariantValueSync_FlagsReady() {
+        setupReadyFlags()
+        let value = manager.getVariantValueSync("feature_int", fallbackValue: -1)
+        AssertEqual(value, 101)
+    }
+
+    func testGetVariantValueSync_FlagsReady_MissingFlag() {
+        setupReadyFlags()
+        let value = manager.getVariantValueSync("missing_feature", fallbackValue: "default")
+        AssertEqual(value, "default")
+    }
+
+    func testGetVariantValueSync_FlagsNotReady() {
+        XCTAssertFalse(manager.areFlagsReady())
+        let value = manager.getVariantValueSync("feature_int", fallbackValue: -1)
+        AssertEqual(value, -1)
+    }
+
+    func testIsFlagEnabledSync_FlagsReady_True() {
+        setupReadyFlags()
+        XCTAssertTrue(manager.isEnabledSync("feature_bool_true"))
+    }
+
+    func testIsFlagEnabledSync_FlagsReady_False() {
+        setupReadyFlags()
+        XCTAssertFalse(manager.isEnabledSync("feature_bool_false"))
+    }
+
+    func testIsFlagEnabledSync_FlagsReady_MissingFlag_UsesFallback() {
+        setupReadyFlags()
+        XCTAssertTrue(manager.isEnabledSync("missing", fallbackValue: true))
+        XCTAssertFalse(manager.isEnabledSync("missing", fallbackValue: false))
+    }
+
+    func testIsFlagEnabledSync_FlagsReady_NonBoolValue_UsesFallback() {
+        setupReadyFlags()
+        XCTAssertTrue(manager.isEnabledSync("feature_string", fallbackValue: true))  // String value
+        XCTAssertFalse(manager.isEnabledSync("feature_int", fallbackValue: false))  // Int value
+        XCTAssertTrue(manager.isEnabledSync("feature_null", fallbackValue: true))  // Null value
+    }
+
+    func testIsFlagEnabledSync_FlagsNotReady_UsesFallback() {
+        XCTAssertFalse(manager.areFlagsReady())
+        XCTAssertTrue(manager.isEnabledSync("feature_bool_true", fallbackValue: true))
+        XCTAssertFalse(manager.isEnabledSync("feature_bool_true", fallbackValue: false))
+    }
+
+    // --- Async Flag Retrieval Tests ---
+
+    func testGetVariant_Async_FlagsReady_ExistingFlag_XCTWaiter() {
+        setupReadyFlags()
+        let receivedData = getVariantAsync("feature_double")
+        XCTAssertNotNil(receivedData, "Received data should be non-nil after successful wait")
+        AssertEqual(receivedData?.key, "v_double")
+        AssertEqual(receivedData?.value, 99.9)
+    }
+
+    func testGetVariant_Async_FlagsReady_MissingFlag_UsesFallback() {
+        setupReadyFlags()
+        let fallback = MixpanelFlagVariant(key: "fb_async", value: -1)
+        let receivedData = getVariantAsync("missing_feature", fallback: fallback)
+        XCTAssertNotNil(receivedData)
+        AssertEqual(receivedData?.key, fallback.key)
+        AssertEqual(receivedData?.value, fallback.value)
+        XCTAssertEqual(mockDelegate.trackedEvents.count, 0, "Should not track fallback")
+    }
+
+    // Test fetch triggering and completion via getFeature when not ready
+    func testGetVariant_Async_FlagsNotReady_FetchSuccess() {
+        XCTAssertFalse(manager.areFlagsReady())
+
+        // Setup tracking expectation *before* calling getFeature
+        mockDelegate.trackExpectation = XCTestExpectation(description: "Tracking call for fetch success")
+
+        let receivedData = getVariantAsync("feature_int", timeout: 10.0)
+
+        // Wait for tracking to complete
+        wait(for: [mockDelegate.trackExpectation!], timeout: 10.0)
+
+        XCTAssertNotNil(receivedData)
+        AssertEqual(receivedData?.key, "v_int")
+        AssertEqual(receivedData?.value, 101)
+        XCTAssertTrue(manager.areFlagsReady(), "Flags should be ready after successful fetch")
+        XCTAssertEqual(mockDelegate.trackedEvents.count, 1, "Tracking event should have been recorded")
+    }
+
+    func testGetVariant_Async_FlagsNotReady_FetchFailure() {
+        // Configure mock to simulate failure without network delay
+        configureMockFetch(success: false, flags: nil, withDelay: false)
+
+        XCTAssertFalse(manager.areFlagsReady())
+        let fallback = MixpanelFlagVariant(key: "fb_fail", value: "failed_fetch")
+        let receivedData = getVariantAsync("feature_string", fallback: fallback, timeout: 10.0)
+
+        XCTAssertNotNil(receivedData)
+        AssertEqual(receivedData?.key, fallback.key)  // Should receive fallback
+        AssertEqual(receivedData?.value, fallback.value)
+        XCTAssertFalse(manager.areFlagsReady(), "Flags should still not be ready after failed fetch")
+        XCTAssertEqual(
+            mockDelegate.trackedEvents.count, 0, "Should not track on fetch failure/fallback")
+
+        // Reset mock configuration back to success for other tests
+        resetMockToSuccess()
+    }
+
+    // --- Bulk Flag Retrieval Tests (getAllVariants) ---
+
+    func testGetAllVariantsSync_FlagsReady() {
+        simulateFetchSuccess()
+        let allVariants = manager.getAllVariantsSync()
+        XCTAssertEqual(allVariants.count, sampleFlags.count, "Should return all flags")
+        // Verify specific flags exist
+        XCTAssertNotNil(allVariants["feature_bool_true"], "Should contain feature_bool_true")
+        XCTAssertNotNil(allVariants["feature_string"], "Should contain feature_string")
+        XCTAssertNotNil(allVariants["feature_int"], "Should contain feature_int")
+        // Verify values
+        AssertEqual(allVariants["feature_bool_true"]?.key, "v_true")
+        AssertEqual(allVariants["feature_bool_true"]?.value, true)
+        AssertEqual(allVariants["feature_string"]?.value, "test_string")
+    }
+
+    func testGetAllVariantsSync_FlagsNotReady() {
+        XCTAssertFalse(manager.areFlagsReady(), "Precondition: flags should not be ready")
+        let allVariants = manager.getAllVariantsSync()
+        XCTAssertTrue(allVariants.isEmpty, "Should return empty dictionary when flags not ready")
+    }
+
+    func testGetAllVariantsSync_NoTracking() {
+        simulateFetchSuccess()
+        _ = manager.getAllVariantsSync()
+        // Wait briefly to ensure no unexpected tracking call
+        let expectation = XCTestExpectation(description: "Wait briefly for no track")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { expectation.fulfill() }
+        wait(for: [expectation], timeout: 0.5)
+        XCTAssertTrue(mockDelegate.trackedEvents.isEmpty, "getAllVariantsSync should not trigger tracking")
+    }
+
+    func testGetAllVariants_Async_FlagsReady() {
+        simulateFetchSuccess()
+        let expectation = XCTestExpectation(description: "getAllVariants completion")
+        var receivedVariants: [String: MixpanelFlagVariant]?
+        var assertionError: String?
+
+        manager.getAllVariants { variants in
+            if !Thread.isMainThread {
+                assertionError = "Completion not on main thread"
+            }
+            receivedVariants = variants
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+
+        if let error = assertionError {
+            XCTFail(error)
+        }
+        XCTAssertNotNil(receivedVariants, "Should receive variants")
+        XCTAssertEqual(receivedVariants?.count, sampleFlags.count, "Should return all flags")
+        AssertEqual(receivedVariants?["feature_double"]?.key, "v_double")
+        AssertEqual(receivedVariants?["feature_double"]?.value, 99.9)
+    }
+
+    func testGetAllVariants_Async_FlagsNotReady_FetchSucceeds() {
+        XCTAssertFalse(manager.areFlagsReady(), "Precondition: flags should not be ready")
+        let expectation = XCTestExpectation(description: "getAllVariants triggers fetch and succeeds")
+        var receivedVariants: [String: MixpanelFlagVariant]?
+
+        manager.getAllVariants { variants in
+            XCTAssertTrue(Thread.isMainThread, "Completion should be on main thread")
+            receivedVariants = variants
+            expectation.fulfill()
+        }
+
+        // MockFeatureFlagManager will automatically handle the fetch simulation
+        wait(for: [expectation], timeout: 10.0)
+
+        XCTAssertNotNil(receivedVariants, "Should receive variants after fetch")
+        XCTAssertEqual(receivedVariants?.count, sampleFlags.count, "Should return all flags after fetch")
+        XCTAssertTrue(manager.areFlagsReady(), "Flags should be ready after successful fetch")
+    }
+
+    func testGetAllVariants_Async_FlagsNotReady_FetchFails() {
+        // Configure mock to simulate failure
+        if let mockManager = manager as? MockFeatureFlagManager {
+            mockManager.simulatedFetchResult = (success: false, flags: nil)
+        }
+
+        XCTAssertFalse(manager.areFlagsReady(), "Precondition: flags should not be ready")
+        let expectation = XCTestExpectation(description: "getAllVariants triggers fetch and fails")
+        var receivedVariants: [String: MixpanelFlagVariant]?
+
+        manager.getAllVariants { variants in
+            XCTAssertTrue(Thread.isMainThread, "Completion should be on main thread")
+            receivedVariants = variants
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 10.0)
+
+        XCTAssertNotNil(receivedVariants, "Should receive result even on failure")
+        XCTAssertTrue(receivedVariants?.isEmpty ?? false, "Should return empty dictionary on fetch failure")
+        XCTAssertFalse(manager.areFlagsReady(), "Flags should not be ready after failed fetch")
+    }
+
+    func testGetAllVariants_Async_NoTracking() {
+        simulateFetchSuccess()
+        let expectation = XCTestExpectation(description: "getAllVariants completion for tracking test")
+
+        manager.getAllVariants { _ in
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+
+        // Wait briefly to ensure no unexpected tracking call
+        let waitExpectation = XCTestExpectation(description: "Wait briefly for no track")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { waitExpectation.fulfill() }
+        wait(for: [waitExpectation], timeout: 0.5)
+
+        XCTAssertTrue(mockDelegate.trackedEvents.isEmpty, "getAllVariants should not trigger tracking")
+    }
+
+    // --- Tracking Tests ---
+
+    func testTracking_CalledOncePerFeature() {
+        simulateFetchSuccess()  // Flags ready
+
+        mockDelegate.trackExpectation = XCTestExpectation(
+            description: "Track called once for feature_bool_true")
+        mockDelegate.trackExpectation?.expectedFulfillmentCount = 1  // Expect exactly one call
+
+        // Call sync methods multiple times
+        _ = manager.getVariantSync("feature_bool_true", fallback: defaultFallback)
+        _ = manager.getVariantValueSync("feature_bool_true", fallbackValue: nil)
+        _ = manager.isEnabledSync("feature_bool_true")
+
+        // Call async method
+        let asyncExpectation = XCTestExpectation(
+            description: "Async getFeature completes for tracking test")
+        manager.getVariant("feature_bool_true", fallback: defaultFallback) { _ in
+            asyncExpectation.fulfill()
+        }
+
+        // Wait for async call AND the track expectation
+        wait(for: [asyncExpectation, mockDelegate.trackExpectation!], timeout: 10.0)
+
+        // Verify track delegate method was called exactly once
+        let trueEvents = mockDelegate.trackedEvents.filter {
+            $0.properties?["Experiment name"] as? String == "feature_bool_true"
+        }
+        XCTAssertEqual(trueEvents.count, 1, "Track should only be called once for the same feature")
+
+        // --- Call for a *different* feature ---
+        mockDelegate.trackExpectation = XCTestExpectation(
+            description: "Track called for feature_string")
+        _ = manager.getVariantSync("feature_string", fallback: defaultFallback)
+        wait(for: [mockDelegate.trackExpectation!], timeout: 10.0)
+
+        let stringEvents = mockDelegate.trackedEvents.filter {
+            $0.properties?["Experiment name"] as? String == "feature_string"
+        }
+        XCTAssertEqual(stringEvents.count, 1, "Track should be called again for a different feature")
+
+        // Verify total calls
+        XCTAssertEqual(mockDelegate.trackedEvents.count, 2, "Total track calls should be 2")
+    }
+
+    func testTracking_SendsCorrectProperties() {
+        setupReadyFlags()
+        expectTracking {
+            _ = manager.getVariantSync("feature_int", fallback: defaultFallback)
+        }
+        verifyTrackedEvent(experimentName: "feature_int", variantName: "v_int", checkTimingProperties: true)
+    }
+
+    func testTracking_IncludesTimingProperties() {
+        setupReadyFlags()
+        expectTracking {
+            _ = manager.getVariantSync("feature_string", fallback: defaultFallback)
+        }
+        verifyTrackedEvent(
+            experimentName: "feature_string", variantName: "v_str", checkTimingProperties: true, expectedLatency: 150)
+    }
+
+    func testTracking_DoesNotTrackForFallback_Sync() {
+        setupReadyFlags()
+        _ = manager.getVariantSync("missing_feature", fallback: MixpanelFlagVariant(key: "fb", value: "v"))
+        waitBriefly()
+        XCTAssertEqual(
+            mockDelegate.trackedEvents.count, 0,
+            "Track should not be called when a fallback is used (sync)")
+    }
+
+    func testTracking_DoesNotTrackForFallback_Async() {
+        setupReadyFlags()
+        getVariantAsync("missing_feature", fallback: MixpanelFlagVariant(key: "fb", value: "v"))
+        XCTAssertEqual(
+            mockDelegate.trackedEvents.count, 0,
+            "Track should not be called when a fallback is used (async)")
+    }
+
+    // --- Concurrency Tests ---
+
+    // Test concurrent fetch attempts (via getFeature when not ready)
+    func testConcurrentGetFeature_WhenNotReady_OnlyOneFetch() {
+        // Disable network delay since timing isn't what we're testing
+        configureMockFetch(success: true, flags: nil, withDelay: false)
+        XCTAssertFalse(manager.areFlagsReady())
+
+        let numConcurrentCalls = 5
+        var expectations: [XCTestExpectation] = []
+        var completionResults: [MixpanelFlagVariant?] = Array(repeating: nil, count: numConcurrentCalls)
+
+        // Use a more descriptive fallback to help with debugging
+        let testFallback = MixpanelFlagVariant(key: "fallback_key", value: "fallback_value")
+
+        // Expect tracking only ONCE for the actual feature if fetch succeeds
+        mockDelegate.trackExpectation = XCTestExpectation(description: "Track call (should be once)")
+        mockDelegate.trackExpectation?.expectedFulfillmentCount = 1
+
+        print("Starting \(numConcurrentCalls) concurrent getFeature calls...")
+
+        for i in 0..<numConcurrentCalls {
+            let exp = XCTestExpectation(description: "Async getFeature \(i) completes")
+            expectations.append(exp)
+            DispatchQueue.global().async {  // Simulate calls from different threads
+                self.manager.getVariant("feature_bool_true", fallback: testFallback) { data in
+                    print("Completion handler \(i) called with data: \(String(describing: data))")
+                    completionResults[i] = data
+                    exp.fulfill()
+                }
+            }
+        }
+        print("Concurrent calls dispatched.")
+
+        // MockFeatureFlagManager will automatically handle the fetch simulation
+        // No need for manual simulateFetchSuccess() - the mock handles it
+
+        // Wait for all getFeature completions AND the single tracking call
+        wait(for: expectations + [mockDelegate.trackExpectation!], timeout: 10.0)  // Much longer timeout for CI
+
+        // Verify all completions received the correct data
+        for i in 0..<numConcurrentCalls {
+            XCTAssertNotNil(completionResults[i], "Completion \(i) did not receive data")
+            // Check if we got the actual flag data, not the fallback
+            if completionResults[i]?.key == testFallback.key {
+                XCTFail("Completion \(i) received fallback instead of actual flag data")
+            }
+            AssertEqual(completionResults[i]?.key, "v_true")
+            AssertEqual(completionResults[i]?.value, true)
+        }
+
+        // Verify flags are ready and tracking occurred only once
+        XCTAssertTrue(manager.areFlagsReady())
+        let trackEvents = mockDelegate.trackedEvents.filter {
+            $0.properties?["Experiment name"] as? String == "feature_bool_true"
+        }
+        XCTAssertEqual(
+            trackEvents.count, 1, "Tracking should have occurred exactly once despite concurrent calls")
+
+        // Verify only one network fetch was triggered
+        if let mockManager = manager as? MockFeatureFlagManager {
+            XCTAssertEqual(
+                mockManager.fetchRequestCount, 1,
+                "Should have made exactly one fetch request despite concurrent calls")
+        }
+    }
+
+    // --- Response Parser Tests ---
+
+    func testResponseParserFunction() {
+        // Test the response parser functionality by simulating various JSON responses
+        // We'll create test data and parse it directly using JSONDecoder
+
+        // Helper function to parse JSON data like the actual implementation does
+        let parseResponse: (Data) -> FlagsResponse? = { data in
+            do {
+                return try JSONDecoder().decode(FlagsResponse.self, from: data)
+            } catch {
+                print("Error parsing flags JSON: \(error)")
+                return nil
+            }
+        }
+
+        // Create various test data scenarios
+        let validJSON = """
+            {
+                "flags": {
+                    "test_flag": {
+                        "variant_key": "test_variant",
+                        "variant_value": "test_value"
+                    }
+                }
+            }
+            """.data(using: .utf8)!
+
+        let emptyFlagsJSON = """
+            {
+                "flags": {}
+            }
+            """.data(using: .utf8)!
+
+        let nullFlagsJSON = """
+            {
+                "flags": null
+            }
+            """.data(using: .utf8)!
+
+        let malformedJSON = "not json".data(using: .utf8)!
+
+        // Test valid JSON with flags
+        let validResult = parseResponse(validJSON)
+        XCTAssertNotNil(validResult, "Parser should handle valid JSON")
+        XCTAssertNotNil(validResult?.flags, "Flags should be non-nil")
+        XCTAssertEqual(validResult?.flags?.count, 1, "Should have one flag")
+        XCTAssertEqual(validResult?.flags?["test_flag"]?.key, "test_variant")
+        XCTAssertEqual(validResult?.flags?["test_flag"]?.value as? String, "test_value")
+
+        // Test empty flags object
+        let emptyResult = parseResponse(emptyFlagsJSON)
+        XCTAssertNotNil(emptyResult, "Parser should handle empty flags object")
+        XCTAssertNotNil(emptyResult?.flags, "Flags should be non-nil")
+        XCTAssertEqual(emptyResult?.flags?.count, 0, "Flags should be empty")
+
+        // Test null flags field
+        let nullResult = parseResponse(nullFlagsJSON)
+        XCTAssertNotNil(nullResult, "Parser should handle null flags")
+        XCTAssertNil(nullResult?.flags, "Flags should be nil when null in JSON")
+
+        // Test malformed JSON
+        let malformedResult = parseResponse(malformedJSON)
+        XCTAssertNil(malformedResult, "Parser should return nil for malformed JSON")
+
+        // Test with multiple flags
+        let multipleFlagsJSON = """
+            {
+                "flags": {
+                    "feature_a": {
+                        "variant_key": "variant_a",
+                        "variant_value": true
+                    },
+                    "feature_b": {
+                        "variant_key": "variant_b",
+                        "variant_value": 42
+                    },
+                    "feature_c": {
+                        "variant_key": "variant_c",
+                        "variant_value": null
+                    }
+                }
+            }
+            """.data(using: .utf8)!
+
+        let multiResult = parseResponse(multipleFlagsJSON)
+        XCTAssertNotNil(multiResult, "Parser should handle multiple flags")
+        XCTAssertEqual(multiResult?.flags?.count, 3, "Should have three flags")
+        XCTAssertEqual(multiResult?.flags?["feature_a"]?.value as? Bool, true)
+        XCTAssertEqual(multiResult?.flags?["feature_b"]?.value as? Int, 42)
+        XCTAssertNil(multiResult?.flags?["feature_c"]?.value, "Null value should be preserved")
+
+        // Test with missing required fields
+        let missingFieldJSON = """
+            {
+                "not_flags": {}
+            }
+            """.data(using: .utf8)!
+
+        let missingFieldResult = parseResponse(missingFieldJSON)
+        XCTAssertNotNil(missingFieldResult, "Parser should handle missing flags field")
+        XCTAssertNil(missingFieldResult?.flags, "Flags should be nil when field is missing")
+
+        let optionalExperimentPropertiesJSON = """
+            {
+                "flags": {
+                    "active_experiment_flag": {
+                        "variant_key": "A",
+                        "variant_value": "A",
+                        "experiment_id": "447db52b-ec4a-4186-8d89-f9ba7bc7d7dd",
+                        "is_experiment_active": true,
+                        "is_qa_tester": false
+                    },
+                    "experiment_flag_for_qa_user": {
+                        "variant_key": "B",
+                        "variant_value": "B",
+                        "experiment_id": "447db52b-ec4a-4186-8d89-f9ba7bc7d7dd",
+                        "is_experiment_active": false,
+                        "is_qa_tester": true
+                    },
+                    "flag_with_no_optionals": {
+                        "variant_key": "C",
+                        "variant_value": "C"
+                    }
+                }
+            }
+            """.data(using: .utf8)!
+
+        let experimentResult = parseResponse(optionalExperimentPropertiesJSON)
+        XCTAssertNotNil(experimentResult)
+        XCTAssertEqual(experimentResult?.flags?.count, 3)
+
+        let activeFlag = experimentResult?.flags?["active_experiment_flag"]
+        XCTAssertEqual(activeFlag?.key, "A")
+        XCTAssertEqual(activeFlag?.value as? String, "A")
+        XCTAssertEqual(activeFlag?.experimentID, "447db52b-ec4a-4186-8d89-f9ba7bc7d7dd")
+        XCTAssertEqual(activeFlag?.isExperimentActive, true)
+        XCTAssertEqual(activeFlag?.isQATester, false)
+
+        let qaFlag = experimentResult?.flags?["experiment_flag_for_qa_user"]
+        XCTAssertEqual(qaFlag?.key, "B")
+        XCTAssertEqual(qaFlag?.value as? String, "B")
+        XCTAssertEqual(qaFlag?.experimentID, "447db52b-ec4a-4186-8d89-f9ba7bc7d7dd")
+        XCTAssertEqual(qaFlag?.isExperimentActive, false)
+        XCTAssertEqual(qaFlag?.isQATester, true)
+
+        let minimalFlag = experimentResult?.flags?["flag_with_no_optionals"]
+        XCTAssertEqual(minimalFlag?.key, "C")
+        XCTAssertEqual(minimalFlag?.value as? String, "C")
+        XCTAssertNil(minimalFlag?.experimentID)
+        XCTAssertNil(minimalFlag?.isExperimentActive)
+        XCTAssertNil(minimalFlag?.isQATester)
+    }
+
+    // --- Delegate Error Handling Tests ---
+
+    func testDelegateNilHandling() {
+        // Set up with flags ready, but then remove delegate
+        simulateFetchSuccess()
+        manager.delegate = nil
+
+        // Test all operations with nil delegate
+
+        // Synchronous operations
+        let syncData = manager.getVariantSync("feature_bool_true", fallback: defaultFallback)
+        XCTAssertEqual(syncData.key, "v_true")
+        XCTAssertEqual(syncData.value as? Bool, true)
+
+        // Async operations
+        let expectation = XCTestExpectation(description: "Async with nil delegate")
+        manager.getVariant("feature_int", fallback: defaultFallback) { data in
+            XCTAssertEqual(data.key, "v_int")
+            XCTAssertEqual(data.value as? Int, 101)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        // No tracking calls should succeed, but operations should still work
+        // This is "success" as the code doesn't crash when delegate is nil
+    }
+
+    func testFetchWithNoDelegate() {
+        // Create manager with no delegate
+        let noDelegate = FeatureFlagManager(
+            serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated),
+            instanceName: "test", delegate: nil)
+
+        // Try to load flags
+        noDelegate.loadFlags()
+
+        // Verify no crash; attempt a flag fetch after a short delay
+        let expectation = XCTestExpectation(description: "Check after attempted fetch")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            XCTAssertFalse(noDelegate.areFlagsReady(), "Flags should not be ready without delegate")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testDelegateConfigDisabledHandling() {
+        // Set delegate options to disabled
+        mockDelegate.options = MixpanelOptions(token: "test", featureFlagOptions: FeatureFlagOptions(enabled: false))
+
+        // Try to load flags
+        manager.loadFlags()
+
+        // Verify no fetch is triggered
+        let expectation = XCTestExpectation(description: "Check disabled options behavior")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            XCTAssertFalse(
+                self.manager.areFlagsReady(), "Flags should not be ready when options disabled")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    // --- AnyCodable Edge Cases ---
+
+    func testAnyCodableWithComplexTypes() {
+        // Use reflection to test AnyCodable directly
+
+        // Test with nested array
+        let nestedArrayJSON = """
+            {
+                "variant_key": "complex_array",
+                "variant_value": [1, "string", true, [2, 3], {"key": "value"}]
+            }
+            """.data(using: .utf8)!
+
+        do {
+            let decoder = JSONDecoder()
+            let flagData = try decoder.decode(MixpanelFlagVariant.self, from: nestedArrayJSON)
+
+            XCTAssertEqual(flagData.key, "complex_array")
+            XCTAssertNotNil(flagData.value, "Value should not be nil")
+
+            // Verify array structure
+            guard let array = flagData.value as? [Any?] else {
+                XCTFail("Value should be an array")
+                return
+            }
+
+            XCTAssertEqual(array.count, 5, "Array should have 5 elements")
+            XCTAssertEqual(array[0] as? Int, 1)
+            XCTAssertEqual(array[1] as? String, "string")
+            XCTAssertEqual(array[2] as? Bool, true)
+
+            // Nested array check
+            guard let nestedArray = array[3] as? [Any?] else {
+                XCTFail("Element 3 should be an array")
+                return
+            }
+            XCTAssertEqual(nestedArray.count, 2)
+            XCTAssertEqual(nestedArray[0] as? Int, 2)
+            XCTAssertEqual(nestedArray[1] as? Int, 3)
+
+            // Nested dictionary check
+            guard let nestedDict = array[4] as? [String: Any?] else {
+                XCTFail("Element 4 should be a dictionary")
+                return
+            }
+            XCTAssertEqual(nestedDict.count, 1)
+            XCTAssertEqual(nestedDict["key"] as? String, "value")
+
+        } catch {
+            XCTFail("Failed to decode nested array JSON: \(error)")
+        }
+
+        // Test with deeply nested object
+        let nestedObjectJSON = """
+            {
+                "variant_key": "complex_object",
+                "variant_value": {
+                    "str": "value",
+                    "num": 42,
+                    "bool": true,
+                    "null": null,
+                    "array": [1, 2],
+                    "nested": {
+                        "deeper": {
+                            "deepest": "bottom"
+                        }
+                    }
+                }
+            }
+            """.data(using: .utf8)!
+
+        do {
+            let decoder = JSONDecoder()
+            let flagData = try decoder.decode(MixpanelFlagVariant.self, from: nestedObjectJSON)
+
+            XCTAssertEqual(flagData.key, "complex_object")
+            XCTAssertNotNil(flagData.value, "Value should not be nil")
+
+            // Verify dictionary structure
+            guard let dict = flagData.value as? [String: Any?] else {
+                XCTFail("Value should be a dictionary")
+                return
+            }
+
+            XCTAssertEqual(dict.count, 6, "Dictionary should have 6 keys")
+            XCTAssertEqual(dict["str"] as? String, "value")
+            XCTAssertEqual(dict["num"] as? Int, 42)
+            XCTAssertEqual(dict["bool"] as? Bool, true)
+            XCTAssertTrue(dict.keys.contains("null"), "Key 'null' should exist")
+            if let nullEntry = dict["null"] {
+                // Key exists with a value of nil (as wanted)
+                XCTAssertNil(nullEntry, "Value for null key should be nil")
+            } else {
+                // Key doesn't exist (which would be wrong)
+                XCTFail("'null' key should exist in dictionary")
+            }
+
+            // Check nested array
+            guard let array = dict["array"] as? [Any?] else {
+                XCTFail("Array key should contain an array")
+                return
+            }
+            XCTAssertEqual(array.count, 2)
+
+            // Check deeply nested structure
+            guard let nested = dict["nested"] as? [String: Any?] else {
+                XCTFail("Nested key should contain dictionary")
+                return
+            }
+
+            guard let deeper = nested["deeper"] as? [String: Any?] else {
+                XCTFail("Deeper key should contain dictionary")
+                return
+            }
+
+            XCTAssertEqual(deeper["deepest"] as? String, "bottom")
+
+        } catch {
+            XCTFail("Failed to decode nested object JSON: \(error)")
+        }
+    }
+
+    func testAnyCodableWithInvalidTypes() {
+        // Test case where variant_value has an unsupported type
+        // Note: This is harder to test directly since JSON doesn't have many "invalid" types
+        // We can test error handling by constructing invalid JSON manually
+
+        let unsupportedTypeJSON = """
+            {
+                "variant_key": "invalid_type",
+                "variant_value": "infinity"
+            }
+            """.data(using: .utf8)!
+
+        // This is a valid test since the string will decode properly
+        do {
+            let decoder = JSONDecoder()
+            let flagData = try decoder.decode(MixpanelFlagVariant.self, from: unsupportedTypeJSON)
+            XCTAssertEqual(flagData.key, "invalid_type")
+            XCTAssertEqual(flagData.value as? String, "infinity")
+        } catch {
+            XCTFail("Should not fail with simple string value: \(error)")
+        }
+
+        // Test handling of missing variant_value
+        let missingValueJSON = """
+            {
+                "variant_key": "missing_value"
+            }
+            """.data(using: .utf8)!
+
+        do {
+            let decoder = JSONDecoder()
+            let _ = try decoder.decode(MixpanelFlagVariant.self, from: missingValueJSON)
+            XCTFail("Decoding should fail with missing variant_value")
+        } catch {
+            // This is expected to fail, so the test passes
+            XCTAssertTrue(error is DecodingError, "Error should be a DecodingError")
+        }
+    }
+
+    func testFeatureFlagContextIncludesDeviceId() {
+        // Test that device_id is included in the feature flags context
+        let testAnonymousId = "test_device_id_12345"
+        let testDistinctId = "test_distinct_id_67890"
+
+        let mockDelegate = MockFeatureFlagDelegate(
+            options: MixpanelOptions(token: "test", featureFlagOptions: FeatureFlagOptions(enabled: true)),
+            distinctId: testDistinctId,
+            anonymousId: testAnonymousId
+        )
+
+        let manager = FeatureFlagManager(
+            serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated),
+            instanceName: "test", delegate: mockDelegate)
+
+        // Verify the delegate methods return expected values
+        XCTAssertEqual(mockDelegate.getDistinctId(), testDistinctId)
+        XCTAssertEqual(mockDelegate.getAnonymousId(), testAnonymousId)
+
+        // Verify call counts
+        XCTAssertEqual(mockDelegate.getDistinctIdCallCount, 1)
+        XCTAssertEqual(mockDelegate.getAnonymousIdCallCount, 1)
+    }
+
+    func testFeatureFlagContextWithNilAnonymousId() {
+        // Test that device_id is not included when anonymous ID is nil
+        let testDistinctId = "test_distinct_id_67890"
+
+        let mockDelegate = MockFeatureFlagDelegate(
+            options: MixpanelOptions(token: "test", featureFlagOptions: FeatureFlagOptions(enabled: true)),
+            distinctId: testDistinctId,
+            anonymousId: nil
+        )
+
+        let manager = FeatureFlagManager(
+            serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated),
+            instanceName: "test", delegate: mockDelegate)
+
+        // Verify the delegate methods return expected values
+        XCTAssertEqual(mockDelegate.getDistinctId(), testDistinctId)
+        XCTAssertNil(mockDelegate.getAnonymousId())
+
+        // Verify call counts
+        XCTAssertEqual(mockDelegate.getDistinctIdCallCount, 1)
+        XCTAssertEqual(mockDelegate.getAnonymousIdCallCount, 1)
+    }
+
+    func testAccessQueueKeyFunctionality() {
+        // Test that _performTrackingDelegateCall correctly determines if it's on the accessQueue
+        simulateFetchSuccess()
+
+        // First scenario: Call from accessQueue (should read timing properties directly)
+        let syncExpectation = XCTestExpectation(description: "Sync tracking completes")
+
+        // Reset tracked events
+        mockDelegate.trackedEvents.removeAll()
+        mockDelegate.trackExpectation = syncExpectation
+
+        // Call getVariantSync which should trigger tracking from within the accessQueue
+        _ = manager.getVariantSync("feature_double", fallback: defaultFallback)
+
+        wait(for: [syncExpectation], timeout: 5.0)
+
+        // Verify tracking occurred with timing properties
+        XCTAssertEqual(mockDelegate.trackedEvents.count, 1, "Should have tracked once")
+        let syncTrackedEvent = mockDelegate.trackedEvents[0]
+        XCTAssertEqual(syncTrackedEvent.event, "$experiment_started")
+
+        // Verify timing properties are present
+        let syncProps = syncTrackedEvent.properties!
+        XCTAssertNotNil(syncProps["timeLastFetched"], "Should have timeLastFetched")
+        XCTAssertNotNil(syncProps["fetchLatencyMs"], "Should have fetchLatencyMs")
+        XCTAssertEqual(syncProps["fetchLatencyMs"] as? Int, 150, "Should have expected latency")
+
+        // Second scenario: Call from outside accessQueue (should sync to read properties)
+        let asyncExpectation = XCTestExpectation(description: "Async tracking completes")
+
+        // Reset tracked events and set up new tracking expectation
+        mockDelegate.trackedEvents.removeAll()
+        mockDelegate.trackExpectation = asyncExpectation
+
+        // Use async getVariant which may trigger tracking from different queue contexts
+        manager.getVariant("feature_null", fallback: defaultFallback) { _ in
+            // This completion runs on main queue
+        }
+
+        wait(for: [asyncExpectation], timeout: 5.0)
+
+        // Verify tracking occurred with timing properties
+        XCTAssertEqual(mockDelegate.trackedEvents.count, 1, "Should have tracked once")
+        let asyncTrackedEvent = mockDelegate.trackedEvents[0]
+        XCTAssertEqual(asyncTrackedEvent.event, "$experiment_started")
+
+        // Verify timing properties are present (should be the same regardless of queue)
+        let asyncProps = asyncTrackedEvent.properties!
+        XCTAssertNotNil(asyncProps["timeLastFetched"], "Should have timeLastFetched")
+        XCTAssertNotNil(asyncProps["fetchLatencyMs"], "Should have fetchLatencyMs")
+        XCTAssertEqual(asyncProps["fetchLatencyMs"] as? Int, 150, "Should have expected latency")
+    }
+
+    func testTrackingFromDifferentQueueContexts() {
+        // Test that tracking works correctly when called from various queue contexts
+        simulateFetchSuccess()
+
+        let testQueue = DispatchQueue(label: "test.queue")
+        let concurrentQueue = DispatchQueue(label: "test.concurrent", attributes: .concurrent)
+
+        // Track expectations for multiple calls
+        let expectationCount = 3
+        var expectations: [XCTestExpectation] = []
+        for i in 0..<expectationCount {
+            expectations.append(XCTestExpectation(description: "Track call \(i)"))
+        }
+
+        mockDelegate.trackedEvents.removeAll()
+        var trackIndex = 0
+
+        // Set custom track handler to fulfill expectations in order
+        let syncQueue = DispatchQueue(label: "test.sync")
+        mockDelegate.customTrackHandler = { event, properties in
+            syncQueue.sync {
+                if trackIndex < expectations.count {
+                    expectations[trackIndex].fulfill()
+                    trackIndex += 1
+                }
+            }
+        }
+
+        // Test 1: From custom serial queue
+        testQueue.async {
+            _ = self.manager.getVariantSync("feature_bool_true", fallback: self.defaultFallback)
+        }
+
+        // Test 2: From concurrent queue
+        concurrentQueue.async {
+            _ = self.manager.getVariantSync("feature_bool_false", fallback: self.defaultFallback)
+        }
+
+        // Test 3: From main queue
+        DispatchQueue.main.async {
+            _ = self.manager.getVariantSync("feature_string", fallback: self.defaultFallback)
+        }
+
+        // Wait for all tracking to complete
+        wait(for: expectations, timeout: 5.0)
+
+        // Verify all tracking calls included timing properties
+        XCTAssertEqual(mockDelegate.trackedEvents.count, expectationCount)
+
+        for (index, event) in mockDelegate.trackedEvents.enumerated() {
+            XCTAssertEqual(
+                event.event, "$experiment_started", "Event \(index) should be $experiment_started")
+            let props = event.properties!
+            XCTAssertNotNil(props["timeLastFetched"], "Event \(index) should have timeLastFetched")
+            XCTAssertNotNil(props["fetchLatencyMs"], "Event \(index) should have fetchLatencyMs")
+            XCTAssertEqual(
+                props["fetchLatencyMs"] as? Int, 150, "Event \(index) should have expected latency")
+        }
+    }
+
+    func testTrackingIncludesOptionalProperties() {
+        // Set up flags with experiment properties
+        let flagsWithExperiment: [String: MixpanelFlagVariant] = [
+            "experiment_flag": MixpanelFlagVariant(
+                key: "variant_a", value: true, isExperimentActive: true, isQATester: false, experimentID: "exp_123")
         ]
-        mockMgr.pendingFirstTimeEventNames = [event1.eventName, event2.eventName]
-      }
+        simulateFetchSuccess(flags: flagsWithExperiment)
 
-      // Trigger first event
-      mockMgr.checkFirstTimeEvents(eventName: "Event A", properties: [:])
+        mockDelegate.trackExpectation = XCTestExpectation(description: "Track with experiment properties")
+        _ = manager.getVariantSync("experiment_flag", fallback: defaultFallback)
+        wait(for: [mockDelegate.trackExpectation!], timeout: 1.0)
 
-      // Wait for first event activation using predicate
-      let firstActivated = NSPredicate { _, _ in
-        var activated = false
-        mockMgr.flagsLock.read { activated = mockMgr.activatedFirstTimeEvents.contains("multi-event-flag:hash1") }
-        return activated
-      }
-      wait(for: [XCTNSPredicateExpectation(predicate: firstActivated, object: nil)], timeout: 10.0)
-
-      // Verify first event activated
-      mockMgr.flagsLock.read {
-        let flag = mockMgr.flags?["multi-event-flag"]
-        XCTAssertEqual(flag?.key, "variant1", "First event should activate")
-        XCTAssertEqual(flag?.value as? String, "first")
-        XCTAssertTrue(mockMgr.activatedFirstTimeEvents.contains("multi-event-flag:hash1"))
-      }
-
-      // Trigger second event - should overwrite the flag with the second variant
-      mockMgr.checkFirstTimeEvents(eventName: "Event B", properties: [:])
-
-      // Wait for second event activation using predicate
-      let secondActivated = NSPredicate { _, _ in
-        var activated = false
-        mockMgr.flagsLock.read { activated = mockMgr.activatedFirstTimeEvents.contains("multi-event-flag:hash2") }
-        return activated
-      }
-      wait(for: [XCTNSPredicateExpectation(predicate: secondActivated, object: nil)], timeout: 10.0)
-
-      mockMgr.flagsLock.read {
-        let flag = mockMgr.flags?["multi-event-flag"]
-        XCTAssertEqual(flag?.key, "variant2", "Flag should update to second activated variant")
-        XCTAssertEqual(flag?.value as? String, "second")
-        // Both events should be marked as activated
-        XCTAssertTrue(mockMgr.activatedFirstTimeEvents.contains("multi-event-flag:hash1"))
-        XCTAssertTrue(mockMgr.activatedFirstTimeEvents.contains("multi-event-flag:hash2"))
-      }
-    }
-  }
-
-  func testRecordFirstTimeEvent_NetworkFailure() {
-    // Test that network failures are handled gracefully
-    if let mockMgr = mockManager as? MockFeatureFlagManager {
-      // Set up test to simulate network failure
-      mockMgr.simulateRecordFirstTimeEventFailure = true
-
-      let pendingVariant = MixpanelFlagVariant(key: "activated", value: true)
-      let pendingEvent = createPendingEvent(
-        flagKey: "network-fail-test",
-        eventName: "Test Event",
-        filters: nil,
-        pendingVariant: pendingVariant
-      )
-
-      mockMgr.flagsLock.write {
-        mockMgr.flags = ["network-fail-test": createControlVariant()]
-        mockMgr.pendingFirstTimeEvents = ["network-fail-test:hash123": pendingEvent]
-        mockMgr.pendingFirstTimeEventNames = [pendingEvent.eventName]
-      }
-
-      // Trigger event
-      mockMgr.checkFirstTimeEvents(eventName: "Test Event", properties: [:])
-
-      // Wait for the async activation to complete
-      let activated = NSPredicate { _, _ in
-        var done = false
-        mockMgr.flagsLock.read { done = mockMgr.activatedFirstTimeEvents.contains("network-fail-test:hash123") }
-        return done
-      }
-      wait(for: [XCTNSPredicateExpectation(predicate: activated, object: nil)], timeout: 10.0)
-
-      // Verify flag is still activated despite network failure
-      mockMgr.flagsLock.read {
-        let flag = mockMgr.flags?["network-fail-test"]
-        XCTAssertEqual(flag?.key, "activated", "Flag should be activated even if network call fails")
-        XCTAssertTrue(mockMgr.activatedFirstTimeEvents.contains("network-fail-test:hash123"))
-      }
-
-      // Verify recordFirstTimeEvent was called (even though it failed)
-      XCTAssertGreaterThan(mockMgr.recordFirstTimeEventCallCount, 0,
-        "recordFirstTimeEvent should be called even when network fails")
-    }
-  }
-
-  // MARK: Helper Methods
-
-  private func createPendingEvent(
-    flagKey: String,
-    eventName: String,
-    filters: [String: Any]?,
-    pendingVariant: MixpanelFlagVariant,
-    firstTimeEventHash: String = "hash123"
-  ) -> PendingFirstTimeEvent {
-    let json: [String: Any] = [
-      "flag_key": flagKey,
-      "flag_id": "test-flag-id",
-      "project_id": 1,
-      "first_time_event_hash": firstTimeEventHash,
-      "event_name": eventName,
-      "property_filters": filters as Any,
-      "pending_variant": [
-        "variant_key": pendingVariant.key,
-        "variant_value": pendingVariant.value as Any,
-        "experiment_id": pendingVariant.experimentID as Any,
-        "is_experiment_active": pendingVariant.isExperimentActive as Any,
-        "is_qa_tester": pendingVariant.isQATester as Any
-      ]
-    ]
-
-    let data = try! JSONSerialization.data(withJSONObject: json)
-    return try! JSONDecoder().decode(PendingFirstTimeEvent.self, from: data)
-  }
-
-  // --- FeatureFlagOptions Tests ---
-
-  func testFeatureFlagOptions_DefaultValues() {
-    let options = FeatureFlagOptions()
-    XCTAssertFalse(options.enabled, "enabled should default to false")
-    XCTAssertTrue(options.context.isEmpty, "context should default to empty")
-    XCTAssertTrue(options.prefetchFlags, "prefetchFlags should default to true")
-  }
-
-  func testFeatureFlagOptions_CustomValues() {
-    let options = FeatureFlagOptions(
-      enabled: true,
-      context: ["key": "value"],
-      prefetchFlags: false
-    )
-    XCTAssertTrue(options.enabled)
-    XCTAssertEqual(options.context["key"] as? String, "value")
-    XCTAssertFalse(options.prefetchFlags)
-  }
-
-  func testMixpanelOptions_FeatureFlagOptionsOverridesFlat() {
-    // When featureFlagOptions is provided, it should take precedence
-    let options = MixpanelOptions(
-      token: "test",
-      featureFlagsEnabled: false,
-      featureFlagsContext: [:],
-      featureFlagOptions: FeatureFlagOptions(enabled: true, context: ["custom": "ctx"], prefetchFlags: false)
-    )
-    XCTAssertTrue(options.featureFlagsEnabled, "featureFlagsEnabled should reflect featureFlagOptions.enabled")
-    XCTAssertEqual(options.featureFlagsContext["custom"] as? String, "ctx")
-    XCTAssertTrue(options.featureFlagOptions.enabled)
-    XCTAssertFalse(options.featureFlagOptions.prefetchFlags)
-  }
-
-  func testMixpanelOptions_FlatParamsFeedIntoFeatureFlagOptions() {
-    // When featureFlagOptions is not provided, flat params populate it
-    let options = MixpanelOptions(
-      token: "test",
-      featureFlagsEnabled: true,
-      featureFlagsContext: ["flat": "value"]
-    )
-    XCTAssertTrue(options.featureFlagOptions.enabled, "featureFlagOptions.enabled should match featureFlagsEnabled")
-    XCTAssertEqual(options.featureFlagOptions.context["flat"] as? String, "value")
-    XCTAssertTrue(options.featureFlagOptions.prefetchFlags, "prefetchFlags should default to true")
-  }
-
-  func testPrefetchFlags_True_AutoLoadsFlags() {
-    // With prefetchFlags: true (default), MixpanelInstance.init should call loadFlags()
-    // Use a MockFeatureFlagManager to verify that loadFlags triggers a fetch
-    let delegate = MockFeatureFlagDelegate(
-      options: MixpanelOptions(
-        token: "test",
-        featureFlagOptions: FeatureFlagOptions(enabled: true, prefetchFlags: true)
-      )
-    )
-      let mock = MockFeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: delegate)
-    mock.simulatedFetchResult = (success: true, flags: sampleFlags)
-
-    // Call loadFlags() (which prefetchFlags: true would trigger during init)
-    mock.loadFlags()
-
-    // Wait for the fetch to complete and flags to become ready
-    let flagsReady = NSPredicate { _, _ in mock.areFlagsReady() }
-    wait(for: [XCTNSPredicateExpectation(predicate: flagsReady, object: nil)], timeout: 10.0)
-
-    XCTAssertEqual(mock.fetchRequestCount, 1, "prefetchFlags: true should auto-trigger a flag fetch")
-    XCTAssertTrue(mock.areFlagsReady(), "Flags should be ready after fetch completes")
-
-    // Keep delegate alive for the duration of the test (FeatureFlagManager holds it weakly)
-    _ = delegate
-  }
-
-  func testPrefetchFlags_False_DoesNotAutoLoadFlags() {
-    // With prefetchFlags: false, MixpanelInstance.init should NOT call loadFlags()
-    // Use a MockFeatureFlagManager to verify no fetch is triggered
-    let delegate = MockFeatureFlagDelegate(
-      options: MixpanelOptions(
-        token: "test",
-        featureFlagOptions: FeatureFlagOptions(enabled: true, prefetchFlags: false)
-      )
-    )
-      let mock = MockFeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: delegate)
-    mock.simulatedFetchResult = (success: true, flags: sampleFlags)
-
-    // Do NOT call loadFlags() - simulating prefetchFlags: false behavior
-
-    // Give a brief moment for any async dispatch to occur
-    waitBriefly(timeout: 1.0)
-
-    XCTAssertEqual(mock.fetchRequestCount, 0, "prefetchFlags: false should not trigger a flag fetch")
-    XCTAssertFalse(mock.areFlagsReady(), "No flags should be loaded")
-
-    // Keep delegate alive for the duration of the test (FeatureFlagManager holds it weakly)
-    _ = delegate
-  }
-
-  func testPrefetchFlags_False_ManualLoadStillWorks() {
-    // Even with prefetchFlags: false, calling loadFlags() manually should work
-    let delegate = MockFeatureFlagDelegate(
-      options: MixpanelOptions(
-        token: "test",
-        featureFlagOptions: FeatureFlagOptions(enabled: true, prefetchFlags: false)
-      )
-    )
-
-      let mockManager = MockFeatureFlagManager(serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated), instanceName: "test", delegate: delegate)
-    mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
-
-    // Manually load flags (simulating what user would do after identify)
-    mockManager.loadFlags()
-
-    // Wait for flags to become ready (use predicate to handle slow CI dispatch queues)
-    let readyPredicate = NSPredicate { _, _ in mockManager.areFlagsReady() }
-    let readyExpectation = XCTNSPredicateExpectation(predicate: readyPredicate, object: nil)
-    wait(for: [readyExpectation], timeout: 10.0)
-
-    XCTAssertEqual(mockManager.fetchRequestCount, 1, "Manual loadFlags should trigger fetch")
-    XCTAssertTrue(mockManager.areFlagsReady(), "Flags should be ready after manual load")
-
-    // Keep delegate alive for the duration of the test (FeatureFlagManager holds it weakly)
-    _ = delegate
-  }
-
-  // MARK: - Reset Tests
-
-  /// Calls `reset()` and blocks until its completion fires. We use the completion (rather
-  /// than polling for `flags == nil`) because the polling approach is vacuous in tests where
-  /// `flags` was already nil before the reset — the predicate would match immediately
-  /// without observing the reset block actually running, masking real bugs.
-  private func resetAndWait(_ mockMgr: MockFeatureFlagManager, timeout: TimeInterval = 10.0) {
-    let done = expectation(description: "FeatureFlagManager.reset completes")
-    mockMgr.reset {
-      done.fulfill()
-    }
-    wait(for: [done], timeout: timeout)
-  }
-
-  func testReset_ClearsFlagsAndFetchTiming() {
-    setupReadyFlagsAndVerify()
-
-    guard let mockMgr = mockManager else {
-      XCTFail("Manager is not a MockFeatureFlagManager")
-      return
+        let props = mockDelegate.trackedEvents[0].properties!
+        XCTAssertEqual(props["$experiment_id"] as? String, "exp_123")
+        XCTAssertEqual(props["$is_experiment_active"] as? Bool, true)
+        XCTAssertEqual(props["$is_qa_tester"] as? Bool, false)
     }
 
-    // Sanity check pre-reset state
-    mockMgr.flagsLock.read {
-      XCTAssertNotNil(mockMgr.flags, "Flags should be set before reset")
-      XCTAssertNotNil(mockMgr.timeLastFetched, "timeLastFetched should be set before reset")
-      XCTAssertNotNil(mockMgr.fetchLatencyMs, "fetchLatencyMs should be set before reset")
+    // MARK: - Timing Properties Sanity Tests
+
+    func testTimingPropertiesSanity() {
+        // 1. Test Initial State - Properties should be nil before any fetch
+        XCTAssertNil(manager.timeLastFetched, "timeLastFetched should be nil initially")
+        XCTAssertNil(manager.fetchLatencyMs, "fetchLatencyMs should be nil initially")
+
+        // 2. Test Accurate Timing Calculation with Real Delay
+        if let mockManager = manager as? MockFeatureFlagManager {
+            // Configure mock to simulate a realistic network delay
+            let expectedDelayMs = 250  // 250ms simulated network delay
+            mockManager.shouldSimulateNetworkDelay = true
+
+            // Create a custom expectation to measure actual time
+            let fetchExpectation = XCTestExpectation(description: "Fetch completes with timing")
+            let fetchStartTime = Date()
+
+            // Trigger async fetch
+            manager.getVariant("feature_bool_true", fallback: defaultFallback) { _ in
+                fetchExpectation.fulfill()
+            }
+
+            wait(for: [fetchExpectation], timeout: 10.0)
+
+            // Verify timing properties are set and reasonable
+            XCTAssertNotNil(
+                manager.timeLastFetched, "timeLastFetched should be set after successful fetch")
+            XCTAssertNotNil(manager.fetchLatencyMs, "fetchLatencyMs should be set after successful fetch")
+
+            // 3. Test Reasonable Bounds
+            if let latencyMs = manager.fetchLatencyMs {
+                XCTAssertGreaterThan(latencyMs, 0, "fetchLatencyMs should be positive")
+                XCTAssertLessThan(latencyMs, 30000, "fetchLatencyMs should be less than 30 seconds")
+
+                // Sanity check that the SDK's reported latency is in the same ballpark as the
+                // wall-clock duration of the call. We don't assert tight bounds: `fetchStartTime`
+                // is captured before `getVariant` returns control to the trackingQueue, so on a
+                // contested CI runner the dispatch delay before the mock fetch even starts can
+                // dwarf the simulated 100ms delay. The SDK timer (latencyMs) measures only the
+                // fetch itself, so it can legitimately be much smaller than actualElapsedMs.
+                // Using a 30s tolerance — same as the upper bound on latencyMs above — keeps
+                // this an order-of-magnitude check rather than a tight equivalence one.
+                let actualElapsedMs = Int(Date().timeIntervalSince(fetchStartTime) * 1000)
+                let tolerance = 30000
+                XCTAssertLessThanOrEqual(
+                    abs(latencyMs - actualElapsedMs), tolerance,
+                    "fetchLatencyMs (\(latencyMs)ms) should be close to actual elapsed time (\(actualElapsedMs)ms)"
+                )
+            }
+
+            if let timeLastFetched = manager.timeLastFetched {
+                let timestamp = Int(timeLastFetched.timeIntervalSince1970)
+                let year2020Timestamp = 1_577_836_800  // Jan 1, 2020
+                let year2100Timestamp = 4_102_444_800  // Jan 1, 2100
+
+                XCTAssertGreaterThan(
+                    timestamp, year2020Timestamp, "timeLastFetched should be after year 2020")
+                XCTAssertLessThan(
+                    timestamp, year2100Timestamp, "timeLastFetched should be before year 2100")
+
+                // Verify timestamp is not in the future
+                XCTAssertLessThanOrEqual(
+                    timeLastFetched.timeIntervalSinceNow, 1.0,
+                    "timeLastFetched should not be in the future (allowing 1s tolerance)"
+                )
+            }
+        }
+
+        // 4. Test Update on Subsequent Fetches
+        if let mockManager = manager as? MockFeatureFlagManager {
+            // Store first fetch values
+            let firstFetchTime = manager.timeLastFetched
+            let firstLatency = manager.fetchLatencyMs
+
+            // Wait a bit to ensure time difference
+            Thread.sleep(forTimeInterval: 0.1)
+
+            // Reset flags to trigger new fetch
+            mockManager.flagsLock.write {
+                mockManager.flags = nil
+            }
+
+            // Configure different delay for second fetch
+            mockManager.shouldSimulateNetworkDelay = true
+            mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
+
+            let secondFetchExpectation = XCTestExpectation(description: "Second fetch completes")
+
+            manager.getVariant("feature_string", fallback: defaultFallback) { _ in
+                secondFetchExpectation.fulfill()
+            }
+
+            wait(for: [secondFetchExpectation], timeout: 10.0)
+
+            // Verify timing properties updated
+            XCTAssertNotNil(manager.timeLastFetched, "timeLastFetched should be set after second fetch")
+            XCTAssertNotNil(manager.fetchLatencyMs, "fetchLatencyMs should be set after second fetch")
+
+            if let firstTime = firstFetchTime, let secondTime = manager.timeLastFetched {
+                XCTAssertGreaterThan(
+                    secondTime.timeIntervalSince1970, firstTime.timeIntervalSince1970,
+                    "Second fetch time should be later than first fetch time"
+                )
+            }
+
+            // Latency might be similar but should be independently calculated
+            XCTAssertNotNil(
+                manager.fetchLatencyMs, "fetchLatencyMs should still be set after second fetch")
+        }
+
+        // 5. Test Failed Fetch Behavior
+        if let mockManager = manager as? MockFeatureFlagManager {
+            // Store current valid timing values
+            let validTimeLastFetched = manager.timeLastFetched
+            let validFetchLatency = manager.fetchLatencyMs
+
+            // Reset flags and configure for failure
+            mockManager.flagsLock.write {
+                mockManager.flags = nil
+            }
+            mockManager.simulatedFetchResult = (success: false, flags: nil)
+
+            let failedFetchExpectation = XCTestExpectation(description: "Failed fetch completes")
+
+            manager.getVariant("feature_int", fallback: defaultFallback) { variant in
+                // Should get fallback on failure
+                XCTAssertEqual(
+                    variant.key, self.defaultFallback.key, "Should receive fallback on fetch failure")
+                failedFetchExpectation.fulfill()
+            }
+
+            wait(for: [failedFetchExpectation], timeout: 10.0)
+
+            // Verify timing properties aren't corrupted by failed fetch
+            // They should either remain unchanged or be cleared, but not set to invalid values
+            if manager.timeLastFetched != nil {
+                // If still set, should be the previous valid value
+                XCTAssertEqual(
+                    manager.timeLastFetched?.timeIntervalSince1970,
+                    validTimeLastFetched?.timeIntervalSince1970,
+                    "timeLastFetched should not be updated on failed fetch"
+                )
+            }
+
+            if manager.fetchLatencyMs != nil {
+                // If still set, should be the previous valid value
+                XCTAssertEqual(
+                    manager.fetchLatencyMs, validFetchLatency,
+                    "fetchLatencyMs should not be updated on failed fetch"
+                )
+            }
+
+            // Reset to success for cleanup
+            mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
+        }
+
+        // 6. Test Consistency Between Timing Properties
+        if let mockManager = manager as? MockFeatureFlagManager {
+            // Ensure we have a successful fetch
+            mockManager.flagsLock.write {
+                mockManager.flags = nil
+            }
+
+            let consistencyExpectation = XCTestExpectation(description: "Fetch for consistency check")
+
+            manager.getVariant("feature_double", fallback: defaultFallback) { _ in
+                consistencyExpectation.fulfill()
+            }
+
+            wait(for: [consistencyExpectation], timeout: 10.0)
+
+            // Both should be set or both should be nil
+            if manager.fetchLatencyMs != nil {
+                XCTAssertNotNil(
+                    manager.timeLastFetched,
+                    "If fetchLatencyMs is set, timeLastFetched should also be set"
+                )
+            }
+
+            if manager.timeLastFetched != nil {
+                XCTAssertNotNil(
+                    manager.fetchLatencyMs,
+                    "If timeLastFetched is set, fetchLatencyMs should also be set"
+                )
+            }
+        }
+
+        // 7. Test Timing Properties in Tracking Events
+        // Reset tracked events to test fresh tracking
+        mockDelegate.trackedEvents.removeAll()
+
+        // Use a unique flag name that hasn't been tracked yet to ensure fresh tracking
+        let uniqueFlagName = "test_timing_flag_\(UUID().uuidString.prefix(8))"
+
+        // Create a test flag for this unique name
+        if let mockManager = manager as? MockFeatureFlagManager {
+            var testFlags = sampleFlags
+            testFlags[uniqueFlagName] = MixpanelFlagVariant(key: "timing_test", value: true)
+            mockManager.flagsLock.write {
+                mockManager.flags = testFlags
+            }
+        }
+
+        let trackingExpectation = XCTestExpectation(description: "Tracking includes timing properties")
+        mockDelegate.trackExpectation = trackingExpectation
+
+        // Trigger tracking by accessing the unique flag
+        _ = manager.getVariantSync(uniqueFlagName, fallback: defaultFallback)
+
+        wait(for: [trackingExpectation], timeout: 1.0)
+
+        XCTAssertEqual(mockDelegate.trackedEvents.count, 1, "Should have tracked one event")
+        let trackedEvent = mockDelegate.trackedEvents[0]
+        let props = trackedEvent.properties!
+
+        // Verify timing properties are included in tracking
+        if manager.timeLastFetched != nil {
+            XCTAssertNotNil(props["timeLastFetched"], "Tracking should include timeLastFetched")
+            if let trackedTimestamp = props["timeLastFetched"] as? Int {
+                let expectedTimestamp = Int(manager.timeLastFetched!.timeIntervalSince1970)
+                XCTAssertEqual(
+                    trackedTimestamp, expectedTimestamp,
+                    "Tracked timeLastFetched should match manager's value"
+                )
+            }
+        }
+
+        if manager.fetchLatencyMs != nil {
+            XCTAssertNotNil(props["fetchLatencyMs"], "Tracking should include fetchLatencyMs")
+            if let trackedLatency = props["fetchLatencyMs"] as? Int {
+                XCTAssertEqual(
+                    trackedLatency, manager.fetchLatencyMs!,
+                    "Tracked fetchLatencyMs should match manager's value"
+                )
+            }
+        }
     }
 
-    resetAndWait(mockMgr)
+    func testGETRequestFormat() {
+        // Use a fresh MockFeatureFlagManager with request validation enabled
+        let mockManager = MockFeatureFlagManager(
+            serverURL: "https://api.mixpanel.com", trackingQueue: DispatchQueue.global(qos: .userInitiated),
+            instanceName: "test", delegate: mockDelegate)
+        mockManager.requestValidationEnabled = true
+        mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
 
-    XCTAssertFalse(manager.areFlagsReady(), "Flags should not be ready after reset")
-    mockMgr.flagsLock.read {
-      XCTAssertNil(mockMgr.flags, "flags should be cleared")
-      XCTAssertNil(mockMgr.timeLastFetched, "timeLastFetched should be cleared")
-      XCTAssertNil(mockMgr.fetchLatencyMs, "fetchLatencyMs should be cleared")
-      XCTAssertFalse(mockMgr.isFetching, "isFetching should be false after reset")
-    }
-  }
+        // Trigger a request
+        mockManager.loadFlags()
 
-  func testReset_ClearsTrackedFeaturesSoTrackingFiresAgain() {
-    setupReadyFlagsAndVerify()
+        // Wait for request to be processed (use predicate to handle slow CI dispatch queues)
+        let validatedPredicate = NSPredicate { _, _ in mockManager.lastRequestMethod != nil }
+        let expectation = XCTNSPredicateExpectation(predicate: validatedPredicate, object: nil)
+        wait(for: [expectation], timeout: 10.0)
 
-    guard let mockMgr = mockManager else {
-      XCTFail("Manager is not a MockFeatureFlagManager")
-      return
-    }
+        // Verify no validation errors
+        XCTAssertNil(
+            mockManager.requestValidationError,
+            "Request validation should not have errors: \(mockManager.requestValidationError ?? "")")
 
-    // First read tracks the variant exactly once.
-    expectTracking(expectedCount: 1, description: "Initial tracking") {
-      _ = manager.getVariantSync("feature_string", fallback: defaultFallback)
-    }
+        // Verify GET method
+        XCTAssertEqual(mockManager.lastRequestMethod, .get, "Should use GET method")
 
-    // A second read with the same flag should NOT track again pre-reset.
-    _ = manager.getVariantSync("feature_string", fallback: defaultFallback)
-    waitBriefly()
-    XCTAssertEqual(mockDelegate.trackedEvents.count, 1, "Second read pre-reset should not re-track")
+        // Verify headers
+        XCTAssertNotNil(mockManager.lastRequestHeaders, "Headers should be captured")
+        if let headers = mockManager.lastRequestHeaders {
+            XCTAssertTrue(headers.keys.contains("Authorization"), "Should include Authorization header")
+            XCTAssertTrue(headers["Authorization"]?.starts(with: "Basic ") == true, "Should use Basic auth")
+            XCTAssertFalse(headers.keys.contains("Content-Type"), "Should not include Content-Type header for GET")
+        }
 
-    resetAndWait(mockMgr)
+        // Verify no request body
+        XCTAssertNil(mockManager.lastRequestBody, "GET request should not have a body")
 
-    // Re-populate flags after the reset (mirrors a refetch under a new identity).
-    setupReadyFlags()
+        // Verify query parameters
+        XCTAssertNotNil(mockManager.lastQueryItems, "Query items should be captured")
+        if let queryItems = mockManager.lastQueryItems {
+            let queryDict = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
 
-    // After reset, reading the same flag should track again because the
-    // trackedFeatures set was cleared.
-    expectTracking(expectedCount: 1, description: "Tracking after reset") {
-      _ = manager.getVariantSync("feature_string", fallback: defaultFallback)
-    }
-  }
+            // Check required parameters
+            XCTAssertNotNil(queryDict["context"], "Should include context parameter")
+            XCTAssertEqual(queryDict["token"], "test", "Should include token parameter")
+            XCTAssertEqual(queryDict["mp_lib"], "swift", "Should include mp_lib parameter")
+            XCTAssertEqual(
+                queryDict["$lib_version"], AutomaticProperties.libVersion(), "Should include $lib_version parameter")
 
-  func testReset_ClearsFirstTimeEventState() {
-    guard let mockMgr = mockManager else {
-      XCTFail("Manager is not a MockFeatureFlagManager")
-      return
-    }
-
-    let pendingVariant = MixpanelFlagVariant(key: "activated", value: true)
-    let pendingEvent = createPendingEvent(
-      flagKey: "reset-flag",
-      eventName: "Reset Event",
-      filters: nil,
-      pendingVariant: pendingVariant
-    )
-
-    mockMgr.flagsLock.write {
-      mockMgr.flags = ["reset-flag": createControlVariant()]
-      mockMgr.pendingFirstTimeEvents = ["reset-flag:hash123": pendingEvent]
-      mockMgr.pendingFirstTimeEventNames = [pendingEvent.eventName]
-      mockMgr.activatedFirstTimeEvents.insert("reset-flag:hash123")
-    }
-
-    mockMgr.flagsLock.read {
-      XCTAssertEqual(mockMgr.pendingFirstTimeEvents.count, 1)
-      XCTAssertEqual(mockMgr.pendingFirstTimeEventNames.count, 1)
-      XCTAssertEqual(mockMgr.activatedFirstTimeEvents.count, 1)
+            // Verify context JSON structure
+            if let contextString = queryDict["context"],
+                let contextData = contextString?.data(using: .utf8),
+                let context = try? JSONSerialization.jsonObject(with: contextData) as? [String: Any]
+            {
+                XCTAssertEqual(
+                    context["distinct_id"] as? String, "test_distinct_id", "Context should include distinct_id")
+                XCTAssertEqual(context["device_id"] as? String, "test_anonymous_id", "Context should include device_id")
+            } else {
+                XCTFail("Context should be valid JSON")
+            }
+        }
     }
 
-    resetAndWait(mockMgr)
+    func testGETRequestWithCustomContext() {
+        // Set up custom context
+        let customOptions = MixpanelOptions(
+            token: "custom-token",
+            featureFlagOptions: FeatureFlagOptions(
+                enabled: true,
+                context: [
+                    "user_id": "test-user-123",
+                    "group_id": "test-group-456",
+                ]))
 
-    mockMgr.flagsLock.read {
-      XCTAssertTrue(mockMgr.pendingFirstTimeEvents.isEmpty,
-                    "pendingFirstTimeEvents should be cleared by reset")
-      XCTAssertTrue(mockMgr.pendingFirstTimeEventNames.isEmpty,
-                    "pendingFirstTimeEventNames should be cleared by reset")
-      XCTAssertTrue(mockMgr.activatedFirstTimeEvents.isEmpty,
-                    "activatedFirstTimeEvents should be cleared by reset")
+        let customDelegate = MockFeatureFlagDelegate(
+            options: customOptions,
+            distinctId: "custom-distinct-id",
+            anonymousId: "custom-device-id"
+        )
+
+        let mockManager = MockFeatureFlagManager(
+            serverURL: "https://api.mixpanel.com", trackingQueue: DispatchQueue.global(qos: .userInitiated),
+            instanceName: "test", delegate: customDelegate)
+        mockManager.requestValidationEnabled = true
+        mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
+
+        // Trigger a request
+        mockManager.loadFlags()
+
+        // Wait for request to be processed (use predicate to handle slow CI dispatch queues)
+        let validatedPredicate = NSPredicate { _, _ in mockManager.lastRequestMethod != nil }
+        let expectation = XCTNSPredicateExpectation(predicate: validatedPredicate, object: nil)
+        wait(for: [expectation], timeout: 10.0)
+
+        // Verify no validation errors
+        XCTAssertNil(mockManager.requestValidationError, "Request validation should not have errors")
+
+        // Verify query parameters with custom context
+        XCTAssertNotNil(mockManager.lastQueryItems, "Query items should be captured")
+        if let queryItems = mockManager.lastQueryItems {
+            let queryDict = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
+            XCTAssertEqual(queryDict["token"], "custom-token", "Should include custom token")
+            // Verify context includes both standard and custom fields
+            if let contextString = queryDict["context"],
+                let contextData = contextString?.data(using: .utf8),
+                let context = try? JSONSerialization.jsonObject(with: contextData) as? [String: Any]
+            {
+
+                XCTAssertEqual(
+                    context["distinct_id"] as? String, "custom-distinct-id", "Context should include distinct_id")
+                XCTAssertEqual(context["device_id"] as? String, "custom-device-id", "Context should include device_id")
+                XCTAssertEqual(context["user_id"] as? String, "test-user-123", "Context should include custom user_id")
+                XCTAssertEqual(
+                    context["group_id"] as? String, "test-group-456", "Context should include custom group_id")
+            } else {
+                XCTFail("Context should be valid JSON with custom fields")
+            }
+        }
     }
-  }
 
-  func testReset_PreservesContextSetViaSetContext() {
-    guard let mockMgr = mockManager else {
-      XCTFail("Manager is not a MockFeatureFlagManager")
-      return
+    func testGETRequestWithNilAnonymousId() {
+        // Set up with nil anonymous ID
+        let nilAnonymousDelegate = MockFeatureFlagDelegate(
+            options: MixpanelOptions(token: "test-token", featureFlagOptions: FeatureFlagOptions(enabled: true)),
+            distinctId: "test-distinct-id",
+            anonymousId: nil
+        )
+
+        let mockManager = MockFeatureFlagManager(
+            serverURL: "https://api.mixpanel.com", trackingQueue: DispatchQueue.global(qos: .userInitiated),
+            instanceName: "test", delegate: nilAnonymousDelegate)
+        mockManager.requestValidationEnabled = true
+        mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
+
+        // Trigger a request
+        mockManager.loadFlags()
+
+        // Wait for request to be processed (use predicate to handle slow CI dispatch queues)
+        let validatedPredicate = NSPredicate { _, _ in mockManager.lastRequestMethod != nil }
+        let expectation = XCTNSPredicateExpectation(predicate: validatedPredicate, object: nil)
+        wait(for: [expectation], timeout: 10.0)
+
+        // Verify no validation errors
+        XCTAssertNil(
+            mockManager.requestValidationError, "Request validation should not have errors with nil anonymous ID")
+
+        // Verify context excludes device_id when anonymous ID is nil
+        if let queryItems = mockManager.lastQueryItems {
+            let queryDict = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
+
+            if let contextString = queryDict["context"],
+                let contextData = contextString?.data(using: .utf8),
+                let context = try? JSONSerialization.jsonObject(with: contextData) as? [String: Any]
+            {
+
+                XCTAssertEqual(
+                    context["distinct_id"] as? String, "test-distinct-id", "Context should include distinct_id")
+                XCTAssertNil(context["device_id"], "Context should not include device_id when anonymous ID is nil")
+
+                // Should only contain distinct_id (no additional context configured)
+                XCTAssertEqual(
+                    context.keys.count, 1,
+                    "Context should only contain distinct_id when no device_id or additional context")
+            } else {
+                XCTFail("Context should be valid JSON")
+            }
+        }
     }
 
-    // Default options carry an empty context.
-    mockMgr.flagsLock.read {
-      XCTAssertTrue(mockMgr.flagContext.isEmpty, "Initial flagContext should be empty")
+    // MARK: - First-Time Event Targeting Tests
+
+    // MARK: Response Parsing Tests
+
+    func testParsePendingFirstTimeEvents() {
+        let json = """
+            {
+              "flags": {
+                "test-flag": {
+                  "variant_key": "control",
+                  "variant_value": false
+                }
+              },
+              "pending_first_time_events": [
+                {
+                  "flag_key": "test-flag",
+                  "flag_id": "flag-123",
+                  "project_id": 3,
+                  "first_time_event_hash": "abc123",
+                  "event_name": "Purchase Complete",
+                  "property_filters": {
+                    ">": [{"var": "amount"}, 100]
+                  },
+                  "pending_variant": {
+                    "variant_key": "treatment",
+                    "variant_value": true,
+                    "experiment_id": "exp-456",
+                    "is_experiment_active": true
+                  }
+                }
+              ]
+            }
+            """.data(using: .utf8)!
+
+        do {
+            let response = try JSONDecoder().decode(FlagsResponse.self, from: json)
+            XCTAssertNotNil(response.flags)
+            XCTAssertNotNil(response.pendingFirstTimeEvents)
+            XCTAssertEqual(response.pendingFirstTimeEvents?.count, 1)
+
+            let pendingEvent = response.pendingFirstTimeEvents![0]
+            XCTAssertEqual(pendingEvent.flagKey, "test-flag")
+            XCTAssertEqual(pendingEvent.flagId, "flag-123")
+            XCTAssertEqual(pendingEvent.projectId, 3)
+            XCTAssertEqual(pendingEvent.firstTimeEventHash, "abc123")
+            XCTAssertEqual(pendingEvent.eventName, "Purchase Complete")
+            XCTAssertNotNil(pendingEvent.propertyFilters)
+            XCTAssertEqual(pendingEvent.pendingVariant.key, "treatment")
+            XCTAssertEqual(pendingEvent.pendingVariant.value as? Bool, true)
+        } catch {
+            XCTFail("Failed to parse response: \(error)")
+        }
     }
 
-    let customContext: [String: Any] = [
-      "user_id": "ctx-user",
-      "group_id": "ctx-group",
-    ]
+    func testParseEmptyPendingFirstTimeEvents() {
+        let json = """
+            {
+              "flags": {},
+              "pending_first_time_events": []
+            }
+            """.data(using: .utf8)!
 
-    let setContextExpectation = XCTestExpectation(description: "setContext completes")
-    mockMgr.setContext(customContext) {
-      setContextExpectation.fulfill()
+        do {
+            let response = try JSONDecoder().decode(FlagsResponse.self, from: json)
+            XCTAssertNotNil(response.pendingFirstTimeEvents)
+            XCTAssertEqual(response.pendingFirstTimeEvents?.count, 0)
+        } catch {
+            XCTFail("Failed to parse response: \(error)")
+        }
     }
-    wait(for: [setContextExpectation], timeout: 5.0)
 
-    mockMgr.flagsLock.read {
-      XCTAssertEqual(mockMgr.flagContext["user_id"] as? String, "ctx-user")
-      XCTAssertEqual(mockMgr.flagContext["group_id"] as? String, "ctx-group")
+    // MARK: First-Time Event Matching Tests
+
+    func testFirstTimeEventMatching_ExactNameMatch() {
+        let pendingVariant = createExperimentVariant(key: "activated", value: true, experimentID: "exp-123")
+        let initialVariant = createControlVariant(value: false)
+
+        setupAndTriggerFirstTimeEvent(
+            flagKey: "welcome-modal",
+            eventName: "Dashboard Viewed",
+            pendingVariant: pendingVariant,
+            initialVariant: initialVariant
+        ) { mockMgr in
+            let flag = mockMgr.flags?["welcome-modal"]
+            XCTAssertEqual(flag?.key, "activated")
+            XCTAssertEqual(flag?.value as? Bool, true)
+            XCTAssertTrue(mockMgr.activatedFirstTimeEvents.contains("welcome-modal:hash123"))
+        }
     }
 
-    resetAndWait(mockMgr)
+    func testFirstTimeEventMatching_WithPropertyFilters() {
+        let pendingVariant = createExperimentVariant(key: "premium", value: ["discount": 20], experimentID: "exp-456")
+        let initialVariant = createControlVariant(value: nil)
+        let filters: [String: Any] = [">": [["var": "amount"], 100]]
 
-    // setContext-supplied context should survive reset() — only identity-tied
-    // state (flags, tracking, first-time events, fetch timing) is cleared.
-    mockMgr.flagsLock.read {
-      XCTAssertEqual(mockMgr.flagContext["user_id"] as? String, "ctx-user",
-                     "setContext value should survive reset()")
-      XCTAssertEqual(mockMgr.flagContext["group_id"] as? String, "ctx-group",
-                     "setContext value should survive reset()")
+        setupAndTriggerFirstTimeEvent(
+            flagKey: "premium-welcome",
+            eventName: "Purchase Complete",
+            eventProperties: ["amount": 150],
+            filters: filters,
+            pendingVariant: pendingVariant,
+            initialVariant: initialVariant,
+            firstTimeEventHash: "hash456"
+        ) { mockMgr in
+            let flag = mockMgr.flags?["premium-welcome"]
+            XCTAssertEqual(flag?.key, "premium")
+            XCTAssertTrue(mockMgr.activatedFirstTimeEvents.contains("premium-welcome:hash456"))
+        }
     }
-  }
+
+    func testFirstTimeEventMatching_PropertyFilterNoMatch() {
+        let pendingVariant = MixpanelFlagVariant(key: "premium", value: true)
+        let initialVariant = createControlVariant(value: false)
+        let filters: [String: Any] = [">": [["var": "amount"], 100]]
+
+        // Trigger event with amount < 100 (should NOT match)
+        setupAndTriggerFirstTimeEvent(
+            flagKey: "premium-welcome",
+            eventName: "Purchase Complete",
+            eventProperties: ["amount": 50],
+            filters: filters,
+            pendingVariant: pendingVariant,
+            initialVariant: initialVariant,
+            firstTimeEventHash: "hash456",
+            expectActivation: false
+        ) { mockMgr in
+            let flag = mockMgr.flags?["premium-welcome"]
+            XCTAssertEqual(flag?.key, "control")
+            XCTAssertFalse(mockMgr.activatedFirstTimeEvents.contains("premium-welcome:hash456"))
+        }
+    }
+
+    // MARK: Activation State Tests
+
+    func testFirstTimeEventActivatesOnlyOnce() {
+        if let mockManager = manager as? MockFeatureFlagManager {
+            let pendingVariant = MixpanelFlagVariant(key: "activated", value: true)
+
+            let pendingEvent = createPendingEvent(
+                flagKey: "once-only",
+                eventName: "Test Event",
+                filters: nil,
+                pendingVariant: pendingVariant
+            )
+
+            mockManager.flagsLock.write {
+                mockManager.flags = ["once-only": MixpanelFlagVariant(key: "control", value: false)]
+                mockManager.pendingFirstTimeEvents = ["once-only:hash999": pendingEvent]
+                mockManager.pendingFirstTimeEventNames = [pendingEvent.eventName]
+                // Reset tracking state
+                mockManager.recordFirstTimeEventCallCount = 0
+            }
+
+            // Set up expectation before triggering events
+            let expectation = XCTestExpectation(description: "recordFirstTimeEvent called")
+            mockManager.recordFirstTimeEventExpectation = expectation
+
+            // Trigger event multiple times
+            mockManager.checkFirstTimeEvents(eventName: "Test Event", properties: [:])
+            mockManager.checkFirstTimeEvents(eventName: "Test Event", properties: [:])
+            mockManager.checkFirstTimeEvents(eventName: "Test Event", properties: [:])
+
+            wait(for: [expectation], timeout: 5.0)
+
+            // Verify activation occurred and is tracked
+            mockManager.flagsLock.read {
+                XCTAssertTrue(mockManager.activatedFirstTimeEvents.contains("once-only:hash999"))
+
+                // Verify recordFirstTimeEvent was called exactly once
+                XCTAssertEqual(
+                    mockManager.recordFirstTimeEventCallCount, 1,
+                    "recordFirstTimeEvent should be called exactly once, not \(mockManager.recordFirstTimeEventCallCount) times"
+                )
+
+                // Verify the correct parameters were recorded
+                XCTAssertEqual(mockManager.lastRecordedFlagId, "test-flag-id")
+                XCTAssertEqual(mockManager.lastRecordedProjectId, 1)
+                XCTAssertEqual(mockManager.lastRecordedFirstTimeEventHash, "hash123")
+            }
+        }
+    }
+
+    // MARK: Flag Refresh Edge Cases
+
+    func testFlagRefresh_PreservesActivatedVariants() {
+        if let mockManager = manager as? MockFeatureFlagManager {
+            // Set up initial state with activated variant
+            mockManager.flagsLock.write {
+                mockManager.flags = ["test-flag": MixpanelFlagVariant(key: "activated", value: true)]
+                mockManager.activatedFirstTimeEvents.insert("test-flag:hash123")
+            }
+
+            // Simulate fetch response with different variant for same flag
+            let newFlags = ["test-flag": MixpanelFlagVariant(key: "control", value: false)]
+            mockManager.simulatedFetchResult = (success: true, flags: newFlags)
+
+            // Trigger fetch
+            mockManager.loadFlags()
+
+            let expectation = XCTestExpectation(description: "Fetch completes")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { expectation.fulfill() }
+            wait(for: [expectation], timeout: 5.0)
+
+            // Verify activated variant was preserved
+            mockManager.flagsLock.read {
+                let flag = mockManager.flags?["test-flag"]
+                XCTAssertEqual(flag?.key, "activated", "Activated variant should be preserved")
+                XCTAssertEqual(flag?.value as? Bool, true)
+            }
+        }
+    }
+
+    func testFlagRefresh_KeepsOrphanedActivatedFlags() {
+        if let mockManager = manager as? MockFeatureFlagManager {
+            // Set up initial state with activated variant
+            mockManager.flagsLock.write {
+                mockManager.flags = ["orphaned-flag": MixpanelFlagVariant(key: "activated", value: true)]
+                mockManager.activatedFirstTimeEvents.insert("orphaned-flag:hash123")
+            }
+
+            // Simulate fetch response WITHOUT the orphaned flag
+            let newFlags = ["other-flag": MixpanelFlagVariant(key: "control", value: false)]
+            mockManager.simulatedFetchResult = (success: true, flags: newFlags)
+
+            // Trigger fetch
+            mockManager.loadFlags()
+
+            let expectation = XCTestExpectation(description: "Fetch completes")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { expectation.fulfill() }
+            wait(for: [expectation], timeout: 5.0)
+
+            // Verify orphaned flag was kept
+            mockManager.flagsLock.read {
+                let flag = mockManager.flags?["orphaned-flag"]
+                XCTAssertNotNil(flag, "Orphaned activated flag should be kept")
+                XCTAssertEqual(flag?.key, "activated")
+            }
+        }
+    }
+
+    // MARK: Additional Coverage Tests
+
+    func testFirstTimeEventMatching_EventNameMismatch() {
+        // Test that event name matching is case-sensitive
+        let pendingVariant = MixpanelFlagVariant(key: "activated", value: true)
+        let initialVariant = createControlVariant(value: false)
+
+        setupAndTriggerFirstTimeEvent(
+            flagKey: "event-name-test",
+            eventName: "Purchase Complete",  // Configured event name
+            triggeredEventName: "Purchase Completed",  // Call with different name (mismatch)
+            eventProperties: [:],
+            filters: nil,
+            pendingVariant: pendingVariant,
+            initialVariant: initialVariant,
+            firstTimeEventHash: "hash-mismatch",
+            expectActivation: false
+        ) { mockMgr in
+            // Verify flag stayed at control due to name mismatch
+            let initialFlag = mockMgr.flags?["event-name-test"]
+            XCTAssertEqual(initialFlag?.key, "control", "Flag should remain at control variant")
+            XCTAssertEqual(initialFlag?.value as? Bool, false)
+        }
+
+        // Now try with different case - should also NOT match (case-sensitive)
+        if let mockMgr = mockManager as? MockFeatureFlagManager {
+            mockMgr.checkFirstTimeEvents(eventName: "purchase complete", properties: [:])  // lowercase
+            waitBriefly(timeout: 1.0)
+
+            mockMgr.flagsLock.read {
+                let flag = mockMgr.flags?["event-name-test"]
+                XCTAssertEqual(flag?.key, "control", "Event name matching should be case-sensitive")
+                XCTAssertFalse(mockMgr.activatedFirstTimeEvents.contains("event-name-test:hash-mismatch"))
+            }
+        }
+    }
+
+    func testMultiplePendingEventsOnSameFlag() {
+        // Test that multiple pending events on the same flag work correctly
+        if let mockMgr = mockManager as? MockFeatureFlagManager {
+            let controlVariant = createControlVariant(value: false)
+            let variant1 = MixpanelFlagVariant(key: "variant1", value: "first")
+            let variant2 = MixpanelFlagVariant(key: "variant2", value: "second")
+
+            let event1 = createPendingEvent(
+                flagKey: "multi-event-flag",
+                eventName: "Event A",
+                filters: nil,
+                pendingVariant: variant1,
+                firstTimeEventHash: "hash1"
+            )
+
+            let event2 = createPendingEvent(
+                flagKey: "multi-event-flag",
+                eventName: "Event B",
+                filters: nil,
+                pendingVariant: variant2,
+                firstTimeEventHash: "hash2"
+            )
+
+            mockMgr.flagsLock.write {
+                mockMgr.flags = ["multi-event-flag": controlVariant]
+                mockMgr.pendingFirstTimeEvents = [
+                    "multi-event-flag:hash1": event1,
+                    "multi-event-flag:hash2": event2,
+                ]
+                mockMgr.pendingFirstTimeEventNames = [event1.eventName, event2.eventName]
+            }
+
+            // Trigger first event
+            mockMgr.checkFirstTimeEvents(eventName: "Event A", properties: [:])
+
+            // Wait for first event activation using predicate
+            let firstActivated = NSPredicate { _, _ in
+                var activated = false
+                mockMgr.flagsLock.read {
+                    activated = mockMgr.activatedFirstTimeEvents.contains("multi-event-flag:hash1")
+                }
+                return activated
+            }
+            wait(for: [XCTNSPredicateExpectation(predicate: firstActivated, object: nil)], timeout: 10.0)
+
+            // Verify first event activated
+            mockMgr.flagsLock.read {
+                let flag = mockMgr.flags?["multi-event-flag"]
+                XCTAssertEqual(flag?.key, "variant1", "First event should activate")
+                XCTAssertEqual(flag?.value as? String, "first")
+                XCTAssertTrue(mockMgr.activatedFirstTimeEvents.contains("multi-event-flag:hash1"))
+            }
+
+            // Trigger second event - should overwrite the flag with the second variant
+            mockMgr.checkFirstTimeEvents(eventName: "Event B", properties: [:])
+
+            // Wait for second event activation using predicate
+            let secondActivated = NSPredicate { _, _ in
+                var activated = false
+                mockMgr.flagsLock.read {
+                    activated = mockMgr.activatedFirstTimeEvents.contains("multi-event-flag:hash2")
+                }
+                return activated
+            }
+            wait(for: [XCTNSPredicateExpectation(predicate: secondActivated, object: nil)], timeout: 10.0)
+
+            mockMgr.flagsLock.read {
+                let flag = mockMgr.flags?["multi-event-flag"]
+                XCTAssertEqual(flag?.key, "variant2", "Flag should update to second activated variant")
+                XCTAssertEqual(flag?.value as? String, "second")
+                // Both events should be marked as activated
+                XCTAssertTrue(mockMgr.activatedFirstTimeEvents.contains("multi-event-flag:hash1"))
+                XCTAssertTrue(mockMgr.activatedFirstTimeEvents.contains("multi-event-flag:hash2"))
+            }
+        }
+    }
+
+    func testRecordFirstTimeEvent_NetworkFailure() {
+        // Test that network failures are handled gracefully
+        if let mockMgr = mockManager as? MockFeatureFlagManager {
+            // Set up test to simulate network failure
+            mockMgr.simulateRecordFirstTimeEventFailure = true
+
+            let pendingVariant = MixpanelFlagVariant(key: "activated", value: true)
+            let pendingEvent = createPendingEvent(
+                flagKey: "network-fail-test",
+                eventName: "Test Event",
+                filters: nil,
+                pendingVariant: pendingVariant
+            )
+
+            mockMgr.flagsLock.write {
+                mockMgr.flags = ["network-fail-test": createControlVariant()]
+                mockMgr.pendingFirstTimeEvents = ["network-fail-test:hash123": pendingEvent]
+                mockMgr.pendingFirstTimeEventNames = [pendingEvent.eventName]
+            }
+
+            // Trigger event
+            mockMgr.checkFirstTimeEvents(eventName: "Test Event", properties: [:])
+
+            // Wait for the async activation to complete
+            let activated = NSPredicate { _, _ in
+                var done = false
+                mockMgr.flagsLock.read { done = mockMgr.activatedFirstTimeEvents.contains("network-fail-test:hash123") }
+                return done
+            }
+            wait(for: [XCTNSPredicateExpectation(predicate: activated, object: nil)], timeout: 10.0)
+
+            // Verify flag is still activated despite network failure
+            mockMgr.flagsLock.read {
+                let flag = mockMgr.flags?["network-fail-test"]
+                XCTAssertEqual(flag?.key, "activated", "Flag should be activated even if network call fails")
+                XCTAssertTrue(mockMgr.activatedFirstTimeEvents.contains("network-fail-test:hash123"))
+            }
+
+            // Verify recordFirstTimeEvent was called (even though it failed)
+            XCTAssertGreaterThan(
+                mockMgr.recordFirstTimeEventCallCount, 0,
+                "recordFirstTimeEvent should be called even when network fails")
+        }
+    }
+
+    // MARK: Helper Methods
+
+    private func createPendingEvent(
+        flagKey: String,
+        eventName: String,
+        filters: [String: Any]?,
+        pendingVariant: MixpanelFlagVariant,
+        firstTimeEventHash: String = "hash123"
+    ) -> PendingFirstTimeEvent {
+        let json: [String: Any] = [
+            "flag_key": flagKey,
+            "flag_id": "test-flag-id",
+            "project_id": 1,
+            "first_time_event_hash": firstTimeEventHash,
+            "event_name": eventName,
+            "property_filters": filters as Any,
+            "pending_variant": [
+                "variant_key": pendingVariant.key,
+                "variant_value": pendingVariant.value as Any,
+                "experiment_id": pendingVariant.experimentID as Any,
+                "is_experiment_active": pendingVariant.isExperimentActive as Any,
+                "is_qa_tester": pendingVariant.isQATester as Any,
+            ],
+        ]
+
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        return try! JSONDecoder().decode(PendingFirstTimeEvent.self, from: data)
+    }
+
+    // --- FeatureFlagOptions Tests ---
+
+    func testFeatureFlagOptions_DefaultValues() {
+        let options = FeatureFlagOptions()
+        XCTAssertFalse(options.enabled, "enabled should default to false")
+        XCTAssertTrue(options.context.isEmpty, "context should default to empty")
+        XCTAssertTrue(options.prefetchFlags, "prefetchFlags should default to true")
+    }
+
+    func testFeatureFlagOptions_CustomValues() {
+        let options = FeatureFlagOptions(
+            enabled: true,
+            context: ["key": "value"],
+            prefetchFlags: false
+        )
+        XCTAssertTrue(options.enabled)
+        XCTAssertEqual(options.context["key"] as? String, "value")
+        XCTAssertFalse(options.prefetchFlags)
+    }
+
+    func testMixpanelOptions_FeatureFlagOptionsOverridesFlat() {
+        // When featureFlagOptions is provided, it should take precedence
+        let options = MixpanelOptions(
+            token: "test",
+            featureFlagsEnabled: false,
+            featureFlagsContext: [:],
+            featureFlagOptions: FeatureFlagOptions(enabled: true, context: ["custom": "ctx"], prefetchFlags: false)
+        )
+        XCTAssertTrue(options.featureFlagsEnabled, "featureFlagsEnabled should reflect featureFlagOptions.enabled")
+        XCTAssertEqual(options.featureFlagsContext["custom"] as? String, "ctx")
+        XCTAssertTrue(options.featureFlagOptions.enabled)
+        XCTAssertFalse(options.featureFlagOptions.prefetchFlags)
+    }
+
+    func testMixpanelOptions_FlatParamsFeedIntoFeatureFlagOptions() {
+        // When featureFlagOptions is not provided, flat params populate it
+        let options = MixpanelOptions(
+            token: "test",
+            featureFlagsEnabled: true,
+            featureFlagsContext: ["flat": "value"]
+        )
+        XCTAssertTrue(options.featureFlagOptions.enabled, "featureFlagOptions.enabled should match featureFlagsEnabled")
+        XCTAssertEqual(options.featureFlagOptions.context["flat"] as? String, "value")
+        XCTAssertTrue(options.featureFlagOptions.prefetchFlags, "prefetchFlags should default to true")
+    }
+
+    func testPrefetchFlags_True_AutoLoadsFlags() {
+        // With prefetchFlags: true (default), MixpanelInstance.init should call loadFlags()
+        // Use a MockFeatureFlagManager to verify that loadFlags triggers a fetch
+        let delegate = MockFeatureFlagDelegate(
+            options: MixpanelOptions(
+                token: "test",
+                featureFlagOptions: FeatureFlagOptions(enabled: true, prefetchFlags: true)
+            )
+        )
+        let mock = MockFeatureFlagManager(
+            serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated),
+            instanceName: "test", delegate: delegate)
+        mock.simulatedFetchResult = (success: true, flags: sampleFlags)
+
+        // Call loadFlags() (which prefetchFlags: true would trigger during init)
+        mock.loadFlags()
+
+        // Wait for the fetch to complete and flags to become ready
+        let flagsReady = NSPredicate { _, _ in mock.areFlagsReady() }
+        wait(for: [XCTNSPredicateExpectation(predicate: flagsReady, object: nil)], timeout: 10.0)
+
+        XCTAssertEqual(mock.fetchRequestCount, 1, "prefetchFlags: true should auto-trigger a flag fetch")
+        XCTAssertTrue(mock.areFlagsReady(), "Flags should be ready after fetch completes")
+
+        // Keep delegate alive for the duration of the test (FeatureFlagManager holds it weakly)
+        _ = delegate
+    }
+
+    func testPrefetchFlags_False_DoesNotAutoLoadFlags() {
+        // With prefetchFlags: false, MixpanelInstance.init should NOT call loadFlags()
+        // Use a MockFeatureFlagManager to verify no fetch is triggered
+        let delegate = MockFeatureFlagDelegate(
+            options: MixpanelOptions(
+                token: "test",
+                featureFlagOptions: FeatureFlagOptions(enabled: true, prefetchFlags: false)
+            )
+        )
+        let mock = MockFeatureFlagManager(
+            serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated),
+            instanceName: "test", delegate: delegate)
+        mock.simulatedFetchResult = (success: true, flags: sampleFlags)
+
+        // Do NOT call loadFlags() - simulating prefetchFlags: false behavior
+
+        // Give a brief moment for any async dispatch to occur
+        waitBriefly(timeout: 1.0)
+
+        XCTAssertEqual(mock.fetchRequestCount, 0, "prefetchFlags: false should not trigger a flag fetch")
+        XCTAssertFalse(mock.areFlagsReady(), "No flags should be loaded")
+
+        // Keep delegate alive for the duration of the test (FeatureFlagManager holds it weakly)
+        _ = delegate
+    }
+
+    func testPrefetchFlags_False_ManualLoadStillWorks() {
+        // Even with prefetchFlags: false, calling loadFlags() manually should work
+        let delegate = MockFeatureFlagDelegate(
+            options: MixpanelOptions(
+                token: "test",
+                featureFlagOptions: FeatureFlagOptions(enabled: true, prefetchFlags: false)
+            )
+        )
+
+        let mockManager = MockFeatureFlagManager(
+            serverURL: "https://test.com", trackingQueue: DispatchQueue.global(qos: .userInitiated),
+            instanceName: "test", delegate: delegate)
+        mockManager.simulatedFetchResult = (success: true, flags: sampleFlags)
+
+        // Manually load flags (simulating what user would do after identify)
+        mockManager.loadFlags()
+
+        // Wait for flags to become ready (use predicate to handle slow CI dispatch queues)
+        let readyPredicate = NSPredicate { _, _ in mockManager.areFlagsReady() }
+        let readyExpectation = XCTNSPredicateExpectation(predicate: readyPredicate, object: nil)
+        wait(for: [readyExpectation], timeout: 10.0)
+
+        XCTAssertEqual(mockManager.fetchRequestCount, 1, "Manual loadFlags should trigger fetch")
+        XCTAssertTrue(mockManager.areFlagsReady(), "Flags should be ready after manual load")
+
+        // Keep delegate alive for the duration of the test (FeatureFlagManager holds it weakly)
+        _ = delegate
+    }
+
+    // MARK: - Reset Tests
+
+    /// Calls `reset()` and blocks until its completion fires. We use the completion (rather
+    /// than polling for `flags == nil`) because the polling approach is vacuous in tests where
+    /// `flags` was already nil before the reset — the predicate would match immediately
+    /// without observing the reset block actually running, masking real bugs.
+    private func resetAndWait(_ mockMgr: MockFeatureFlagManager, timeout: TimeInterval = 10.0) {
+        let done = expectation(description: "FeatureFlagManager.reset completes")
+        mockMgr.reset {
+            done.fulfill()
+        }
+        wait(for: [done], timeout: timeout)
+    }
+
+    func testReset_ClearsFlagsAndFetchTiming() {
+        setupReadyFlagsAndVerify()
+
+        guard let mockMgr = mockManager else {
+            XCTFail("Manager is not a MockFeatureFlagManager")
+            return
+        }
+
+        // Sanity check pre-reset state
+        mockMgr.flagsLock.read {
+            XCTAssertNotNil(mockMgr.flags, "Flags should be set before reset")
+            XCTAssertNotNil(mockMgr.timeLastFetched, "timeLastFetched should be set before reset")
+            XCTAssertNotNil(mockMgr.fetchLatencyMs, "fetchLatencyMs should be set before reset")
+        }
+
+        resetAndWait(mockMgr)
+
+        XCTAssertFalse(manager.areFlagsReady(), "Flags should not be ready after reset")
+        mockMgr.flagsLock.read {
+            XCTAssertNil(mockMgr.flags, "flags should be cleared")
+            XCTAssertNil(mockMgr.timeLastFetched, "timeLastFetched should be cleared")
+            XCTAssertNil(mockMgr.fetchLatencyMs, "fetchLatencyMs should be cleared")
+            XCTAssertFalse(mockMgr.isFetching, "isFetching should be false after reset")
+        }
+    }
+
+    func testReset_ClearsTrackedFeaturesSoTrackingFiresAgain() {
+        setupReadyFlagsAndVerify()
+
+        guard let mockMgr = mockManager else {
+            XCTFail("Manager is not a MockFeatureFlagManager")
+            return
+        }
+
+        // First read tracks the variant exactly once.
+        expectTracking(expectedCount: 1, description: "Initial tracking") {
+            _ = manager.getVariantSync("feature_string", fallback: defaultFallback)
+        }
+
+        // A second read with the same flag should NOT track again pre-reset.
+        _ = manager.getVariantSync("feature_string", fallback: defaultFallback)
+        waitBriefly()
+        XCTAssertEqual(mockDelegate.trackedEvents.count, 1, "Second read pre-reset should not re-track")
+
+        resetAndWait(mockMgr)
+
+        // Re-populate flags after the reset (mirrors a refetch under a new identity).
+        setupReadyFlags()
+
+        // After reset, reading the same flag should track again because the
+        // trackedFeatures set was cleared.
+        expectTracking(expectedCount: 1, description: "Tracking after reset") {
+            _ = manager.getVariantSync("feature_string", fallback: defaultFallback)
+        }
+    }
+
+    func testReset_ClearsFirstTimeEventState() {
+        guard let mockMgr = mockManager else {
+            XCTFail("Manager is not a MockFeatureFlagManager")
+            return
+        }
+
+        let pendingVariant = MixpanelFlagVariant(key: "activated", value: true)
+        let pendingEvent = createPendingEvent(
+            flagKey: "reset-flag",
+            eventName: "Reset Event",
+            filters: nil,
+            pendingVariant: pendingVariant
+        )
+
+        mockMgr.flagsLock.write {
+            mockMgr.flags = ["reset-flag": createControlVariant()]
+            mockMgr.pendingFirstTimeEvents = ["reset-flag:hash123": pendingEvent]
+            mockMgr.pendingFirstTimeEventNames = [pendingEvent.eventName]
+            mockMgr.activatedFirstTimeEvents.insert("reset-flag:hash123")
+        }
+
+        mockMgr.flagsLock.read {
+            XCTAssertEqual(mockMgr.pendingFirstTimeEvents.count, 1)
+            XCTAssertEqual(mockMgr.pendingFirstTimeEventNames.count, 1)
+            XCTAssertEqual(mockMgr.activatedFirstTimeEvents.count, 1)
+        }
+
+        resetAndWait(mockMgr)
+
+        mockMgr.flagsLock.read {
+            XCTAssertTrue(
+                mockMgr.pendingFirstTimeEvents.isEmpty,
+                "pendingFirstTimeEvents should be cleared by reset")
+            XCTAssertTrue(
+                mockMgr.pendingFirstTimeEventNames.isEmpty,
+                "pendingFirstTimeEventNames should be cleared by reset")
+            XCTAssertTrue(
+                mockMgr.activatedFirstTimeEvents.isEmpty,
+                "activatedFirstTimeEvents should be cleared by reset")
+        }
+    }
+
+    func testReset_PreservesContextSetViaSetContext() {
+        guard let mockMgr = mockManager else {
+            XCTFail("Manager is not a MockFeatureFlagManager")
+            return
+        }
+
+        // Default options carry an empty context.
+        mockMgr.flagsLock.read {
+            XCTAssertTrue(mockMgr.flagContext.isEmpty, "Initial flagContext should be empty")
+        }
+
+        let customContext: [String: Any] = [
+            "user_id": "ctx-user",
+            "group_id": "ctx-group",
+        ]
+
+        let setContextExpectation = XCTestExpectation(description: "setContext completes")
+        mockMgr.setContext(customContext) {
+            setContextExpectation.fulfill()
+        }
+        wait(for: [setContextExpectation], timeout: 5.0)
+
+        mockMgr.flagsLock.read {
+            XCTAssertEqual(mockMgr.flagContext["user_id"] as? String, "ctx-user")
+            XCTAssertEqual(mockMgr.flagContext["group_id"] as? String, "ctx-group")
+        }
+
+        resetAndWait(mockMgr)
+
+        // setContext-supplied context should survive reset() — only identity-tied
+        // state (flags, tracking, first-time events, fetch timing) is cleared.
+        mockMgr.flagsLock.read {
+            XCTAssertEqual(
+                mockMgr.flagContext["user_id"] as? String, "ctx-user",
+                "setContext value should survive reset()")
+            XCTAssertEqual(
+                mockMgr.flagContext["group_id"] as? String, "ctx-group",
+                "setContext value should survive reset()")
+        }
+    }
 
 }  // End Test Class

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelGroupTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelGroupTests.swift
@@ -13,140 +13,140 @@ import XCTest
 
 class MixpanelGroupTests: MixpanelBaseTests {
 
-  func testGroupSet() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    let p: Properties = ["p1": "a"]
-    testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let msg = groupQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(msg["$group_key"] as! String, groupKey)
-    XCTAssertEqual(msg["$group_id"] as! String, groupID)
-    let q = msg["$set"] as! InternalProperties
-    XCTAssertEqual(q["p1"] as? String, "a", "custom group property not queued")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testGroupSetIntegerID() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = 3
-    let p: Properties = ["p1": "a"]
-    testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let msg = groupQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(msg["$group_key"] as! String, groupKey)
-    XCTAssertEqual(msg["$group_id"] as! Int, groupID)
-    let q = msg["$set"] as! InternalProperties
-    XCTAssertEqual(q["p1"] as? String, "a", "custom group property not queued")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testGroupSetOnce() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    let p: Properties = ["p1": "a"]
-    testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).setOnce(properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let msg = groupQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(msg["$group_key"] as! String, groupKey)
-    XCTAssertEqual(msg["$group_id"] as! String, groupID)
-    let q = msg["$set_once"] as! InternalProperties
-    XCTAssertEqual(q["p1"] as? String, "a", "custom group property not queued")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testGroupSetTo() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(property: "p1", to: "a")
-    waitForTrackingQueue(testMixpanel)
-    let msg = groupQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(msg["$group_key"] as! String, groupKey)
-    XCTAssertEqual(msg["$group_id"] as! String, groupID)
-    let p = msg["$set"] as! InternalProperties
-    XCTAssertEqual(p["p1"] as? String, "a", "custom group property not queued")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testGroupUnset() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).unset(property: "p1")
-    waitForTrackingQueue(testMixpanel)
-    let msg = groupQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(msg["$group_key"] as! String, groupKey)
-    XCTAssertEqual(msg["$group_id"] as! String, groupID)
-    XCTAssertEqual(msg["$unset"] as! [String], ["p1"], "group property unset not queued")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testGroupRemove() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).remove(key: "p1", value: "a")
-    waitForTrackingQueue(testMixpanel)
-    let msg = groupQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(msg["$group_key"] as! String, groupKey)
-    XCTAssertEqual(msg["$group_id"] as! String, groupID)
-    XCTAssertEqual(
-      msg["$remove"] as? [String: String], ["p1": "a"], "group property remove not queued")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testGroupUnion() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).union(key: "p1", values: ["a"])
-    waitForTrackingQueue(testMixpanel)
-    let msg = groupQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(msg["$group_key"] as! String, groupKey)
-    XCTAssertEqual(msg["$group_id"] as! String, groupID)
-    XCTAssertEqual(
-      msg["$union"] as? [String: [String]], ["p1": ["a"]], "group property union not queued")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testGroupAssertPropertyTypes() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    let p: Properties = ["URL": [Data()]]
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(properties: p)
+    func testGroupSet() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        let p: Properties = ["p1": "a"]
+        testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let msg = groupQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(msg["$group_key"] as! String, groupKey)
+        XCTAssertEqual(msg["$group_id"] as! String, groupID)
+        let q = msg["$set"] as! InternalProperties
+        XCTAssertEqual(q["p1"] as? String, "a", "custom group property not queued")
+        removeDBfile(testMixpanel.apiToken)
     }
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(property: "p1", to: [Data()])
-    }
-    removeDBfile(testMixpanel.apiToken)
-  }
 
-  func testDeleteGroup() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    let groupKey = "test_key"
-    let groupID = "test_id"
-    testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).deleteGroup()
-    waitForTrackingQueue(testMixpanel)
-    let msg = groupQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual(msg["$group_key"] as! String, groupKey)
-    XCTAssertEqual(msg["$group_id"] as! String, groupID)
-    let p: InternalProperties = msg["$delete"] as! InternalProperties
-    XCTAssertTrue(p.isEmpty, "incorrect group properties: \(p)")
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testGroupSetIntegerID() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = 3
+        let p: Properties = ["p1": "a"]
+        testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let msg = groupQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(msg["$group_key"] as! String, groupKey)
+        XCTAssertEqual(msg["$group_id"] as! Int, groupID)
+        let q = msg["$set"] as! InternalProperties
+        XCTAssertEqual(q["p1"] as? String, "a", "custom group property not queued")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testGroupSetOnce() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        let p: Properties = ["p1": "a"]
+        testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).setOnce(properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let msg = groupQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(msg["$group_key"] as! String, groupKey)
+        XCTAssertEqual(msg["$group_id"] as! String, groupID)
+        let q = msg["$set_once"] as! InternalProperties
+        XCTAssertEqual(q["p1"] as? String, "a", "custom group property not queued")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testGroupSetTo() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(property: "p1", to: "a")
+        waitForTrackingQueue(testMixpanel)
+        let msg = groupQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(msg["$group_key"] as! String, groupKey)
+        XCTAssertEqual(msg["$group_id"] as! String, groupID)
+        let p = msg["$set"] as! InternalProperties
+        XCTAssertEqual(p["p1"] as? String, "a", "custom group property not queued")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testGroupUnset() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).unset(property: "p1")
+        waitForTrackingQueue(testMixpanel)
+        let msg = groupQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(msg["$group_key"] as! String, groupKey)
+        XCTAssertEqual(msg["$group_id"] as! String, groupID)
+        XCTAssertEqual(msg["$unset"] as! [String], ["p1"], "group property unset not queued")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testGroupRemove() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).remove(key: "p1", value: "a")
+        waitForTrackingQueue(testMixpanel)
+        let msg = groupQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(msg["$group_key"] as! String, groupKey)
+        XCTAssertEqual(msg["$group_id"] as! String, groupID)
+        XCTAssertEqual(
+            msg["$remove"] as? [String: String], ["p1": "a"], "group property remove not queued")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testGroupUnion() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).union(key: "p1", values: ["a"])
+        waitForTrackingQueue(testMixpanel)
+        let msg = groupQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(msg["$group_key"] as! String, groupKey)
+        XCTAssertEqual(msg["$group_id"] as! String, groupID)
+        XCTAssertEqual(
+            msg["$union"] as? [String: [String]], ["p1": ["a"]], "group property union not queued")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testGroupAssertPropertyTypes() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        let p: Properties = ["URL": [Data()]]
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(properties: p)
+        }
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).set(property: "p1", to: [Data()])
+        }
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testDeleteGroup() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        let groupKey = "test_key"
+        let groupID = "test_id"
+        testMixpanel.getGroup(groupKey: groupKey, groupID: groupID).deleteGroup()
+        waitForTrackingQueue(testMixpanel)
+        let msg = groupQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual(msg["$group_key"] as! String, groupKey)
+        XCTAssertEqual(msg["$group_id"] as! String, groupID)
+        let p: InternalProperties = msg["$delete"] as! InternalProperties
+        XCTAssertTrue(p.isEmpty, "incorrect group properties: \(p)")
+        removeDBfile(testMixpanel.apiToken)
+    }
 }

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelOptOutTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelOptOutTests.swift
@@ -12,328 +12,328 @@ import XCTest
 
 class MixpanelOptOutTests: MixpanelBaseTests {
 
-  func testHasOptOutTrackingFlagBeingSetProperlyAfterInitializedWithOptedOutYES() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      testMixpanel.hasOptedOutTracking(),
-      "When initialize with opted out flag set to YES, the current user should have opted out tracking"
-    )
-    testMixpanel.reset()
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testOptInWillAddOptInEvent() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: false, optOutTrackingByDefault: true)
-    testMixpanel.optInTracking()
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertFalse(
-      testMixpanel.hasOptedOutTracking(), "The current user should have opted in tracking")
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 1,
-      "When opted in, event queue should have one even(opt in) being queued")
-
-    if eventQueue(token: testMixpanel.apiToken).count > 0 {
-      let event = eventQueue(token: testMixpanel.apiToken).first
-      XCTAssertEqual(
-        (event!["event"] as? String), "$opt_in",
-        "When opted in, a track '$opt_in' should have been queued")
-    } else {
-      XCTAssertTrue(
-        eventQueue(token: testMixpanel.apiToken).count == 1,
-        "When opted in, event queue should have one even(opt in) being queued")
-    }
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testOptInTrackingForDistinctId() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: false, optOutTrackingByDefault: true)
-    testMixpanel.optInTracking(distinctId: "testDistinctId")
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertFalse(
-      testMixpanel.hasOptedOutTracking(), "The current user should have opted in tracking")
-    waitForTrackingQueue(testMixpanel)
-    let event1 = eventQueue(token: testMixpanel.apiToken).first
-    let event2 = eventQueue(token: testMixpanel.apiToken).last
-    XCTAssertTrue(
-      (event1!["event"] as? String) == "$opt_in" || (event2!["event"] as? String) == "$opt_in",
-      "When opted in, a track '$opt_in' should have been queued")
-    XCTAssertEqual(
-      testMixpanel.distinctId, "testDistinctId", "mixpanel identify failed to set distinct id")
-    XCTAssertEqual(
-      testMixpanel.people.distinctId, "testDistinctId",
-      "mixpanel identify failed to set people distinct id")
-    XCTAssertTrue(
-      unIdentifiedPeopleQueue(token: testMixpanel.apiToken).count == 0,
-      "identify: should move records from unidentified queue")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testOptInTrackingForDistinctIdAndWithEventProperties() {
-    let now = Date()
-    let testProperties: Properties = [
-      "string": "yello",
-      "number": 3,
-      "date": now,
-      "$app_version": "override",
-    ]
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
-    testMixpanel.optInTracking(distinctId: "testDistinctId", properties: testProperties)
-    waitForTrackingQueue(testMixpanel)
-    waitForTrackingQueue(testMixpanel)
-    let eventQueueValue = eventQueue(token: testMixpanel.apiToken)
-    let props = eventQueueValue[0]["properties"] as? InternalProperties
-    XCTAssertEqual(props!["string"] as? String, "yello")
-    XCTAssertEqual(props!["number"] as? NSNumber, 3)
-    compareDate(dateString: props!["date"] as! String, dateDate: now)
-    XCTAssertEqual(
-      props!["$app_version"] as? String, "override", "reserved property override failed")
-
-    if eventQueueValue.count > 0 {
-      let event = eventQueueValue[0]
-      XCTAssertEqual(
-        (event["event"] as? String), "$opt_in",
-        "When opted in, a track '$opt_in' should have been queued")
-    } else {
-      XCTAssertTrue(
-        eventQueueValue.count == 1,
-        "When opted in, event queue should have one even(opt in) being queued")
+    func testHasOptOutTrackingFlagBeingSetProperlyAfterInitializedWithOptedOutYES() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            testMixpanel.hasOptedOutTracking(),
+            "When initialize with opted out flag set to YES, the current user should have opted out tracking"
+        )
+        testMixpanel.reset()
+        removeDBfile(testMixpanel.apiToken)
     }
 
-    XCTAssertEqual(
-      testMixpanel.distinctId, "testDistinctId", "mixpanel identify failed to set distinct id")
-    XCTAssertEqual(
-      testMixpanel.people.distinctId, "testDistinctId",
-      "mixpanel identify failed to set people distinct id")
-    XCTAssertTrue(
-      unIdentifiedPeopleQueue(token: testMixpanel.apiToken).count == 0,
-      "identify: should move records from unidentified queue")
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testOptInWillAddOptInEvent() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: false, optOutTrackingByDefault: true)
+        testMixpanel.optInTracking()
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertFalse(
+            testMixpanel.hasOptedOutTracking(), "The current user should have opted in tracking")
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 1,
+            "When opted in, event queue should have one even(opt in) being queued")
 
-  func testHasOptOutTrackingFlagBeingSetProperlyForMultipleInstances() {
-    let mixpanel1 = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
-    waitForTrackingQueue(mixpanel1)
-    XCTAssertTrue(
-      mixpanel1.hasOptedOutTracking(),
-      "When initialize with opted out flag set to YES, the current user should have opted out tracking"
-    )
-    removeDBfile(mixpanel1.apiToken)
-
-    let mixpanel2 = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: false)
-    XCTAssertFalse(
-      mixpanel2.hasOptedOutTracking(),
-      "When initialize with opted out flag set to NO, the current user should have opted in tracking"
-    )
-    removeDBfile(mixpanel2.apiToken)
-  }
-
-  func testHasOptOutTrackingFlagBeingSetProperlyAfterInitializedWithOptedOutNO() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: false)
-    XCTAssertFalse(
-      testMixpanel.hasOptedOutTracking(),
-      "When initialize with opted out flag set to NO, the current user should have opted out tracking"
-    )
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testHasOptOutTrackingFlagBeingSetProperlyByDefault() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: true)
-    XCTAssertFalse(
-      testMixpanel.hasOptedOutTracking(),
-      "By default, the current user should not opted out tracking")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testHasOptOutTrackingFlagBeingSetProperlyForOptOut() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
-    testMixpanel.optOutTracking()
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      testMixpanel.hasOptedOutTracking(),
-      "When optOutTracking is called, the current user should have opted out tracking")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testHasOptOutTrackingFlagBeingSetProperlyForOptIn() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
-    testMixpanel.optOutTracking()
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      testMixpanel.hasOptedOutTracking(),
-      "When optOutTracking is called, the current user should have opted out tracking")
-    testMixpanel.optInTracking()
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertFalse(
-      testMixpanel.hasOptedOutTracking(),
-      "When optOutTracking is called, the current user should have opted in tracking")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testOptOutTrackingWillNotGenerateEventQueue() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: false, optOutTrackingByDefault: true)
-    testMixpanel.optOutTracking()
-    waitForTrackingQueue(testMixpanel)
-    for i in 0..<50 {
-      testMixpanel.track(event: "event \(i)")
+        if eventQueue(token: testMixpanel.apiToken).count > 0 {
+            let event = eventQueue(token: testMixpanel.apiToken).first
+            XCTAssertEqual(
+                (event!["event"] as? String), "$opt_in",
+                "When opted in, a track '$opt_in' should have been queued")
+        } else {
+            XCTAssertTrue(
+                eventQueue(token: testMixpanel.apiToken).count == 1,
+                "When opted in, event queue should have one even(opt in) being queued")
+        }
+        removeDBfile(testMixpanel.apiToken)
     }
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 0,
-      "When opted out, events should not be queued")
-    removeDBfile(testMixpanel.apiToken)
-  }
 
-  func testOptOutTrackingWillNotGeneratePeopleQueue() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
-    testMixpanel.optOutTracking()
-    for i in 0..<50 {
-      testMixpanel.people.set(property: "p1", to: "\(i)")
+    func testOptInTrackingForDistinctId() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: false, optOutTrackingByDefault: true)
+        testMixpanel.optInTracking(distinctId: "testDistinctId")
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertFalse(
+            testMixpanel.hasOptedOutTracking(), "The current user should have opted in tracking")
+        waitForTrackingQueue(testMixpanel)
+        let event1 = eventQueue(token: testMixpanel.apiToken).first
+        let event2 = eventQueue(token: testMixpanel.apiToken).last
+        XCTAssertTrue(
+            (event1!["event"] as? String) == "$opt_in" || (event2!["event"] as? String) == "$opt_in",
+            "When opted in, a track '$opt_in' should have been queued")
+        XCTAssertEqual(
+            testMixpanel.distinctId, "testDistinctId", "mixpanel identify failed to set distinct id")
+        XCTAssertEqual(
+            testMixpanel.people.distinctId, "testDistinctId",
+            "mixpanel identify failed to set people distinct id")
+        XCTAssertTrue(
+            unIdentifiedPeopleQueue(token: testMixpanel.apiToken).count == 0,
+            "identify: should move records from unidentified queue")
+        removeDBfile(testMixpanel.apiToken)
     }
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel.apiToken).count == 0,
-      "When opted out, events should not be queued")
-    removeDBfile(testMixpanel.apiToken)
-  }
 
-  func testOptOutTrackingWillSkipAlias() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
-    testMixpanel.optOutTracking()
-    testMixpanel.createAlias("testAlias", distinctId: "aDistinctId")
-    XCTAssertNotEqual(testMixpanel.alias, "testAlias", "When opted out, alias should not be set")
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testOptInTrackingForDistinctIdAndWithEventProperties() {
+        let now = Date()
+        let testProperties: Properties = [
+            "string": "yello",
+            "number": 3,
+            "date": now,
+            "$app_version": "override",
+        ]
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
+        testMixpanel.optInTracking(distinctId: "testDistinctId", properties: testProperties)
+        waitForTrackingQueue(testMixpanel)
+        waitForTrackingQueue(testMixpanel)
+        let eventQueueValue = eventQueue(token: testMixpanel.apiToken)
+        let props = eventQueueValue[0]["properties"] as? InternalProperties
+        XCTAssertEqual(props!["string"] as? String, "yello")
+        XCTAssertEqual(props!["number"] as? NSNumber, 3)
+        compareDate(dateString: props!["date"] as! String, dateDate: now)
+        XCTAssertEqual(
+            props!["$app_version"] as? String, "override", "reserved property override failed")
 
-  func testEventBeingTrackedBeforeOptOutShouldNotBeCleared() {
-    let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: true)
-    waitForAsyncTasks()
-    testMixpanel.track(event: "a normal event")
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).count == 2, "events should be queued")
-    testMixpanel.optOutTracking()
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 2,
-      "When opted out, any events tracked before opted out should not be cleared")
-    removeDBfile(testMixpanel.apiToken)
-  }
+        if eventQueueValue.count > 0 {
+            let event = eventQueueValue[0]
+            XCTAssertEqual(
+                (event["event"] as? String), "$opt_in",
+                "When opted in, a track '$opt_in' should have been queued")
+        } else {
+            XCTAssertTrue(
+                eventQueueValue.count == 1,
+                "When opted in, event queue should have one even(opt in) being queued")
+        }
 
-  func testOptOutTrackingRegisterSuperProperties() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
-    let properties: Properties = ["p1": "a", "p2": 3, "p3": Date()]
-    testMixpanel.optOutTracking()
-    testMixpanel.registerSuperProperties(properties)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertNotEqual(
-      NSDictionary(dictionary: testMixpanel.currentSuperProperties()),
-      NSDictionary(dictionary: properties),
-      "When opted out, register super properties should not be successful")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testOptOutTrackingRegisterSuperPropertiesOnce() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
-    let properties: Properties = ["p1": "a", "p2": 3, "p3": Date()]
-    testMixpanel.optOutTracking()
-    testMixpanel.registerSuperPropertiesOnce(properties)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertNotEqual(
-      NSDictionary(dictionary: testMixpanel.currentSuperProperties()),
-      NSDictionary(dictionary: properties),
-      "When opted out, register super properties once should not be successful")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testOptOutWilSkipTimeEvent() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: false, optOutTrackingByDefault: true)
-    testMixpanel.optOutTracking()
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.time(event: "400 Meters")
-    testMixpanel.track(event: "400 Meters")
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertNil(
-      eventQueue(token: testMixpanel.apiToken).last,
-      "When opted out, this event should not be timed.")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testOptOutWillSkipFlushPeople() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: false, flushInterval: 0,
-      optOutTrackingByDefault: true)
-    testMixpanel.optInTracking()
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.identify(distinctId: "d1")
-    waitForTrackingQueue(testMixpanel)
-    for i in 0..<1 {
-      testMixpanel.people.set(property: "p1", to: "\(i)")
+        XCTAssertEqual(
+            testMixpanel.distinctId, "testDistinctId", "mixpanel identify failed to set distinct id")
+        XCTAssertEqual(
+            testMixpanel.people.distinctId, "testDistinctId",
+            "mixpanel identify failed to set people distinct id")
+        XCTAssertTrue(
+            unIdentifiedPeopleQueue(token: testMixpanel.apiToken).count == 0,
+            "identify: should move records from unidentified queue")
+        removeDBfile(testMixpanel.apiToken)
     }
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel.apiToken).count == 1,
-      "When opted in, people queue should have been queued")
 
-    testMixpanel.optOutTracking()
-    waitForTrackingQueue(testMixpanel)
+    func testHasOptOutTrackingFlagBeingSetProperlyForMultipleInstances() {
+        let mixpanel1 = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
+        waitForTrackingQueue(mixpanel1)
+        XCTAssertTrue(
+            mixpanel1.hasOptedOutTracking(),
+            "When initialize with opted out flag set to YES, the current user should have opted out tracking"
+        )
+        removeDBfile(mixpanel1.apiToken)
 
-    testMixpanel.flush()
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      peopleQueue(token: testMixpanel.apiToken).count == 1,
-      "When opted out, people queue should not be flushed")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testOptOutByDefaultTrueSkipsFirstAppOpen() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 0,
-      "When opted out, first app open should not be tracked")
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testOptOutWillSkipFlushEvent() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.optInTracking()
-    testMixpanel.identify(distinctId: "d1")
-    waitForTrackingQueue(testMixpanel)
-    for i in 0..<1 {
-      testMixpanel.track(event: "event \(i)")
+        let mixpanel2 = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: false)
+        XCTAssertFalse(
+            mixpanel2.hasOptedOutTracking(),
+            "When initialize with opted out flag set to NO, the current user should have opted in tracking"
+        )
+        removeDBfile(mixpanel2.apiToken)
     }
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 2,
-      "When opted in, events should have been queued")
 
-    testMixpanel.optOutTracking()
-    waitForTrackingQueue(testMixpanel)
+    func testHasOptOutTrackingFlagBeingSetProperlyAfterInitializedWithOptedOutNO() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: false)
+        XCTAssertFalse(
+            testMixpanel.hasOptedOutTracking(),
+            "When initialize with opted out flag set to NO, the current user should have opted out tracking"
+        )
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-    testMixpanel.flush()
-    waitForTrackingQueue(testMixpanel)
+    func testHasOptOutTrackingFlagBeingSetProperlyByDefault() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: true)
+        XCTAssertFalse(
+            testMixpanel.hasOptedOutTracking(),
+            "By default, the current user should not opted out tracking")
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-    XCTAssertTrue(
-      eventQueue(token: testMixpanel.apiToken).count == 2,
-      "When opted out, events should not be flushed")
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testHasOptOutTrackingFlagBeingSetProperlyForOptOut() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
+        testMixpanel.optOutTracking()
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            testMixpanel.hasOptedOutTracking(),
+            "When optOutTracking is called, the current user should have opted out tracking")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testHasOptOutTrackingFlagBeingSetProperlyForOptIn() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
+        testMixpanel.optOutTracking()
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            testMixpanel.hasOptedOutTracking(),
+            "When optOutTracking is called, the current user should have opted out tracking")
+        testMixpanel.optInTracking()
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertFalse(
+            testMixpanel.hasOptedOutTracking(),
+            "When optOutTracking is called, the current user should have opted in tracking")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testOptOutTrackingWillNotGenerateEventQueue() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: false, optOutTrackingByDefault: true)
+        testMixpanel.optOutTracking()
+        waitForTrackingQueue(testMixpanel)
+        for i in 0..<50 {
+            testMixpanel.track(event: "event \(i)")
+        }
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 0,
+            "When opted out, events should not be queued")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testOptOutTrackingWillNotGeneratePeopleQueue() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
+        testMixpanel.optOutTracking()
+        for i in 0..<50 {
+            testMixpanel.people.set(property: "p1", to: "\(i)")
+        }
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel.apiToken).count == 0,
+            "When opted out, events should not be queued")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testOptOutTrackingWillSkipAlias() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
+        testMixpanel.optOutTracking()
+        testMixpanel.createAlias("testAlias", distinctId: "aDistinctId")
+        XCTAssertNotEqual(testMixpanel.alias, "testAlias", "When opted out, alias should not be set")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testEventBeingTrackedBeforeOptOutShouldNotBeCleared() {
+        let testMixpanel = Mixpanel.initialize(token: randomId(), trackAutomaticEvents: true)
+        waitForAsyncTasks()
+        testMixpanel.track(event: "a normal event")
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(eventQueue(token: testMixpanel.apiToken).count == 2, "events should be queued")
+        testMixpanel.optOutTracking()
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 2,
+            "When opted out, any events tracked before opted out should not be cleared")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testOptOutTrackingRegisterSuperProperties() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
+        let properties: Properties = ["p1": "a", "p2": 3, "p3": Date()]
+        testMixpanel.optOutTracking()
+        testMixpanel.registerSuperProperties(properties)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertNotEqual(
+            NSDictionary(dictionary: testMixpanel.currentSuperProperties()),
+            NSDictionary(dictionary: properties),
+            "When opted out, register super properties should not be successful")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testOptOutTrackingRegisterSuperPropertiesOnce() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
+        let properties: Properties = ["p1": "a", "p2": 3, "p3": Date()]
+        testMixpanel.optOutTracking()
+        testMixpanel.registerSuperPropertiesOnce(properties)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertNotEqual(
+            NSDictionary(dictionary: testMixpanel.currentSuperProperties()),
+            NSDictionary(dictionary: properties),
+            "When opted out, register super properties once should not be successful")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testOptOutWilSkipTimeEvent() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: false, optOutTrackingByDefault: true)
+        testMixpanel.optOutTracking()
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.time(event: "400 Meters")
+        testMixpanel.track(event: "400 Meters")
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertNil(
+            eventQueue(token: testMixpanel.apiToken).last,
+            "When opted out, this event should not be timed.")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testOptOutWillSkipFlushPeople() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: false, flushInterval: 0,
+            optOutTrackingByDefault: true)
+        testMixpanel.optInTracking()
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.identify(distinctId: "d1")
+        waitForTrackingQueue(testMixpanel)
+        for i in 0..<1 {
+            testMixpanel.people.set(property: "p1", to: "\(i)")
+        }
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel.apiToken).count == 1,
+            "When opted in, people queue should have been queued")
+
+        testMixpanel.optOutTracking()
+        waitForTrackingQueue(testMixpanel)
+
+        testMixpanel.flush()
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            peopleQueue(token: testMixpanel.apiToken).count == 1,
+            "When opted out, people queue should not be flushed")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testOptOutByDefaultTrueSkipsFirstAppOpen() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 0,
+            "When opted out, first app open should not be tracked")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testOptOutWillSkipFlushEvent() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.optInTracking()
+        testMixpanel.identify(distinctId: "d1")
+        waitForTrackingQueue(testMixpanel)
+        for i in 0..<1 {
+            testMixpanel.track(event: "event \(i)")
+        }
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 2,
+            "When opted in, events should have been queued")
+
+        testMixpanel.optOutTracking()
+        waitForTrackingQueue(testMixpanel)
+
+        testMixpanel.flush()
+        waitForTrackingQueue(testMixpanel)
+
+        XCTAssertTrue(
+            eventQueue(token: testMixpanel.apiToken).count == 2,
+            "When opted out, events should not be flushed")
+        removeDBfile(testMixpanel.apiToken)
+    }
 }

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelPeopleTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelPeopleTests.swift
@@ -13,231 +13,231 @@ import XCTest
 
 class MixpanelPeopleTests: MixpanelBaseTests {
 
-  func testPeopleSet() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    waitForTrackingQueue(testMixpanel)
-    let p: Properties = ["p1": "a"]
-    testMixpanel.people.set(properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let q = peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
-    XCTAssertEqual(q["p1"] as? String, "a", "custom people property not queued")
-    assertDefaultPeopleProperties(q)
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testPeopleSetOnce() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    let p: Properties = ["p1": "a"]
-    testMixpanel.people.setOnce(properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let q = peopleQueue(token: testMixpanel.apiToken).last!["$set_once"] as! InternalProperties
-    XCTAssertEqual(q["p1"] as? String, "a", "custom people property not queued")
-    assertDefaultPeopleProperties(q)
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testPeopleSetReservedProperty() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    let p: Properties = ["$ios_app_version": "override"]
-    testMixpanel.people.set(properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let q = peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
-    XCTAssertEqual(
-      q["$ios_app_version"] as? String,
-      "override",
-      "reserved property override failed")
-    assertDefaultPeopleProperties(q)
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testPeopleSetTo() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.people.set(property: "p1", to: "a")
-    waitForTrackingQueue(testMixpanel)
-    let p: InternalProperties =
-      peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
-    XCTAssertEqual(p["p1"] as? String, "a", "custom people property not queued")
-    assertDefaultPeopleProperties(p)
-    removeDBfile(testMixpanel.apiToken)
-  }
-
-  func testDropUnidentifiedPeopleRecords() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    waitForAsyncTasks()
-    for i in 0..<505 {
-      testMixpanel.people.set(property: "i", to: i)
+    func testPeopleSet() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        waitForTrackingQueue(testMixpanel)
+        let p: Properties = ["p1": "a"]
+        testMixpanel.people.set(properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let q = peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
+        XCTAssertEqual(q["p1"] as? String, "a", "custom people property not queued")
+        assertDefaultPeopleProperties(q)
+        removeDBfile(testMixpanel.apiToken)
     }
-    waitForTrackingQueue(testMixpanel)
-    XCTAssertTrue(unIdentifiedPeopleQueue(token: testMixpanel.apiToken).count == 506)
-    var r: InternalProperties = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)[1]
-    XCTAssertEqual((r["$set"] as? InternalProperties)?["i"] as? Int, 0)
-    r = unIdentifiedPeopleQueue(token: testMixpanel.apiToken).last!
-    XCTAssertEqual((r["$set"] as? InternalProperties)?["i"] as? Int, 504)
-    removeDBfile(testMixpanel.apiToken)
-  }
 
-  func testPeopleAssertPropertyTypes() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    var p: Properties = ["URL": [Data()]]
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.people.set(properties: p)
+    func testPeopleSetOnce() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        let p: Properties = ["p1": "a"]
+        testMixpanel.people.setOnce(properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let q = peopleQueue(token: testMixpanel.apiToken).last!["$set_once"] as! InternalProperties
+        XCTAssertEqual(q["p1"] as? String, "a", "custom people property not queued")
+        assertDefaultPeopleProperties(q)
+        removeDBfile(testMixpanel.apiToken)
     }
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.people.set(property: "p1", to: [Data()])
+
+    func testPeopleSetReservedProperty() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        let p: Properties = ["$ios_app_version": "override"]
+        testMixpanel.people.set(properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let q = peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
+        XCTAssertEqual(
+            q["$ios_app_version"] as? String,
+            "override",
+            "reserved property override failed")
+        assertDefaultPeopleProperties(q)
+        removeDBfile(testMixpanel.apiToken)
     }
-    p = ["p1": "a"]
-    // increment should require a number
-    XCTExpectAssert("unsupported property type was allowed") {
-      testMixpanel.people.increment(properties: p)
+
+    func testPeopleSetTo() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.people.set(property: "p1", to: "a")
+        waitForTrackingQueue(testMixpanel)
+        let p: InternalProperties =
+            peopleQueue(token: testMixpanel.apiToken).last!["$set"] as! InternalProperties
+        XCTAssertEqual(p["p1"] as? String, "a", "custom people property not queued")
+        assertDefaultPeopleProperties(p)
+        removeDBfile(testMixpanel.apiToken)
     }
-    removeDBfile(testMixpanel.apiToken)
-  }
 
-  func testPeopleIncrement() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    let p: Properties = ["p1": 3]
-    testMixpanel.people.increment(properties: p)
-    waitForTrackingQueue(testMixpanel)
-    let q = peopleQueue(token: testMixpanel.apiToken).last!["$add"] as! InternalProperties
-    XCTAssertTrue(q.count == 1, "incorrect people properties: \(p)")
-    XCTAssertEqual(q["p1"] as? Int, 3, "custom people property not queued")
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testDropUnidentifiedPeopleRecords() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        waitForAsyncTasks()
+        for i in 0..<505 {
+            testMixpanel.people.set(property: "i", to: i)
+        }
+        waitForTrackingQueue(testMixpanel)
+        XCTAssertTrue(unIdentifiedPeopleQueue(token: testMixpanel.apiToken).count == 506)
+        var r: InternalProperties = unIdentifiedPeopleQueue(token: testMixpanel.apiToken)[1]
+        XCTAssertEqual((r["$set"] as? InternalProperties)?["i"] as? Int, 0)
+        r = unIdentifiedPeopleQueue(token: testMixpanel.apiToken).last!
+        XCTAssertEqual((r["$set"] as? InternalProperties)?["i"] as? Int, 504)
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-  func testPeopleIncrementBy() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.people.increment(property: "p1", by: 3)
-    waitForTrackingQueue(testMixpanel)
-    let p: InternalProperties =
-      peopleQueue(token: testMixpanel.apiToken).last!["$add"] as! InternalProperties
-    XCTAssertTrue(p.count == 1, "incorrect people properties: \(p)")
-    XCTAssertEqual(p["p1"] as? Double, 3, "custom people property not queued")
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testPeopleAssertPropertyTypes() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        var p: Properties = ["URL": [Data()]]
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.people.set(properties: p)
+        }
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.people.set(property: "p1", to: [Data()])
+        }
+        p = ["p1": "a"]
+        // increment should require a number
+        XCTExpectAssert("unsupported property type was allowed") {
+            testMixpanel.people.increment(properties: p)
+        }
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-  func testPeopleDeleteUser() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.people.deleteUser()
-    waitForTrackingQueue(testMixpanel)
-    let p: InternalProperties =
-      peopleQueue(token: testMixpanel.apiToken).last!["$delete"] as! InternalProperties
-    XCTAssertTrue(p.isEmpty, "incorrect people properties: \(p)")
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testPeopleIncrement() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        let p: Properties = ["p1": 3]
+        testMixpanel.people.increment(properties: p)
+        waitForTrackingQueue(testMixpanel)
+        let q = peopleQueue(token: testMixpanel.apiToken).last!["$add"] as! InternalProperties
+        XCTAssertTrue(q.count == 1, "incorrect people properties: \(p)")
+        XCTAssertEqual(q["p1"] as? Int, 3, "custom people property not queued")
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-  func testPeopleTrackChargeDecimal() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.people.trackCharge(amount: 25.34)
-    waitForTrackingQueue(testMixpanel)
-    let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
-    let prop =
-      ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
-      as? Double
-    let prop2 = ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?[
-      "$time"]
-    XCTAssertEqual(prop, 25.34)
-    XCTAssertNotNil(prop2)
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testPeopleIncrementBy() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.people.increment(property: "p1", by: 3)
+        waitForTrackingQueue(testMixpanel)
+        let p: InternalProperties =
+            peopleQueue(token: testMixpanel.apiToken).last!["$add"] as! InternalProperties
+        XCTAssertTrue(p.count == 1, "incorrect people properties: \(p)")
+        XCTAssertEqual(p["p1"] as? Double, 3, "custom people property not queued")
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-  func testPeopleTrackChargeZero() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    waitForTrackingQueue(testMixpanel)
-    testMixpanel.people.trackCharge(amount: 0)
-    waitForTrackingQueue(testMixpanel)
-    let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
-    let prop =
-      ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
-      as? Double
-    let prop2 = ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?[
-      "$time"]
-    XCTAssertEqual(prop, 0)
-    XCTAssertNotNil(prop2)
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testPeopleDeleteUser() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.people.deleteUser()
+        waitForTrackingQueue(testMixpanel)
+        let p: InternalProperties =
+            peopleQueue(token: testMixpanel.apiToken).last!["$delete"] as! InternalProperties
+        XCTAssertTrue(p.isEmpty, "incorrect people properties: \(p)")
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-  func testPeopleTrackChargeWithTime() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    let p: Properties = allPropertyTypes()
-    testMixpanel.people.trackCharge(amount: 25, properties: ["$time": p["date"]!])
-    waitForTrackingQueue(testMixpanel)
-    let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
-    let prop =
-      ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
-      as? Double
-    let prop2 =
-      ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$time"]
-      as? String
-    XCTAssertEqual(prop, 25)
-    compareDate(dateString: prop2!, dateDate: p["date"] as! Date)
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testPeopleTrackChargeDecimal() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.people.trackCharge(amount: 25.34)
+        waitForTrackingQueue(testMixpanel)
+        let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
+        let prop =
+            ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
+            as? Double
+        let prop2 = ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?[
+            "$time"]
+        XCTAssertEqual(prop, 25.34)
+        XCTAssertNotNil(prop2)
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-  func testPeopleTrackChargeWithProperties() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.people.trackCharge(amount: 25, properties: ["p1": "a"])
-    waitForTrackingQueue(testMixpanel)
-    let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
-    let prop =
-      ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
-      as? Double
-    let prop2 = ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?[
-      "p1"]
-    XCTAssertEqual(prop, 25)
-    XCTAssertEqual(prop2 as? String, "a")
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testPeopleTrackChargeZero() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        waitForTrackingQueue(testMixpanel)
+        testMixpanel.people.trackCharge(amount: 0)
+        waitForTrackingQueue(testMixpanel)
+        let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
+        let prop =
+            ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
+            as? Double
+        let prop2 = ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?[
+            "$time"]
+        XCTAssertEqual(prop, 0)
+        XCTAssertNotNil(prop2)
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-  func testPeopleTrackCharge() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.people.trackCharge(amount: 25)
-    waitForTrackingQueue(testMixpanel)
-    let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
-    let prop =
-      ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
-      as? Double
-    let prop2 = ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?[
-      "$time"]
-    XCTAssertEqual(prop, 25)
-    XCTAssertNotNil(prop2)
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testPeopleTrackChargeWithTime() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        let p: Properties = allPropertyTypes()
+        testMixpanel.people.trackCharge(amount: 25, properties: ["$time": p["date"]!])
+        waitForTrackingQueue(testMixpanel)
+        let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
+        let prop =
+            ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
+            as? Double
+        let prop2 =
+            ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$time"]
+            as? String
+        XCTAssertEqual(prop, 25)
+        compareDate(dateString: prop2!, dateDate: p["date"] as! Date)
+        removeDBfile(testMixpanel.apiToken)
+    }
 
-  func testPeopleClearCharges() {
-    let testMixpanel = Mixpanel.initialize(
-      token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
-    testMixpanel.identify(distinctId: "d1")
-    testMixpanel.people.clearCharges()
-    waitForTrackingQueue(testMixpanel)
-    let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
-    let transactions = (r["$set"] as? InternalProperties)?["$transactions"] as? [MixpanelType]
-    XCTAssertEqual(transactions?.count, 0)
-    removeDBfile(testMixpanel.apiToken)
-  }
+    func testPeopleTrackChargeWithProperties() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.people.trackCharge(amount: 25, properties: ["p1": "a"])
+        waitForTrackingQueue(testMixpanel)
+        let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
+        let prop =
+            ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
+            as? Double
+        let prop2 = ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?[
+            "p1"]
+        XCTAssertEqual(prop, 25)
+        XCTAssertEqual(prop2 as? String, "a")
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testPeopleTrackCharge() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.people.trackCharge(amount: 25)
+        waitForTrackingQueue(testMixpanel)
+        let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
+        let prop =
+            ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?["$amount"]
+            as? Double
+        let prop2 = ((r["$append"] as? InternalProperties)?["$transactions"] as? InternalProperties)?[
+            "$time"]
+        XCTAssertEqual(prop, 25)
+        XCTAssertNotNil(prop2)
+        removeDBfile(testMixpanel.apiToken)
+    }
+
+    func testPeopleClearCharges() {
+        let testMixpanel = Mixpanel.initialize(
+            token: randomId(), trackAutomaticEvents: true, flushInterval: 60)
+        testMixpanel.identify(distinctId: "d1")
+        testMixpanel.people.clearCharges()
+        waitForTrackingQueue(testMixpanel)
+        let r: InternalProperties = peopleQueue(token: testMixpanel.apiToken).last!
+        let transactions = (r["$set"] as? InternalProperties)?["$transactions"] as? [MixpanelType]
+        XCTAssertEqual(transactions?.count, 0)
+        removeDBfile(testMixpanel.apiToken)
+    }
 }

--- a/MixpanelDemo/MixpanelDemoTests/TestConstants.swift
+++ b/MixpanelDemo/MixpanelDemoTests/TestConstants.swift
@@ -14,22 +14,22 @@ let kFakeServerUrl = "https://34a272abf23d.com"
 
 extension XCTestCase {
 
-  func XCTExpectAssert(
-    _ expectedMessage: String, file: StaticString = #file, line: UInt = #line, block: () -> Void
-  ) {
-    let exp = expectation(description: expectedMessage)
+    func XCTExpectAssert(
+        _ expectedMessage: String, file: StaticString = #file, line: UInt = #line, block: () -> Void
+    ) {
+        let exp = expectation(description: expectedMessage)
 
-    Assertions.assertClosure = {
-      (condition, message, file, line) in
-      if !condition {
-        exp.fulfill()
-      }
+        Assertions.assertClosure = {
+            (condition, message, file, line) in
+            if !condition {
+                exp.fulfill()
+            }
+        }
+
+        // Call code.
+        block()
+        waitForExpectations(timeout: 60, handler: nil)
+        Assertions.assertClosure = Assertions.swiftAssertClosure
     }
-
-    // Call code.
-    block()
-    waitForExpectations(timeout: 60, handler: nil)
-    Assertions.assertClosure = Assertions.swiftAssertClosure
-  }
 
 }

--- a/MixpanelDemo/MixpanelDemoWatch Extension/ExtensionDelegate.swift
+++ b/MixpanelDemo/MixpanelDemoWatch Extension/ExtensionDelegate.swift
@@ -11,53 +11,53 @@ import WatchKit
 
 class ExtensionDelegate: NSObject, WKExtensionDelegate {
 
-  func applicationDidFinishLaunching() {
-    var ADD_YOUR_MIXPANEL_TOKEN_BELOW_🛠🛠🛠🛠🛠🛠: String
-    Mixpanel.initialize(token: "MIXPANEL_TOKEN")
-    Mixpanel.mainInstance().loggingEnabled = true
-    Mixpanel.mainInstance().registerSuperProperties(["super watch properties": 1])
-    // Perform any final initialization of your application.
-  }
-
-  func applicationDidBecomeActive() {
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-  }
-
-  func applicationWillResignActive() {
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, etc.
-  }
-
-  func handle(_ backgroundTasks: Set<WKRefreshBackgroundTask>) {
-    // Sent when the system needs to launch the application in the background to process tasks. Tasks arrive in a set, so loop through and process each one.
-    for task in backgroundTasks {
-      // Use a switch statement to check the task type
-      switch task {
-      case let backgroundTask as WKApplicationRefreshBackgroundTask:
-        // Be sure to complete the background task once you’re done.
-        backgroundTask.setTaskCompletedWithSnapshot(false)
-      case let snapshotTask as WKSnapshotRefreshBackgroundTask:
-        // Snapshot tasks have a unique completion call, make sure to set your expiration date
-        snapshotTask.setTaskCompleted(
-          restoredDefaultState: true, estimatedSnapshotExpiration: Date.distantFuture, userInfo: nil
-        )
-      case let connectivityTask as WKWatchConnectivityRefreshBackgroundTask:
-        // Be sure to complete the connectivity task once you’re done.
-        connectivityTask.setTaskCompletedWithSnapshot(false)
-      case let urlSessionTask as WKURLSessionRefreshBackgroundTask:
-        // Be sure to complete the URL session task once you’re done.
-        urlSessionTask.setTaskCompletedWithSnapshot(false)
-      case let relevantShortcutTask as WKRelevantShortcutRefreshBackgroundTask:
-        // Be sure to complete the relevant-shortcut task once you're done.
-        relevantShortcutTask.setTaskCompletedWithSnapshot(false)
-      case let intentDidRunTask as WKIntentDidRunRefreshBackgroundTask:
-        // Be sure to complete the intent-did-run task once you're done.
-        intentDidRunTask.setTaskCompletedWithSnapshot(false)
-      default:
-        // make sure to complete unhandled task types
-        task.setTaskCompletedWithSnapshot(false)
-      }
+    func applicationDidFinishLaunching() {
+        var ADD_YOUR_MIXPANEL_TOKEN_BELOW_🛠🛠🛠🛠🛠🛠: String
+        Mixpanel.initialize(token: "MIXPANEL_TOKEN")
+        Mixpanel.mainInstance().loggingEnabled = true
+        Mixpanel.mainInstance().registerSuperProperties(["super watch properties": 1])
+        // Perform any final initialization of your application.
     }
-  }
+
+    func applicationDidBecomeActive() {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillResignActive() {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, etc.
+    }
+
+    func handle(_ backgroundTasks: Set<WKRefreshBackgroundTask>) {
+        // Sent when the system needs to launch the application in the background to process tasks. Tasks arrive in a set, so loop through and process each one.
+        for task in backgroundTasks {
+            // Use a switch statement to check the task type
+            switch task {
+                case let backgroundTask as WKApplicationRefreshBackgroundTask:
+                    // Be sure to complete the background task once you’re done.
+                    backgroundTask.setTaskCompletedWithSnapshot(false)
+                case let snapshotTask as WKSnapshotRefreshBackgroundTask:
+                    // Snapshot tasks have a unique completion call, make sure to set your expiration date
+                    snapshotTask.setTaskCompleted(
+                        restoredDefaultState: true, estimatedSnapshotExpiration: Date.distantFuture, userInfo: nil
+                    )
+                case let connectivityTask as WKWatchConnectivityRefreshBackgroundTask:
+                    // Be sure to complete the connectivity task once you’re done.
+                    connectivityTask.setTaskCompletedWithSnapshot(false)
+                case let urlSessionTask as WKURLSessionRefreshBackgroundTask:
+                    // Be sure to complete the URL session task once you’re done.
+                    urlSessionTask.setTaskCompletedWithSnapshot(false)
+                case let relevantShortcutTask as WKRelevantShortcutRefreshBackgroundTask:
+                    // Be sure to complete the relevant-shortcut task once you're done.
+                    relevantShortcutTask.setTaskCompletedWithSnapshot(false)
+                case let intentDidRunTask as WKIntentDidRunRefreshBackgroundTask:
+                    // Be sure to complete the intent-did-run task once you're done.
+                    intentDidRunTask.setTaskCompletedWithSnapshot(false)
+                default:
+                    // make sure to complete unhandled task types
+                    task.setTaskCompletedWithSnapshot(false)
+            }
+        }
+    }
 
 }

--- a/MixpanelDemo/MixpanelDemoWatch Extension/InterfaceController.swift
+++ b/MixpanelDemo/MixpanelDemoWatch Extension/InterfaceController.swift
@@ -12,43 +12,43 @@ import WatchKit
 
 class InterfaceController: WKInterfaceController {
 
-  @IBOutlet weak var timeSomethingButton: WKInterfaceButton!
+    @IBOutlet weak var timeSomethingButton: WKInterfaceButton!
 
-  var currentlyTiming = false
+    var currentlyTiming = false
 
-  override func awake(withContext context: Any?) {
-    super.awake(withContext: context)
-  }
-
-  override func willActivate() {
-    // This method is called when watch view controller is about to be visible to user
-    super.willActivate()
-  }
-
-  @IBAction func trackButtonTapped() {
-    Mixpanel.mainInstance().track(event: "trackButtonTapped")
-  }
-
-  @IBAction func timeButtonTapped() {
-    if !currentlyTiming {
-      Mixpanel.mainInstance().time(event: "time something")
-      timeSomethingButton.setTitle("Finish Timing")
-    } else {
-      Mixpanel.mainInstance().track(event: "time something")
-      timeSomethingButton.setTitle("Time Something")
+    override func awake(withContext context: Any?) {
+        super.awake(withContext: context)
     }
-    currentlyTiming = !currentlyTiming
-  }
 
-  @IBAction func identifyButtonTapped() {
-    let watchName = WKInterfaceDevice.current().systemName
-    Mixpanel.mainInstance().people.set(properties: ["watch": watchName])
-    Mixpanel.mainInstance().identify(distinctId: Mixpanel.mainInstance().distinctId)
-  }
+    override func willActivate() {
+        // This method is called when watch view controller is about to be visible to user
+        super.willActivate()
+    }
 
-  override func didDeactivate() {
-    // This method is called when watch view controller is no longer visible
-    super.didDeactivate()
-  }
+    @IBAction func trackButtonTapped() {
+        Mixpanel.mainInstance().track(event: "trackButtonTapped")
+    }
+
+    @IBAction func timeButtonTapped() {
+        if !currentlyTiming {
+            Mixpanel.mainInstance().time(event: "time something")
+            timeSomethingButton.setTitle("Finish Timing")
+        } else {
+            Mixpanel.mainInstance().track(event: "time something")
+            timeSomethingButton.setTitle("Time Something")
+        }
+        currentlyTiming = !currentlyTiming
+    }
+
+    @IBAction func identifyButtonTapped() {
+        let watchName = WKInterfaceDevice.current().systemName
+        Mixpanel.mainInstance().people.set(properties: ["watch": watchName])
+        Mixpanel.mainInstance().identify(distinctId: Mixpanel.mainInstance().distinctId)
+    }
+
+    override func didDeactivate() {
+        // This method is called when watch view controller is no longer visible
+        super.didDeactivate()
+    }
 
 }

--- a/Package.swift
+++ b/Package.swift
@@ -3,37 +3,37 @@
 import PackageDescription
 
 let package = Package(
-  name: "Mixpanel",
-  platforms: [
-    .iOS(.v12),
-    .tvOS(.v12),
-    .macOS(.v10_13),
-    .watchOS(.v4),
-  ],
-  products: [
-    .library(name: "Mixpanel", targets: ["Mixpanel"])
-  ],
-  dependencies: [
-    .package(
-      url: "https://github.com/advantagefse/json-logic-swift",
-      from: "1.2.0"
-    ),
-    .package(
-      url: "https://github.com/mixpanel/mixpanel-swift-common.git",
-      from: "1.0.0"
-    )
-  ],
-  targets: [
-    .target(
-      name: "Mixpanel",
-      dependencies: [
-        .product(name: "MixpanelSwiftCommon", package: "mixpanel-swift-common"),
-        .product(name: "jsonlogic", package: "json-logic-swift"),
-      ],
-      path: "Sources",
-      resources: [
-        .copy("Mixpanel/PrivacyInfo.xcprivacy")
-      ]
-    )
-  ]
+    name: "Mixpanel",
+    platforms: [
+        .iOS(.v12),
+        .tvOS(.v12),
+        .macOS(.v10_13),
+        .watchOS(.v4),
+    ],
+    products: [
+        .library(name: "Mixpanel", targets: ["Mixpanel"])
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/advantagefse/json-logic-swift",
+            from: "1.2.0"
+        ),
+        .package(
+            url: "https://github.com/mixpanel/mixpanel-swift-common.git",
+            from: "1.0.0"
+        ),
+    ],
+    targets: [
+        .target(
+            name: "Mixpanel",
+            dependencies: [
+                .product(name: "MixpanelSwiftCommon", package: "mixpanel-swift-common"),
+                .product(name: "jsonlogic", package: "json-logic-swift"),
+            ],
+            path: "Sources",
+            resources: [
+                .copy("Mixpanel/PrivacyInfo.xcprivacy")
+            ]
+        )
+    ]
 )

--- a/Sources/AutomaticEvents.swift
+++ b/Sources/AutomaticEvents.swift
@@ -7,39 +7,39 @@
 //
 
 protocol AEDelegate: AnyObject {
-  func track(event: String?, properties: Properties?)
-  func setOnce(properties: Properties)
-  func increment(property: String, by: Double)
+    func track(event: String?, properties: Properties?)
+    func setOnce(properties: Properties)
+    func increment(property: String, by: Double)
 }
 
 #if os(iOS) || os(tvOS) || os(visionOS) || os(macOS)
-  import Foundation
-  import StoreKit
-  #if os(macOS)
-    import Cocoa
-  #else
-    import UIKit
-  #endif
+import Foundation
+import StoreKit
+#if os(macOS)
+import Cocoa
+#else
+import UIKit
+#endif
 
-  class AutomaticEvents: NSObject, SKPaymentTransactionObserver, SKProductsRequestDelegate {
+class AutomaticEvents: NSObject, SKPaymentTransactionObserver, SKProductsRequestDelegate {
 
     var _minimumSessionDuration: UInt64 = 10000
     var minimumSessionDuration: UInt64 {
-      get {
-        return _minimumSessionDuration
-      }
-      set {
-        _minimumSessionDuration = newValue
-      }
+        get {
+            return _minimumSessionDuration
+        }
+        set {
+            _minimumSessionDuration = newValue
+        }
     }
     var _maximumSessionDuration: UInt64 = UINT64_MAX
     var maximumSessionDuration: UInt64 {
-      get {
-        return _maximumSessionDuration
-      }
-      set {
-        _maximumSessionDuration = newValue
-      }
+        get {
+            return _maximumSessionDuration
+        }
+        set {
+            _maximumSessionDuration = newValue
+        }
     }
 
     var awaitingTransactions = [String: SKPaymentTransaction]()
@@ -50,131 +50,131 @@ protocol AEDelegate: AnyObject {
     var hasAddedObserver = false
 
     let awaitingTransactionsWriteLock = DispatchQueue(
-      label: "com.mixpanel.awaiting_transactions_writeLock", qos: .userInitiated,
-      autoreleaseFrequency: .workItem)
+        label: "com.mixpanel.awaiting_transactions_writeLock", qos: .userInitiated,
+        autoreleaseFrequency: .workItem)
 
     func initializeEvents(instanceName: String) {
-      let legacyFirstOpenKey = "MPFirstOpen"
-      let firstOpenKey = "MPFirstOpen-\(instanceName)"
-      // do not track `$ae_first_open` again if the legacy key exist,
-      // but we will start using the key with the mixpanel token in favour of multiple instances support
-      if let defaults = defaults, !defaults.bool(forKey: legacyFirstOpenKey) {
-        if !defaults.bool(forKey: firstOpenKey) {
-          defaults.set(true, forKey: firstOpenKey)
-          defaults.synchronize()
-          delegate?.track(event: "$ae_first_open", properties: ["$ae_first_app_open_date": Date()])
-          delegate?.setOnce(properties: ["$ae_first_app_open_date": Date()])
+        let legacyFirstOpenKey = "MPFirstOpen"
+        let firstOpenKey = "MPFirstOpen-\(instanceName)"
+        // do not track `$ae_first_open` again if the legacy key exist,
+        // but we will start using the key with the mixpanel token in favour of multiple instances support
+        if let defaults = defaults, !defaults.bool(forKey: legacyFirstOpenKey) {
+            if !defaults.bool(forKey: firstOpenKey) {
+                defaults.set(true, forKey: firstOpenKey)
+                defaults.synchronize()
+                delegate?.track(event: "$ae_first_open", properties: ["$ae_first_app_open_date": Date()])
+                delegate?.setOnce(properties: ["$ae_first_app_open_date": Date()])
+            }
         }
-      }
-      if let defaults = defaults, let infoDict = Bundle.main.infoDictionary {
-        let appVersionKey = "MPAppVersion"
-        let appVersionValue = infoDict["CFBundleShortVersionString"]
-        let savedVersionValue = defaults.string(forKey: appVersionKey)
-        if let appVersionValue = appVersionValue as? String,
-          let savedVersionValue = savedVersionValue,
-          appVersionValue.compare(savedVersionValue, options: .numeric, range: nil, locale: nil)
-            == .orderedDescending
-        {
-          delegate?.track(
-            event: "$ae_updated", properties: ["$ae_updated_version": appVersionValue])
-          defaults.set(appVersionValue, forKey: appVersionKey)
-          defaults.synchronize()
-        } else if savedVersionValue == nil {
-          defaults.set(appVersionValue, forKey: appVersionKey)
-          defaults.synchronize()
+        if let defaults = defaults, let infoDict = Bundle.main.infoDictionary {
+            let appVersionKey = "MPAppVersion"
+            let appVersionValue = infoDict["CFBundleShortVersionString"]
+            let savedVersionValue = defaults.string(forKey: appVersionKey)
+            if let appVersionValue = appVersionValue as? String,
+                let savedVersionValue = savedVersionValue,
+                appVersionValue.compare(savedVersionValue, options: .numeric, range: nil, locale: nil)
+                    == .orderedDescending
+            {
+                delegate?.track(
+                    event: "$ae_updated", properties: ["$ae_updated_version": appVersionValue])
+                defaults.set(appVersionValue, forKey: appVersionKey)
+                defaults.synchronize()
+            } else if savedVersionValue == nil {
+                defaults.set(appVersionValue, forKey: appVersionKey)
+                defaults.synchronize()
+            }
         }
-      }
 
-      #if os(macOS)
+        #if os(macOS)
         NotificationCenter.default.addObserver(
-          self,
-          selector: #selector(appWillResignActive(_:)),
-          name: NSApplication.willResignActiveNotification,
-          object: nil)
-
-        NotificationCenter.default.addObserver(
-          self,
-          selector: #selector(appDidBecomeActive(_:)),
-          name: NSApplication.didBecomeActiveNotification,
-          object: nil)
-      #else
-        NotificationCenter.default.addObserver(
-          self,
-          selector: #selector(appWillResignActive(_:)),
-          name: UIApplication.willResignActiveNotification,
-          object: nil)
+            self,
+            selector: #selector(appWillResignActive(_:)),
+            name: NSApplication.willResignActiveNotification,
+            object: nil)
 
         NotificationCenter.default.addObserver(
-          self,
-          selector: #selector(appDidBecomeActive(_:)),
-          name: UIApplication.didBecomeActiveNotification,
-          object: nil)
-      #endif
+            self,
+            selector: #selector(appDidBecomeActive(_:)),
+            name: NSApplication.didBecomeActiveNotification,
+            object: nil)
+        #else
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appWillResignActive(_:)),
+            name: UIApplication.willResignActiveNotification,
+            object: nil)
 
-      SKPaymentQueue.default().add(self)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidBecomeActive(_:)),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil)
+        #endif
+
+        SKPaymentQueue.default().add(self)
     }
 
     @objc func appWillResignActive(_ notification: Notification) {
-      sessionLength = roundOneDigit(num: Date().timeIntervalSince1970 - sessionStartTime)
-      if sessionLength >= Double(minimumSessionDuration / 1000)
-        && sessionLength <= Double(maximumSessionDuration / 1000)
-      {
-        delegate?.track(event: "$ae_session", properties: ["$ae_session_length": sessionLength])
-        delegate?.increment(property: "$ae_total_app_sessions", by: 1)
-        delegate?.increment(property: "$ae_total_app_session_length", by: sessionLength)
-      }
+        sessionLength = roundOneDigit(num: Date().timeIntervalSince1970 - sessionStartTime)
+        if sessionLength >= Double(minimumSessionDuration / 1000)
+            && sessionLength <= Double(maximumSessionDuration / 1000)
+        {
+            delegate?.track(event: "$ae_session", properties: ["$ae_session_length": sessionLength])
+            delegate?.increment(property: "$ae_total_app_sessions", by: 1)
+            delegate?.increment(property: "$ae_total_app_session_length", by: sessionLength)
+        }
     }
 
     @objc func appDidBecomeActive(_ notification: Notification) {
-      sessionStartTime = Date().timeIntervalSince1970
+        sessionStartTime = Date().timeIntervalSince1970
     }
 
     func paymentQueue(
-      _ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]
+        _ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]
     ) {
-      var productsRequest = SKProductsRequest()
-      var productIdentifiers: Set<String> = []
-      awaitingTransactionsWriteLock.async { [self] in
-        for transaction: AnyObject in transactions {
-          if let trans = transaction as? SKPaymentTransaction {
-            switch trans.transactionState {
-            case .purchased:
-              productIdentifiers.insert(trans.payment.productIdentifier)
-              awaitingTransactions[trans.payment.productIdentifier] = trans
-            case .failed: break
-            case .restored: break
-            default: break
+        var productsRequest = SKProductsRequest()
+        var productIdentifiers: Set<String> = []
+        awaitingTransactionsWriteLock.async { [self] in
+            for transaction: AnyObject in transactions {
+                if let trans = transaction as? SKPaymentTransaction {
+                    switch trans.transactionState {
+                        case .purchased:
+                            productIdentifiers.insert(trans.payment.productIdentifier)
+                            awaitingTransactions[trans.payment.productIdentifier] = trans
+                        case .failed: break
+                        case .restored: break
+                        default: break
+                    }
+                }
             }
-          }
+            if !productIdentifiers.isEmpty {
+                productsRequest = SKProductsRequest(productIdentifiers: productIdentifiers)
+                productsRequest.delegate = self
+                productsRequest.start()
+            }
         }
-        if !productIdentifiers.isEmpty {
-          productsRequest = SKProductsRequest(productIdentifiers: productIdentifiers)
-          productsRequest.delegate = self
-          productsRequest.start()
-        }
-      }
 
     }
 
     func roundOneDigit(num: TimeInterval) -> TimeInterval {
-      return round(num * 10.0) / 10.0
+        return round(num * 10.0) / 10.0
     }
 
     func productsRequest(_ request: SKProductsRequest, didReceive response: SKProductsResponse) {
-      awaitingTransactionsWriteLock.async { [self] in
-        for product in response.products {
-          if let trans = awaitingTransactions[product.productIdentifier] {
-            delegate?.track(
-              event: "$ae_iap",
-              properties: [
-                "$ae_iap_price": "\(product.price)",
-                "$ae_iap_quantity": trans.payment.quantity,
-                "$ae_iap_name": product.productIdentifier,
-              ])
-            awaitingTransactions.removeValue(forKey: product.productIdentifier)
-          }
+        awaitingTransactionsWriteLock.async { [self] in
+            for product in response.products {
+                if let trans = awaitingTransactions[product.productIdentifier] {
+                    delegate?.track(
+                        event: "$ae_iap",
+                        properties: [
+                            "$ae_iap_price": "\(product.price)",
+                            "$ae_iap_quantity": trans.payment.quantity,
+                            "$ae_iap_name": product.productIdentifier,
+                        ])
+                    awaitingTransactions.removeValue(forKey: product.productIdentifier)
+                }
+            }
         }
-      }
     }
-  }
+}
 #endif

--- a/Sources/AutomaticProperties.swift
+++ b/Sources/AutomaticProperties.swift
@@ -9,178 +9,178 @@
 import Foundation
 
 #if os(iOS) || os(tvOS) || os(visionOS)
-  import UIKit
+import UIKit
 #elseif os(macOS)
-  import Cocoa
+import Cocoa
 #elseif canImport(WatchKit)
-  import WatchKit
+import WatchKit
 #endif
 
 class AutomaticProperties {
-  static let automaticPropertiesLock = ReadWriteLock(label: "automaticPropertiesLock")
+    static let automaticPropertiesLock = ReadWriteLock(label: "automaticPropertiesLock")
 
-  static var properties: InternalProperties = {
-    var p = InternalProperties()
+    static var properties: InternalProperties = {
+        var p = InternalProperties()
 
-    #if os(iOS) || os(tvOS)
-      // Screen size is captured via setUIProperties() called during SDK initialization.
-      // See: https://github.com/mixpanel/mixpanel-swift/issues/522
+        #if os(iOS) || os(tvOS)
+        // Screen size is captured via setUIProperties() called during SDK initialization.
+        // See: https://github.com/mixpanel/mixpanel-swift/issues/522
 
-      #if targetEnvironment(macCatalyst)
+        #if targetEnvironment(macCatalyst)
         p["$os"] = "macOS"
         p["$os_version"] = ProcessInfo.processInfo.operatingSystemVersionString
-      #else
+        #else
         if AutomaticProperties.isiOSAppOnMac() {
-          // iOS App Running on Apple Silicon Mac
-          p["$os"] = "macOS"
-          // unfortunately, there is no API that reports the correct macOS version
-          // for "Designed for iPad" apps running on macOS, so we omit it here rather than mis-report
+            // iOS App Running on Apple Silicon Mac
+            p["$os"] = "macOS"
+            // unfortunately, there is no API that reports the correct macOS version
+            // for "Designed for iPad" apps running on macOS, so we omit it here rather than mis-report
         } else {
-          p["$os"] = UIDevice.current.systemName
-          p["$os_version"] = UIDevice.current.systemVersion
+            p["$os"] = UIDevice.current.systemName
+            p["$os_version"] = UIDevice.current.systemVersion
         }
-      #endif
-    #elseif os(macOS)
-      // Screen size is captured via setUIProperties() called during SDK initialization
-      p["$os"] = "macOS"
-      p["$os_version"] = ProcessInfo.processInfo.operatingSystemVersionString
-    #elseif os(watchOS)
-      // WatchKit APIs are thread-safe, capture screen size immediately
-      let watchDevice = WKInterfaceDevice.current()
-      p["$os"] = watchDevice.systemName
-      p["$os_version"] = watchDevice.systemVersion
-      p["$watch_model"] = AutomaticProperties.watchModel()
-      let screenSize = watchDevice.screenBounds.size
-      p["$screen_width"] = Int(screenSize.width)
-      p["$screen_height"] = Int(screenSize.height)
-    #elseif os(visionOS)
-      p["$os"] = "visionOS"
-      p["$os_version"] = UIDevice.current.systemVersion
-    #endif
-
-    let infoDict = Bundle.main.infoDictionary ?? [:]
-    p["$app_build_number"] = infoDict["CFBundleVersion"] as? String ?? "Unknown"
-    p["$app_version_string"] = infoDict["CFBundleShortVersionString"] as? String ?? "Unknown"
-
-    p["mp_lib"] = "swift"
-    p["$lib_version"] = AutomaticProperties.libVersion()
-    p["$manufacturer"] = "Apple"
-    p["$model"] = AutomaticProperties.deviceModel()
-
-    return p
-  }()
-
-  static var peopleProperties: InternalProperties = {
-    var p = InternalProperties()
-    let infoDict = Bundle.main.infoDictionary
-    if let infoDict = infoDict {
-      p["$ios_app_version"] = infoDict["CFBundleVersion"]
-      p["$ios_app_release"] = infoDict["CFBundleShortVersionString"]
-    }
-    p["$ios_device_model"] = AutomaticProperties.deviceModel()
-    #if !os(OSX) && !os(watchOS) && !os(visionOS)
-      p["$ios_version"] = UIDevice.current.systemVersion
-    #else
-      p["$ios_version"] = ProcessInfo.processInfo.operatingSystemVersionString
-    #endif
-    p["$ios_lib_version"] = AutomaticProperties.libVersion()
-    p["$swift_lib_version"] = AutomaticProperties.libVersion()
-
-    return p
-  }()
-
-  /// Captures UI-related properties (screen size) that require main thread access.
-  /// Should be called during SDK initialization.
-  ///
-  /// Thread safety:
-  /// - Dispatches to main thread asynchronously
-  static func setUIProperties() {
-    #if os(iOS) || os(tvOS) || os(macOS)
-    DispatchQueue.main.async {
-        // IMPORTANT: Capture screen size on main thread BEFORE entering write lock.
-        // The write lock executes closures on its internal queue (background thread),
-        // so we must access UIScreen/NSScreen here while still on main thread.
-        #if os(iOS) || os(tvOS)
-          let screenSize = UIScreen.main.bounds.size
-          let height = Int(screenSize.height)
-          let width = Int(screenSize.width)
+        #endif
         #elseif os(macOS)
-          let screenSize = NSScreen.main?.frame.size
-          let height = screenSize.map { Int($0.height) }
-          let width = screenSize.map { Int($0.width) }
+        // Screen size is captured via setUIProperties() called during SDK initialization
+        p["$os"] = "macOS"
+        p["$os_version"] = ProcessInfo.processInfo.operatingSystemVersionString
+        #elseif os(watchOS)
+        // WatchKit APIs are thread-safe, capture screen size immediately
+        let watchDevice = WKInterfaceDevice.current()
+        p["$os"] = watchDevice.systemName
+        p["$os_version"] = watchDevice.systemVersion
+        p["$watch_model"] = AutomaticProperties.watchModel()
+        let screenSize = watchDevice.screenBounds.size
+        p["$screen_width"] = Int(screenSize.width)
+        p["$screen_height"] = Int(screenSize.height)
+        #elseif os(visionOS)
+        p["$os"] = "visionOS"
+        p["$os_version"] = UIDevice.current.systemVersion
         #endif
 
-        // Now update properties dictionary under lock (with already-captured values)
-        automaticPropertiesLock.write {
-          #if os(iOS) || os(tvOS)
-            properties["$screen_height"] = height
-            properties["$screen_width"] = width
-          #elseif os(macOS)
-            if let height = height, let width = width {
-              properties["$screen_height"] = height
-              properties["$screen_width"] = width
+        let infoDict = Bundle.main.infoDictionary ?? [:]
+        p["$app_build_number"] = infoDict["CFBundleVersion"] as? String ?? "Unknown"
+        p["$app_version_string"] = infoDict["CFBundleShortVersionString"] as? String ?? "Unknown"
+
+        p["mp_lib"] = "swift"
+        p["$lib_version"] = AutomaticProperties.libVersion()
+        p["$manufacturer"] = "Apple"
+        p["$model"] = AutomaticProperties.deviceModel()
+
+        return p
+    }()
+
+    static var peopleProperties: InternalProperties = {
+        var p = InternalProperties()
+        let infoDict = Bundle.main.infoDictionary
+        if let infoDict = infoDict {
+            p["$ios_app_version"] = infoDict["CFBundleVersion"]
+            p["$ios_app_release"] = infoDict["CFBundleShortVersionString"]
+        }
+        p["$ios_device_model"] = AutomaticProperties.deviceModel()
+        #if !os(OSX) && !os(watchOS) && !os(visionOS)
+        p["$ios_version"] = UIDevice.current.systemVersion
+        #else
+        p["$ios_version"] = ProcessInfo.processInfo.operatingSystemVersionString
+        #endif
+        p["$ios_lib_version"] = AutomaticProperties.libVersion()
+        p["$swift_lib_version"] = AutomaticProperties.libVersion()
+
+        return p
+    }()
+
+    /// Captures UI-related properties (screen size) that require main thread access.
+    /// Should be called during SDK initialization.
+    ///
+    /// Thread safety:
+    /// - Dispatches to main thread asynchronously
+    static func setUIProperties() {
+        #if os(iOS) || os(tvOS) || os(macOS)
+        DispatchQueue.main.async {
+            // IMPORTANT: Capture screen size on main thread BEFORE entering write lock.
+            // The write lock executes closures on its internal queue (background thread),
+            // so we must access UIScreen/NSScreen here while still on main thread.
+            #if os(iOS) || os(tvOS)
+            let screenSize = UIScreen.main.bounds.size
+            let height = Int(screenSize.height)
+            let width = Int(screenSize.width)
+            #elseif os(macOS)
+            let screenSize = NSScreen.main?.frame.size
+            let height = screenSize.map { Int($0.height) }
+            let width = screenSize.map { Int($0.width) }
+            #endif
+
+            // Now update properties dictionary under lock (with already-captured values)
+            automaticPropertiesLock.write {
+                #if os(iOS) || os(tvOS)
+                properties["$screen_height"] = height
+                properties["$screen_width"] = width
+                #elseif os(macOS)
+                if let height = height, let width = width {
+                    properties["$screen_height"] = height
+                    properties["$screen_width"] = width
+                }
+                #endif
             }
-          #endif
+        }
+        #endif
+    }
+
+    class func deviceModel() -> String {
+        var modelCode: String = "Unknown"
+        if AutomaticProperties.isiOSAppOnMac() {
+            // iOS App Running on Apple Silicon Mac
+            var size = 0
+            sysctlbyname("hw.model", nil, &size, nil, 0)
+            var model = [CChar](repeating: 0, count: size)
+            sysctlbyname("hw.model", &model, &size, nil, 0)
+            modelCode = String(cString: model)
+        } else {
+            var systemInfo = utsname()
+            uname(&systemInfo)
+            let size = MemoryLayout<CChar>.size
+            modelCode = withUnsafePointer(to: &systemInfo.machine) {
+                $0.withMemoryRebound(to: CChar.self, capacity: size) {
+                    String(cString: UnsafePointer<CChar>($0))
+                }
+            }
+        }
+        return modelCode
+    }
+
+    #if os(watchOS)
+    class func watchModel() -> String {
+        let watchSize38mm = Int(136)
+        let watchSize40mm = Int(162)
+        let watchSize42mm = Int(156)
+        let watchSize44mm = Int(184)
+
+        let screenWidth = Int(WKInterfaceDevice.current().screenBounds.size.width)
+        switch screenWidth {
+            case watchSize38mm:
+                return "Apple Watch 38mm"
+            case watchSize40mm:
+                return "Apple Watch 40mm"
+            case watchSize42mm:
+                return "Apple Watch 42mm"
+            case watchSize44mm:
+                return "Apple Watch 44mm"
+            default:
+                return "Apple Watch"
         }
     }
     #endif
-  }
 
-  class func deviceModel() -> String {
-    var modelCode: String = "Unknown"
-    if AutomaticProperties.isiOSAppOnMac() {
-      // iOS App Running on Apple Silicon Mac
-      var size = 0
-      sysctlbyname("hw.model", nil, &size, nil, 0)
-      var model = [CChar](repeating: 0, count: size)
-      sysctlbyname("hw.model", &model, &size, nil, 0)
-      modelCode = String(cString: model)
-    } else {
-      var systemInfo = utsname()
-      uname(&systemInfo)
-      let size = MemoryLayout<CChar>.size
-      modelCode = withUnsafePointer(to: &systemInfo.machine) {
-        $0.withMemoryRebound(to: CChar.self, capacity: size) {
-          String(cString: UnsafePointer<CChar>($0))
+    class func isiOSAppOnMac() -> Bool {
+        var isiOSAppOnMac = false
+        if #available(iOS 14.0, macOS 11.0, watchOS 7.0, tvOS 14.0, *) {
+            isiOSAppOnMac = ProcessInfo.processInfo.isiOSAppOnMac
         }
-      }
+        return isiOSAppOnMac
     }
-    return modelCode
-  }
 
-  #if os(watchOS)
-    class func watchModel() -> String {
-      let watchSize38mm = Int(136)
-      let watchSize40mm = Int(162)
-      let watchSize42mm = Int(156)
-      let watchSize44mm = Int(184)
-
-      let screenWidth = Int(WKInterfaceDevice.current().screenBounds.size.width)
-      switch screenWidth {
-      case watchSize38mm:
-        return "Apple Watch 38mm"
-      case watchSize40mm:
-        return "Apple Watch 40mm"
-      case watchSize42mm:
-        return "Apple Watch 42mm"
-      case watchSize44mm:
-        return "Apple Watch 44mm"
-      default:
-        return "Apple Watch"
-      }
+    class func libVersion() -> String {
+        return "6.4.1"
     }
-  #endif
-
-  class func isiOSAppOnMac() -> Bool {
-    var isiOSAppOnMac = false
-    if #available(iOS 14.0, macOS 11.0, watchOS 7.0, tvOS 14.0, *) {
-      isiOSAppOnMac = ProcessInfo.processInfo.isiOSAppOnMac
-    }
-    return isiOSAppOnMac
-  }
-
-  class func libVersion() -> String {
-    return "6.4.1"
-  }
 
 }

--- a/Sources/Constants.swift
+++ b/Sources/Constants.swift
@@ -9,33 +9,33 @@
 import Foundation
 
 #if !os(OSX)
-  import UIKit
+import UIKit
 #endif  // !os(OSX)
 
 struct QueueConstants {
-  static var queueSize = 5000
+    static var queueSize = 5000
 }
 
 struct APIConstants {
-  static let maxBatchSize = 50
-  static let flushSize = 1000
-  static let minRetryBackoff = 60.0
-  static let maxRetryBackoff = 600.0
-  static let failuresTillBackoff = 2
+    static let maxBatchSize = 50
+    static let flushSize = 1000
+    static let minRetryBackoff = 60.0
+    static let maxRetryBackoff = 600.0
+    static let failuresTillBackoff = 2
 }
 
 struct BundleConstants {
-  static let ID = "com.mixpanel.Mixpanel"
+    static let ID = "com.mixpanel.Mixpanel"
 }
 
 struct GzipSettings {
-  static let gzipHeaderOffset = Int32(16)
+    static let gzipHeaderOffset = Int32(16)
 }
 
 #if !os(OSX) && !os(watchOS) && !os(visionOS)
-  extension UIDevice {
+extension UIDevice {
     var iPhoneX: Bool {
-      return UIScreen.main.nativeBounds.height == 2436
+        return UIScreen.main.nativeBounds.height == 2436
     }
-  }
+}
 #endif  // !os(OSX)

--- a/Sources/Data+Compression.swift
+++ b/Sources/Data+Compression.swift
@@ -9,97 +9,97 @@ import Foundation
 import zlib
 
 public enum GzipError: Swift.Error {
-  case stream
-  case data
-  case memory
-  case buffer
-  case version
-  case unknown(code: Int)
+    case stream
+    case data
+    case memory
+    case buffer
+    case version
+    case unknown(code: Int)
 
-  init(code: Int32) {
-    switch code {
-    case Z_STREAM_ERROR:
-      self = .stream
-    case Z_DATA_ERROR:
-      self = .data
-    case Z_MEM_ERROR:
-      self = .memory
-    case Z_BUF_ERROR:
-      self = .buffer
-    case Z_VERSION_ERROR:
-      self = .version
-    default:
-      self = .unknown(code: Int(code))
+    init(code: Int32) {
+        switch code {
+            case Z_STREAM_ERROR:
+                self = .stream
+            case Z_DATA_ERROR:
+                self = .data
+            case Z_MEM_ERROR:
+                self = .memory
+            case Z_BUF_ERROR:
+                self = .buffer
+            case Z_VERSION_ERROR:
+                self = .version
+            default:
+                self = .unknown(code: Int(code))
+        }
     }
-  }
 }
 
 extension Data {
-  /// Compresses the data using gzip compression.
-  /// Adapted from: https://github.com/1024jp/GzipSwift/blob/main/Sources/Gzip/Data%2BGzip.swift
-  /// - Parameter level: Compression level.
-  /// - Returns: The compressed data.
-  /// - Throws: `GzipError` if compression fails.
-  public func gzipCompressed(level: Int32 = Z_DEFAULT_COMPRESSION) throws -> Data {
-    guard !self.isEmpty else {
-      MixpanelLogger.warn(message: "Empty Data object cannot be compressed.")
-      return Data()
+    /// Compresses the data using gzip compression.
+    /// Adapted from: https://github.com/1024jp/GzipSwift/blob/main/Sources/Gzip/Data%2BGzip.swift
+    /// - Parameter level: Compression level.
+    /// - Returns: The compressed data.
+    /// - Throws: `GzipError` if compression fails.
+    public func gzipCompressed(level: Int32 = Z_DEFAULT_COMPRESSION) throws -> Data {
+        guard !self.isEmpty else {
+            MixpanelLogger.warn(message: "Empty Data object cannot be compressed.")
+            return Data()
+        }
+
+        let originalSize = self.count
+
+        var stream = z_stream()
+        stream.next_in = UnsafeMutablePointer<Bytef>(
+            mutating: (self as NSData).bytes.bindMemory(to: Bytef.self, capacity: self.count))
+        stream.avail_in = uint(self.count)
+
+        let windowBits = MAX_WBITS + GzipSettings.gzipHeaderOffset  // Use gzip header instead of zlib header
+        let memLevel = MAX_MEM_LEVEL
+        let strategy = Z_DEFAULT_STRATEGY
+
+        var status = deflateInit2_(
+            &stream, level, Z_DEFLATED, windowBits, memLevel, strategy, ZLIB_VERSION,
+            Int32(MemoryLayout<z_stream>.size))
+        guard status == Z_OK else {
+            throw GzipError(code: status)
+        }
+
+        var compressedData = Data(count: self.count / 2)
+        repeat {
+            if Int(stream.total_out) >= compressedData.count {
+                compressedData.count += self.count / 2
+            }
+            let bufferPointer = compressedData.withUnsafeMutableBytes {
+                $0.baseAddress?.assumingMemoryBound(to: Bytef.self)
+            }
+            guard let bufferPointer = bufferPointer else {
+                throw GzipError(code: Z_BUF_ERROR)
+            }
+            stream.next_out = bufferPointer.advanced(by: Int(stream.total_out))
+            stream.avail_out = uint(compressedData.count) - uint(stream.total_out)
+
+            status = deflate(&stream, Z_FINISH)
+        } while stream.avail_out == 0 && status == Z_OK
+
+        guard status == Z_STREAM_END else {
+            throw GzipError(code: status)
+        }
+
+        deflateEnd(&stream)
+        compressedData.count = Int(stream.total_out)
+
+        let compressedSize = compressedData.count
+        let compressionRatio = Double(compressedSize) / Double(originalSize)
+        let compressionPercentage = (1 - compressionRatio) * 100
+
+        let roundedCompressionRatio = floor(compressionRatio * 1000) / 1000
+        let roundedCompressionPercentage = floor(compressionPercentage * 1000) / 1000
+
+        MixpanelLogger.info(
+            message:
+                "Payload gzipped: original size = \(originalSize) bytes, compressed size = \(compressedSize) bytes, compression ratio = \(roundedCompressionRatio), compression percentage = \(roundedCompressionPercentage)%"
+        )
+
+        return compressedData
     }
-
-    let originalSize = self.count
-
-    var stream = z_stream()
-    stream.next_in = UnsafeMutablePointer<Bytef>(
-      mutating: (self as NSData).bytes.bindMemory(to: Bytef.self, capacity: self.count))
-    stream.avail_in = uint(self.count)
-
-    let windowBits = MAX_WBITS + GzipSettings.gzipHeaderOffset  // Use gzip header instead of zlib header
-    let memLevel = MAX_MEM_LEVEL
-    let strategy = Z_DEFAULT_STRATEGY
-
-    var status = deflateInit2_(
-      &stream, level, Z_DEFLATED, windowBits, memLevel, strategy, ZLIB_VERSION,
-      Int32(MemoryLayout<z_stream>.size))
-    guard status == Z_OK else {
-      throw GzipError(code: status)
-    }
-
-    var compressedData = Data(count: self.count / 2)
-    repeat {
-      if Int(stream.total_out) >= compressedData.count {
-        compressedData.count += self.count / 2
-      }
-      let bufferPointer = compressedData.withUnsafeMutableBytes {
-        $0.baseAddress?.assumingMemoryBound(to: Bytef.self)
-      }
-      guard let bufferPointer = bufferPointer else {
-        throw GzipError(code: Z_BUF_ERROR)
-      }
-      stream.next_out = bufferPointer.advanced(by: Int(stream.total_out))
-      stream.avail_out = uint(compressedData.count) - uint(stream.total_out)
-
-      status = deflate(&stream, Z_FINISH)
-    } while stream.avail_out == 0 && status == Z_OK
-
-    guard status == Z_STREAM_END else {
-      throw GzipError(code: status)
-    }
-
-    deflateEnd(&stream)
-    compressedData.count = Int(stream.total_out)
-
-    let compressedSize = compressedData.count
-    let compressionRatio = Double(compressedSize) / Double(originalSize)
-    let compressionPercentage = (1 - compressionRatio) * 100
-
-    let roundedCompressionRatio = floor(compressionRatio * 1000) / 1000
-    let roundedCompressionPercentage = floor(compressionPercentage * 1000) / 1000
-
-    MixpanelLogger.info(
-      message:
-        "Payload gzipped: original size = \(originalSize) bytes, compressed size = \(compressedSize) bytes, compression ratio = \(roundedCompressionRatio), compression percentage = \(roundedCompressionPercentage)%"
-    )
-
-    return compressedData
-  }
 }

--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -9,36 +9,36 @@
 import Foundation
 
 enum PropertyError: Error {
-  case invalidType(type: Any)
+    case invalidType(type: Any)
 }
 
 class Assertions {
-  static var assertClosure = swiftAssertClosure
-  static let swiftAssertClosure = { Swift.assert($0, $1, file: $2, line: $3) }
+    static var assertClosure = swiftAssertClosure
+    static let swiftAssertClosure = { Swift.assert($0, $1, file: $2, line: $3) }
 }
 
 func MPAssert(
-  _ condition: @autoclosure () -> Bool,
-  _ message: @autoclosure () -> String = "",
-  file: StaticString = #file,
-  line: UInt = #line
+    _ condition: @autoclosure () -> Bool,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #file,
+    line: UInt = #line
 ) {
-  Assertions.assertClosure(condition(), message(), file, line)
+    Assertions.assertClosure(condition(), message(), file, line)
 }
 
 class ErrorHandler {
-  class func wrap<ReturnType>(_ f: () throws -> ReturnType?) -> ReturnType? {
-    do {
-      return try f()
-    } catch let error {
-      logError(error)
-      return nil
+    class func wrap<ReturnType>(_ f: () throws -> ReturnType?) -> ReturnType? {
+        do {
+            return try f()
+        } catch let error {
+            logError(error)
+            return nil
+        }
     }
-  }
 
-  class func logError(_ error: Error) {
-    let stackSymbols = Thread.callStackSymbols
-    MixpanelLogger.error(message: "Error: \(error) \n Stack Symbols: \(stackSymbols)")
-  }
+    class func logError(_ error: Error) {
+        let stackSymbols = Thread.callStackSymbols
+        MixpanelLogger.error(message: "Error: \(error) \n Stack Symbols: \(stackSymbols)")
+    }
 
 }

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -6,130 +6,133 @@ import jsonlogic
 // Wrapper to help decode 'Any' types within Codable structures
 // (Keep AnyCodable as defined previously, it holds the necessary decoding logic)
 struct AnyCodable: Decodable {
-  let value: Any?
+    let value: Any?
 
-  init(from decoder: Decoder) throws {
-    let container = try decoder.singleValueContainer()
-    if let intValue = try? container.decode(Int.self) {
-      value = intValue
-    } else if let doubleValue = try? container.decode(Double.self) {
-      value = doubleValue
-    } else if let stringValue = try? container.decode(String.self) {
-      value = stringValue
-    } else if let boolValue = try? container.decode(Bool.self) {
-      value = boolValue
-    } else if let arrayValue = try? container.decode([AnyCodable].self) {
-      value = arrayValue.map { $0.value }
-    } else if let dictValue = try? container.decode([String: AnyCodable].self) {
-      value = dictValue.mapValues { $0.value }
-    } else if container.decodeNil() {
-      value = nil
-    } else {
-      let context = DecodingError.Context(
-        codingPath: decoder.codingPath, debugDescription: "Unsupported type in AnyCodable.")
-      throw DecodingError.dataCorrupted(context)
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let intValue = try? container.decode(Int.self) {
+            value = intValue
+        } else if let doubleValue = try? container.decode(Double.self) {
+            value = doubleValue
+        } else if let stringValue = try? container.decode(String.self) {
+            value = stringValue
+        } else if let boolValue = try? container.decode(Bool.self) {
+            value = boolValue
+        } else if let arrayValue = try? container.decode([AnyCodable].self) {
+            value = arrayValue.map { $0.value }
+        } else if let dictValue = try? container.decode([String: AnyCodable].self) {
+            value = dictValue.mapValues { $0.value }
+        } else if container.decodeNil() {
+            value = nil
+        } else {
+            let context = DecodingError.Context(
+                codingPath: decoder.codingPath, debugDescription: "Unsupported type in AnyCodable.")
+            throw DecodingError.dataCorrupted(context)
+        }
     }
-  }
 }
 
 // Represents the variant associated with a feature flag
 public struct MixpanelFlagVariant: Decodable {
-  public let key: String  // Corresponds to 'variant_key' from API
-  public let value: Any?  // Corresponds to 'variant_value' from API
-  public let experimentID: String? // Corresponds to 'experiment_id' from API
-  public let isExperimentActive: Bool? // Corresponds to 'is_experiment_active' from API
-  public let isQATester: Bool? // Corresponds to 'is_qa_tester' from API
+    public let key: String  // Corresponds to 'variant_key' from API
+    public let value: Any?  // Corresponds to 'variant_value' from API
+    public let experimentID: String?  // Corresponds to 'experiment_id' from API
+    public let isExperimentActive: Bool?  // Corresponds to 'is_experiment_active' from API
+    public let isQATester: Bool?  // Corresponds to 'is_qa_tester' from API
 
-  /// Where this variant was sourced from. Always non-nil — every `MixpanelFlagVariant`
-  /// carries a definite source. `.fallback` for developer-supplied fallback instances;
-  /// `.network` or `.persistence(persistedAt:)` when the SDK serves a variant. For
-  /// persisted variants, the timestamp lives on the `.persistence` case so invalid
-  /// combinations like "network with a timestamp" are unrepresentable.
-  public let source: Source
+    /// Where this variant was sourced from. Always non-nil — every `MixpanelFlagVariant`
+    /// carries a definite source. `.fallback` for developer-supplied fallback instances;
+    /// `.network` or `.persistence(persistedAt:)` when the SDK serves a variant. For
+    /// persisted variants, the timestamp lives on the `.persistence` case so invalid
+    /// combinations like "network with a timestamp" are unrepresentable.
+    public let source: Source
 
-  /// Identifies where a served variant came from.
-  public enum Source {
-    /// Variant assigned by the most recent successful `/flags/` network call.
-    case network
-    /// Variant loaded from the on-disk persistence layer. `persistedAt` is the time the
-    /// variant set was originally written to disk.
-    case persistence(persistedAt: Date)
-    /// Developer-supplied fallback returned because the SDK had no value to serve (flag
-    /// not in the loaded set, flags never loaded, fetch failed under NetworkFirst, etc.).
-    case fallback
-  }
-
-  enum CodingKeys: String, CodingKey {
-    case key = "variant_key"
-    case value = "variant_value"
-    case experimentID = "experiment_id"
-    case isExperimentActive = "is_experiment_active"
-    case isQATester = "is_qa_tester"
-  }
-
-  public init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    key = try container.decode(String.self, forKey: .key)
-
-    // Directly decode the 'variant_value' using AnyCodable.
-    // If the key is missing, it throws.
-    // If the value is null, AnyCodable handles it.
-    // If the value is an unsupported type, AnyCodable throws.
-    let anyCodableValue = try container.decode(AnyCodable.self, forKey: .value)
-    value = anyCodableValue.value  // Extract the underlying Any? value
-
-    // Decode optional fields for tracking
-    experimentID = try container.decodeIfPresent(String.self, forKey: .experimentID)
-    isExperimentActive = try container.decodeIfPresent(Bool.self, forKey: .isExperimentActive)
-    isQATester = try container.decodeIfPresent(Bool.self, forKey: .isQATester)
-    // Decoded variants are immediately re-stamped via `withSource` before being placed in
-    // `flags`, so the customer never observes `.fallback` here. Defaulting to `.fallback`
-    // keeps `source` non-optional without needing a sentinel "unstamped" case.
-    source = .fallback
-  }
-
-  // Helper initializer with fallbacks, value defaults to key if nil
-  public init(key: String = "", value: Any? = nil, isExperimentActive: Bool? = nil, isQATester: Bool? = nil, experimentID: String? = nil) {
-    self.key = key
-    if let value = value {
-      self.value = value
-    } else {
-      self.value = key
+    /// Identifies where a served variant came from.
+    public enum Source {
+        /// Variant assigned by the most recent successful `/flags/` network call.
+        case network
+        /// Variant loaded from the on-disk persistence layer. `persistedAt` is the time the
+        /// variant set was originally written to disk.
+        case persistence(persistedAt: Date)
+        /// Developer-supplied fallback returned because the SDK had no value to serve (flag
+        /// not in the loaded set, flags never loaded, fetch failed under NetworkFirst, etc.).
+        case fallback
     }
-    self.experimentID = experimentID
-    self.isExperimentActive = isExperimentActive
-    self.isQATester = isQATester
-    self.source = .fallback
-  }
 
-  /// Internal initializer used when stamping a served variant with its origin.
-  internal init(
-    key: String,
-    value: Any?,
-    experimentID: String?,
-    isExperimentActive: Bool?,
-    isQATester: Bool?,
-    source: Source
-  ) {
-    self.key = key
-    self.value = value
-    self.experimentID = experimentID
-    self.isExperimentActive = isExperimentActive
-    self.isQATester = isQATester
-    self.source = source
-  }
+    enum CodingKeys: String, CodingKey {
+        case key = "variant_key"
+        case value = "variant_value"
+        case experimentID = "experiment_id"
+        case isExperimentActive = "is_experiment_active"
+        case isQATester = "is_qa_tester"
+    }
 
-  /// Returns a copy of this variant stamped with the given source. Other fields are preserved.
-  internal func withSource(_ source: Source) -> MixpanelFlagVariant {
-    return MixpanelFlagVariant(
-      key: self.key,
-      value: self.value,
-      experimentID: self.experimentID,
-      isExperimentActive: self.isExperimentActive,
-      isQATester: self.isQATester,
-      source: source
-    )
-  }
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        key = try container.decode(String.self, forKey: .key)
+
+        // Directly decode the 'variant_value' using AnyCodable.
+        // If the key is missing, it throws.
+        // If the value is null, AnyCodable handles it.
+        // If the value is an unsupported type, AnyCodable throws.
+        let anyCodableValue = try container.decode(AnyCodable.self, forKey: .value)
+        value = anyCodableValue.value  // Extract the underlying Any? value
+
+        // Decode optional fields for tracking
+        experimentID = try container.decodeIfPresent(String.self, forKey: .experimentID)
+        isExperimentActive = try container.decodeIfPresent(Bool.self, forKey: .isExperimentActive)
+        isQATester = try container.decodeIfPresent(Bool.self, forKey: .isQATester)
+        // Decoded variants are immediately re-stamped via `withSource` before being placed in
+        // `flags`, so the customer never observes `.fallback` here. Defaulting to `.fallback`
+        // keeps `source` non-optional without needing a sentinel "unstamped" case.
+        source = .fallback
+    }
+
+    // Helper initializer with fallbacks, value defaults to key if nil
+    public init(
+        key: String = "", value: Any? = nil, isExperimentActive: Bool? = nil, isQATester: Bool? = nil,
+        experimentID: String? = nil
+    ) {
+        self.key = key
+        if let value = value {
+            self.value = value
+        } else {
+            self.value = key
+        }
+        self.experimentID = experimentID
+        self.isExperimentActive = isExperimentActive
+        self.isQATester = isQATester
+        self.source = .fallback
+    }
+
+    /// Internal initializer used when stamping a served variant with its origin.
+    internal init(
+        key: String,
+        value: Any?,
+        experimentID: String?,
+        isExperimentActive: Bool?,
+        isQATester: Bool?,
+        source: Source
+    ) {
+        self.key = key
+        self.value = value
+        self.experimentID = experimentID
+        self.isExperimentActive = isExperimentActive
+        self.isQATester = isQATester
+        self.source = source
+    }
+
+    /// Returns a copy of this variant stamped with the given source. Other fields are preserved.
+    internal func withSource(_ source: Source) -> MixpanelFlagVariant {
+        return MixpanelFlagVariant(
+            key: self.key,
+            value: self.value,
+            experimentID: self.experimentID,
+            isExperimentActive: self.isExperimentActive,
+            isQATester: self.isQATester,
+            source: source
+        )
+    }
 }
 
 // MARK: - PendingFirstTimeEvent
@@ -182,293 +185,293 @@ struct PendingFirstTimeEvent: Decodable {
 
 // Response structure for the /flags endpoint
 struct FlagsResponse: Decodable {
-  let flags: [String: MixpanelFlagVariant]?  // Dictionary where key is flag name
-  let pendingFirstTimeEvents: [PendingFirstTimeEvent]?  // Array of pending first-time event definitions
+    let flags: [String: MixpanelFlagVariant]?  // Dictionary where key is flag name
+    let pendingFirstTimeEvents: [PendingFirstTimeEvent]?  // Array of pending first-time event definitions
 
-  enum CodingKeys: String, CodingKey {
-    case flags
-    case pendingFirstTimeEvents = "pending_first_time_events"
-  }
+    enum CodingKeys: String, CodingKey {
+        case flags
+        case pendingFirstTimeEvents = "pending_first_time_events"
+    }
 }
 
 // --- FeatureFlagDelegate Protocol ---
 public protocol MixpanelFlagDelegate: AnyObject {
-  func getOptions() -> MixpanelOptions
-  func getDistinctId() -> String
-  func getAnonymousId() -> String?
-  func track(event: String?, properties: Properties?)
+    func getOptions() -> MixpanelOptions
+    func getDistinctId() -> String
+    func getAnonymousId() -> String?
+    func track(event: String?, properties: Properties?)
 }
 
 /// A protocol defining the public interface for a feature flagging system.
 public protocol MixpanelFlags {
 
-  /// The delegate responsible for handling feature flag lifecycle events,
-  /// such as tracking. It is declared `weak` to prevent retain cycles.
-  var delegate: MixpanelFlagDelegate? { get set }
+    /// The delegate responsible for handling feature flag lifecycle events,
+    /// such as tracking. It is declared `weak` to prevent retain cycles.
+    var delegate: MixpanelFlagDelegate? { get set }
 
-  // --- Public Methods ---
+    // --- Public Methods ---
 
-  /// Initiates the loading or refreshing of flags
-  func loadFlags()
+    /// Initiates the loading or refreshing of flags
+    func loadFlags()
 
-  /// Initiates the loading or refreshing of flags with a completion callback.
-  /// The completion handler is called with `true` on success and `false` on failure.
-  func loadFlags(completion: ((Bool) -> Void)?)
+    /// Initiates the loading or refreshing of flags with a completion callback.
+    /// The completion handler is called with `true` on success and `false` on failure.
+    func loadFlags(completion: ((Bool) -> Void)?)
 
-  /// Synchronously checks if flag variants are in memory and available for synchronous access.
-  ///
-  /// - Note: When a persisting `variantLookupPolicy` is configured (`.persistenceUntilNetworkSuccess` or
-  ///   `.networkFirst`), this can return `true` before the SDK has spoken to the network this
-  ///   session — the returned variants may be stale data from a previous session. Use the
-  ///   `source` field on the served `MixpanelFlagVariant` to distinguish: `.network` for
-  ///   fresh values, `.persistence(persistedAt:)` for on-disk persisted values (with the
-  ///   persistence timestamp).
-  ///
-  /// - Returns: `true` if flag variants are available in memory (from network or persistence),
-  ///            `false` otherwise.
-  func areFlagsReady() -> Bool
+    /// Synchronously checks if flag variants are in memory and available for synchronous access.
+    ///
+    /// - Note: When a persisting `variantLookupPolicy` is configured (`.persistenceUntilNetworkSuccess` or
+    ///   `.networkFirst`), this can return `true` before the SDK has spoken to the network this
+    ///   session — the returned variants may be stale data from a previous session. Use the
+    ///   `source` field on the served `MixpanelFlagVariant` to distinguish: `.network` for
+    ///   fresh values, `.persistence(persistedAt:)` for on-disk persisted values (with the
+    ///   persistence timestamp).
+    ///
+    /// - Returns: `true` if flag variants are available in memory (from network or persistence),
+    ///            `false` otherwise.
+    func areFlagsReady() -> Bool
 
-  // --- Sync Flag Retrieval ---
+    // --- Sync Flag Retrieval ---
 
-  /// Synchronously retrieves the complete `MixpanelFlagVariant` for a given flag name.
-  /// If the feature flag is found and flags are ready, its variant is returned.
-  /// Otherwise, the provided `fallback` `MixpanelFlagVariant` is returned.
-  /// This method will also trigger any necessary tracking logic for the accessed flag.
-  ///
-  /// - Important: This method may block the calling thread until the value can be retrieved.
-  ///   It is NOT recommended to call this from the main UI thread.
-  ///   If flags are not ready (`areFlagsReady()` is false), this method returns the `fallback`
-  ///   value, but it may still block while waiting for queued tracking or activation work to complete.
-  ///   If called immediately after track(), variants may not be activated yet due to a
-  ///   race condition as track is executed asynchronously. Use `getVariant` instead.
-  ///
-  /// - Parameters:
-  ///   - flagName: The unique identifier for the feature flag.
-  ///   - fallback: The `MixpanelFlagVariant` to return if the specified flag is not found
-  ///               or if the flags are not yet loaded.
-  /// - Returns: The `MixpanelFlagVariant` associated with `flagName`, or the `fallback` variant.
-  func getVariantSync(_ flagName: String, fallback: MixpanelFlagVariant) -> MixpanelFlagVariant
+    /// Synchronously retrieves the complete `MixpanelFlagVariant` for a given flag name.
+    /// If the feature flag is found and flags are ready, its variant is returned.
+    /// Otherwise, the provided `fallback` `MixpanelFlagVariant` is returned.
+    /// This method will also trigger any necessary tracking logic for the accessed flag.
+    ///
+    /// - Important: This method may block the calling thread until the value can be retrieved.
+    ///   It is NOT recommended to call this from the main UI thread.
+    ///   If flags are not ready (`areFlagsReady()` is false), this method returns the `fallback`
+    ///   value, but it may still block while waiting for queued tracking or activation work to complete.
+    ///   If called immediately after track(), variants may not be activated yet due to a
+    ///   race condition as track is executed asynchronously. Use `getVariant` instead.
+    ///
+    /// - Parameters:
+    ///   - flagName: The unique identifier for the feature flag.
+    ///   - fallback: The `MixpanelFlagVariant` to return if the specified flag is not found
+    ///               or if the flags are not yet loaded.
+    /// - Returns: The `MixpanelFlagVariant` associated with `flagName`, or the `fallback` variant.
+    func getVariantSync(_ flagName: String, fallback: MixpanelFlagVariant) -> MixpanelFlagVariant
 
-  /// Asynchronously retrieves the complete `MixpanelFlagVariant` for a given flag name.
-  /// If flags are not ready, an attempt will be made to load them.
-  /// The `completion` handler is called with the `MixpanelFlagVariant` for the flag,
-  /// or the `fallback` variant if the flag is not found or loading fails.
-  /// This method will also trigger any necessary tracking logic for the accessed flag.
-  /// The completion handler is typically invoked on the main thread.
-  ///
-  /// - Parameters:
-  ///   - flagName: The unique identifier for the feature flag.
-  ///   - fallback: The `MixpanelFlagVariant` to use as a default if the specified flag
-  ///               is not found or an error occurs during fetching.
-  ///   - completion: A closure that is called with the resulting `MixpanelFlagVariant`.
-  ///                 This closure will be executed on the main dispatch queue.
-  func getVariant(
-    _ flagName: String, fallback: MixpanelFlagVariant,
-    completion: @escaping (MixpanelFlagVariant) -> Void)
+    /// Asynchronously retrieves the complete `MixpanelFlagVariant` for a given flag name.
+    /// If flags are not ready, an attempt will be made to load them.
+    /// The `completion` handler is called with the `MixpanelFlagVariant` for the flag,
+    /// or the `fallback` variant if the flag is not found or loading fails.
+    /// This method will also trigger any necessary tracking logic for the accessed flag.
+    /// The completion handler is typically invoked on the main thread.
+    ///
+    /// - Parameters:
+    ///   - flagName: The unique identifier for the feature flag.
+    ///   - fallback: The `MixpanelFlagVariant` to use as a default if the specified flag
+    ///               is not found or an error occurs during fetching.
+    ///   - completion: A closure that is called with the resulting `MixpanelFlagVariant`.
+    ///                 This closure will be executed on the main dispatch queue.
+    func getVariant(
+        _ flagName: String, fallback: MixpanelFlagVariant,
+        completion: @escaping (MixpanelFlagVariant) -> Void)
 
-  /// Synchronously retrieves the underlying value of a feature flag.
-  /// This is a convenience method that extracts the `value` property from the `MixpanelFlagVariant`
-  /// obtained via `getVariantSync`.
-  ///
-  /// - Important: This method may block the calling thread until the value can be retrieved.
-  ///   It is NOT recommended to call this from the main UI thread.
-  ///   If flags are not ready (`areFlagsReady()` is false), this method returns the `fallbackValue`,
-  ///   but it may still block while waiting for queued tracking or activation work to complete.
-  ///   If called immediately after track(), variants may not be activated yet due to a
-  ///   race condition as track is executed asynchronously. Use `getVariantValue` instead.
-  ///
-  /// - Parameters:
-  ///   - flagName: The unique identifier for the feature flag.
-  ///   - fallbackValue: The default value to return if the flag is not found,
-  ///                    its variant doesn't contain a value, or flags are not ready.
-  /// - Returns: The value of the feature flag, or `fallbackValue`. The type is `Any?`.
-  func getVariantValueSync(_ flagName: String, fallbackValue: Any?) -> Any?
+    /// Synchronously retrieves the underlying value of a feature flag.
+    /// This is a convenience method that extracts the `value` property from the `MixpanelFlagVariant`
+    /// obtained via `getVariantSync`.
+    ///
+    /// - Important: This method may block the calling thread until the value can be retrieved.
+    ///   It is NOT recommended to call this from the main UI thread.
+    ///   If flags are not ready (`areFlagsReady()` is false), this method returns the `fallbackValue`,
+    ///   but it may still block while waiting for queued tracking or activation work to complete.
+    ///   If called immediately after track(), variants may not be activated yet due to a
+    ///   race condition as track is executed asynchronously. Use `getVariantValue` instead.
+    ///
+    /// - Parameters:
+    ///   - flagName: The unique identifier for the feature flag.
+    ///   - fallbackValue: The default value to return if the flag is not found,
+    ///                    its variant doesn't contain a value, or flags are not ready.
+    /// - Returns: The value of the feature flag, or `fallbackValue`. The type is `Any?`.
+    func getVariantValueSync(_ flagName: String, fallbackValue: Any?) -> Any?
 
-  /// Asynchronously retrieves the underlying value of a feature flag.
-  /// This is a convenience method that extracts the `value` property from the `MixpanelFlagVariant`
-  /// obtained via `getVariant`. If flags are not ready, an attempt will be made to load them.
-  /// The `completion` handler is called with the flag's value or the `fallbackValue`.
-  /// The completion handler is typically invoked on the main thread.
-  ///
-  /// - Parameters:
-  ///   - flagName: The unique identifier for the feature flag.
-  ///   - fallbackValue: The default value to use if the flag is not found,
-  ///                    fetching fails, or its variant doesn't contain a value.
-  ///   - completion: A closure that is called with the resulting value (`Any?`).
-  ///                 This closure will be executed on the main dispatch queue.
-  func getVariantValue(
-    _ flagName: String, fallbackValue: Any?, completion: @escaping (Any?) -> Void)
+    /// Asynchronously retrieves the underlying value of a feature flag.
+    /// This is a convenience method that extracts the `value` property from the `MixpanelFlagVariant`
+    /// obtained via `getVariant`. If flags are not ready, an attempt will be made to load them.
+    /// The `completion` handler is called with the flag's value or the `fallbackValue`.
+    /// The completion handler is typically invoked on the main thread.
+    ///
+    /// - Parameters:
+    ///   - flagName: The unique identifier for the feature flag.
+    ///   - fallbackValue: The default value to use if the flag is not found,
+    ///                    fetching fails, or its variant doesn't contain a value.
+    ///   - completion: A closure that is called with the resulting value (`Any?`).
+    ///                 This closure will be executed on the main dispatch queue.
+    func getVariantValue(
+        _ flagName: String, fallbackValue: Any?, completion: @escaping (Any?) -> Void)
 
-  /// Synchronously checks if a specific feature flag is considered "enabled".
-  /// This typically involves retrieving the flag's value and evaluating it as a boolean.
-  /// The exact logic for what constitutes "enabled" (e.g., `true`, non-nil, a specific string)
-  /// should be defined by the implementing class.
-  ///
-  /// - Important: This method may block the calling thread until the value can be retrieved.
-  ///   It is NOT recommended to call this from the main UI thread.
-  ///   If flags are not ready (`areFlagsReady()` is false), this method returns the `fallbackValue`,
-  ///   but it may still block while waiting for queued tracking or activation work to complete.
-  ///
-  /// - Parameters:
-  ///   - flagName: The unique identifier for the feature flag.
-  ///   - fallbackValue: The boolean value to return if the flag is not found,
-  ///                    cannot be evaluated as a boolean, or flags are not ready. Defaults to `false`.
-  /// - Returns: `true` if the flag is considered enabled, `false` otherwise (including if `fallbackValue` is used).
-  func isEnabledSync(_ flagName: String, fallbackValue: Bool) -> Bool
+    /// Synchronously checks if a specific feature flag is considered "enabled".
+    /// This typically involves retrieving the flag's value and evaluating it as a boolean.
+    /// The exact logic for what constitutes "enabled" (e.g., `true`, non-nil, a specific string)
+    /// should be defined by the implementing class.
+    ///
+    /// - Important: This method may block the calling thread until the value can be retrieved.
+    ///   It is NOT recommended to call this from the main UI thread.
+    ///   If flags are not ready (`areFlagsReady()` is false), this method returns the `fallbackValue`,
+    ///   but it may still block while waiting for queued tracking or activation work to complete.
+    ///
+    /// - Parameters:
+    ///   - flagName: The unique identifier for the feature flag.
+    ///   - fallbackValue: The boolean value to return if the flag is not found,
+    ///                    cannot be evaluated as a boolean, or flags are not ready. Defaults to `false`.
+    /// - Returns: `true` if the flag is considered enabled, `false` otherwise (including if `fallbackValue` is used).
+    func isEnabledSync(_ flagName: String, fallbackValue: Bool) -> Bool
 
-  /// Asynchronously checks if a specific feature flag is considered "enabled".
-  /// This typically involves retrieving the flag's value and evaluating it as a boolean.
-  /// If flags are not ready, an attempt will be made to load them.
-  /// The `completion` handler is called with the boolean result.
-  /// The completion handler is typically invoked on the main thread.
-  ///
-  /// - Parameters:
-  ///   - flagName: The unique identifier for the feature flag.
-  ///   - fallbackValue: The boolean value to use if the flag is not found, fetching fails,
-  ///                    or it cannot be evaluated as a boolean. Defaults to `false`.
-  ///   - completion: A closure that is called with the boolean result.
-  ///                 This closure will be executed on the main dispatch queue.
-  func isEnabled(_ flagName: String, fallbackValue: Bool, completion: @escaping (Bool) -> Void)
+    /// Asynchronously checks if a specific feature flag is considered "enabled".
+    /// This typically involves retrieving the flag's value and evaluating it as a boolean.
+    /// If flags are not ready, an attempt will be made to load them.
+    /// The `completion` handler is called with the boolean result.
+    /// The completion handler is typically invoked on the main thread.
+    ///
+    /// - Parameters:
+    ///   - flagName: The unique identifier for the feature flag.
+    ///   - fallbackValue: The boolean value to use if the flag is not found, fetching fails,
+    ///                    or it cannot be evaluated as a boolean. Defaults to `false`.
+    ///   - completion: A closure that is called with the boolean result.
+    ///                 This closure will be executed on the main dispatch queue.
+    func isEnabled(_ flagName: String, fallbackValue: Bool, completion: @escaping (Bool) -> Void)
 
-  // --- Bulk Flag Retrieval ---
+    // --- Bulk Flag Retrieval ---
 
-  /// Synchronously retrieves all currently fetched feature flag variants.
-  /// Returns an empty dictionary if flags have not been loaded yet.
-  /// This method does not trigger tracking for any flags.
-  ///
-  /// - Important: This method may block the calling thread until the value can be retrieved.
-  ///   It is NOT recommended to call this from the main UI thread.
-  ///   If flags are not ready (`areFlagsReady()` is false), it returns an empty dictionary
-  ///   immediately without fetching, but it may still block while waiting for queued tracking
-  ///   or activation work to complete.
-  ///   If called immediately after track(), variants may not be activated yet due to a
-  ///   race condition as track is executed asynchronously. Use `getAllVariants` instead.
-  ///
-  /// - Returns: A dictionary mapping flag names to their `MixpanelFlagVariant` values,
-  ///            or an empty dictionary if flags are not ready.
-  func getAllVariantsSync() -> [String: MixpanelFlagVariant]
+    /// Synchronously retrieves all currently fetched feature flag variants.
+    /// Returns an empty dictionary if flags have not been loaded yet.
+    /// This method does not trigger tracking for any flags.
+    ///
+    /// - Important: This method may block the calling thread until the value can be retrieved.
+    ///   It is NOT recommended to call this from the main UI thread.
+    ///   If flags are not ready (`areFlagsReady()` is false), it returns an empty dictionary
+    ///   immediately without fetching, but it may still block while waiting for queued tracking
+    ///   or activation work to complete.
+    ///   If called immediately after track(), variants may not be activated yet due to a
+    ///   race condition as track is executed asynchronously. Use `getAllVariants` instead.
+    ///
+    /// - Returns: A dictionary mapping flag names to their `MixpanelFlagVariant` values,
+    ///            or an empty dictionary if flags are not ready.
+    func getAllVariantsSync() -> [String: MixpanelFlagVariant]
 
-  /// Asynchronously retrieves all feature flag variants.
-  /// If flags are not ready, an attempt will be made to load them.
-  /// This method does not trigger tracking for any flags.
-  /// The completion handler is typically invoked on the main thread.
-  ///
-  /// - Parameter completion: A closure that is called with a dictionary mapping flag names
-  ///                         to their `MixpanelFlagVariant` values. Returns an empty dictionary
-  ///                         if fetching fails.
-  func getAllVariants(completion: @escaping ([String: MixpanelFlagVariant]) -> Void)
+    /// Asynchronously retrieves all feature flag variants.
+    /// If flags are not ready, an attempt will be made to load them.
+    /// This method does not trigger tracking for any flags.
+    /// The completion handler is typically invoked on the main thread.
+    ///
+    /// - Parameter completion: A closure that is called with a dictionary mapping flag names
+    ///                         to their `MixpanelFlagVariant` values. Returns an empty dictionary
+    ///                         if fetching fails.
+    func getAllVariants(completion: @escaping ([String: MixpanelFlagVariant]) -> Void)
 
-  /// Replaces the current custom flag evaluation context entirely and triggers a flag re-fetch.
-  ///
-  /// In-memory variants and the on-disk persistence layer are intentionally NOT cleared — the
-  /// persistence layer is keyed on distinctId only, so it remains valid for this user across
-  /// context changes. The next successful fetch under the new context will overwrite the
-  /// persistence layer with fresh values.
-  ///
-  /// - Parameters:
-  ///   - context: The new context dictionary to use for flag evaluation.
-  ///   - completion: A closure called when the fetch under the new context completes (success
-  ///     or failure). Always invoked exactly once.
-  func setContext(_ context: [String: Any], completion: @escaping () -> Void)
+    /// Replaces the current custom flag evaluation context entirely and triggers a flag re-fetch.
+    ///
+    /// In-memory variants and the on-disk persistence layer are intentionally NOT cleared — the
+    /// persistence layer is keyed on distinctId only, so it remains valid for this user across
+    /// context changes. The next successful fetch under the new context will overwrite the
+    /// persistence layer with fresh values.
+    ///
+    /// - Parameters:
+    ///   - context: The new context dictionary to use for flag evaluation.
+    ///   - completion: A closure called when the fetch under the new context completes (success
+    ///     or failure). Always invoked exactly once.
+    func setContext(_ context: [String: Any], completion: @escaping () -> Void)
 }
 
 // --- FeatureFlagManager Class ---
 
 class FeatureFlagManager: MixpanelFlags {
 
-  weak var delegate: MixpanelFlagDelegate? {
-    didSet {
-      if let context = delegate?.getOptions().featureFlagOptions.context, !context.isEmpty {
-        flagsLock.write {
-          if self.flagContext.isEmpty {
-            self.flagContext = context
-          }
+    weak var delegate: MixpanelFlagDelegate? {
+        didSet {
+            if let context = delegate?.getOptions().featureFlagOptions.context, !context.isEmpty {
+                flagsLock.write {
+                    if self.flagContext.isEmpty {
+                        self.flagContext = context
+                    }
+                }
+            }
         }
-      }
     }
-  }
 
     var serverURL: String!
-  // Thread safety using ReadWriteLock (consistent with Track, People, MixpanelInstance)
-  internal let flagsLock = ReadWriteLock(label: "com.mixpanel.featureflagmanager")
+    // Thread safety using ReadWriteLock (consistent with Track, People, MixpanelInstance)
+    internal let flagsLock = ReadWriteLock(label: "com.mixpanel.featureflagmanager")
 
-  // Internal State - Protected by flagsLock
-  var flags: [String: MixpanelFlagVariant]? = nil
-  var isFetching: Bool = false
-  // `internal` so tests that override `_performFetchRequest` can mirror production's
-  // post-success state mutation (clearing the dedup window after a successful fetch).
-  internal var trackedFeatures: Set<String> = Set()
-  private var fetchCompletionHandlers: [(Bool) -> Void] = []
+    // Internal State - Protected by flagsLock
+    var flags: [String: MixpanelFlagVariant]? = nil
+    var isFetching: Bool = false
+    // `internal` so tests that override `_performFetchRequest` can mirror production's
+    // post-success state mutation (clearing the dedup window after a successful fetch).
+    internal var trackedFeatures: Set<String> = Set()
+    private var fetchCompletionHandlers: [(Bool) -> Void] = []
 
-  /// `persistedAt` from the persisted blob currently sitting in `flags`. Lifetime matches
-  /// the persistence-derived state (`flags` + `pendingFirstTimeEvents`):
-  ///   - Set in `_loadPersistedVariants` when we read the blob from disk
-  ///   - Cleared in the network-fetch success closure (the in-memory blob is fully
-  ///     `.network`-stamped after a refresh, so the persisted timestamp no longer applies)
-  ///   - Cleared in `reset()` along with the rest of the per-user state
-  ///
-  /// Stored separately from the `.persistence(persistedAt:)` variant case so we can answer
-  /// "is the loaded blob past TTL?" even when `flags` is empty (the previous session may
-  /// have persisted an empty response).
-  ///
-  /// Also doubles as the "NetworkFirst is still awaiting a successful network response"
-  /// signal — see `isNetworkFirstAwaitingFetch()`. Stays set across failed fetches so each
-  /// subsequent NetworkFirst async lookup re-attempts the network until one succeeds.
-  ///
-  /// `internal` so tests that inject `.persistence` variants directly can match the
-  /// production invariant.
-  internal var loadedBlobPersistedAt: Date?
+    /// `persistedAt` from the persisted blob currently sitting in `flags`. Lifetime matches
+    /// the persistence-derived state (`flags` + `pendingFirstTimeEvents`):
+    ///   - Set in `_loadPersistedVariants` when we read the blob from disk
+    ///   - Cleared in the network-fetch success closure (the in-memory blob is fully
+    ///     `.network`-stamped after a refresh, so the persisted timestamp no longer applies)
+    ///   - Cleared in `reset()` along with the rest of the per-user state
+    ///
+    /// Stored separately from the `.persistence(persistedAt:)` variant case so we can answer
+    /// "is the loaded blob past TTL?" even when `flags` is empty (the previous session may
+    /// have persisted an empty response).
+    ///
+    /// Also doubles as the "NetworkFirst is still awaiting a successful network response"
+    /// signal — see `isNetworkFirstAwaitingFetch()`. Stays set across failed fetches so each
+    /// subsequent NetworkFirst async lookup re-attempts the network until one succeeds.
+    ///
+    /// `internal` so tests that inject `.persistence` variants directly can match the
+    /// production invariant.
+    internal var loadedBlobPersistedAt: Date?
 
-  /// Per-instance name used as the UserDefaults key prefix for the on-disk persistence layer.
-  /// Captured from the delegate at init so we can persist/clear without holding a delegate
-  /// reference during async work.
-  private let instanceName: String
+    /// Per-instance name used as the UserDefaults key prefix for the on-disk persistence layer.
+    /// Captured from the delegate at init so we can persist/clear without holding a delegate
+    /// reference during async work.
+    private let instanceName: String
 
-  // First-time event targeting state
-  internal var pendingFirstTimeEvents: [String: PendingFirstTimeEvent] = [:]  // Keyed by "flagKey:firstTimeEventHash"
+    // First-time event targeting state
+    internal var pendingFirstTimeEvents: [String: PendingFirstTimeEvent] = [:]  // Keyed by "flagKey:firstTimeEventHash"
 
-  /// O(1) lookup set of event names that have pending first-time events.
-  /// Maintained in parallel with `pendingFirstTimeEvents` to avoid iterating
-  /// the full dictionary on every tracked event.
-  internal var pendingFirstTimeEventNames: Set<String> = Set()
+    /// O(1) lookup set of event names that have pending first-time events.
+    /// Maintained in parallel with `pendingFirstTimeEvents` to avoid iterating
+    /// the full dictionary on every tracked event.
+    internal var pendingFirstTimeEventNames: Set<String> = Set()
 
-  /// Stores "flagKey:firstTimeEventHash" keys for activated first-time events.
-  /// This set grows throughout the session as events are activated.
-  /// It is session-scoped and cleared on app restart.
-  internal var activatedFirstTimeEvents: Set<String> = Set()
+    /// Stores "flagKey:firstTimeEventHash" keys for activated first-time events.
+    /// This set grows throughout the session as events are activated.
+    /// It is session-scoped and cleared on app restart.
+    internal var activatedFirstTimeEvents: Set<String> = Set()
 
-  // Flag evaluation context (protected by flagsLock)
-  internal var flagContext: [String: Any]
+    // Flag evaluation context (protected by flagsLock)
+    internal var flagContext: [String: Any]
 
-  // Timing tracking properties
-  private var fetchStartTime: Date?
-  var timeLastFetched: Date?
-  var fetchLatencyMs: Int?
+    // Timing tracking properties
+    private var fetchStartTime: Date?
+    var timeLastFetched: Date?
+    var fetchLatencyMs: Int?
 
-  /// Bumped on `reset()` so in-flight fetches dispatched pre-reset don't poison post-reset state.
-  /// Captured at the start of `_performFetchRequest` and re-checked before applying results.
-  private var fetchGeneration: Int = 0
+    /// Bumped on `reset()` so in-flight fetches dispatched pre-reset don't poison post-reset state.
+    /// Captured at the start of `_performFetchRequest` and re-checked before applying results.
+    private var fetchGeneration: Int = 0
 
-  // Configuration
-  private var currentOptions: MixpanelOptions? { delegate?.getOptions() }
-  private var flagsRoute = "/flags/"
+    // Configuration
+    private var currentOptions: MixpanelOptions? { delegate?.getOptions() }
+    private var flagsRoute = "/flags/"
 
-  /// Resolved variant lookup policy snapshot. Computed once at init via
-  /// `VariantLookupPolicy.effective(_:)`, which collapses any persisting policy with
-  /// non-positive TTL down to `.networkOnly` (with a warning logged). Treat this as the
-  /// canonical policy — downstream code should never re-read from `delegate?.getOptions()`.
-  private let resolvedLookupPolicy: VariantLookupPolicy
+    /// Resolved variant lookup policy snapshot. Computed once at init via
+    /// `VariantLookupPolicy.effective(_:)`, which collapses any persisting policy with
+    /// non-positive TTL down to `.networkOnly` (with a warning logged). Treat this as the
+    /// canonical policy — downstream code should never re-read from `delegate?.getOptions()`.
+    private let resolvedLookupPolicy: VariantLookupPolicy
 
-  // Queue for synchronizing flag operations with tracking. `internal` rather than `private`
-  // so tests can post barrier tasks to wait for queued work (persistence load on init, etc.).
-  internal var trackingQueue: DispatchQueue
+    // Queue for synchronizing flag operations with tracking. `internal` rather than `private`
+    // so tests can post barrier tasks to wait for queued work (persistence load on init, etc.).
+    internal var trackingQueue: DispatchQueue
 
-  // Initializers
+    // Initializers
     internal init(
-      serverURL: String,
-      trackingQueue: DispatchQueue,
-      instanceName: String,
-      delegate: MixpanelFlagDelegate? = nil
+        serverURL: String,
+        trackingQueue: DispatchQueue,
+        instanceName: String,
+        delegate: MixpanelFlagDelegate? = nil
     ) {
         self.serverURL = serverURL
         self.trackingQueue = trackingQueue
@@ -479,7 +482,7 @@ class FeatureFlagManager: MixpanelFlags {
         // to `.networkOnly` (since "persist on every fetch but TTL makes nothing serve" does
         // no useful work). Logs a warning when the substitution happens.
         let requestedPolicy =
-          delegate?.getOptions().featureFlagOptions.variantLookupPolicy ?? .networkOnly
+            delegate?.getOptions().featureFlagOptions.variantLookupPolicy ?? .networkOnly
         self.resolvedLookupPolicy = VariantLookupPolicy.effective(requestedPolicy)
 
         // Dispatch the init-time persistence work on the tracking queue so UserDefaults I/O
@@ -488,917 +491,933 @@ class FeatureFlagManager: MixpanelFlags {
         // any stale blob left over from a previous session that used a persisting policy.
         if let options = delegate?.getOptions(), options.featureFlagOptions.enabled {
             switch self.resolvedLookupPolicy {
-            case .persistenceUntilNetworkSuccess, .networkFirst:
-                trackingQueue.async { [weak self] in
-                    self?._loadPersistedVariants()
+                case .persistenceUntilNetworkSuccess, .networkFirst:
+                    trackingQueue.async { [weak self] in
+                        self?._loadPersistedVariants()
+                    }
+                case .networkOnly:
+                    trackingQueue.async { [weak self] in
+                        guard let self = self else { return }
+                        MixpanelPersistence.deleteFlagsPersistence(instanceName: self.instanceName)
+                    }
+            }
+        }
+    }
+
+    // --- Public Methods ---
+
+    func loadFlags() {
+        loadFlags(completion: nil)
+    }
+
+    func loadFlags(completion: ((Bool) -> Void)?) {
+        // Dispatch fetch trigger to allow caller to continue
+        trackingQueue.async { [weak self] in
+            self?._fetchFlagsIfNeeded(completion: completion)
+        }
+    }
+
+    /// Clears all in-memory feature flag state (in-memory variants, tracked-flag set, fetch
+    /// timing, first-time event state) AND wipes the on-disk persistence blob. Intended for
+    /// identity-change paths: `MixpanelInstance.reset()`, `identify` when distinctId actually
+    /// changes, and `optOutTracking`. `setContext` deliberately does NOT call this — context
+    /// changes don't invalidate the persisted blob (it is keyed on distinctId only).
+    ///
+    /// Posts to the tracking queue so the mutation is serialized with reads and fetches. Any
+    /// in-flight fetch dispatched before this call is discarded when it completes (via the
+    /// generation check in `_performFetchRequest`'s success/failure closures). Pending
+    /// fetch-completion handlers are invoked with `false` so callers don't hang.
+    ///
+    /// `completion` (optional) fires on the tracking queue once the in-memory state has been
+    /// cleared, so callers (notably `MixpanelInstance.reset(completion:)`) can defer their own
+    /// completion until after the wipe — without it, a customer calling a sync flag API from
+    /// the outer reset completion handler could observe pre-reset variants.
+    func reset(completion: (() -> Void)? = nil) {
+        trackingQueue.async { [weak self] in
+            guard let self = self else {
+                completion?()
+                return
+            }
+
+            var orphanedHandlers: [(Bool) -> Void] = []
+            self.flagsLock.write {
+                self.fetchGeneration &+= 1
+                self.flags = nil
+                self.loadedBlobPersistedAt = nil
+                self.trackedFeatures.removeAll()
+                self.pendingFirstTimeEvents.removeAll()
+                self.pendingFirstTimeEventNames.removeAll()
+                self.activatedFirstTimeEvents.removeAll()
+                self.fetchStartTime = nil
+                self.timeLastFetched = nil
+                self.fetchLatencyMs = nil
+                orphanedHandlers = self.fetchCompletionHandlers
+                self.fetchCompletionHandlers.removeAll()
+                self.isFetching = false
+            }
+
+            // Wipe the on-disk persistence blob so a freshly-identified user can't be served the
+            // prior user's variants. `MixpanelInstance.reset()` also wipes via
+            // deleteMPUserDefaultsData, so this is defensive (idempotent) but keeps the manager
+            // self-contained.
+            MixpanelPersistence.deleteFlagsPersistence(instanceName: self.instanceName)
+
+            DispatchQueue.main.async {
+                orphanedHandlers.forEach { $0(false) }
+            }
+
+            completion?()
+        }
+    }
+
+    func setContext(_ context: [String: Any], completion: @escaping () -> Void) {
+        flagsLock.write {
+            self.flagContext = context
+        }
+        trackingQueue.async { [weak self] in
+            self?._fetchFlagsIfNeeded { _ in
+                completion()
+            }
+        }
+    }
+
+    func areFlagsReady() -> Bool {
+        var result: Bool = false
+        flagsLock.read {
+            result = (flags != nil)
+        }
+        return result
+    }
+
+    // --- Sync Flag Retrieval ---
+
+    func getVariantSync(_ flagName: String, fallback: MixpanelFlagVariant) -> MixpanelFlagVariant {
+        if Thread.isMainThread {
+            MixpanelLogger.warn(
+                message:
+                    "It is NOT recommended to call this method from the main thread as it might block the calling thread until the value can be retrieved. Consider using async getVariant() instead."
+            )
+        }
+        return _getVariantSyncImpl(flagName, fallback: fallback)
+    }
+
+    private func _getVariantSyncImpl(_ flagName: String, fallback: MixpanelFlagVariant) -> MixpanelFlagVariant {
+        var flagVariant: MixpanelFlagVariant?
+        var tracked = false
+        var capturedTimeLastFetched: Date?
+        var capturedFetchLatencyMs: Int?
+
+        // Use write lock to perform atomic check-and-set for tracking
+        flagsLock.write {
+            guard let currentFlags = self.flags else { return }
+
+            // Treat expired persisted variants as not-present — return the developer fallback and
+            // skip tracking, since the customer effectively didn't receive a value. The blob
+            // stays on disk; the next successful fetch overwrites it.
+            if let variant = currentFlags[flagName], !self.isVariantExpired(variant) {
+                flagVariant = variant
+
+                // Perform atomic check-and-set for tracking
+                if !self.trackedFeatures.contains(flagName) {
+                    self.trackedFeatures.insert(flagName)
+                    tracked = true
+                    // Capture timing data while in lock
+                    capturedTimeLastFetched = self.timeLastFetched
+                    capturedFetchLatencyMs = self.fetchLatencyMs
                 }
-            case .networkOnly:
-                trackingQueue.async { [weak self] in
-                    guard let self = self else { return }
-                    MixpanelPersistence.deleteFlagsPersistence(instanceName: self.instanceName)
+            }
+            // If flag wasn't found OR was expired, flagVariant remains nil
+        }
+
+        // Now, process the results outside the lock
+
+        if let foundVariant = flagVariant {
+            // If tracking was done *in this call*, call the delegate with timing data
+            if tracked {
+                self._performTrackingDelegateCall(
+                    flagName: flagName,
+                    variant: foundVariant,
+                    timeLastFetched: capturedTimeLastFetched,
+                    fetchLatencyMs: capturedFetchLatencyMs
+                )
+            }
+            return foundVariant
+        } else {
+            MixpanelLogger.info(message: "Flag '\(flagName)' not found or flags not ready. Returning fallback.")
+            return fallback
+        }
+    }
+
+    // --- Async Flag Retrieval ---
+
+    func getVariant(
+        _ flagName: String, fallback: MixpanelFlagVariant,
+        completion: @escaping (MixpanelFlagVariant) -> Void
+    ) {
+        trackingQueue.async { [weak self] in
+            guard let self = self else { return }
+
+            var flagVariant: MixpanelFlagVariant?
+            var needsTrackingCheck = false
+            var canServeImmediately = false
+            var servingFromPersistedBlob = false
+
+            // Read state with lock. Serve immediately when flags are populated, NetworkFirst
+            // isn't still gating on a successful network response, AND the loaded blob isn't past
+            // TTL. The blob-staleness check is what makes the async path fall through to a fetch
+            // when persisted values have aged out mid-session — the inline TTL check below would
+            // otherwise silently serve the developer fallback without refreshing.
+            self.flagsLock.read {
+                guard let currentFlags = self.flags,
+                    !self.isNetworkFirstAwaitingFetch(),
+                    !self.loadedFlagsAreStale()
+                else { return }
+                canServeImmediately = true
+                servingFromPersistedBlob = self.loadedBlobPersistedAt != nil
+                if let variant = currentFlags[flagName], !self.isVariantExpired(variant) {
+                    flagVariant = variant
+                    needsTrackingCheck = !self.trackedFeatures.contains(flagName)
+                }
+            }
+
+            if canServeImmediately {
+                // PersistenceUntilNetworkSuccess "serve persisted now, refresh in background":
+                // when the immediate-serve path is satisfied by the persisted blob (not yet
+                // overwritten by a successful fetch), kick off a background fetch with no
+                // completion handler so we don't await it. Idempotent — `_fetchFlagsIfNeeded`
+                // dedupes via `isFetching`. Self-stops once the fetch clears
+                // `loadedBlobPersistedAt`.
+                if servingFromPersistedBlob,
+                    case .persistenceUntilNetworkSuccess = self.resolvedLookupPolicy
+                {
+                    self._fetchFlagsIfNeeded(completion: nil)
+                }
+                let result = flagVariant ?? fallback
+                if flagVariant != nil, needsTrackingCheck {
+                    // Perform atomic check-and-track
+                    self._trackFlagIfNeeded(flagName: flagName, variant: result)
+                }
+                DispatchQueue.main.async { completion(result) }
+
+            } else {
+                // Flags not yet servable. Either nothing in memory, or NetworkFirst awaiting the
+                // initial network response. Trigger a fetch and serve from `flags` afterward.
+                // On failure, `flags` is left untouched: NetworkFirst with a persistence hit still
+                // has persisted values (Source.persistence); everything else stays nil and we serve
+                // the fallback.
+                MixpanelLogger.debug(
+                    message: "Flags not yet servable, attempting fetch for getVariant '\(flagName)'...")
+                self._fetchFlagsIfNeeded { _ in
+                    // Hop back to the tracking queue so we can read flags + run the tracking check
+                    // atomically. Whether the fetch succeeded or not, _getVariantSyncImpl returns the
+                    // variant from `flags` if present (persisted or network) else the fallback.
+                    self.trackingQueue.async {
+                        let result = self._getVariantSyncImpl(flagName, fallback: fallback)
+                        DispatchQueue.main.async { completion(result) }
+                    }
                 }
             }
         }
     }
 
-  // --- Public Methods ---
-
-  func loadFlags() {
-    loadFlags(completion: nil)
-  }
-
-  func loadFlags(completion: ((Bool) -> Void)?) {
-    // Dispatch fetch trigger to allow caller to continue
-      trackingQueue.async { [weak self] in
-      self?._fetchFlagsIfNeeded(completion: completion)
+    func getVariantValueSync(_ flagName: String, fallbackValue: Any?) -> Any? {
+        return getVariantSync(flagName, fallback: MixpanelFlagVariant(value: fallbackValue)).value
     }
-  }
 
-  /// Clears all in-memory feature flag state (in-memory variants, tracked-flag set, fetch
-  /// timing, first-time event state) AND wipes the on-disk persistence blob. Intended for
-  /// identity-change paths: `MixpanelInstance.reset()`, `identify` when distinctId actually
-  /// changes, and `optOutTracking`. `setContext` deliberately does NOT call this — context
-  /// changes don't invalidate the persisted blob (it is keyed on distinctId only).
-  ///
-  /// Posts to the tracking queue so the mutation is serialized with reads and fetches. Any
-  /// in-flight fetch dispatched before this call is discarded when it completes (via the
-  /// generation check in `_performFetchRequest`'s success/failure closures). Pending
-  /// fetch-completion handlers are invoked with `false` so callers don't hang.
-  ///
-  /// `completion` (optional) fires on the tracking queue once the in-memory state has been
-  /// cleared, so callers (notably `MixpanelInstance.reset(completion:)`) can defer their own
-  /// completion until after the wipe — without it, a customer calling a sync flag API from
-  /// the outer reset completion handler could observe pre-reset variants.
-  func reset(completion: (() -> Void)? = nil) {
-    trackingQueue.async { [weak self] in
-      guard let self = self else {
-        completion?()
-        return
-      }
-
-      var orphanedHandlers: [(Bool) -> Void] = []
-      self.flagsLock.write {
-        self.fetchGeneration &+= 1
-        self.flags = nil
-        self.loadedBlobPersistedAt = nil
-        self.trackedFeatures.removeAll()
-        self.pendingFirstTimeEvents.removeAll()
-        self.pendingFirstTimeEventNames.removeAll()
-        self.activatedFirstTimeEvents.removeAll()
-        self.fetchStartTime = nil
-        self.timeLastFetched = nil
-        self.fetchLatencyMs = nil
-        orphanedHandlers = self.fetchCompletionHandlers
-        self.fetchCompletionHandlers.removeAll()
-        self.isFetching = false
-      }
-
-      // Wipe the on-disk persistence blob so a freshly-identified user can't be served the
-      // prior user's variants. `MixpanelInstance.reset()` also wipes via
-      // deleteMPUserDefaultsData, so this is defensive (idempotent) but keeps the manager
-      // self-contained.
-      MixpanelPersistence.deleteFlagsPersistence(instanceName: self.instanceName)
-
-      DispatchQueue.main.async {
-        orphanedHandlers.forEach { $0(false) }
-      }
-
-      completion?()
-    }
-  }
-
-  func setContext(_ context: [String: Any], completion: @escaping () -> Void) {
-    flagsLock.write {
-      self.flagContext = context
-    }
-    trackingQueue.async { [weak self] in
-      self?._fetchFlagsIfNeeded { _ in
-        completion()
-      }
-    }
-  }
-
-  func areFlagsReady() -> Bool {
-    var result: Bool = false
-    flagsLock.read {
-      result = (flags != nil)
-    }
-    return result
-  }
-
-  // --- Sync Flag Retrieval ---
-
-  func getVariantSync(_ flagName: String, fallback: MixpanelFlagVariant) -> MixpanelFlagVariant {
-    if Thread.isMainThread {
-      MixpanelLogger.warn(
-        message: "It is NOT recommended to call this method from the main thread as it might block the calling thread until the value can be retrieved. Consider using async getVariant() instead."
-      )
-    }
-      return _getVariantSyncImpl(flagName, fallback: fallback)
-  }
-
-  private func _getVariantSyncImpl(_ flagName: String, fallback: MixpanelFlagVariant) -> MixpanelFlagVariant {
-    var flagVariant: MixpanelFlagVariant?
-    var tracked = false
-    var capturedTimeLastFetched: Date?
-    var capturedFetchLatencyMs: Int?
-
-    // Use write lock to perform atomic check-and-set for tracking
-    flagsLock.write {
-      guard let currentFlags = self.flags else { return }
-
-      // Treat expired persisted variants as not-present — return the developer fallback and
-      // skip tracking, since the customer effectively didn't receive a value. The blob
-      // stays on disk; the next successful fetch overwrites it.
-      if let variant = currentFlags[flagName], !self.isVariantExpired(variant) {
-        flagVariant = variant
-
-        // Perform atomic check-and-set for tracking
-        if !self.trackedFeatures.contains(flagName) {
-          self.trackedFeatures.insert(flagName)
-          tracked = true
-          // Capture timing data while in lock
-          capturedTimeLastFetched = self.timeLastFetched
-          capturedFetchLatencyMs = self.fetchLatencyMs
+    func getVariantValue(
+        _ flagName: String, fallbackValue: Any?, completion: @escaping (Any?) -> Void
+    ) {
+        getVariant(flagName, fallback: MixpanelFlagVariant(value: fallbackValue)) { flagVariant in
+            completion(flagVariant.value)
         }
-      }
-      // If flag wasn't found OR was expired, flagVariant remains nil
     }
 
-    // Now, process the results outside the lock
-
-    if let foundVariant = flagVariant {
-      // If tracking was done *in this call*, call the delegate with timing data
-      if tracked {
-        self._performTrackingDelegateCall(
-          flagName: flagName,
-          variant: foundVariant,
-          timeLastFetched: capturedTimeLastFetched,
-          fetchLatencyMs: capturedFetchLatencyMs
-        )
-      }
-      return foundVariant
-    } else {
-      MixpanelLogger.info(message: "Flag '\(flagName)' not found or flags not ready. Returning fallback.")
-      return fallback
+    func isEnabledSync(_ flagName: String, fallbackValue: Bool = false) -> Bool {
+        let variantValue = getVariantValueSync(flagName, fallbackValue: fallbackValue)
+        return self._evaluateBooleanFlag(
+            flagName: flagName, variantValue: variantValue, fallbackValue: fallbackValue)
     }
-  }
 
-  // --- Async Flag Retrieval ---
-
-  func getVariant(
-    _ flagName: String, fallback: MixpanelFlagVariant,
-    completion: @escaping (MixpanelFlagVariant) -> Void
-  ) {
-      trackingQueue.async { [weak self] in
-      guard let self = self else { return }
-
-      var flagVariant: MixpanelFlagVariant?
-      var needsTrackingCheck = false
-      var canServeImmediately = false
-      var servingFromPersistedBlob = false
-
-      // Read state with lock. Serve immediately when flags are populated, NetworkFirst
-      // isn't still gating on a successful network response, AND the loaded blob isn't past
-      // TTL. The blob-staleness check is what makes the async path fall through to a fetch
-      // when persisted values have aged out mid-session — the inline TTL check below would
-      // otherwise silently serve the developer fallback without refreshing.
-      self.flagsLock.read {
-        guard let currentFlags = self.flags,
-              !self.isNetworkFirstAwaitingFetch(),
-              !self.loadedFlagsAreStale() else { return }
-        canServeImmediately = true
-        servingFromPersistedBlob = self.loadedBlobPersistedAt != nil
-        if let variant = currentFlags[flagName], !self.isVariantExpired(variant) {
-          flagVariant = variant
-          needsTrackingCheck = !self.trackedFeatures.contains(flagName)
+    func isEnabled(
+        _ flagName: String, fallbackValue: Bool = false, completion: @escaping (Bool) -> Void
+    ) {
+        getVariantValue(flagName, fallbackValue: fallbackValue) { [weak self] variantValue in
+            guard let self = self else {
+                completion(fallbackValue)
+                return
+            }
+            let result = self._evaluateBooleanFlag(
+                flagName: flagName, variantValue: variantValue, fallbackValue: fallbackValue)
+            completion(result)
         }
-      }
-
-      if canServeImmediately {
-        // PersistenceUntilNetworkSuccess "serve persisted now, refresh in background":
-        // when the immediate-serve path is satisfied by the persisted blob (not yet
-        // overwritten by a successful fetch), kick off a background fetch with no
-        // completion handler so we don't await it. Idempotent — `_fetchFlagsIfNeeded`
-        // dedupes via `isFetching`. Self-stops once the fetch clears
-        // `loadedBlobPersistedAt`.
-        if servingFromPersistedBlob,
-           case .persistenceUntilNetworkSuccess = self.resolvedLookupPolicy {
-          self._fetchFlagsIfNeeded(completion: nil)
-        }
-        let result = flagVariant ?? fallback
-        if flagVariant != nil, needsTrackingCheck {
-          // Perform atomic check-and-track
-          self._trackFlagIfNeeded(flagName: flagName, variant: result)
-        }
-        DispatchQueue.main.async { completion(result) }
-
-      } else {
-        // Flags not yet servable. Either nothing in memory, or NetworkFirst awaiting the
-        // initial network response. Trigger a fetch and serve from `flags` afterward.
-        // On failure, `flags` is left untouched: NetworkFirst with a persistence hit still
-        // has persisted values (Source.persistence); everything else stays nil and we serve
-        // the fallback.
-        MixpanelLogger.debug(message: "Flags not yet servable, attempting fetch for getVariant '\(flagName)'...")
-        self._fetchFlagsIfNeeded { _ in
-          // Hop back to the tracking queue so we can read flags + run the tracking check
-          // atomically. Whether the fetch succeeded or not, _getVariantSyncImpl returns the
-          // variant from `flags` if present (persisted or network) else the fallback.
-          self.trackingQueue.async {
-            let result = self._getVariantSyncImpl(flagName, fallback: fallback)
-            DispatchQueue.main.async { completion(result) }
-          }
-        }
-      }
     }
-  }
 
-  func getVariantValueSync(_ flagName: String, fallbackValue: Any?) -> Any? {
-    return getVariantSync(flagName, fallback: MixpanelFlagVariant(value: fallbackValue)).value
-  }
-
-  func getVariantValue(
-    _ flagName: String, fallbackValue: Any?, completion: @escaping (Any?) -> Void
-  ) {
-    getVariant(flagName, fallback: MixpanelFlagVariant(value: fallbackValue)) { flagVariant in
-      completion(flagVariant.value)
-    }
-  }
-
-  func isEnabledSync(_ flagName: String, fallbackValue: Bool = false) -> Bool {
-    let variantValue = getVariantValueSync(flagName, fallbackValue: fallbackValue)
-    return self._evaluateBooleanFlag(
-      flagName: flagName, variantValue: variantValue, fallbackValue: fallbackValue)
-  }
-
-  func isEnabled(
-    _ flagName: String, fallbackValue: Bool = false, completion: @escaping (Bool) -> Void
-  ) {
-    getVariantValue(flagName, fallbackValue: fallbackValue) { [weak self] variantValue in
-      guard let self = self else {
-        completion(fallbackValue)
-        return
-      }
-      let result = self._evaluateBooleanFlag(
-        flagName: flagName, variantValue: variantValue, fallbackValue: fallbackValue)
-      completion(result)
-    }
-  }
-
-  // --- Bulk Flag Retrieval ---
+    // --- Bulk Flag Retrieval ---
 
     func getAllVariantsSync() -> [String: MixpanelFlagVariant] {
         if Thread.isMainThread {
             MixpanelLogger.warn(
-                message: "It is NOT recommended to call this method from the main thread as it might block the calling thread until the value can be retrieved. Consider using async getAllVariants() instead."
+                message:
+                    "It is NOT recommended to call this method from the main thread as it might block the calling thread until the value can be retrieved. Consider using async getAllVariants() instead."
             )
         }
         return _getAllVariantsSyncImpl()
     }
 
-  private func _getAllVariantsSyncImpl() -> [String: MixpanelFlagVariant] {
-    var result: [String: MixpanelFlagVariant] = [:]
-    flagsLock.read {
-      // Filter out expired persisted variants — same rule as getVariantSync. Keep `.network`
-      // and unexpired `.persistence(persistedAt:)` entries.
-      if let currentFlags = self.flags {
-        result = currentFlags.filter { _, variant in !self.isVariantExpired(variant) }
-      }
-    }
-    return result
-  }
-
-  func getAllVariants(completion: @escaping ([String: MixpanelFlagVariant]) -> Void) {
-      trackingQueue.async { [weak self] in
-      guard let self = self else {
-        DispatchQueue.main.async { completion([:]) }
-        return
-      }
-
-      var canServeImmediately = false
-      var servingFromPersistedBlob = false
-      self.flagsLock.read {
-        canServeImmediately = (self.flags != nil)
-          && !self.isNetworkFirstAwaitingFetch()
-          && !self.loadedFlagsAreStale()
-        servingFromPersistedBlob = self.loadedBlobPersistedAt != nil
-      }
-      if canServeImmediately {
-        // PersistenceUntilNetworkSuccess "serve persisted now, refresh in background":
-        // see the matching block in `getVariant` for the full rationale.
-        if servingFromPersistedBlob,
-           case .persistenceUntilNetworkSuccess = self.resolvedLookupPolicy {
-          self._fetchFlagsIfNeeded(completion: nil)
+    private func _getAllVariantsSyncImpl() -> [String: MixpanelFlagVariant] {
+        var result: [String: MixpanelFlagVariant] = [:]
+        flagsLock.read {
+            // Filter out expired persisted variants — same rule as getVariantSync. Keep `.network`
+            // and unexpired `.persistence(persistedAt:)` entries.
+            if let currentFlags = self.flags {
+                result = currentFlags.filter { _, variant in !self.isVariantExpired(variant) }
+            }
         }
-        // Use the sync impl so the expired-filter is applied consistently.
-        let result = self._getAllVariantsSyncImpl()
-        DispatchQueue.main.async { completion(result) }
-      } else {
-        // Either nothing in memory yet, NetworkFirst awaiting the initial network response,
-        // or the loaded persisted blob is past TTL. Trigger a fetch and serve from `flags`
-        // afterward — on success it has the fresh values, on NetworkFirst failure the
-        // persisted values stayed in place (still served, _getAllVariantsSyncImpl filters
-        // any expired entries).
-        MixpanelLogger.debug(message: "Flags not yet servable, attempting fetch for getAllVariants...")
-        self._fetchFlagsIfNeeded { _ in
-          DispatchQueue.main.async { completion(self._getAllVariantsSyncImpl()) }
+        return result
+    }
+
+    func getAllVariants(completion: @escaping ([String: MixpanelFlagVariant]) -> Void) {
+        trackingQueue.async { [weak self] in
+            guard let self = self else {
+                DispatchQueue.main.async { completion([:]) }
+                return
+            }
+
+            var canServeImmediately = false
+            var servingFromPersistedBlob = false
+            self.flagsLock.read {
+                canServeImmediately =
+                    (self.flags != nil)
+                    && !self.isNetworkFirstAwaitingFetch()
+                    && !self.loadedFlagsAreStale()
+                servingFromPersistedBlob = self.loadedBlobPersistedAt != nil
+            }
+            if canServeImmediately {
+                // PersistenceUntilNetworkSuccess "serve persisted now, refresh in background":
+                // see the matching block in `getVariant` for the full rationale.
+                if servingFromPersistedBlob,
+                    case .persistenceUntilNetworkSuccess = self.resolvedLookupPolicy
+                {
+                    self._fetchFlagsIfNeeded(completion: nil)
+                }
+                // Use the sync impl so the expired-filter is applied consistently.
+                let result = self._getAllVariantsSyncImpl()
+                DispatchQueue.main.async { completion(result) }
+            } else {
+                // Either nothing in memory yet, NetworkFirst awaiting the initial network response,
+                // or the loaded persisted blob is past TTL. Trigger a fetch and serve from `flags`
+                // afterward — on success it has the fresh values, on NetworkFirst failure the
+                // persisted values stayed in place (still served, _getAllVariantsSyncImpl filters
+                // any expired entries).
+                MixpanelLogger.debug(message: "Flags not yet servable, attempting fetch for getAllVariants...")
+                self._fetchFlagsIfNeeded { _ in
+                    DispatchQueue.main.async { completion(self._getAllVariantsSyncImpl()) }
+                }
+            }
         }
-      }
-    }
-  }
-
-  // --- Fetching Logic (Simplified by Serial Queue) ---
-
-  // Internal function to handle fetch logic and state checks
-  private func _fetchFlagsIfNeeded(completion: ((Bool) -> Void)?) {
-    let optionsSnapshot = self.currentOptions
-
-    guard let options = optionsSnapshot, options.featureFlagOptions.enabled else {
-      MixpanelLogger.debug(message: "Feature flags are disabled, not fetching.")
-      // Dispatch completion to main queue to avoid potential deadlock
-      DispatchQueue.main.async {
-        completion?(false)
-      }
-      return  // Exit method
     }
 
-    var shouldStartFetch = false
+    // --- Fetching Logic (Simplified by Serial Queue) ---
 
-    // Access/Modify isFetching and fetchCompletionHandlers with write lock
-    flagsLock.write {
-      if let completion = completion {
-        self.fetchCompletionHandlers.append(completion)
-      }
-      if !self.isFetching {
-        self.isFetching = true
-        shouldStartFetch = true
-      } else {
-        MixpanelLogger.debug(message: "Fetch already in progress, queueing completion handler.")
-      }
-    }
+    // Internal function to handle fetch logic and state checks
+    private func _fetchFlagsIfNeeded(completion: ((Bool) -> Void)?) {
+        let optionsSnapshot = self.currentOptions
 
-    if shouldStartFetch {
-      MixpanelLogger.info(message: "Starting flag fetch...")
-      // Already on a background queue (callers dispatch before calling this method)
-      self._performFetchRequest()
-    }
-  }
-
-  // Performs the actual network request construction and call
-  internal func _performFetchRequest() {
-    // Record fetch start time and snapshot the current generation. The snapshot is checked
-    // in the success/failure closures so a fetch that was dispatched before reset() does not
-    // overwrite the freshly cleared state.
-    let startTime = Date()
-    var generation = 0
-    flagsLock.write {
-      self.fetchStartTime = startTime
-      generation = self.fetchGeneration
-    }
-
-    guard let delegate = self.delegate, let options = self.currentOptions else {
-      MixpanelLogger.error(message: "Delegate or options missing for fetch.")
-      self._completeFetch(success: false)
-      return
-    }
-
-    let distinctId = delegate.getDistinctId()
-    let anonymousId = delegate.getAnonymousId()
-    MixpanelLogger.debug(message: "Fetching flags for distinct ID: \(distinctId)")
-
-    var context: [String: Any] = [:]
-    flagsLock.read {
-      context = self.flagContext
-    }
-    context["distinct_id"] = distinctId
-    if let anonymousId = anonymousId {
-      context["device_id"] = anonymousId
-    }
-
-    guard
-      let contextData = try? JSONSerialization.data(
-        withJSONObject: context, options: []),
-      let contextString = String(data: contextData, encoding: .utf8)
-    else {
-      MixpanelLogger.error(message: "Failed to serialize context for flags.")
-      self._completeFetch(success: false)
-      return
-    }
-
-    guard let headers = createAuthHeaders(token: options.token) else {
-      MixpanelLogger.error(message: "Failed to create auth headers.")
-      self._completeFetch(success: false)
-      return
-    }
-
-    let queryItems = [
-      URLQueryItem(name: "context", value: contextString),
-      URLQueryItem(name: "token", value: options.token),
-      URLQueryItem(name: "mp_lib", value: "swift"),
-      URLQueryItem(name: "$lib_version", value: AutomaticProperties.libVersion())
-    ]
-
-    // Capture the raw response bytes via a reference holder so we can persist the wire
-    // format unchanged. Storing raw JSON (rather than re-encoding the parsed variants)
-    // keeps the parser as the single source of truth and carries `pending_first_time_events`
-    // through to subsequent loads for free.
-    let rawHolder = RawDataHolder()
-    let responseParser: (Data) -> FlagsResponse? = { data in
-      rawHolder.data = data
-      do { return try JSONDecoder().decode(FlagsResponse.self, from: data) } catch {
-        MixpanelLogger.error(message: "Error parsing flags JSON: \(error)")
-        return nil
-      }
-    }
-    let resource = Network.buildResource(
-      path: flagsRoute, method: .get, queryItems: queryItems, headers: headers,
-      parse: responseParser)
-
-    // Capture the distinctId at dispatch time. Using this (rather than re-reading delegate
-    // state at write time) ensures the persisted blob is keyed to the user we actually
-    // fetched for, even if identify() raced ahead.
-    let distinctIdAtDispatch = distinctId
-
-    // Make the API request
-    Network.apiRequest(
-      base: serverURL,
-      resource: resource,
-      failure: { [weak self] reason, data, response in
-        MixpanelLogger.error(message: "Failed to fetch flags. Reason: \(reason)")
-        guard let self = self else { return }
-        if self.isStaleFetch(generation: generation) {
-          MixpanelLogger.debug(
-            message: "Discarding flag fetch failure from stale generation \(generation).")
-          return
+        guard let options = optionsSnapshot, options.featureFlagOptions.enabled else {
+            MixpanelLogger.debug(message: "Feature flags are disabled, not fetching.")
+            // Dispatch completion to main queue to avoid potential deadlock
+            DispatchQueue.main.async {
+                completion?(false)
+            }
+            return  // Exit method
         }
-        // We've definitively failed to get a network response. Persisted values stay in
-        // place since we don't touch them on failure — `loadedBlobPersistedAt` also stays
-        // set, which means the next NetworkFirst async lookup will retry the network (the
-        // gate is "still serving from persistence," not "the very first call"). Per the
-        // spec, NetworkFirst retries until one fetch succeeds.
-        self._completeFetch(success: false)
-      },
-      success: { [weak self] (flagsResponse, response) in
-        MixpanelLogger.info(message: "Successfully fetched flags.  \(flagsResponse)")
-        guard let self = self else { return }
-        if self.isStaleFetch(generation: generation) {
-          MixpanelLogger.debug(
-            message: "Discarding flag fetch result from stale generation \(generation).")
-          return
-        }
-        let fetchEndTime = Date()
 
-        // Merge flags and update state with write lock
-        let (mergedFlags, mergedPendingEvents, mergedPendingEventNames) = self.mergeFlags(
-          responseFlags: flagsResponse.flags,
-          responsePendingEvents: flagsResponse.pendingFirstTimeEvents
+        var shouldStartFetch = false
+
+        // Access/Modify isFetching and fetchCompletionHandlers with write lock
+        flagsLock.write {
+            if let completion = completion {
+                self.fetchCompletionHandlers.append(completion)
+            }
+            if !self.isFetching {
+                self.isFetching = true
+                shouldStartFetch = true
+            } else {
+                MixpanelLogger.debug(message: "Fetch already in progress, queueing completion handler.")
+            }
+        }
+
+        if shouldStartFetch {
+            MixpanelLogger.info(message: "Starting flag fetch...")
+            // Already on a background queue (callers dispatch before calling this method)
+            self._performFetchRequest()
+        }
+    }
+
+    // Performs the actual network request construction and call
+    internal func _performFetchRequest() {
+        // Record fetch start time and snapshot the current generation. The snapshot is checked
+        // in the success/failure closures so a fetch that was dispatched before reset() does not
+        // overwrite the freshly cleared state.
+        let startTime = Date()
+        var generation = 0
+        flagsLock.write {
+            self.fetchStartTime = startTime
+            generation = self.fetchGeneration
+        }
+
+        guard let delegate = self.delegate, let options = self.currentOptions else {
+            MixpanelLogger.error(message: "Delegate or options missing for fetch.")
+            self._completeFetch(success: false)
+            return
+        }
+
+        let distinctId = delegate.getDistinctId()
+        let anonymousId = delegate.getAnonymousId()
+        MixpanelLogger.debug(message: "Fetching flags for distinct ID: \(distinctId)")
+
+        var context: [String: Any] = [:]
+        flagsLock.read {
+            context = self.flagContext
+        }
+        context["distinct_id"] = distinctId
+        if let anonymousId = anonymousId {
+            context["device_id"] = anonymousId
+        }
+
+        guard
+            let contextData = try? JSONSerialization.data(
+                withJSONObject: context, options: []),
+            let contextString = String(data: contextData, encoding: .utf8)
+        else {
+            MixpanelLogger.error(message: "Failed to serialize context for flags.")
+            self._completeFetch(success: false)
+            return
+        }
+
+        guard let headers = createAuthHeaders(token: options.token) else {
+            MixpanelLogger.error(message: "Failed to create auth headers.")
+            self._completeFetch(success: false)
+            return
+        }
+
+        let queryItems = [
+            URLQueryItem(name: "context", value: contextString),
+            URLQueryItem(name: "token", value: options.token),
+            URLQueryItem(name: "mp_lib", value: "swift"),
+            URLQueryItem(name: "$lib_version", value: AutomaticProperties.libVersion()),
+        ]
+
+        // Capture the raw response bytes via a reference holder so we can persist the wire
+        // format unchanged. Storing raw JSON (rather than re-encoding the parsed variants)
+        // keeps the parser as the single source of truth and carries `pending_first_time_events`
+        // through to subsequent loads for free.
+        let rawHolder = RawDataHolder()
+        let responseParser: (Data) -> FlagsResponse? = { data in
+            rawHolder.data = data
+            do { return try JSONDecoder().decode(FlagsResponse.self, from: data) } catch {
+                MixpanelLogger.error(message: "Error parsing flags JSON: \(error)")
+                return nil
+            }
+        }
+        let resource = Network.buildResource(
+            path: flagsRoute, method: .get, queryItems: queryItems, headers: headers,
+            parse: responseParser)
+
+        // Capture the distinctId at dispatch time. Using this (rather than re-reading delegate
+        // state at write time) ensures the persisted blob is keyed to the user we actually
+        // fetched for, even if identify() raced ahead.
+        let distinctIdAtDispatch = distinctId
+
+        // Make the API request
+        Network.apiRequest(
+            base: serverURL,
+            resource: resource,
+            failure: { [weak self] reason, data, response in
+                MixpanelLogger.error(message: "Failed to fetch flags. Reason: \(reason)")
+                guard let self = self else { return }
+                if self.isStaleFetch(generation: generation) {
+                    MixpanelLogger.debug(
+                        message: "Discarding flag fetch failure from stale generation \(generation).")
+                    return
+                }
+                // We've definitively failed to get a network response. Persisted values stay in
+                // place since we don't touch them on failure — `loadedBlobPersistedAt` also stays
+                // set, which means the next NetworkFirst async lookup will retry the network (the
+                // gate is "still serving from persistence," not "the very first call"). Per the
+                // spec, NetworkFirst retries until one fetch succeeds.
+                self._completeFetch(success: false)
+            },
+            success: { [weak self] (flagsResponse, response) in
+                MixpanelLogger.info(message: "Successfully fetched flags.  \(flagsResponse)")
+                guard let self = self else { return }
+                if self.isStaleFetch(generation: generation) {
+                    MixpanelLogger.debug(
+                        message: "Discarding flag fetch result from stale generation \(generation).")
+                    return
+                }
+                let fetchEndTime = Date()
+
+                // Merge flags and update state with write lock
+                let (mergedFlags, mergedPendingEvents, mergedPendingEventNames) = self.mergeFlags(
+                    responseFlags: flagsResponse.flags,
+                    responsePendingEvents: flagsResponse.pendingFirstTimeEvents
+                )
+
+                // Stamp every variant with .network before publishing. mergeFlags may have preserved
+                // some prior-flag entries (activated first-time events) — those came from a prior
+                // network response too, so .network is correct for them as well.
+                let stampedFlags = mergedFlags.mapValues { $0.withSource(.network) }
+
+                // Snapshot the persistence-policy decision OUTSIDE the lock to avoid calling into
+                // the delegate (`getOptions()`) while holding the write lock — keeps the lock
+                // surface narrow and avoids potential deadlocks if a future delegate impl ever takes
+                // a lock of its own.
+                let shouldPersist = self.shouldPersistVariants()
+
+                // Single critical section: gate the in-memory write AND the on-disk persistence
+                // write on the same generation check. Without this, a reset() between the lock
+                // release and the disk write could leak prior-user variants onto disk under the
+                // prior-user distinctId (the next session's distinctId check would catch it, but
+                // the disk write is wasted I/O and confusing in logs).
+                var didApplyResults = false
+                self.flagsLock.write {
+                    // Re-check generation under the lock in case reset() raced between the check above
+                    // and the write. If stale, drop the result without touching state or completing.
+                    guard generation == self.fetchGeneration else { return }
+                    self.flags = stampedFlags
+                    self.loadedBlobPersistedAt = nil
+                    self.pendingFirstTimeEvents = mergedPendingEvents
+                    self.pendingFirstTimeEventNames = mergedPendingEventNames
+                    // Reset the per-flag $experiment_started dedup window. Without this, a flag whose
+                    // variant value changed between fetches (e.g. persistence-loaded "control" →
+                    // network "treatment", or a re-fetch under a new server-side rule) would serve the
+                    // new value but silently skip tracking — analytics would still show the prior
+                    // exposure. Clearing here means each successful fetch gets a fresh shot at firing
+                    // $experiment_started for any accessed flag. Trade-off: occasional duplicate
+                    // events when the variant didn't actually change across fetches; we accept that
+                    // for analytics correctness.
+                    self.trackedFeatures.removeAll()
+                    // Successful fetch overwrites the persisted-blob marker — derived helpers like
+                    // `isNetworkFirstAwaitingFetch()` and `loadedFlagsAreStale()` correctly flip to
+                    // false on the next read since `loadedBlobPersistedAt` is now nil (cleared above).
+
+                    // Calculate timing metrics
+                    if let startTime = self.fetchStartTime {
+                        let latencyMs = Int(fetchEndTime.timeIntervalSince(startTime) * 1000)
+                        self.fetchLatencyMs = latencyMs
+                    }
+                    self.timeLastFetched = fetchEndTime
+
+                    MixpanelLogger.debug(
+                        message:
+                            "Flags updated: \(self.flags ?? [:]), Pending events: \(self.pendingFirstTimeEvents.count)")
+                    didApplyResults = true
+                }
+
+                // Persist the raw response so future sessions / failed fetches can fall back. Writes
+                // are gated by the lookup policy via `shouldPersist` (true for `.persistenceUntilNetworkSuccess`
+                // and `.networkFirst`, false for `.networkOnly`). Skipped when `didApplyResults` is
+                // false because that means the generation check failed (reset raced ahead) and we
+                // shouldn't overwrite the persisted blob with prior-user data. UserDefaults I/O is
+                // kept outside the lock since it can block.
+                if didApplyResults,
+                    shouldPersist,
+                    let rawData = rawHolder.data,
+                    let rawString = String(data: rawData, encoding: .utf8)
+                {
+                    let blob = FlagsPersistenceBlob(
+                        persistedAt: fetchEndTime,
+                        distinctId: distinctIdAtDispatch,
+                        response: rawString
+                    )
+                    MixpanelPersistence.saveFlagsPersistence(blob, instanceName: self.instanceName)
+                }
+
+                self._completeFetch(success: true)
+            }
         )
+    }
 
-        // Stamp every variant with .network before publishing. mergeFlags may have preserved
-        // some prior-flag entries (activated first-time events) — those came from a prior
-        // network response too, so .network is correct for them as well.
-        let stampedFlags = mergedFlags.mapValues { $0.withSource(.network) }
+    /// Internal reference-type holder so the response-parser closure can hand the raw response
+    /// bytes back to the success closure for persistence. Class (not struct) so the captured
+    /// reference shares state across closure invocations.
+    private final class RawDataHolder {
+        var data: Data?
+    }
 
-        // Snapshot the persistence-policy decision OUTSIDE the lock to avoid calling into
-        // the delegate (`getOptions()`) while holding the write lock — keeps the lock
-        // surface narrow and avoids potential deadlocks if a future delegate impl ever takes
-        // a lock of its own.
-        let shouldPersist = self.shouldPersistVariants()
+    // MARK: - Persistence Helpers
 
-        // Single critical section: gate the in-memory write AND the on-disk persistence
-        // write on the same generation check. Without this, a reset() between the lock
-        // release and the disk write could leak prior-user variants onto disk under the
-        // prior-user distinctId (the next session's distinctId check would catch it, but
-        // the disk write is wasted I/O and confusing in logs).
-        var didApplyResults = false
-        self.flagsLock.write {
-          // Re-check generation under the lock in case reset() raced between the check above
-          // and the write. If stale, drop the result without touching state or completing.
-          guard generation == self.fetchGeneration else { return }
-          self.flags = stampedFlags
-          self.loadedBlobPersistedAt = nil
-          self.pendingFirstTimeEvents = mergedPendingEvents
-          self.pendingFirstTimeEventNames = mergedPendingEventNames
-          // Reset the per-flag $experiment_started dedup window. Without this, a flag whose
-          // variant value changed between fetches (e.g. persistence-loaded "control" →
-          // network "treatment", or a re-fetch under a new server-side rule) would serve the
-          // new value but silently skip tracking — analytics would still show the prior
-          // exposure. Clearing here means each successful fetch gets a fresh shot at firing
-          // $experiment_started for any accessed flag. Trade-off: occasional duplicate
-          // events when the variant didn't actually change across fetches; we accept that
-          // for analytics correctness.
-          self.trackedFeatures.removeAll()
-          // Successful fetch overwrites the persisted-blob marker — derived helpers like
-          // `isNetworkFirstAwaitingFetch()` and `loadedFlagsAreStale()` correctly flip to
-          // false on the next read since `loadedBlobPersistedAt` is now nil (cleared above).
-
-          // Calculate timing metrics
-          if let startTime = self.fetchStartTime {
-            let latencyMs = Int(fetchEndTime.timeIntervalSince(startTime) * 1000)
-            self.fetchLatencyMs = latencyMs
-          }
-          self.timeLastFetched = fetchEndTime
-
-          MixpanelLogger.debug(message: "Flags updated: \(self.flags ?? [:]), Pending events: \(self.pendingFirstTimeEvents.count)")
-          didApplyResults = true
+    /// Loads the on-disk persistence blob, validates distinctId + TTL, parses, stamps every
+    /// variant with `.persistence(persistedAt:)`, and writes into `flags`. Both
+    /// `.persistenceUntilNetworkSuccess` and `.networkFirst` populate `flags` directly so sync
+    /// lookups and `areFlagsReady()` reflect persisted values. The difference between policies
+    /// is enforced at async-lookup time via `isNetworkFirstAwaitingFetch()`: NetworkFirst gates
+    /// async lookups on a successful network response (i.e., until `loadedBlobPersistedAt` is
+    /// cleared by a successful fetch), per the ERD.
+    ///
+    /// Runs on the tracking queue (called from init).
+    internal func _loadPersistedVariants() {
+        guard let blob = MixpanelPersistence.loadFlagsPersistence(instanceName: self.instanceName) else {
+            return
         }
 
-        // Persist the raw response so future sessions / failed fetches can fall back. Writes
-        // are gated by the lookup policy via `shouldPersist` (true for `.persistenceUntilNetworkSuccess`
-        // and `.networkFirst`, false for `.networkOnly`). Skipped when `didApplyResults` is
-        // false because that means the generation check failed (reset raced ahead) and we
-        // shouldn't overwrite the persisted blob with prior-user data. UserDefaults I/O is
-        // kept outside the lock since it can block.
-        if didApplyResults,
-           shouldPersist,
-           let rawData = rawHolder.data,
-           let rawString = String(data: rawData, encoding: .utf8) {
-          let blob = FlagsPersistenceBlob(
-            persistedAt: fetchEndTime,
-            distinctId: distinctIdAtDispatch,
-            response: rawString
-          )
-          MixpanelPersistence.saveFlagsPersistence(blob, instanceName: self.instanceName)
+        // distinctId check — refuse to serve another user's variants under this user's identity.
+        // Wipe the stale blob so it doesn't sit on disk for someone who no longer uses this device.
+        // This is a parallel of the active "distinctId changes" paths (identify/reset/optOut)
+        // applied to the cross-session case where the change happened while the app was killed.
+        let delegate = self.delegate
+        let currentDistinctId = delegate?.getDistinctId() ?? ""
+        if blob.distinctId != currentDistinctId {
+            MixpanelLogger.debug(message: "Persisted flags belong to a different distinct_id; clearing.")
+            MixpanelPersistence.deleteFlagsPersistence(instanceName: self.instanceName)
+            return
         }
 
-        self._completeFetch(success: true)
-      }
-    )
-  }
-
-  /// Internal reference-type holder so the response-parser closure can hand the raw response
-  /// bytes back to the success closure for persistence. Class (not struct) so the captured
-  /// reference shares state across closure invocations.
-  private final class RawDataHolder {
-    var data: Data?
-  }
-
-  // MARK: - Persistence Helpers
-
-  /// Loads the on-disk persistence blob, validates distinctId + TTL, parses, stamps every
-  /// variant with `.persistence(persistedAt:)`, and writes into `flags`. Both
-  /// `.persistenceUntilNetworkSuccess` and `.networkFirst` populate `flags` directly so sync
-  /// lookups and `areFlagsReady()` reflect persisted values. The difference between policies
-  /// is enforced at async-lookup time via `isNetworkFirstAwaitingFetch()`: NetworkFirst gates
-  /// async lookups on a successful network response (i.e., until `loadedBlobPersistedAt` is
-  /// cleared by a successful fetch), per the ERD.
-  ///
-  /// Runs on the tracking queue (called from init).
-  internal func _loadPersistedVariants() {
-    guard let blob = MixpanelPersistence.loadFlagsPersistence(instanceName: self.instanceName) else {
-      return
-    }
-
-    // distinctId check — refuse to serve another user's variants under this user's identity.
-    // Wipe the stale blob so it doesn't sit on disk for someone who no longer uses this device.
-    // This is a parallel of the active "distinctId changes" paths (identify/reset/optOut)
-    // applied to the cross-session case where the change happened while the app was killed.
-    let delegate = self.delegate
-    let currentDistinctId = delegate?.getDistinctId() ?? ""
-    if blob.distinctId != currentDistinctId {
-      MixpanelLogger.debug(message: "Persisted flags belong to a different distinct_id; clearing.")
-      MixpanelPersistence.deleteFlagsPersistence(instanceName: self.instanceName)
-      return
-    }
-
-    // TTL check — discard expired entries. `persistenceTtlSeconds()` returns nil under
-    // `.networkOnly` (we wouldn't be here in that case) and otherwise a positive TTL
-    // (non-positive values are filtered out at policy resolution).
-    if let ttl = self.persistenceTtlSeconds(),
-       Date().timeIntervalSince(blob.persistedAt) > ttl {
-      MixpanelLogger.debug(message: "Persisted flags expired; ignoring.")
-      return
-    }
-
-    // Parse the raw response. The persistence layer self-heals structural failures (bad
-    // JSON envelope) on read, but a structurally-valid blob with an unparseable `response`
-    // string would stick on disk and fail every cold-start. Wipe it here too so the next
-    // successful fetch gets a clean slate.
-    guard let responseData = blob.response.data(using: .utf8),
-          let parsed = try? JSONDecoder().decode(FlagsResponse.self, from: responseData) else {
-      MixpanelLogger.warn(message: "Failed to parse persisted flags response; clearing.")
-      MixpanelPersistence.deleteFlagsPersistence(instanceName: self.instanceName)
-      return
-    }
-
-    let parsedFlags = parsed.flags ?? [:]
-    let stamped = parsedFlags.mapValues { $0.withSource(.persistence(persistedAt: blob.persistedAt)) }
-
-    // Build pending-event lookups so first-time event matching keeps working from
-    // persistence.
-    var pendingEvents: [String: PendingFirstTimeEvent] = [:]
-    var pendingEventNames: Set<String> = []
-    if let events = parsed.pendingFirstTimeEvents {
-      for event in events {
-        let key = self.getPendingEventKey(event.flagKey, event.firstTimeEventHash)
-        pendingEvents[key] = event
-        pendingEventNames.insert(event.eventName)
-      }
-    }
-
-    flagsLock.write {
-      // Defer to network values if a fetch already raced ahead of us between init and now.
-      guard self.flags == nil else { return }
-      self.flags = stamped
-      self.loadedBlobPersistedAt = blob.persistedAt
-      self.pendingFirstTimeEvents = pendingEvents
-      self.pendingFirstTimeEventNames = pendingEventNames
-      // For NetworkFirst, async lookups must wait for a successful network response.
-      // `isNetworkFirstAwaitingFetch()` derives that gate from the policy +
-      // `loadedBlobPersistedAt` — no separate flag to keep in sync.
-      MixpanelLogger.debug(message: "Loaded \(stamped.count) persisted variants into memory.")
-    }
-  }
-
-  /// Returns `true` when the policy is `.networkFirst` and we're still serving from the
-  /// persisted blob (no successful network fetch has overwritten it yet). Async lookups
-  /// gate on this to honor the NetworkFirst spec ("wait on network call, only serve
-  /// persisted values if it fails") while still letting sync lookups + `areFlagsReady()`
-  /// see the persisted values.
-  ///
-  /// Stays true across failed fetches so each subsequent async lookup re-attempts the
-  /// network until one succeeds, matching the pre-persistence behavior where a `nil`
-  /// `flags` caused getVariant to retry indefinitely.
-  ///
-  /// Caller must hold `flagsLock`.
-  private func isNetworkFirstAwaitingFetch() -> Bool {
-    guard case .networkFirst = self.resolvedLookupPolicy else { return false }
-    return self.loadedBlobPersistedAt != nil
-  }
-
-  /// Returns the configured TTL in seconds, or `nil` for `.networkOnly` (no expiry check).
-  /// Reads from `resolvedLookupPolicy`, so non-positive TTLs have already been collapsed to
-  /// `.networkOnly` at init — anything returned here is `> 0`.
-  private func persistenceTtlSeconds() -> TimeInterval? {
-    switch self.resolvedLookupPolicy {
-    case .networkOnly:
-      return nil
-    case .persistenceUntilNetworkSuccess(let ttl), .networkFirst(let ttl):
-      return ttl
-    }
-  }
-
-  /// Whether successful fetches should be persisted to disk. Derived from the resolved
-  /// policy: `.persistenceUntilNetworkSuccess` and `.networkFirst` write to disk;
-  /// `.networkOnly` doesn't.
-  private func shouldPersistVariants() -> Bool {
-    switch self.resolvedLookupPolicy {
-    case .networkOnly:
-      return false
-    case .persistenceUntilNetworkSuccess, .networkFirst:
-      return true
-    }
-  }
-
-  /// Returns true if the loaded persisted blob is past TTL. Uses `loadedBlobPersistedAt`
-  /// rather than inspecting variant sources so the check works uniformly whether the blob
-  /// has flags in it or is empty (a previous session may have persisted a no-flags
-  /// response — we still want TTL to govern when to refresh).
-  ///
-  /// Returns false when no persisted blob is in memory or under `.networkOnly`.
-  ///
-  /// Caller must hold `flagsLock`.
-  private func loadedFlagsAreStale() -> Bool {
-    guard let persistedAt = self.loadedBlobPersistedAt,
-          let ttl = self.persistenceTtlSeconds() else { return false }
-    return Date().timeIntervalSince(persistedAt) > ttl
-  }
-
-  /// Returns true if the variant was loaded from the persistence layer and has aged past
-  /// the configured TTL. `.network` and `.fallback` variants are never expired — including
-  /// activated first-time-event variants, which are deliberately stamped `.network` to
-  /// survive blob expiration.
-  ///
-  /// Get-paths use this to skip stale persisted values mid-session — once a variant's TTL
-  /// elapses while loaded in memory, subsequent `getVariant` calls return the developer
-  /// fallback instead of the stale value. The on-disk blob is intentionally NOT deleted
-  /// (per the "don't clear if TTL has expired on getVariant" rule); the next successful
-  /// network fetch overwrites it.
-  private func isVariantExpired(_ variant: MixpanelFlagVariant) -> Bool {
-    guard case .persistence(let persistedAt) = variant.source else { return false }
-    guard let ttl = self.persistenceTtlSeconds() else { return false }
-    return Date().timeIntervalSince(persistedAt) > ttl
-  }
-
-  /// Returns true if the captured `generation` no longer matches the current generation,
-  /// meaning the fetch was started before a `reset()` and its result should be discarded.
-  private func isStaleFetch(generation: Int) -> Bool {
-    var current = 0
-    flagsLock.read {
-      current = self.fetchGeneration
-    }
-    return current != generation
-  }
-
-  // Centralized fetch completion logic
-  func _completeFetch(success: Bool) {
-    var handlers: [(Bool) -> Void] = []
-
-    flagsLock.write {
-      self.isFetching = false
-      handlers = self.fetchCompletionHandlers
-      self.fetchCompletionHandlers.removeAll()
-    }
-
-    DispatchQueue.main.async {
-      handlers.forEach { $0(success) }
-    }
-  }
-
-  // --- Flag Merging Helper ---
-  func mergeFlags(
-    responseFlags: [String: MixpanelFlagVariant]?,
-    responsePendingEvents: [PendingFirstTimeEvent]?
-  ) -> (flags: [String: MixpanelFlagVariant], pendingEvents: [String: PendingFirstTimeEvent], pendingEventNames: Set<String>) {
-    var newFlags: [String: MixpanelFlagVariant] = [:]
-    var newPendingEvents: [String: PendingFirstTimeEvent] = [:]
-    var newPendingEventNames: Set<String> = Set()
-
-    var currentFlags: [String: MixpanelFlagVariant]?
-    var activatedEvents: Set<String> = []
-
-    // Read current state with lock
-    flagsLock.read {
-      currentFlags = self.flags
-      activatedEvents = self.activatedFirstTimeEvents
-    }
-
-    // Process flags from response
-    if let responseFlags = responseFlags {
-      for (flagKey, variant) in responseFlags {
-        // Check if any event for this flag was activated
-        let hasActivatedEvent = activatedEvents.contains { eventKey in
-          eventKey.hasPrefix("\(flagKey):")
+        // TTL check — discard expired entries. `persistenceTtlSeconds()` returns nil under
+        // `.networkOnly` (we wouldn't be here in that case) and otherwise a positive TTL
+        // (non-positive values are filtered out at policy resolution).
+        if let ttl = self.persistenceTtlSeconds(),
+            Date().timeIntervalSince(blob.persistedAt) > ttl
+        {
+            MixpanelLogger.debug(message: "Persisted flags expired; ignoring.")
+            return
         }
 
-        if hasActivatedEvent, let currentFlag = currentFlags?[flagKey] {
-          // Preserve activated variant
-          newFlags[flagKey] = currentFlag
+        // Parse the raw response. The persistence layer self-heals structural failures (bad
+        // JSON envelope) on read, but a structurally-valid blob with an unparseable `response`
+        // string would stick on disk and fail every cold-start. Wipe it here too so the next
+        // successful fetch gets a clean slate.
+        guard let responseData = blob.response.data(using: .utf8),
+            let parsed = try? JSONDecoder().decode(FlagsResponse.self, from: responseData)
+        else {
+            MixpanelLogger.warn(message: "Failed to parse persisted flags response; clearing.")
+            MixpanelPersistence.deleteFlagsPersistence(instanceName: self.instanceName)
+            return
+        }
+
+        let parsedFlags = parsed.flags ?? [:]
+        let stamped = parsedFlags.mapValues { $0.withSource(.persistence(persistedAt: blob.persistedAt)) }
+
+        // Build pending-event lookups so first-time event matching keeps working from
+        // persistence.
+        var pendingEvents: [String: PendingFirstTimeEvent] = [:]
+        var pendingEventNames: Set<String> = []
+        if let events = parsed.pendingFirstTimeEvents {
+            for event in events {
+                let key = self.getPendingEventKey(event.flagKey, event.firstTimeEventHash)
+                pendingEvents[key] = event
+                pendingEventNames.insert(event.eventName)
+            }
+        }
+
+        flagsLock.write {
+            // Defer to network values if a fetch already raced ahead of us between init and now.
+            guard self.flags == nil else { return }
+            self.flags = stamped
+            self.loadedBlobPersistedAt = blob.persistedAt
+            self.pendingFirstTimeEvents = pendingEvents
+            self.pendingFirstTimeEventNames = pendingEventNames
+            // For NetworkFirst, async lookups must wait for a successful network response.
+            // `isNetworkFirstAwaitingFetch()` derives that gate from the policy +
+            // `loadedBlobPersistedAt` — no separate flag to keep in sync.
+            MixpanelLogger.debug(message: "Loaded \(stamped.count) persisted variants into memory.")
+        }
+    }
+
+    /// Returns `true` when the policy is `.networkFirst` and we're still serving from the
+    /// persisted blob (no successful network fetch has overwritten it yet). Async lookups
+    /// gate on this to honor the NetworkFirst spec ("wait on network call, only serve
+    /// persisted values if it fails") while still letting sync lookups + `areFlagsReady()`
+    /// see the persisted values.
+    ///
+    /// Stays true across failed fetches so each subsequent async lookup re-attempts the
+    /// network until one succeeds, matching the pre-persistence behavior where a `nil`
+    /// `flags` caused getVariant to retry indefinitely.
+    ///
+    /// Caller must hold `flagsLock`.
+    private func isNetworkFirstAwaitingFetch() -> Bool {
+        guard case .networkFirst = self.resolvedLookupPolicy else { return false }
+        return self.loadedBlobPersistedAt != nil
+    }
+
+    /// Returns the configured TTL in seconds, or `nil` for `.networkOnly` (no expiry check).
+    /// Reads from `resolvedLookupPolicy`, so non-positive TTLs have already been collapsed to
+    /// `.networkOnly` at init — anything returned here is `> 0`.
+    private func persistenceTtlSeconds() -> TimeInterval? {
+        switch self.resolvedLookupPolicy {
+            case .networkOnly:
+                return nil
+            case .persistenceUntilNetworkSuccess(let ttl), .networkFirst(let ttl):
+                return ttl
+        }
+    }
+
+    /// Whether successful fetches should be persisted to disk. Derived from the resolved
+    /// policy: `.persistenceUntilNetworkSuccess` and `.networkFirst` write to disk;
+    /// `.networkOnly` doesn't.
+    private func shouldPersistVariants() -> Bool {
+        switch self.resolvedLookupPolicy {
+            case .networkOnly:
+                return false
+            case .persistenceUntilNetworkSuccess, .networkFirst:
+                return true
+        }
+    }
+
+    /// Returns true if the loaded persisted blob is past TTL. Uses `loadedBlobPersistedAt`
+    /// rather than inspecting variant sources so the check works uniformly whether the blob
+    /// has flags in it or is empty (a previous session may have persisted a no-flags
+    /// response — we still want TTL to govern when to refresh).
+    ///
+    /// Returns false when no persisted blob is in memory or under `.networkOnly`.
+    ///
+    /// Caller must hold `flagsLock`.
+    private func loadedFlagsAreStale() -> Bool {
+        guard let persistedAt = self.loadedBlobPersistedAt,
+            let ttl = self.persistenceTtlSeconds()
+        else { return false }
+        return Date().timeIntervalSince(persistedAt) > ttl
+    }
+
+    /// Returns true if the variant was loaded from the persistence layer and has aged past
+    /// the configured TTL. `.network` and `.fallback` variants are never expired — including
+    /// activated first-time-event variants, which are deliberately stamped `.network` to
+    /// survive blob expiration.
+    ///
+    /// Get-paths use this to skip stale persisted values mid-session — once a variant's TTL
+    /// elapses while loaded in memory, subsequent `getVariant` calls return the developer
+    /// fallback instead of the stale value. The on-disk blob is intentionally NOT deleted
+    /// (per the "don't clear if TTL has expired on getVariant" rule); the next successful
+    /// network fetch overwrites it.
+    private func isVariantExpired(_ variant: MixpanelFlagVariant) -> Bool {
+        guard case .persistence(let persistedAt) = variant.source else { return false }
+        guard let ttl = self.persistenceTtlSeconds() else { return false }
+        return Date().timeIntervalSince(persistedAt) > ttl
+    }
+
+    /// Returns true if the captured `generation` no longer matches the current generation,
+    /// meaning the fetch was started before a `reset()` and its result should be discarded.
+    private func isStaleFetch(generation: Int) -> Bool {
+        var current = 0
+        flagsLock.read {
+            current = self.fetchGeneration
+        }
+        return current != generation
+    }
+
+    // Centralized fetch completion logic
+    func _completeFetch(success: Bool) {
+        var handlers: [(Bool) -> Void] = []
+
+        flagsLock.write {
+            self.isFetching = false
+            handlers = self.fetchCompletionHandlers
+            self.fetchCompletionHandlers.removeAll()
+        }
+
+        DispatchQueue.main.async {
+            handlers.forEach { $0(success) }
+        }
+    }
+
+    // --- Flag Merging Helper ---
+    func mergeFlags(
+        responseFlags: [String: MixpanelFlagVariant]?,
+        responsePendingEvents: [PendingFirstTimeEvent]?
+    ) -> (
+        flags: [String: MixpanelFlagVariant], pendingEvents: [String: PendingFirstTimeEvent],
+        pendingEventNames: Set<String>
+    ) {
+        var newFlags: [String: MixpanelFlagVariant] = [:]
+        var newPendingEvents: [String: PendingFirstTimeEvent] = [:]
+        var newPendingEventNames: Set<String> = Set()
+
+        var currentFlags: [String: MixpanelFlagVariant]?
+        var activatedEvents: Set<String> = []
+
+        // Read current state with lock
+        flagsLock.read {
+            currentFlags = self.flags
+            activatedEvents = self.activatedFirstTimeEvents
+        }
+
+        // Process flags from response
+        if let responseFlags = responseFlags {
+            for (flagKey, variant) in responseFlags {
+                // Check if any event for this flag was activated
+                let hasActivatedEvent = activatedEvents.contains { eventKey in
+                    eventKey.hasPrefix("\(flagKey):")
+                }
+
+                if hasActivatedEvent, let currentFlag = currentFlags?[flagKey] {
+                    // Preserve activated variant
+                    newFlags[flagKey] = currentFlag
+                } else {
+                    // Use server's current variant
+                    newFlags[flagKey] = variant
+                }
+            }
+        }
+
+        // Process pending first-time events from response
+        if let responsePendingEvents = responsePendingEvents {
+            for pendingEvent in responsePendingEvents {
+                let eventKey = self.getPendingEventKey(pendingEvent.flagKey, pendingEvent.firstTimeEventHash)
+
+                // Skip if already activated
+                if activatedEvents.contains(eventKey) {
+                    continue
+                }
+
+                newPendingEvents[eventKey] = pendingEvent
+                newPendingEventNames.insert(pendingEvent.eventName)
+            }
+        }
+
+        // Preserve orphaned activated flags
+        for eventKey in activatedEvents {
+            guard let flagKey = self.getFlagKeyFromPendingEventKey(eventKey) else {
+                MixpanelLogger.warn(message: "Failed to parse flag key from event key: \(eventKey)")
+                continue
+            }
+            if newFlags[flagKey] == nil, let orphanedFlag = currentFlags?[flagKey] {
+                newFlags[flagKey] = orphanedFlag
+            }
+        }
+
+        return (flags: newFlags, pendingEvents: newPendingEvents, pendingEventNames: newPendingEventNames)
+    }
+
+    // --- Tracking Logic ---
+
+    // Performs the atomic check and triggers delegate call if needed
+    private func _trackFlagIfNeeded(flagName: String, variant: MixpanelFlagVariant) {
+        var shouldCallDelegate = false
+        var capturedTimeLastFetched: Date?
+        var capturedFetchLatencyMs: Int?
+
+        // Use write lock for atomic check-and-set
+        flagsLock.write {
+            if !self.trackedFeatures.contains(flagName) {
+                self.trackedFeatures.insert(flagName)
+                shouldCallDelegate = true
+                // Capture timing data while in lock
+                capturedTimeLastFetched = self.timeLastFetched
+                capturedFetchLatencyMs = self.fetchLatencyMs
+            }
+        }
+
+        // Call delegate outside the lock if tracking occurred
+        if shouldCallDelegate {
+            self._performTrackingDelegateCall(
+                flagName: flagName,
+                variant: variant,
+                timeLastFetched: capturedTimeLastFetched,
+                fetchLatencyMs: capturedFetchLatencyMs
+            )
+        }
+    }
+
+    // Helper to call the delegate with timing data passed as parameters
+    private func _performTrackingDelegateCall(
+        flagName: String,
+        variant: MixpanelFlagVariant,
+        timeLastFetched: Date? = nil,
+        fetchLatencyMs: Int? = nil
+    ) {
+        guard let delegate = self.delegate else { return }
+
+        var properties: Properties = [
+            "Experiment name": flagName,
+            "Variant name": variant.key,
+            "$experiment_type": "feature_flag",
+        ]
+
+        // Add timing properties if provided
+        if let timeLastFetched = timeLastFetched {
+            properties["timeLastFetched"] = Int(timeLastFetched.timeIntervalSince1970)
+        }
+        if let fetchLatencyMs = fetchLatencyMs {
+            properties["fetchLatencyMs"] = fetchLatencyMs
+        }
+
+        if let experimentID = variant.experimentID {
+            properties["$experiment_id"] = experimentID
+        }
+        if let isExperimentActive = variant.isExperimentActive {
+            properties["$is_experiment_active"] = isExperimentActive
+        }
+        if let isQATester = variant.isQATester {
+            properties["$is_qa_tester"] = isQATester
+        }
+
+        // Source tracking properties. `$variant_source` is sent for every served variant
+        // (`.network` or `.persistence`) to match the JS SDK. `$persisted_at_in_ms` and
+        // `$ttl_in_ms` are persistence-only — the timestamp is the raw epoch millis the blob
+        // was written, sent without any delta calculation so the server can derive what it
+        // needs. Tracking only fires for served variants, so `.fallback` won't appear here.
+        switch variant.source {
+            case .network:
+                properties["$variant_source"] = "network"
+            case .persistence(let persistedAt):
+                properties["$variant_source"] = "persistence"
+                properties["$persisted_at_in_ms"] = Int(persistedAt.timeIntervalSince1970 * 1000)
+                if let ttl = self.persistenceTtlSeconds() {
+                    properties["$ttl_in_ms"] = Int(ttl * 1000)
+                }
+            case .fallback:
+                break
+        }
+
+        // Dispatch delegate call asynchronously to main thread for safety
+        DispatchQueue.main.async {
+            delegate.track(event: "$experiment_started", properties: properties)
+            MixpanelLogger.debug(message: "Tracked $experiment_started for \(flagName) (dispatched to main)")
+        }
+    }
+
+    // --- Boolean Evaluation Helper ---
+    private func _evaluateBooleanFlag(flagName: String, variantValue: Any?, fallbackValue: Bool)
+        -> Bool
+    {
+        guard let val = variantValue else { return fallbackValue }
+        if let boolVal = val as? Bool {
+            return boolVal
         } else {
-          // Use server's current variant
-          newFlags[flagKey] = variant
+            MixpanelLogger.error(message: "Flag '\(flagName)' is not Bool")
+            return fallbackValue
         }
-      }
     }
 
-    // Process pending first-time events from response
-    if let responsePendingEvents = responsePendingEvents {
-      for pendingEvent in responsePendingEvents {
-        let eventKey = self.getPendingEventKey(pendingEvent.flagKey, pendingEvent.firstTimeEventHash)
-
-        // Skip if already activated
-        if activatedEvents.contains(eventKey) {
-          continue
+    // --- Auth Header Helper ---
+    private func createAuthHeaders(token: String, includeContentType: Bool = false) -> [String: String]? {
+        guard let authData = "\(token):".data(using: .utf8) else {
+            return nil
         }
 
-        newPendingEvents[eventKey] = pendingEvent
-        newPendingEventNames.insert(pendingEvent.eventName)
-      }
+        var headers = ["Authorization": "Basic \(authData.base64EncodedString())"]
+
+        if includeContentType {
+            headers["Content-Type"] = "application/json"
+        }
+
+        return headers
     }
 
-    // Preserve orphaned activated flags
-    for eventKey in activatedEvents {
-      guard let flagKey = self.getFlagKeyFromPendingEventKey(eventKey) else {
-        MixpanelLogger.warn(message: "Failed to parse flag key from event key: \(eventKey)")
-        continue
-      }
-      if newFlags[flagKey] == nil, let orphanedFlag = currentFlags?[flagKey] {
-        newFlags[flagKey] = orphanedFlag
-      }
+    // MARK: - First-Time Event Helpers
+
+    /// Generate a unique key for a pending first-time event
+    private func getPendingEventKey(_ flagKey: String, _ firstTimeEventHash: String) -> String {
+        return "\(flagKey):\(firstTimeEventHash)"
     }
 
-    return (flags: newFlags, pendingEvents: newPendingEvents, pendingEventNames: newPendingEventNames)
-  }
-
-  // --- Tracking Logic ---
-
-  // Performs the atomic check and triggers delegate call if needed
-  private func _trackFlagIfNeeded(flagName: String, variant: MixpanelFlagVariant) {
-    var shouldCallDelegate = false
-    var capturedTimeLastFetched: Date?
-    var capturedFetchLatencyMs: Int?
-
-    // Use write lock for atomic check-and-set
-    flagsLock.write {
-      if !self.trackedFeatures.contains(flagName) {
-        self.trackedFeatures.insert(flagName)
-        shouldCallDelegate = true
-        // Capture timing data while in lock
-        capturedTimeLastFetched = self.timeLastFetched
-        capturedFetchLatencyMs = self.fetchLatencyMs
-      }
+    /// Extract the flag key from a pending event key
+    private func getFlagKeyFromPendingEventKey(_ eventKey: String) -> String? {
+        return eventKey.split(separator: ":", maxSplits: 1).first.map { String($0) }
     }
 
-    // Call delegate outside the lock if tracking occurred
-    if shouldCallDelegate {
-      self._performTrackingDelegateCall(
-        flagName: flagName,
-        variant: variant,
-        timeLastFetched: capturedTimeLastFetched,
-        fetchLatencyMs: capturedFetchLatencyMs
-      )
-    }
-  }
-
-  // Helper to call the delegate with timing data passed as parameters
-  private func _performTrackingDelegateCall(
-    flagName: String,
-    variant: MixpanelFlagVariant,
-    timeLastFetched: Date? = nil,
-    fetchLatencyMs: Int? = nil
-  ) {
-    guard let delegate = self.delegate else { return }
-
-    var properties: Properties = [
-      "Experiment name": flagName,
-      "Variant name": variant.key,
-      "$experiment_type": "feature_flag",
-    ]
-
-    // Add timing properties if provided
-    if let timeLastFetched = timeLastFetched {
-      properties["timeLastFetched"] = Int(timeLastFetched.timeIntervalSince1970)
-    }
-    if let fetchLatencyMs = fetchLatencyMs {
-      properties["fetchLatencyMs"] = fetchLatencyMs
-    }
-
-    if let experimentID = variant.experimentID {
-      properties["$experiment_id"] = experimentID
-    }
-    if let isExperimentActive = variant.isExperimentActive {
-      properties["$is_experiment_active"] = isExperimentActive
-    }
-    if let isQATester = variant.isQATester {
-      properties["$is_qa_tester"] = isQATester
-    }
-
-    // Source tracking properties. `$variant_source` is sent for every served variant
-    // (`.network` or `.persistence`) to match the JS SDK. `$persisted_at_in_ms` and
-    // `$ttl_in_ms` are persistence-only — the timestamp is the raw epoch millis the blob
-    // was written, sent without any delta calculation so the server can derive what it
-    // needs. Tracking only fires for served variants, so `.fallback` won't appear here.
-    switch variant.source {
-    case .network:
-      properties["$variant_source"] = "network"
-    case .persistence(let persistedAt):
-      properties["$variant_source"] = "persistence"
-      properties["$persisted_at_in_ms"] = Int(persistedAt.timeIntervalSince1970 * 1000)
-      if let ttl = self.persistenceTtlSeconds() {
-        properties["$ttl_in_ms"] = Int(ttl * 1000)
-      }
-    case .fallback:
-      break
-    }
-
-    // Dispatch delegate call asynchronously to main thread for safety
-    DispatchQueue.main.async {
-      delegate.track(event: "$experiment_started", properties: properties)
-      MixpanelLogger.debug(message: "Tracked $experiment_started for \(flagName) (dispatched to main)")
-    }
-  }
-
-  // --- Boolean Evaluation Helper ---
-  private func _evaluateBooleanFlag(flagName: String, variantValue: Any?, fallbackValue: Bool)
-    -> Bool
-  {
-    guard let val = variantValue else { return fallbackValue }
-    if let boolVal = val as? Bool {
-      return boolVal
-    } else {
-      MixpanelLogger.error(message: "Flag '\(flagName)' is not Bool")
-      return fallbackValue
-    }
-  }
-
-  // --- Auth Header Helper ---
-  private func createAuthHeaders(token: String, includeContentType: Bool = false) -> [String: String]? {
-    guard let authData = "\(token):".data(using: .utf8) else {
-      return nil
-    }
-
-    var headers = ["Authorization": "Basic \(authData.base64EncodedString())"]
-
-    if includeContentType {
-      headers["Content-Type"] = "application/json"
-    }
-
-    return headers
-  }
-
-  // MARK: - First-Time Event Helpers
-
-  /// Generate a unique key for a pending first-time event
-  private func getPendingEventKey(_ flagKey: String, _ firstTimeEventHash: String) -> String {
-    return "\(flagKey):\(firstTimeEventHash)"
-  }
-
-  /// Extract the flag key from a pending event key
-  private func getFlagKeyFromPendingEventKey(_ eventKey: String) -> String? {
-    return eventKey.split(separator: ":", maxSplits: 1).first.map { String($0) }
-  }
-
-  // MARK: - First-Time Event Checking
+    // MARK: - First-Time Event Checking
 
     /// Checks if a tracked event matches any pending first-time events and activates the corresponding variant.
     ///
@@ -1415,33 +1434,36 @@ class FeatureFlagManager: MixpanelFlags {
             hasPendingEvent = self.pendingFirstTimeEventNames.contains(eventName)
         }
         guard hasPendingEvent else { return }
-        
+
         // Snapshot pending events with lock
         // Note: We don't snapshot activatedFirstTimeEvents because we'll check it
         // atomically later under write lock to avoid TOCTOU race
         var pendingEventsCopy: [String: PendingFirstTimeEvent] = [:]
-        
+
         flagsLock.read {
             pendingEventsCopy = self.pendingFirstTimeEvents
         }
-        
+
         // Iterate through all pending first-time events
         for (eventKey, pendingEvent) in pendingEventsCopy {
             // Check exact event name match (case-sensitive)
             if eventName != pendingEvent.eventName {
                 continue
             }
-            
+
             // Evaluate property filters using json-logic-swift library
             if let filters = pendingEvent.propertyFilters, !filters.isEmpty {
                 // Convert to JSON strings for json-logic-swift library
                 guard let rulesString = pendingEvent.propertyFiltersJSON,
-                      let dataJSON = try? JSONSerialization.data(withJSONObject: properties),
-                      let dataString = String(data: dataJSON, encoding: .utf8) else {
-                    MixpanelLogger.warn(message: "Failed to serialize JsonLogic filters for event '\(eventKey)' matching '\(eventName)'")
+                    let dataJSON = try? JSONSerialization.data(withJSONObject: properties),
+                    let dataString = String(data: dataJSON, encoding: .utf8)
+                else {
+                    MixpanelLogger.warn(
+                        message: "Failed to serialize JsonLogic filters for event '\(eventKey)' matching '\(eventName)'"
+                    )
                     continue
                 }
-                
+
                 // Evaluate the filter
                 do {
                     let result: Bool = try applyRule(rulesString, to: dataString)
@@ -1454,11 +1476,11 @@ class FeatureFlagManager: MixpanelFlags {
                     continue
                 }
             }
-            
+
             // Event matched! Try to activate the variant atomically
             let flagKey = pendingEvent.flagKey
             var shouldActivate = false
-            
+
             // Atomic check-and-set: Ensure only one thread activates this event.
             // This prevents duplicate recordFirstTimeEvent calls and flag variant changes
             // when multiple threads concurrently process the same event.
@@ -1478,21 +1500,21 @@ class FeatureFlagManager: MixpanelFlags {
                     shouldActivate = true
                 }
             }
-            
+
             // Only proceed with external calls if we successfully activated
             if shouldActivate {
                 MixpanelLogger.info(message: "First-time event matched for flag '\(flagKey)': \(eventName)")
-                
+
                 // Track the feature flag check event with the new variant
                 self._trackFlagIfNeeded(flagName: flagKey, variant: pendingEvent.pendingVariant)
-                
+
                 guard let delegate = self.delegate else {
                     MixpanelLogger.error(message: "Delegate missing for recording first-time event")
                     return
                 }
-                
+
                 let distinctId = delegate.getDistinctId()
-                
+
                 DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                     // Record to backend (fire-and-forget)
                     self?.recordFirstTimeEvent(
@@ -1506,66 +1528,69 @@ class FeatureFlagManager: MixpanelFlags {
         }
     }
 
-  /// Records a first-time event activation to the backend
-  internal func recordFirstTimeEvent(flagId: String, projectId: Int, firstTimeEventHash: String, distinctId: String) {
-    let url = "/flags/\(flagId)/first-time-events"
+    /// Records a first-time event activation to the backend
+    internal func recordFirstTimeEvent(flagId: String, projectId: Int, firstTimeEventHash: String, distinctId: String) {
+        let url = "/flags/\(flagId)/first-time-events"
 
-    let queryItems = [
-      URLQueryItem(name: "mp_lib", value: "swift"),
-      URLQueryItem(name: "$lib_version", value: AutomaticProperties.libVersion())
-    ]
+        let queryItems = [
+            URLQueryItem(name: "mp_lib", value: "swift"),
+            URLQueryItem(name: "$lib_version", value: AutomaticProperties.libVersion()),
+        ]
 
-    let payload: [String: Any] = [
-      "distinct_id": distinctId,
-      "project_id": projectId,
-      "first_time_event_hash": firstTimeEventHash
-    ]
+        let payload: [String: Any] = [
+            "distinct_id": distinctId,
+            "project_id": projectId,
+            "first_time_event_hash": firstTimeEventHash,
+        ]
 
-    guard let jsonData = try? JSONSerialization.data(withJSONObject: payload),
-          let options = currentOptions else {
-      MixpanelLogger.error(message: "Failed to prepare first-time event recording request")
-      return
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: payload),
+            let options = currentOptions
+        else {
+            MixpanelLogger.error(message: "Failed to prepare first-time event recording request")
+            return
+        }
+
+        guard let headers = createAuthHeaders(token: options.token, includeContentType: true) else {
+            MixpanelLogger.error(message: "Failed to create auth headers for first-time event recording")
+            return
+        }
+
+        let responseParser: (Data) -> Bool? = { _ in true }
+        let resource = Network.buildResource(
+            path: url,
+            method: .post,
+            requestBody: jsonData,
+            queryItems: queryItems,
+            headers: headers,
+            parse: responseParser
+        )
+
+        MixpanelLogger.debug(message: "Recording first-time event for flag: \(flagId)")
+
+        // Fire-and-forget POST request
+        Network.apiRequest(
+            base: serverURL,
+            resource: resource,
+            failure: { reason, _, _ in
+                // Silent failure - cohort sync will catch up
+                MixpanelLogger.warn(message: "Failed to record first-time event for flag \(flagId): \(reason)")
+            },
+            success: { _, _ in
+                MixpanelLogger.debug(message: "Successfully recorded first-time event for flag \(flagId)")
+            }
+        )
     }
-
-    guard let headers = createAuthHeaders(token: options.token, includeContentType: true) else {
-      MixpanelLogger.error(message: "Failed to create auth headers for first-time event recording")
-      return
-    }
-
-    let responseParser: (Data) -> Bool? = { _ in true }
-    let resource = Network.buildResource(
-      path: url,
-      method: .post,
-      requestBody: jsonData,
-      queryItems: queryItems,
-      headers: headers,
-      parse: responseParser
-    )
-
-    MixpanelLogger.debug(message: "Recording first-time event for flag: \(flagId)")
-
-    // Fire-and-forget POST request
-    Network.apiRequest(
-      base: serverURL,
-      resource: resource,
-      failure: { reason, _, _ in
-        // Silent failure - cohort sync will catch up
-        MixpanelLogger.warn(message: "Failed to record first-time event for flag \(flagId): \(reason)")
-      },
-      success: { _, _ in
-        MixpanelLogger.debug(message: "Successfully recorded first-time event for flag \(flagId)")
-      }
-    )
-  }
 }
 
 // MARK: - DEBUG Extensions for MixpanelDemo
 
 #if DEBUG
 extension PendingFirstTimeEvent {
-    init(flagKey: String, flagId: String, projectId: Int,
-         firstTimeEventHash: String, eventName: String,
-         propertyFilters: [String: Any]?, pendingVariant: MixpanelFlagVariant) {
+    init(
+        flagKey: String, flagId: String, projectId: Int,
+        firstTimeEventHash: String, eventName: String,
+        propertyFilters: [String: Any]?, pendingVariant: MixpanelFlagVariant
+    ) {
         self.flagKey = flagKey
         self.flagId = flagId
         self.projectId = projectId
@@ -1582,8 +1607,10 @@ extension PendingFirstTimeEvent {
 }
 
 extension FeatureFlagManager {
-    internal func injectMockFirstTimeEvents(_ mockEvents: [PendingFirstTimeEvent],
-                                           _ mockFlags: [String: MixpanelFlagVariant]) {
+    internal func injectMockFirstTimeEvents(
+        _ mockEvents: [PendingFirstTimeEvent],
+        _ mockFlags: [String: MixpanelFlagVariant]
+    ) {
         flagsLock.write {
             self.activatedFirstTimeEvents.removeAll()
             self.flags = mockFlags

--- a/Sources/FileLogging.swift
+++ b/Sources/FileLogging.swift
@@ -10,31 +10,31 @@ import Foundation
 
 /// Logs all messages to a file
 class FileLogging: MixpanelLogging {
-  private let fileHandle: FileHandle
+    private let fileHandle: FileHandle
 
-  init(path: String) {
-    if let handle = FileHandle(forWritingAtPath: path) {
-      fileHandle = handle
-    } else {
-      fileHandle = FileHandle.standardError
+    init(path: String) {
+        if let handle = FileHandle(forWritingAtPath: path) {
+            fileHandle = handle
+        } else {
+            fileHandle = FileHandle.standardError
+        }
+
+        // Move to the end of the file so we can append messages
+        fileHandle.seekToEndOfFile()
     }
 
-    // Move to the end of the file so we can append messages
-    fileHandle.seekToEndOfFile()
-  }
-
-  deinit {
-    // Ensure we close the file handle to clear the resources
-    fileHandle.closeFile()
-  }
-
-  func addMessage(message: MixpanelLogMessage) {
-    let string =
-      "File: \(message.file) - Func: \(message.function) - "
-      + "Level: \(message.level.rawValue) - Message: \(message.text)"
-    if let data = string.data(using: String.Encoding.utf8) {
-      // Write the message as data to the file
-      fileHandle.write(data)
+    deinit {
+        // Ensure we close the file handle to clear the resources
+        fileHandle.closeFile()
     }
-  }
+
+    func addMessage(message: MixpanelLogMessage) {
+        let string =
+            "File: \(message.file) - Func: \(message.function) - "
+            + "Level: \(message.level.rawValue) - Message: \(message.text)"
+        if let data = string.data(using: String.Encoding.utf8) {
+            // Write the message as data to the file
+            fileHandle.write(data)
+        }
+    }
 }

--- a/Sources/Flush.swift
+++ b/Sources/Flush.swift
@@ -9,184 +9,184 @@
 import Foundation
 
 protocol FlushDelegate: AnyObject {
-  func flush(performFullFlush: Bool, completion: (() -> Void)?)
-  func flushSuccess(type: FlushType, ids: [Int32])
+    func flush(performFullFlush: Bool, completion: (() -> Void)?)
+    func flushSuccess(type: FlushType, ids: [Int32])
 
-  #if os(iOS)
+    #if os(iOS)
     func updateNetworkActivityIndicator(_ on: Bool)
-  #endif  // os(iOS)
+    #endif  // os(iOS)
 }
 
 class Flush: AppLifecycle {
-  var timer: Timer?
-  weak var delegate: FlushDelegate?
-  var useIPAddressForGeoLocation = true
-  var flushRequest: FlushRequest
-  var flushOnBackground = true
-  var _flushInterval = 0.0
-  var _flushBatchSize = APIConstants.maxBatchSize
-  private var _serverURL = BasePath.DefaultMixpanelAPI
-  private let flushRequestReadWriteLock: DispatchQueue
+    var timer: Timer?
+    weak var delegate: FlushDelegate?
+    var useIPAddressForGeoLocation = true
+    var flushRequest: FlushRequest
+    var flushOnBackground = true
+    var _flushInterval = 0.0
+    var _flushBatchSize = APIConstants.maxBatchSize
+    private var _serverURL = BasePath.DefaultMixpanelAPI
+    private let flushRequestReadWriteLock: DispatchQueue
 
-  var useGzipCompression: Bool
+    var useGzipCompression: Bool
 
-  var serverURL: String {
-    get {
-      flushRequestReadWriteLock.sync {
-        return _serverURL
-      }
-    }
-    set {
-      flushRequestReadWriteLock.sync(
-        flags: .barrier,
-        execute: {
-          _serverURL = newValue
-          self.flushRequest.serverURL = newValue
-        })
-    }
-  }
-
-  var flushInterval: Double {
-    get {
-      flushRequestReadWriteLock.sync {
-        return _flushInterval
-      }
-    }
-    set {
-      flushRequestReadWriteLock.sync(
-        flags: .barrier,
-        execute: {
-          _flushInterval = newValue
-        })
-
-      delegate?.flush(performFullFlush: false, completion: nil)
-      startFlushTimer()
-    }
-  }
-
-  var flushBatchSize: Int {
-    get {
-      return _flushBatchSize
-    }
-    set {
-      _flushBatchSize = newValue
-    }
-  }
-
-  required init(serverURL: String, useGzipCompression: Bool) {
-    self.flushRequest = FlushRequest(serverURL: serverURL)
-    self.useGzipCompression = useGzipCompression
-    _serverURL = serverURL
-    flushRequestReadWriteLock = DispatchQueue(
-      label: "com.mixpanel.flush_interval.lock", qos: .utility, attributes: .concurrent,
-      autoreleaseFrequency: .workItem)
-  }
-
-  func flushQueue(
-    _ queue: Queue, type: FlushType, headers: [String: String], queryItems: [URLQueryItem]
-  ) {
-    if flushRequest.requestNotAllowed() {
-      return
-    }
-    flushQueueInBatches(queue, type: type, headers: headers, queryItems: queryItems)
-  }
-
-  func startFlushTimer() {
-    stopFlushTimer()
-    DispatchQueue.main.async { [weak self] in
-      guard let self = self else {
-        return
-      }
-
-      if self.flushInterval > 0 {
-        self.timer?.invalidate()
-        self.timer = Timer.scheduledTimer(
-          timeInterval: self.flushInterval,
-          target: self,
-          selector: #selector(self.flushSelector),
-          userInfo: nil,
-          repeats: true)
-      }
-    }
-  }
-
-  @objc func flushSelector() {
-    delegate?.flush(performFullFlush: false, completion: nil)
-  }
-
-  func stopFlushTimer() {
-    if let timer = timer {
-      DispatchQueue.main.async { [weak self, timer] in
-        timer.invalidate()
-        self?.timer = nil
-      }
-    }
-  }
-
-  func flushQueueInBatches(
-    _ queue: Queue, type: FlushType, headers: [String: String], queryItems: [URLQueryItem]
-  ) {
-    var mutableQueue = queue
-    while !mutableQueue.isEmpty {
-      let batchSize = min(mutableQueue.count, flushBatchSize)
-      let range = 0..<batchSize
-      let batch = Array(mutableQueue[range])
-      let ids: [Int32] = batch.map { entity in
-        (entity["id"] as? Int32) ?? 0
-      }
-      // Log data payload sent
-      MixpanelLogger.debug(message: "Sending batch of data")
-      MixpanelLogger.debug(message: batch as Any)
-      let requestData = JSONHandler.encodeAPIData(batch)
-      if let requestData = requestData {
-        #if os(iOS)
-          if !MixpanelInstance.isiOSAppExtension() {
-            delegate?.updateNetworkActivityIndicator(true)
-          }
-        #endif  // os(iOS)
-        let success = flushRequest.sendRequest(
-          requestData,
-          type: type,
-          useIP: useIPAddressForGeoLocation,
-          headers: headers,
-          queryItems: queryItems, useGzipCompression: useGzipCompression)
-        #if os(iOS)
-          if !MixpanelInstance.isiOSAppExtension() {
-            delegate?.updateNetworkActivityIndicator(false)
-          }
-        #endif  // os(iOS)
-        if success {
-          // remove
-          delegate?.flushSuccess(type: type, ids: ids)
-          mutableQueue = self.removeProcessedBatch(
-            batchSize: batchSize,
-            queue: mutableQueue,
-            type: type)
-        } else {
-          break
+    var serverURL: String {
+        get {
+            flushRequestReadWriteLock.sync {
+                return _serverURL
+            }
         }
-      }
+        set {
+            flushRequestReadWriteLock.sync(
+                flags: .barrier,
+                execute: {
+                    _serverURL = newValue
+                    self.flushRequest.serverURL = newValue
+                })
+        }
     }
-  }
 
-  func removeProcessedBatch(batchSize: Int, queue: Queue, type: FlushType) -> Queue {
-    var shadowQueue = queue
-    let range = 0..<batchSize
-    if let lastIndex = range.last, shadowQueue.count - 1 > lastIndex {
-      shadowQueue.removeSubrange(range)
-    } else {
-      shadowQueue.removeAll()
+    var flushInterval: Double {
+        get {
+            flushRequestReadWriteLock.sync {
+                return _flushInterval
+            }
+        }
+        set {
+            flushRequestReadWriteLock.sync(
+                flags: .barrier,
+                execute: {
+                    _flushInterval = newValue
+                })
+
+            delegate?.flush(performFullFlush: false, completion: nil)
+            startFlushTimer()
+        }
     }
-    return shadowQueue
-  }
 
-  // MARK: - Lifecycle
-  func applicationDidBecomeActive() {
-    startFlushTimer()
-  }
+    var flushBatchSize: Int {
+        get {
+            return _flushBatchSize
+        }
+        set {
+            _flushBatchSize = newValue
+        }
+    }
 
-  func applicationWillResignActive() {
-    stopFlushTimer()
-  }
+    required init(serverURL: String, useGzipCompression: Bool) {
+        self.flushRequest = FlushRequest(serverURL: serverURL)
+        self.useGzipCompression = useGzipCompression
+        _serverURL = serverURL
+        flushRequestReadWriteLock = DispatchQueue(
+            label: "com.mixpanel.flush_interval.lock", qos: .utility, attributes: .concurrent,
+            autoreleaseFrequency: .workItem)
+    }
+
+    func flushQueue(
+        _ queue: Queue, type: FlushType, headers: [String: String], queryItems: [URLQueryItem]
+    ) {
+        if flushRequest.requestNotAllowed() {
+            return
+        }
+        flushQueueInBatches(queue, type: type, headers: headers, queryItems: queryItems)
+    }
+
+    func startFlushTimer() {
+        stopFlushTimer()
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            if self.flushInterval > 0 {
+                self.timer?.invalidate()
+                self.timer = Timer.scheduledTimer(
+                    timeInterval: self.flushInterval,
+                    target: self,
+                    selector: #selector(self.flushSelector),
+                    userInfo: nil,
+                    repeats: true)
+            }
+        }
+    }
+
+    @objc func flushSelector() {
+        delegate?.flush(performFullFlush: false, completion: nil)
+    }
+
+    func stopFlushTimer() {
+        if let timer = timer {
+            DispatchQueue.main.async { [weak self, timer] in
+                timer.invalidate()
+                self?.timer = nil
+            }
+        }
+    }
+
+    func flushQueueInBatches(
+        _ queue: Queue, type: FlushType, headers: [String: String], queryItems: [URLQueryItem]
+    ) {
+        var mutableQueue = queue
+        while !mutableQueue.isEmpty {
+            let batchSize = min(mutableQueue.count, flushBatchSize)
+            let range = 0..<batchSize
+            let batch = Array(mutableQueue[range])
+            let ids: [Int32] = batch.map { entity in
+                (entity["id"] as? Int32) ?? 0
+            }
+            // Log data payload sent
+            MixpanelLogger.debug(message: "Sending batch of data")
+            MixpanelLogger.debug(message: batch as Any)
+            let requestData = JSONHandler.encodeAPIData(batch)
+            if let requestData = requestData {
+                #if os(iOS)
+                if !MixpanelInstance.isiOSAppExtension() {
+                    delegate?.updateNetworkActivityIndicator(true)
+                }
+                #endif  // os(iOS)
+                let success = flushRequest.sendRequest(
+                    requestData,
+                    type: type,
+                    useIP: useIPAddressForGeoLocation,
+                    headers: headers,
+                    queryItems: queryItems, useGzipCompression: useGzipCompression)
+                #if os(iOS)
+                if !MixpanelInstance.isiOSAppExtension() {
+                    delegate?.updateNetworkActivityIndicator(false)
+                }
+                #endif  // os(iOS)
+                if success {
+                    // remove
+                    delegate?.flushSuccess(type: type, ids: ids)
+                    mutableQueue = self.removeProcessedBatch(
+                        batchSize: batchSize,
+                        queue: mutableQueue,
+                        type: type)
+                } else {
+                    break
+                }
+            }
+        }
+    }
+
+    func removeProcessedBatch(batchSize: Int, queue: Queue, type: FlushType) -> Queue {
+        var shadowQueue = queue
+        let range = 0..<batchSize
+        if let lastIndex = range.last, shadowQueue.count - 1 > lastIndex {
+            shadowQueue.removeSubrange(range)
+        } else {
+            shadowQueue.removeAll()
+        }
+        return shadowQueue
+    }
+
+    // MARK: - Lifecycle
+    func applicationDidBecomeActive() {
+        startFlushTimer()
+    }
+
+    func applicationWillResignActive() {
+        stopFlushTimer()
+    }
 
 }

--- a/Sources/FlushRequest.swift
+++ b/Sources/FlushRequest.swift
@@ -9,121 +9,121 @@
 import Foundation
 
 enum FlushType: String {
-  case events = "/track/"
-  case people = "/engage/"
-  case groups = "/groups/"
+    case events = "/track/"
+    case people = "/engage/"
+    case groups = "/groups/"
 }
 
 class FlushRequest: Network {
 
-  var networkRequestsAllowedAfterTime = 0.0
-  var networkConsecutiveFailures = 0
+    var networkRequestsAllowedAfterTime = 0.0
+    var networkConsecutiveFailures = 0
 
-  func sendRequest(
-    _ requestData: String,
-    type: FlushType,
-    useIP: Bool,
-    headers: [String: String],
-    queryItems: [URLQueryItem] = [],
-    useGzipCompression: Bool
-  ) -> Bool {
+    func sendRequest(
+        _ requestData: String,
+        type: FlushType,
+        useIP: Bool,
+        headers: [String: String],
+        queryItems: [URLQueryItem] = [],
+        useGzipCompression: Bool
+    ) -> Bool {
 
-    let responseParser: (Data) -> Int? = { data in
-      let response = String(data: data, encoding: String.Encoding.utf8)
-      if let response = response {
-        return Int(response) ?? 0
-      }
-      return nil
-    }
-
-    var resourceHeaders: [String: String] = ["Content-Type": "application/json"].merging(headers) {
-      (_, new) in new
-    }
-    var compressedData: Data? = nil
-
-    if useGzipCompression && type == .events {
-      if let requestDataRaw = requestData.data(using: .utf8) {
-        do {
-          compressedData = try requestDataRaw.gzipCompressed()
-          resourceHeaders["Content-Encoding"] = "gzip"
-        } catch {
-          MixpanelLogger.error(message: "Failed to compress data with gzip: \(error)")
+        let responseParser: (Data) -> Int? = { data in
+            let response = String(data: data, encoding: String.Encoding.utf8)
+            if let response = response {
+                return Int(response) ?? 0
+            }
+            return nil
         }
-      }
-    }
-    let ipString = useIP ? "1" : "0"
-    var resourceQueryItems: [URLQueryItem] = [URLQueryItem(name: "ip", value: ipString)]
-    resourceQueryItems.append(contentsOf: queryItems)
-    let resource = Network.buildResource(
-      path: type.rawValue,
-      method: .post,
-      requestBody: compressedData ?? requestData.data(using: .utf8),
-      queryItems: resourceQueryItems,
-      headers: resourceHeaders,
-      parse: responseParser)
-    var result = false
-    let semaphore = DispatchSemaphore(value: 0)
-    flushRequestHandler(
-      serverURL,
-      resource: resource,
-      completion: { success in
-        result = success
-        semaphore.signal()
-      })
-    _ = semaphore.wait(timeout: .now() + 120.0)
-    return result
-  }
 
-  private func flushRequestHandler(
-    _ base: String,
-    resource: Resource<Int>,
-    completion: @escaping (Bool) -> Void
-  ) {
-
-    Network.apiRequest(
-      base: base, resource: resource,
-      failure: { (reason, _, response) in
-        self.networkConsecutiveFailures += 1
-        self.updateRetryDelay(response)
-        MixpanelLogger.warn(
-          message: "API request to \(resource.path) has failed with reason \(reason)")
-        completion(false)
-      },
-      success: { (result, response) in
-        self.networkConsecutiveFailures = 0
-        self.updateRetryDelay(response)
-        if result == 0 {
-          MixpanelLogger.info(message: "\(base) api rejected some items")
+        var resourceHeaders: [String: String] = ["Content-Type": "application/json"].merging(headers) {
+            (_, new) in new
         }
-        completion(true)
-      })
-  }
+        var compressedData: Data? = nil
 
-  private func updateRetryDelay(_ response: URLResponse?) {
-    var retryTime = 0.0
-    let retryHeader = (response as? HTTPURLResponse)?.allHeaderFields["Retry-After"] as? String
-    if let retryHeader = retryHeader, let retryHeaderParsed = (Double(retryHeader)) {
-      retryTime = retryHeaderParsed
+        if useGzipCompression && type == .events {
+            if let requestDataRaw = requestData.data(using: .utf8) {
+                do {
+                    compressedData = try requestDataRaw.gzipCompressed()
+                    resourceHeaders["Content-Encoding"] = "gzip"
+                } catch {
+                    MixpanelLogger.error(message: "Failed to compress data with gzip: \(error)")
+                }
+            }
+        }
+        let ipString = useIP ? "1" : "0"
+        var resourceQueryItems: [URLQueryItem] = [URLQueryItem(name: "ip", value: ipString)]
+        resourceQueryItems.append(contentsOf: queryItems)
+        let resource = Network.buildResource(
+            path: type.rawValue,
+            method: .post,
+            requestBody: compressedData ?? requestData.data(using: .utf8),
+            queryItems: resourceQueryItems,
+            headers: resourceHeaders,
+            parse: responseParser)
+        var result = false
+        let semaphore = DispatchSemaphore(value: 0)
+        flushRequestHandler(
+            serverURL,
+            resource: resource,
+            completion: { success in
+                result = success
+                semaphore.signal()
+            })
+        _ = semaphore.wait(timeout: .now() + 120.0)
+        return result
     }
 
-    if networkConsecutiveFailures >= APIConstants.failuresTillBackoff {
-      retryTime = max(
-        retryTime,
-        retryBackOffTimeWithConsecutiveFailures(networkConsecutiveFailures))
+    private func flushRequestHandler(
+        _ base: String,
+        resource: Resource<Int>,
+        completion: @escaping (Bool) -> Void
+    ) {
+
+        Network.apiRequest(
+            base: base, resource: resource,
+            failure: { (reason, _, response) in
+                self.networkConsecutiveFailures += 1
+                self.updateRetryDelay(response)
+                MixpanelLogger.warn(
+                    message: "API request to \(resource.path) has failed with reason \(reason)")
+                completion(false)
+            },
+            success: { (result, response) in
+                self.networkConsecutiveFailures = 0
+                self.updateRetryDelay(response)
+                if result == 0 {
+                    MixpanelLogger.info(message: "\(base) api rejected some items")
+                }
+                completion(true)
+            })
     }
-    let retryDate = Date(timeIntervalSinceNow: retryTime)
-    networkRequestsAllowedAfterTime = retryDate.timeIntervalSince1970
-  }
 
-  private func retryBackOffTimeWithConsecutiveFailures(_ failureCount: Int) -> TimeInterval {
-    let time = pow(2.0, Double(failureCount) - 1) * 60 + Double(arc4random_uniform(30))
-    return min(
-      max(APIConstants.minRetryBackoff, time),
-      APIConstants.maxRetryBackoff)
-  }
+    private func updateRetryDelay(_ response: URLResponse?) {
+        var retryTime = 0.0
+        let retryHeader = (response as? HTTPURLResponse)?.allHeaderFields["Retry-After"] as? String
+        if let retryHeader = retryHeader, let retryHeaderParsed = (Double(retryHeader)) {
+            retryTime = retryHeaderParsed
+        }
 
-  func requestNotAllowed() -> Bool {
-    return Date().timeIntervalSince1970 < networkRequestsAllowedAfterTime
-  }
+        if networkConsecutiveFailures >= APIConstants.failuresTillBackoff {
+            retryTime = max(
+                retryTime,
+                retryBackOffTimeWithConsecutiveFailures(networkConsecutiveFailures))
+        }
+        let retryDate = Date(timeIntervalSinceNow: retryTime)
+        networkRequestsAllowedAfterTime = retryDate.timeIntervalSince1970
+    }
+
+    private func retryBackOffTimeWithConsecutiveFailures(_ failureCount: Int) -> TimeInterval {
+        let time = pow(2.0, Double(failureCount) - 1) * 60 + Double(arc4random_uniform(30))
+        return min(
+            max(APIConstants.minRetryBackoff, time),
+            APIConstants.maxRetryBackoff)
+    }
+
+    func requestNotAllowed() -> Bool {
+        return Date().timeIntervalSince1970 < networkRequestsAllowedAfterTime
+    }
 
 }

--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -12,154 +12,154 @@ import Foundation
 /// the main Mixpanel instance.
 open class Group {
 
-  let apiToken: String
-  let serialQueue: DispatchQueue
-  let lock: ReadWriteLock
-  let groupKey: String
-  let groupID: MixpanelType
-  weak var delegate: FlushDelegate?
-  let metadata: SessionMetadata
-  let mixpanelPersistence: MixpanelPersistence
-  weak var mixpanelInstance: MixpanelInstance?
+    let apiToken: String
+    let serialQueue: DispatchQueue
+    let lock: ReadWriteLock
+    let groupKey: String
+    let groupID: MixpanelType
+    weak var delegate: FlushDelegate?
+    let metadata: SessionMetadata
+    let mixpanelPersistence: MixpanelPersistence
+    weak var mixpanelInstance: MixpanelInstance?
 
-  init(
-    apiToken: String,
-    serialQueue: DispatchQueue,
-    lock: ReadWriteLock,
-    groupKey: String,
-    groupID: MixpanelType,
-    metadata: SessionMetadata,
-    mixpanelPersistence: MixpanelPersistence,
-    mixpanelInstance: MixpanelInstance
-  ) {
-    self.apiToken = apiToken
-    self.serialQueue = serialQueue
-    self.lock = lock
-    self.groupKey = groupKey
-    self.groupID = groupID
-    self.metadata = metadata
-    self.mixpanelPersistence = mixpanelPersistence
-    self.mixpanelInstance = mixpanelInstance
-  }
-
-  func addGroupRecordToQueueWithAction(_ action: String, properties: InternalProperties) {
-    if mixpanelInstance?.hasOptedOutTracking() ?? false {
-      return
-    }
-    let epochMilliseconds = round(Date().timeIntervalSince1970 * 1000)
-
-    serialQueue.async {
-      var r = InternalProperties()
-      var p = InternalProperties()
-      r["$token"] = self.apiToken
-      r["$time"] = epochMilliseconds
-      if action == "$unset" {
-        // $unset takes an array of property names which is supplied to this method
-        // in the properties parameter under the key "$properties"
-        r[action] = properties["$properties"]
-      } else {
-        p += properties
-        r[action] = p
-      }
-      self.metadata.toDict(isEvent: false).forEach { (k, v) in r[k] = v }
-
-      r["$group_key"] = self.groupKey
-      r["$group_id"] = self.groupID
-      self.mixpanelPersistence.saveEntity(r, type: .groups)
+    init(
+        apiToken: String,
+        serialQueue: DispatchQueue,
+        lock: ReadWriteLock,
+        groupKey: String,
+        groupID: MixpanelType,
+        metadata: SessionMetadata,
+        mixpanelPersistence: MixpanelPersistence,
+        mixpanelInstance: MixpanelInstance
+    ) {
+        self.apiToken = apiToken
+        self.serialQueue = serialQueue
+        self.lock = lock
+        self.groupKey = groupKey
+        self.groupID = groupID
+        self.metadata = metadata
+        self.mixpanelPersistence = mixpanelPersistence
+        self.mixpanelInstance = mixpanelInstance
     }
 
-    if MixpanelInstance.isiOSAppExtension() {
-      delegate?.flush(performFullFlush: false, completion: nil)
+    func addGroupRecordToQueueWithAction(_ action: String, properties: InternalProperties) {
+        if mixpanelInstance?.hasOptedOutTracking() ?? false {
+            return
+        }
+        let epochMilliseconds = round(Date().timeIntervalSince1970 * 1000)
+
+        serialQueue.async {
+            var r = InternalProperties()
+            var p = InternalProperties()
+            r["$token"] = self.apiToken
+            r["$time"] = epochMilliseconds
+            if action == "$unset" {
+                // $unset takes an array of property names which is supplied to this method
+                // in the properties parameter under the key "$properties"
+                r[action] = properties["$properties"]
+            } else {
+                p += properties
+                r[action] = p
+            }
+            self.metadata.toDict(isEvent: false).forEach { (k, v) in r[k] = v }
+
+            r["$group_key"] = self.groupKey
+            r["$group_id"] = self.groupID
+            self.mixpanelPersistence.saveEntity(r, type: .groups)
+        }
+
+        if MixpanelInstance.isiOSAppExtension() {
+            delegate?.flush(performFullFlush: false, completion: nil)
+        }
     }
-  }
 
-  // MARK: - Group
+    // MARK: - Group
 
-  /**
-     Sets properties on this group.
+    /**
+       Sets properties on this group.
+    
+       Property keys must be String objects and the supported value types need to conform to MixpanelType.
+       MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
+       If the existing group record on the server already has a value for a given property, the old
+       value is overwritten. Other existing properties will not be affected.
+    
+       - parameter properties: properties dictionary
+       */
+    open func set(properties: Properties) {
+        assertPropertyTypes(properties)
+        addGroupRecordToQueueWithAction("$set", properties: properties)
+    }
 
-     Property keys must be String objects and the supported value types need to conform to MixpanelType.
-     MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
-     If the existing group record on the server already has a value for a given property, the old
-     value is overwritten. Other existing properties will not be affected.
+    /**
+       Convenience method for setting a single property in Mixpanel Groups.
+    
+       Property keys must be String objects and the supported value types need to conform to MixpanelType.
+       MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
+    
+       - parameter property: property name
+       - parameter to:       property value
+       */
+    open func set(property: String, to: MixpanelType) {
+        set(properties: [property: to])
+    }
 
-     - parameter properties: properties dictionary
-     */
-  open func set(properties: Properties) {
-    assertPropertyTypes(properties)
-    addGroupRecordToQueueWithAction("$set", properties: properties)
-  }
+    /**
+       Sets properties on the current Mixpanel Group, but doesn't overwrite if
+       there is an existing value.
+    
+       This method is identical to `set:` except it will only set
+       properties that are not already set. It is particularly useful for collecting
+       data about dates representing the first time something happened.
+    
+       - parameter properties: properties dictionary
+       */
+    open func setOnce(properties: Properties) {
+        assertPropertyTypes(properties)
+        addGroupRecordToQueueWithAction("$set_once", properties: properties)
+    }
 
-  /**
-     Convenience method for setting a single property in Mixpanel Groups.
+    /**
+       Remove a property and its value from a group's profile in Mixpanel Groups.
+    
+       For properties that don't exist there will be no effect.
+    
+       - parameter property: name of the property to unset
+       */
+    open func unset(property: String) {
+        addGroupRecordToQueueWithAction("$unset", properties: ["$properties": [property]])
+    }
 
-     Property keys must be String objects and the supported value types need to conform to MixpanelType.
-     MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
+    /**
+       Removes list properties.
+    
+       Property keys must be String objects and the supported value types need to conform to MixpanelType.
+       MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
+    
+       - parameter properties: mapping of list property names to values to remove
+       */
+    open func remove(key: String, value: MixpanelType) {
+        let properties = [key: value]
+        assertPropertyTypes(properties)
+        addGroupRecordToQueueWithAction("$remove", properties: properties)
+    }
 
-     - parameter property: property name
-     - parameter to:       property value
-     */
-  open func set(property: String, to: MixpanelType) {
-    set(properties: [property: to])
-  }
+    /**
+       Union list properties.
+    
+       Property values must be array objects.
+    
+       - parameter properties: mapping of list property names to lists to union
+       */
+    open func union(key: String, values: [MixpanelType]) {
+        let properties = [key: values]
+        addGroupRecordToQueueWithAction("$union", properties: properties)
+    }
 
-  /**
-     Sets properties on the current Mixpanel Group, but doesn't overwrite if
-     there is an existing value.
-
-     This method is identical to `set:` except it will only set
-     properties that are not already set. It is particularly useful for collecting
-     data about dates representing the first time something happened.
-
-     - parameter properties: properties dictionary
-     */
-  open func setOnce(properties: Properties) {
-    assertPropertyTypes(properties)
-    addGroupRecordToQueueWithAction("$set_once", properties: properties)
-  }
-
-  /**
-     Remove a property and its value from a group's profile in Mixpanel Groups.
-
-     For properties that don't exist there will be no effect.
-
-     - parameter property: name of the property to unset
-     */
-  open func unset(property: String) {
-    addGroupRecordToQueueWithAction("$unset", properties: ["$properties": [property]])
-  }
-
-  /**
-     Removes list properties.
-
-     Property keys must be String objects and the supported value types need to conform to MixpanelType.
-     MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
-
-     - parameter properties: mapping of list property names to values to remove
-     */
-  open func remove(key: String, value: MixpanelType) {
-    let properties = [key: value]
-    assertPropertyTypes(properties)
-    addGroupRecordToQueueWithAction("$remove", properties: properties)
-  }
-
-  /**
-     Union list properties.
-
-     Property values must be array objects.
-
-     - parameter properties: mapping of list property names to lists to union
-     */
-  open func union(key: String, values: [MixpanelType]) {
-    let properties = [key: values]
-    addGroupRecordToQueueWithAction("$union", properties: properties)
-  }
-
-  /**
-     Delete group's record from Mixpanel Groups.
-     */
-  open func deleteGroup() {
-    addGroupRecordToQueueWithAction("$delete", properties: [:])
-    mixpanelInstance?.removeCachedGroup(groupKey: groupKey, groupID: groupID)
-  }
+    /**
+       Delete group's record from Mixpanel Groups.
+       */
+    open func deleteGroup() {
+        addGroupRecordToQueueWithAction("$delete", properties: [:])
+        mixpanelInstance?.removeCachedGroup(groupKey: groupKey, groupID: groupID)
+    }
 }

--- a/Sources/JSONHandler.swift
+++ b/Sources/JSONHandler.swift
@@ -10,120 +10,120 @@ import Foundation
 
 class JSONHandler {
 
-  typealias MPObjectToParse = Any
+    typealias MPObjectToParse = Any
 
-  class func encodeAPIData(_ obj: MPObjectToParse) -> String? {
-    let data: Data? = serializeJSONObject(obj)
+    class func encodeAPIData(_ obj: MPObjectToParse) -> String? {
+        let data: Data? = serializeJSONObject(obj)
 
-    guard let d = data else {
-      MixpanelLogger.warn(message: "couldn't serialize object")
-      return nil
+        guard let d = data else {
+            MixpanelLogger.warn(message: "couldn't serialize object")
+            return nil
+        }
+
+        return String(decoding: d, as: UTF8.self)
     }
 
-    return String(decoding: d, as: UTF8.self)
-  }
-
-  class func deserializeData(_ data: Data) -> MPObjectToParse? {
-    var object: MPObjectToParse?
-    do {
-      object = try JSONSerialization.jsonObject(with: data, options: [])
-    } catch {
-      MixpanelLogger.warn(message: "exception decoding object data")
-    }
-    return object
-  }
-
-  class func serializeJSONObject(_ obj: MPObjectToParse) -> Data? {
-    let serializableJSONObject: MPObjectToParse
-    if let jsonObject = makeObjectSerializable(obj) as? [Any] {
-      serializableJSONObject = jsonObject.filter {
-        JSONSerialization.isValidJSONObject($0)
-      }
-    } else {
-      serializableJSONObject = makeObjectSerializable(obj)
+    class func deserializeData(_ data: Data) -> MPObjectToParse? {
+        var object: MPObjectToParse?
+        do {
+            object = try JSONSerialization.jsonObject(with: data, options: [])
+        } catch {
+            MixpanelLogger.warn(message: "exception decoding object data")
+        }
+        return object
     }
 
-    guard JSONSerialization.isValidJSONObject(serializableJSONObject) else {
-      MixpanelLogger.warn(message: "object isn't valid and can't be serialzed to JSON")
-      return nil
+    class func serializeJSONObject(_ obj: MPObjectToParse) -> Data? {
+        let serializableJSONObject: MPObjectToParse
+        if let jsonObject = makeObjectSerializable(obj) as? [Any] {
+            serializableJSONObject = jsonObject.filter {
+                JSONSerialization.isValidJSONObject($0)
+            }
+        } else {
+            serializableJSONObject = makeObjectSerializable(obj)
+        }
+
+        guard JSONSerialization.isValidJSONObject(serializableJSONObject) else {
+            MixpanelLogger.warn(message: "object isn't valid and can't be serialzed to JSON")
+            return nil
+        }
+
+        var serializedObject: Data?
+        do {
+            serializedObject =
+                try JSONSerialization
+                .data(withJSONObject: serializableJSONObject, options: [])
+        } catch {
+            MixpanelLogger.warn(message: "exception encoding api data")
+        }
+        return serializedObject
     }
 
-    var serializedObject: Data?
-    do {
-      serializedObject =
-        try JSONSerialization
-        .data(withJSONObject: serializableJSONObject, options: [])
-    } catch {
-      MixpanelLogger.warn(message: "exception encoding api data")
+    private class func makeObjectSerializable(_ obj: MPObjectToParse) -> MPObjectToParse {
+        switch obj {
+            case let obj as NSNumber:
+                if isBoolNumber(obj) {
+                    return obj.boolValue
+                } else if isInvalidNumber(obj) {
+                    return String(describing: obj)
+                } else {
+                    return obj
+                }
+
+            case let obj as Double where obj.isFinite && !obj.isNaN:
+                return obj
+
+            case let obj as Float where obj.isFinite && !obj.isNaN:
+                return obj
+
+            case is String, is Int, is UInt, is UInt64, is Bool:
+                return obj
+
+            case let obj as [Any?]:
+                // nil values in Array properties are dropped
+                let nonNilEls: [Any] = obj.compactMap({ $0 })
+                return nonNilEls.map { makeObjectSerializable($0) }
+
+            case let obj as [Any]:
+                return obj.map { makeObjectSerializable($0) }
+
+            case let obj as InternalProperties:
+                var serializedDict = InternalProperties()
+                _ = obj.map { e in
+                    serializedDict[e.key] =
+                        makeObjectSerializable(e.value)
+                }
+                return serializedDict
+
+            case let obj as Date:
+                let dateFormatter = DateFormatter()
+                dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+                dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
+                dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+                return dateFormatter.string(from: obj)
+
+            case let obj as URL:
+                return obj.absoluteString
+
+            default:
+                let objString = String(describing: obj)
+                if objString == "nil" {
+                    // all nil properties outside of Arrays are converted to NSNull()
+                    return NSNull()
+                } else {
+                    MixpanelLogger.info(message: "enforcing string on object")
+                    return objString
+                }
+        }
     }
-    return serializedObject
-  }
 
-  private class func makeObjectSerializable(_ obj: MPObjectToParse) -> MPObjectToParse {
-    switch obj {
-    case let obj as NSNumber:
-      if isBoolNumber(obj) {
-        return obj.boolValue
-      } else if isInvalidNumber(obj) {
-        return String(describing: obj)
-      } else {
-        return obj
-      }
-
-    case let obj as Double where obj.isFinite && !obj.isNaN:
-      return obj
-
-    case let obj as Float where obj.isFinite && !obj.isNaN:
-      return obj
-
-    case is String, is Int, is UInt, is UInt64, is Bool:
-      return obj
-
-    case let obj as [Any?]:
-      // nil values in Array properties are dropped
-      let nonNilEls: [Any] = obj.compactMap({ $0 })
-      return nonNilEls.map { makeObjectSerializable($0) }
-
-    case let obj as [Any]:
-      return obj.map { makeObjectSerializable($0) }
-
-    case let obj as InternalProperties:
-      var serializedDict = InternalProperties()
-      _ = obj.map { e in
-        serializedDict[e.key] =
-          makeObjectSerializable(e.value)
-      }
-      return serializedDict
-
-    case let obj as Date:
-      let dateFormatter = DateFormatter()
-      dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-      dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
-      dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-      return dateFormatter.string(from: obj)
-
-    case let obj as URL:
-      return obj.absoluteString
-
-    default:
-      let objString = String(describing: obj)
-      if objString == "nil" {
-        // all nil properties outside of Arrays are converted to NSNull()
-        return NSNull()
-      } else {
-        MixpanelLogger.info(message: "enforcing string on object")
-        return objString
-      }
+    private class func isBoolNumber(_ num: NSNumber) -> Bool {
+        let boolID = CFBooleanGetTypeID()
+        let numID = CFGetTypeID(num)
+        return numID == boolID
     }
-  }
 
-  private class func isBoolNumber(_ num: NSNumber) -> Bool {
-    let boolID = CFBooleanGetTypeID()
-    let numID = CFGetTypeID(num)
-    return numID == boolID
-  }
-
-  private class func isInvalidNumber(_ num: NSNumber) -> Bool {
-    return num.doubleValue.isInfinite || num.doubleValue.isNaN
-  }
+    private class func isInvalidNumber(_ num: NSNumber) -> Bool {
+        return num.doubleValue.isInfinite || num.doubleValue.isNaN
+    }
 }

--- a/Sources/MPDB.swift
+++ b/Sources/MPDB.swift
@@ -10,302 +10,303 @@ import Foundation
 import SQLite3
 
 class MPDB {
-  private var connection: OpaquePointer?
-  private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
-  private let DB_FILE_NAME: String = "MPDB.sqlite"
+    private var connection: OpaquePointer?
+    private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+    private let DB_FILE_NAME: String = "MPDB.sqlite"
 
-  let apiToken: String
+    let apiToken: String
 
-  init(token: String) {
-    // token can be instanceName which can be any string so we strip all non-alhpanumeric characters to prevent SQL errors
-    apiToken = String(token.unicodeScalars.filter({ CharacterSet.alphanumerics.contains($0) }))
-    open()
-  }
-
-  deinit {
-    close()
-  }
-
-  private func pathToDb() -> String? {
-    let manager = FileManager.default
-    #if os(iOS)
-      let url = manager.urls(for: .libraryDirectory, in: .userDomainMask).last
-    #else
-      let url = manager.urls(for: .cachesDirectory, in: .userDomainMask).last
-    #endif  // os(iOS)
-
-    guard let urlUnwrapped = url?.appendingPathComponent(apiToken + "_" + DB_FILE_NAME).path else {
-      return nil
+    init(token: String) {
+        // token can be instanceName which can be any string so we strip all non-alhpanumeric characters to prevent SQL errors
+        apiToken = String(token.unicodeScalars.filter({ CharacterSet.alphanumerics.contains($0) }))
+        open()
     }
-    return urlUnwrapped
-  }
 
-  private func tableNameFor(_ persistenceType: PersistenceType) -> String {
-    return "mixpanel_\(apiToken)_\(persistenceType)"
-  }
-
-  private func reconnect() {
-    MixpanelLogger.warn(message: "No database connection found. Calling MPDB.open()")
-    open()
-  }
-
-  func open() {
-    if apiToken.isEmpty {
-      MixpanelLogger.error(message: "Project token must not be empty. Database cannot be opened.")
-      return
-    }
-    if let dbPath = pathToDb() {
-      // On iOS (excluding Mac Catalyst and simulator), use SQLITE_OPEN_FILEPROTECTION_COMPLETEUNTILFIRSTUSERAUTHENTICATION
-      // so the database and its WAL/SHM files remain accessible in the background after first
-      // unlock. Without this, WAL file fsync/pwrite can hang indefinitely when the screen is
-      // locked during background execution, causing a watchdog kill.
-      // Mac Catalyst and the simulator use macOS/host file systems with no Data Protection,
-      // so the flag is unnecessary and can cause issues there.
-      #if os(iOS) && !targetEnvironment(macCatalyst) && !targetEnvironment(simulator)
-        let openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_COMPLETEUNTILFIRSTUSERAUTHENTICATION
-      #else
-        let openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
-      #endif
-      if sqlite3_open_v2(dbPath, &connection, openFlags, nil)
-        != SQLITE_OK
-      {
-        logSqlError(message: "Error opening or creating database at path: \(dbPath)")
+    deinit {
         close()
-      } else {
-        MixpanelLogger.info(
-          message: "Successfully opened connection to database at path: \(dbPath)")
-        if let db = connection {
-          let pragmaString = "PRAGMA journal_mode=WAL;"
-          var pragmaStatement: OpaquePointer?
-          if sqlite3_prepare_v2(db, pragmaString, -1, &pragmaStatement, nil) == SQLITE_OK {
-            if sqlite3_step(pragmaStatement) == SQLITE_ROW {
-              let res = String(cString: sqlite3_column_text(pragmaStatement, 0))
-              MixpanelLogger.info(message: "SQLite journal mode set to \(res)")
-            } else {
-              logSqlError(message: "Failed to enable journal_mode=WAL")
-            }
-          } else {
-            logSqlError(message: "PRAGMA journal_mode=WAL statement could not be prepared")
-          }
-          sqlite3_finalize(pragmaStatement)
-        } else {
-          reconnect()
-        }
-        createTablesAndIndexes()
-      }
     }
-  }
 
-  func close() {
-    sqlite3_close(connection)
-    connection = nil
-    MixpanelLogger.info(message: "Connection to database closed.")
-  }
-
-  private func recreate() {
-    close()
-    if let dbPath = pathToDb() {
-      do {
+    private func pathToDb() -> String? {
         let manager = FileManager.default
-        if manager.fileExists(atPath: dbPath) {
-          try manager.removeItem(atPath: dbPath)
-          MixpanelLogger.info(message: "Deleted database file at path: \(dbPath)")
+        #if os(iOS)
+        let url = manager.urls(for: .libraryDirectory, in: .userDomainMask).last
+        #else
+        let url = manager.urls(for: .cachesDirectory, in: .userDomainMask).last
+        #endif  // os(iOS)
+
+        guard let urlUnwrapped = url?.appendingPathComponent(apiToken + "_" + DB_FILE_NAME).path else {
+            return nil
         }
-      } catch let error {
-        MixpanelLogger.error(
-          message: "Unable to remove database file at path: \(dbPath), error: \(error)")
-      }
+        return urlUnwrapped
     }
-    reconnect()
-  }
 
-  private func createTableFor(_ persistenceType: PersistenceType) {
-    if let db = connection {
-      let tableName = tableNameFor(persistenceType)
-      let createTableString =
-        "CREATE TABLE IF NOT EXISTS \(tableName)(id integer primary key autoincrement,data blob,time real,flag integer);"
-      var createTableStatement: OpaquePointer?
-      if sqlite3_prepare_v2(db, createTableString, -1, &createTableStatement, nil) == SQLITE_OK {
-        if sqlite3_step(createTableStatement) == SQLITE_DONE {
-          MixpanelLogger.info(message: "\(tableName) table created")
-        } else {
-          logSqlError(message: "\(tableName) table create failed")
+    private func tableNameFor(_ persistenceType: PersistenceType) -> String {
+        return "mixpanel_\(apiToken)_\(persistenceType)"
+    }
+
+    private func reconnect() {
+        MixpanelLogger.warn(message: "No database connection found. Calling MPDB.open()")
+        open()
+    }
+
+    func open() {
+        if apiToken.isEmpty {
+            MixpanelLogger.error(message: "Project token must not be empty. Database cannot be opened.")
+            return
         }
-      } else {
-        logSqlError(message: "CREATE statement for table \(tableName) could not be prepared")
-      }
-      sqlite3_finalize(createTableStatement)
-    } else {
-      reconnect()
-    }
-  }
-
-  private func createIndexFor(_ persistenceType: PersistenceType) {
-    if let db = connection {
-      let tableName = tableNameFor(persistenceType)
-      let indexName = "idx_\(persistenceType)_time"
-      let createIndexString = "CREATE INDEX IF NOT EXISTS \(indexName) ON \(tableName) (time);"
-      var createIndexStatement: OpaquePointer?
-      if sqlite3_prepare_v2(db, createIndexString, -1, &createIndexStatement, nil) == SQLITE_OK {
-        if sqlite3_step(createIndexStatement) == SQLITE_DONE {
-          MixpanelLogger.info(message: "\(indexName) index created")
-        } else {
-          logSqlError(message: "\(indexName) index creation failed")
-        }
-      } else {
-        logSqlError(message: "CREATE statement for index \(indexName) could not be prepared")
-      }
-      sqlite3_finalize(createIndexStatement)
-    } else {
-      reconnect()
-    }
-  }
-
-  private func createTablesAndIndexes() {
-    createTableFor(PersistenceType.events)
-    createIndexFor(PersistenceType.events)
-    createTableFor(PersistenceType.people)
-    createIndexFor(PersistenceType.people)
-    createTableFor(PersistenceType.groups)
-    createIndexFor(PersistenceType.groups)
-  }
-
-  func insertRow(_ persistenceType: PersistenceType, data: Data, flag: Bool = false) {
-    if let db = connection {
-      let tableName = tableNameFor(persistenceType)
-      let insertString = "INSERT INTO \(tableName) (data, flag, time) VALUES(?, ?, ?);"
-      var insertStatement: OpaquePointer?
-      data.withUnsafeBytes { rawBuffer in
-        if let pointer = rawBuffer.baseAddress {
-          if sqlite3_prepare_v2(db, insertString, -1, &insertStatement, nil) == SQLITE_OK {
-            sqlite3_bind_blob(insertStatement, 1, pointer, Int32(rawBuffer.count), SQLITE_TRANSIENT)
-            sqlite3_bind_int(insertStatement, 2, flag ? 1 : 0)
-            sqlite3_bind_double(insertStatement, 3, Date().timeIntervalSince1970)
-            if sqlite3_step(insertStatement) == SQLITE_DONE {
-              MixpanelLogger.info(message: "Successfully inserted row into table \(tableName)")
+        if let dbPath = pathToDb() {
+            // On iOS (excluding Mac Catalyst and simulator), use SQLITE_OPEN_FILEPROTECTION_COMPLETEUNTILFIRSTUSERAUTHENTICATION
+            // so the database and its WAL/SHM files remain accessible in the background after first
+            // unlock. Without this, WAL file fsync/pwrite can hang indefinitely when the screen is
+            // locked during background execution, causing a watchdog kill.
+            // Mac Catalyst and the simulator use macOS/host file systems with no Data Protection,
+            // so the flag is unnecessary and can cause issues there.
+            #if os(iOS) && !targetEnvironment(macCatalyst) && !targetEnvironment(simulator)
+            let openFlags =
+                SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
+                | SQLITE_OPEN_FILEPROTECTION_COMPLETEUNTILFIRSTUSERAUTHENTICATION
+            #else
+            let openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
+            #endif
+            if sqlite3_open_v2(dbPath, &connection, openFlags, nil)
+                != SQLITE_OK
+            {
+                logSqlError(message: "Error opening or creating database at path: \(dbPath)")
+                close()
             } else {
-              logSqlError(message: "Failed to insert row into table \(tableName)")
-              recreate()
+                MixpanelLogger.info(
+                    message: "Successfully opened connection to database at path: \(dbPath)")
+                if let db = connection {
+                    let pragmaString = "PRAGMA journal_mode=WAL;"
+                    var pragmaStatement: OpaquePointer?
+                    if sqlite3_prepare_v2(db, pragmaString, -1, &pragmaStatement, nil) == SQLITE_OK {
+                        if sqlite3_step(pragmaStatement) == SQLITE_ROW {
+                            let res = String(cString: sqlite3_column_text(pragmaStatement, 0))
+                            MixpanelLogger.info(message: "SQLite journal mode set to \(res)")
+                        } else {
+                            logSqlError(message: "Failed to enable journal_mode=WAL")
+                        }
+                    } else {
+                        logSqlError(message: "PRAGMA journal_mode=WAL statement could not be prepared")
+                    }
+                    sqlite3_finalize(pragmaStatement)
+                } else {
+                    reconnect()
+                }
+                createTablesAndIndexes()
             }
-          } else {
-            logSqlError(message: "INSERT statement for table \(tableName) could not be prepared")
-            recreate()
-          }
-          sqlite3_finalize(insertStatement)
         }
-      }
-    } else {
-      reconnect()
     }
-  }
 
-  func deleteRows(_ persistenceType: PersistenceType, ids: [Int32] = [], isDeleteAll: Bool = false)
-  {
-    if let db = connection {
-      let tableName = tableNameFor(persistenceType)
-      let deleteString =
-        "DELETE FROM \(tableName)\(isDeleteAll ? "" : " WHERE id IN \(idsSqlString(ids))")"
-      var deleteStatement: OpaquePointer?
-      if sqlite3_prepare_v2(db, deleteString, -1, &deleteStatement, nil) == SQLITE_OK {
-        if sqlite3_step(deleteStatement) == SQLITE_DONE {
-          MixpanelLogger.info(message: "Successfully deleted rows from table \(tableName)")
-        } else {
-          logSqlError(message: "Failed to delete rows from table \(tableName)")
-          recreate()
-        }
-      } else {
-        logSqlError(message: "DELETE statement for table \(tableName) could not be prepared")
-        recreate()
-      }
-      sqlite3_finalize(deleteStatement)
-    } else {
-      reconnect()
+    func close() {
+        sqlite3_close(connection)
+        connection = nil
+        MixpanelLogger.info(message: "Connection to database closed.")
     }
-  }
 
-  private func idsSqlString(_ ids: [Int32] = []) -> String {
-    var sqlString = "("
-    for id in ids {
-      sqlString += "\(id),"
-    }
-    sqlString = String(sqlString.dropLast())
-    sqlString += ")"
-    return sqlString
-  }
-
-  func updateRowsFlag(_ persistenceType: PersistenceType, newFlag: Bool) {
-    if let db = connection {
-      let tableName = tableNameFor(persistenceType)
-      let updateString = "UPDATE \(tableName) SET flag = \(newFlag) where flag = \(!newFlag)"
-      var updateStatement: OpaquePointer?
-      if sqlite3_prepare_v2(db, updateString, -1, &updateStatement, nil) == SQLITE_OK {
-        if sqlite3_step(updateStatement) == SQLITE_DONE {
-          MixpanelLogger.info(message: "Successfully updated rows from table \(tableName)")
-        } else {
-          logSqlError(message: "Failed to update rows from table \(tableName)")
-          recreate()
-        }
-      } else {
-        logSqlError(message: "UPDATE statement for table \(tableName) could not be prepared")
-        recreate()
-      }
-      sqlite3_finalize(updateStatement)
-    } else {
-      reconnect()
-    }
-  }
-
-  func readRows(_ persistenceType: PersistenceType, numRows: Int, flag: Bool = false)
-    -> [InternalProperties]
-  {
-    var rows: [InternalProperties] = []
-    if let db = connection {
-      let tableName = tableNameFor(persistenceType)
-      let selectString = """
-        SELECT id, data FROM \(tableName) WHERE flag = \(flag ? 1 : 0) \
-        ORDER BY time\(numRows == Int.max ? "" : " LIMIT \(numRows)")
-        """
-      var selectStatement: OpaquePointer?
-      var rowsRead: Int = 0
-      if sqlite3_prepare_v2(db, selectString, -1, &selectStatement, nil) == SQLITE_OK {
-        while sqlite3_step(selectStatement) == SQLITE_ROW {
-          if let blob = sqlite3_column_blob(selectStatement, 1) {
-            let blobLength = sqlite3_column_bytes(selectStatement, 1)
-            let data = Data(bytes: blob, count: Int(blobLength))
-            let id = sqlite3_column_int(selectStatement, 0)
-
-            if let jsonObject = JSONHandler.deserializeData(data) as? InternalProperties {
-              var entity = jsonObject
-              entity["id"] = id
-              rows.append(entity)
+    private func recreate() {
+        close()
+        if let dbPath = pathToDb() {
+            do {
+                let manager = FileManager.default
+                if manager.fileExists(atPath: dbPath) {
+                    try manager.removeItem(atPath: dbPath)
+                    MixpanelLogger.info(message: "Deleted database file at path: \(dbPath)")
+                }
+            } catch let error {
+                MixpanelLogger.error(
+                    message: "Unable to remove database file at path: \(dbPath), error: \(error)")
             }
-            rowsRead += 1
-          } else {
-            logSqlError(message: "No blob found in data column for row in \(tableName)")
-          }
         }
-        if rowsRead > 0 {
-          MixpanelLogger.info(message: "Successfully read \(rowsRead) from table \(tableName)")
-        }
-      } else {
-        logSqlError(message: "SELECT statement for table \(tableName) could not be prepared")
-      }
-      sqlite3_finalize(selectStatement)
-    } else {
-      reconnect()
+        reconnect()
     }
-    return rows
-  }
 
-  private func logSqlError(message: String? = nil) {
-    if let db = connection {
-      if let msg = message {
-        MixpanelLogger.error(message: msg)
-      }
-      let sqlError = String(cString: sqlite3_errmsg(db)!)
-      MixpanelLogger.error(message: sqlError)
-    } else {
-      reconnect()
+    private func createTableFor(_ persistenceType: PersistenceType) {
+        if let db = connection {
+            let tableName = tableNameFor(persistenceType)
+            let createTableString =
+                "CREATE TABLE IF NOT EXISTS \(tableName)(id integer primary key autoincrement,data blob,time real,flag integer);"
+            var createTableStatement: OpaquePointer?
+            if sqlite3_prepare_v2(db, createTableString, -1, &createTableStatement, nil) == SQLITE_OK {
+                if sqlite3_step(createTableStatement) == SQLITE_DONE {
+                    MixpanelLogger.info(message: "\(tableName) table created")
+                } else {
+                    logSqlError(message: "\(tableName) table create failed")
+                }
+            } else {
+                logSqlError(message: "CREATE statement for table \(tableName) could not be prepared")
+            }
+            sqlite3_finalize(createTableStatement)
+        } else {
+            reconnect()
+        }
     }
-  }
+
+    private func createIndexFor(_ persistenceType: PersistenceType) {
+        if let db = connection {
+            let tableName = tableNameFor(persistenceType)
+            let indexName = "idx_\(persistenceType)_time"
+            let createIndexString = "CREATE INDEX IF NOT EXISTS \(indexName) ON \(tableName) (time);"
+            var createIndexStatement: OpaquePointer?
+            if sqlite3_prepare_v2(db, createIndexString, -1, &createIndexStatement, nil) == SQLITE_OK {
+                if sqlite3_step(createIndexStatement) == SQLITE_DONE {
+                    MixpanelLogger.info(message: "\(indexName) index created")
+                } else {
+                    logSqlError(message: "\(indexName) index creation failed")
+                }
+            } else {
+                logSqlError(message: "CREATE statement for index \(indexName) could not be prepared")
+            }
+            sqlite3_finalize(createIndexStatement)
+        } else {
+            reconnect()
+        }
+    }
+
+    private func createTablesAndIndexes() {
+        createTableFor(PersistenceType.events)
+        createIndexFor(PersistenceType.events)
+        createTableFor(PersistenceType.people)
+        createIndexFor(PersistenceType.people)
+        createTableFor(PersistenceType.groups)
+        createIndexFor(PersistenceType.groups)
+    }
+
+    func insertRow(_ persistenceType: PersistenceType, data: Data, flag: Bool = false) {
+        if let db = connection {
+            let tableName = tableNameFor(persistenceType)
+            let insertString = "INSERT INTO \(tableName) (data, flag, time) VALUES(?, ?, ?);"
+            var insertStatement: OpaquePointer?
+            data.withUnsafeBytes { rawBuffer in
+                if let pointer = rawBuffer.baseAddress {
+                    if sqlite3_prepare_v2(db, insertString, -1, &insertStatement, nil) == SQLITE_OK {
+                        sqlite3_bind_blob(insertStatement, 1, pointer, Int32(rawBuffer.count), SQLITE_TRANSIENT)
+                        sqlite3_bind_int(insertStatement, 2, flag ? 1 : 0)
+                        sqlite3_bind_double(insertStatement, 3, Date().timeIntervalSince1970)
+                        if sqlite3_step(insertStatement) == SQLITE_DONE {
+                            MixpanelLogger.info(message: "Successfully inserted row into table \(tableName)")
+                        } else {
+                            logSqlError(message: "Failed to insert row into table \(tableName)")
+                            recreate()
+                        }
+                    } else {
+                        logSqlError(message: "INSERT statement for table \(tableName) could not be prepared")
+                        recreate()
+                    }
+                    sqlite3_finalize(insertStatement)
+                }
+            }
+        } else {
+            reconnect()
+        }
+    }
+
+    func deleteRows(_ persistenceType: PersistenceType, ids: [Int32] = [], isDeleteAll: Bool = false) {
+        if let db = connection {
+            let tableName = tableNameFor(persistenceType)
+            let deleteString =
+                "DELETE FROM \(tableName)\(isDeleteAll ? "" : " WHERE id IN \(idsSqlString(ids))")"
+            var deleteStatement: OpaquePointer?
+            if sqlite3_prepare_v2(db, deleteString, -1, &deleteStatement, nil) == SQLITE_OK {
+                if sqlite3_step(deleteStatement) == SQLITE_DONE {
+                    MixpanelLogger.info(message: "Successfully deleted rows from table \(tableName)")
+                } else {
+                    logSqlError(message: "Failed to delete rows from table \(tableName)")
+                    recreate()
+                }
+            } else {
+                logSqlError(message: "DELETE statement for table \(tableName) could not be prepared")
+                recreate()
+            }
+            sqlite3_finalize(deleteStatement)
+        } else {
+            reconnect()
+        }
+    }
+
+    private func idsSqlString(_ ids: [Int32] = []) -> String {
+        var sqlString = "("
+        for id in ids {
+            sqlString += "\(id),"
+        }
+        sqlString = String(sqlString.dropLast())
+        sqlString += ")"
+        return sqlString
+    }
+
+    func updateRowsFlag(_ persistenceType: PersistenceType, newFlag: Bool) {
+        if let db = connection {
+            let tableName = tableNameFor(persistenceType)
+            let updateString = "UPDATE \(tableName) SET flag = \(newFlag) where flag = \(!newFlag)"
+            var updateStatement: OpaquePointer?
+            if sqlite3_prepare_v2(db, updateString, -1, &updateStatement, nil) == SQLITE_OK {
+                if sqlite3_step(updateStatement) == SQLITE_DONE {
+                    MixpanelLogger.info(message: "Successfully updated rows from table \(tableName)")
+                } else {
+                    logSqlError(message: "Failed to update rows from table \(tableName)")
+                    recreate()
+                }
+            } else {
+                logSqlError(message: "UPDATE statement for table \(tableName) could not be prepared")
+                recreate()
+            }
+            sqlite3_finalize(updateStatement)
+        } else {
+            reconnect()
+        }
+    }
+
+    func readRows(_ persistenceType: PersistenceType, numRows: Int, flag: Bool = false)
+        -> [InternalProperties]
+    {
+        var rows: [InternalProperties] = []
+        if let db = connection {
+            let tableName = tableNameFor(persistenceType)
+            let selectString = """
+                SELECT id, data FROM \(tableName) WHERE flag = \(flag ? 1 : 0) \
+                ORDER BY time\(numRows == Int.max ? "" : " LIMIT \(numRows)")
+                """
+            var selectStatement: OpaquePointer?
+            var rowsRead: Int = 0
+            if sqlite3_prepare_v2(db, selectString, -1, &selectStatement, nil) == SQLITE_OK {
+                while sqlite3_step(selectStatement) == SQLITE_ROW {
+                    if let blob = sqlite3_column_blob(selectStatement, 1) {
+                        let blobLength = sqlite3_column_bytes(selectStatement, 1)
+                        let data = Data(bytes: blob, count: Int(blobLength))
+                        let id = sqlite3_column_int(selectStatement, 0)
+
+                        if let jsonObject = JSONHandler.deserializeData(data) as? InternalProperties {
+                            var entity = jsonObject
+                            entity["id"] = id
+                            rows.append(entity)
+                        }
+                        rowsRead += 1
+                    } else {
+                        logSqlError(message: "No blob found in data column for row in \(tableName)")
+                    }
+                }
+                if rowsRead > 0 {
+                    MixpanelLogger.info(message: "Successfully read \(rowsRead) from table \(tableName)")
+                }
+            } else {
+                logSqlError(message: "SELECT statement for table \(tableName) could not be prepared")
+            }
+            sqlite3_finalize(selectStatement)
+        } else {
+            reconnect()
+        }
+        return rows
+    }
+
+    private func logSqlError(message: String? = nil) {
+        if let db = connection {
+            if let msg = message {
+                MixpanelLogger.error(message: msg)
+            }
+            let sqlError = String(cString: sqlite3_errmsg(db)!)
+            MixpanelLogger.error(message: sqlError)
+        } else {
+            reconnect()
+        }
+    }
 }

--- a/Sources/Mixpanel.swift
+++ b/Sources/Mixpanel.swift
@@ -9,25 +9,25 @@
 import Foundation
 
 #if !os(OSX)
-  import UIKit
+import UIKit
 #endif  // os(OSX)
 
 /// The primary class for integrating Mixpanel with your app.
 open class Mixpanel {
 
-  @discardableResult
-  open class func initialize(options: MixpanelOptions) -> MixpanelInstance {
-    return MixpanelManager.sharedInstance.initialize(options: options)
-  }
+    @discardableResult
+    open class func initialize(options: MixpanelOptions) -> MixpanelInstance {
+        return MixpanelManager.sharedInstance.initialize(options: options)
+    }
 
-  #if !os(OSX) && !os(watchOS)
+    #if !os(OSX) && !os(watchOS)
     /**
      Initializes an instance of the API with the given project token.
-
+    
      Returns a new Mixpanel instance API object. This allows you to create more than one instance
      of the API object, which is convenient if you'd like to send data to more than
      one Mixpanel project from a single app.
-
+    
      - parameter token:                     your project token
      - parameter trackAutomaticEvents:      Whether or not to collect common mobile events
      - parameter flushInterval:             Optional. Interval to run background flushing
@@ -38,44 +38,44 @@ open class Mixpanel {
      - parameter superProperties:           Optional. Super properties dictionary to register during initialization
      - parameter serverURL:                 Optional. Mixpanel cluster URL
      - parameter useGzipCompression:        Optional. Whether to use gzip compression for network requests.
-
+    
      - important: If you have more than one Mixpanel instance, it is beneficial to initialize
      the instances with an instanceName. Then they can be reached by calling getInstance with name.
-
+    
      - returns: returns a mixpanel instance if needed to keep throughout the project.
      You can always get the instance by calling getInstance(name)
      */
     @discardableResult
     open class func initialize(
-      token apiToken: String,
-      trackAutomaticEvents: Bool,
-      flushInterval: Double = 60,
-      instanceName: String? = nil,
-      optOutTrackingByDefault: Bool = false,
-      useUniqueDistinctId: Bool = false,
-      superProperties: Properties? = nil,
-      serverURL: String? = nil,
-      useGzipCompression: Bool = false
+        token apiToken: String,
+        trackAutomaticEvents: Bool,
+        flushInterval: Double = 60,
+        instanceName: String? = nil,
+        optOutTrackingByDefault: Bool = false,
+        useUniqueDistinctId: Bool = false,
+        superProperties: Properties? = nil,
+        serverURL: String? = nil,
+        useGzipCompression: Bool = false
     ) -> MixpanelInstance {
-      return MixpanelManager.sharedInstance.initialize(
-        token: apiToken,
-        flushInterval: flushInterval,
-        instanceName: ((instanceName != nil) ? instanceName! : apiToken),
-        trackAutomaticEvents: trackAutomaticEvents,
-        optOutTrackingByDefault: optOutTrackingByDefault,
-        useUniqueDistinctId: useUniqueDistinctId,
-        superProperties: superProperties,
-        serverURL: serverURL,
-        useGzipCompression: useGzipCompression)
+        return MixpanelManager.sharedInstance.initialize(
+            token: apiToken,
+            flushInterval: flushInterval,
+            instanceName: ((instanceName != nil) ? instanceName! : apiToken),
+            trackAutomaticEvents: trackAutomaticEvents,
+            optOutTrackingByDefault: optOutTrackingByDefault,
+            useUniqueDistinctId: useUniqueDistinctId,
+            superProperties: superProperties,
+            serverURL: serverURL,
+            useGzipCompression: useGzipCompression)
     }
 
     /**
      Initializes an instance of the API with the given project token.
-
+    
      Returns a new Mixpanel instance API object. This allows you to create more than one instance
      of the API object, which is convenient if you'd like to send data to more than
      one Mixpanel project from a single app.
-
+    
      - parameter token:                     your project token
      - parameter trackAutomaticEvents:      Whether or not to collect common mobile events
      - parameter flushInterval:             Optional. Interval to run background flushing
@@ -86,45 +86,45 @@ open class Mixpanel {
      - parameter superProperties:           Optional. Super properties dictionary to register during initialization
      - parameter proxyServerConfig:         Optional. Setup for proxy server.
      - parameter useGzipCompression:        Optional. Whether to use gzip compression for network requests.
-
+    
      - important: If you have more than one Mixpanel instance, it is beneficial to initialize
      the instances with an instanceName. Then they can be reached by calling getInstance with name.
-
+    
      - returns: returns a mixpanel instance if needed to keep throughout the project.
      You can always get the instance by calling getInstance(name)
      */
 
     @discardableResult
     open class func initialize(
-      token apiToken: String,
-      trackAutomaticEvents: Bool,
-      flushInterval: Double = 60,
-      instanceName: String? = nil,
-      optOutTrackingByDefault: Bool = false,
-      useUniqueDistinctId: Bool = false,
-      superProperties: Properties? = nil,
-      proxyServerConfig: ProxyServerConfig,
-      useGzipCompression: Bool = false
+        token apiToken: String,
+        trackAutomaticEvents: Bool,
+        flushInterval: Double = 60,
+        instanceName: String? = nil,
+        optOutTrackingByDefault: Bool = false,
+        useUniqueDistinctId: Bool = false,
+        superProperties: Properties? = nil,
+        proxyServerConfig: ProxyServerConfig,
+        useGzipCompression: Bool = false
     ) -> MixpanelInstance {
-      return MixpanelManager.sharedInstance.initialize(
-        token: apiToken,
-        flushInterval: flushInterval,
-        instanceName: ((instanceName != nil) ? instanceName! : apiToken),
-        trackAutomaticEvents: trackAutomaticEvents,
-        optOutTrackingByDefault: optOutTrackingByDefault,
-        useUniqueDistinctId: useUniqueDistinctId,
-        superProperties: superProperties,
-        proxyServerConfig: proxyServerConfig,
-        useGzipCompression: useGzipCompression)
+        return MixpanelManager.sharedInstance.initialize(
+            token: apiToken,
+            flushInterval: flushInterval,
+            instanceName: ((instanceName != nil) ? instanceName! : apiToken),
+            trackAutomaticEvents: trackAutomaticEvents,
+            optOutTrackingByDefault: optOutTrackingByDefault,
+            useUniqueDistinctId: useUniqueDistinctId,
+            superProperties: superProperties,
+            proxyServerConfig: proxyServerConfig,
+            useGzipCompression: useGzipCompression)
     }
-  #else
+    #else
     /**
      Initializes an instance of the API with the given project token (MAC OS ONLY).
-
+    
      Returns a new Mixpanel instance API object. This allows you to create more than one instance
      of the API object, which is convenient if you'd like to send data to more than
      one Mixpanel project from a single app.
-
+    
      - parameter token:                     your project token
      - parameter flushInterval:             Optional. Interval to run background flushing
      - parameter instanceName:              Optional. The name you want to uniquely identify the Mixpanel Instance.
@@ -135,45 +135,45 @@ open class Mixpanel {
      - parameter serverURL:                 Optional. Mixpanel cluster URL
      - parameter useGzipCompression:        Optional. Whether to use gzip compression for network requests.
      - parameter trackAutomaticEvents:      Optional. Whether or not to collect common events. Defaults to false.
-
+    
      - important: If you have more than one Mixpanel instance, it is beneficial to initialize
      the instances with an instanceName. Then they can be reached by calling getInstance with name.
-
+    
      - returns: returns a mixpanel instance if needed to keep throughout the project.
      You can always get the instance by calling getInstance(name)
      */
 
     @discardableResult
     open class func initialize(
-      token apiToken: String,
-      flushInterval: Double = 60,
-      instanceName: String? = nil,
-      optOutTrackingByDefault: Bool = false,
-      useUniqueDistinctId: Bool = false,
-      superProperties: Properties? = nil,
-      serverURL: String? = nil,
-      useGzipCompression: Bool = false,
-      trackAutomaticEvents: Bool = false
+        token apiToken: String,
+        flushInterval: Double = 60,
+        instanceName: String? = nil,
+        optOutTrackingByDefault: Bool = false,
+        useUniqueDistinctId: Bool = false,
+        superProperties: Properties? = nil,
+        serverURL: String? = nil,
+        useGzipCompression: Bool = false,
+        trackAutomaticEvents: Bool = false
     ) -> MixpanelInstance {
-      return MixpanelManager.sharedInstance.initialize(
-        token: apiToken,
-        flushInterval: flushInterval,
-        instanceName: ((instanceName != nil) ? instanceName! : apiToken),
-        trackAutomaticEvents: trackAutomaticEvents,
-        optOutTrackingByDefault: optOutTrackingByDefault,
-        useUniqueDistinctId: useUniqueDistinctId,
-        superProperties: superProperties,
-        serverURL: serverURL,
-        useGzipCompression: useGzipCompression)
+        return MixpanelManager.sharedInstance.initialize(
+            token: apiToken,
+            flushInterval: flushInterval,
+            instanceName: ((instanceName != nil) ? instanceName! : apiToken),
+            trackAutomaticEvents: trackAutomaticEvents,
+            optOutTrackingByDefault: optOutTrackingByDefault,
+            useUniqueDistinctId: useUniqueDistinctId,
+            superProperties: superProperties,
+            serverURL: serverURL,
+            useGzipCompression: useGzipCompression)
     }
 
     /**
      Initializes an instance of the API with the given project token (MAC OS ONLY).
-
+    
      Returns a new Mixpanel instance API object. This allows you to create more than one instance
      of the API object, which is convenient if you'd like to send data to more than
      one Mixpanel project from a single app.
-
+    
      - parameter token:                     your project token
      - parameter flushInterval:             Optional. Interval to run background flushing
      - parameter instanceName:              Optional. The name you want to uniquely identify the Mixpanel Instance.
@@ -184,245 +184,245 @@ open class Mixpanel {
      - parameter proxyServerConfig:         Optional. Setup for proxy server.
      - parameter useGzipCompression:        Optional. Whether to use gzip compression for network requests.
      - parameter trackAutomaticEvents:      Optional. Whether or not to collect common events. Defaults to false.
-
+    
      - important: If you have more than one Mixpanel instance, it is beneficial to initialize
      the instances with an instanceName. Then they can be reached by calling getInstance with name.
-
+    
      - returns: returns a mixpanel instance if needed to keep throughout the project.
      You can always get the instance by calling getInstance(name)
      */
 
     @discardableResult
     open class func initialize(
-      token apiToken: String,
-      flushInterval: Double = 60,
-      instanceName: String? = nil,
-      optOutTrackingByDefault: Bool = false,
-      useUniqueDistinctId: Bool = false,
-      superProperties: Properties? = nil,
-      proxyServerConfig: ProxyServerConfig,
-      useGzipCompression: Bool = false,
-      trackAutomaticEvents: Bool = false
+        token apiToken: String,
+        flushInterval: Double = 60,
+        instanceName: String? = nil,
+        optOutTrackingByDefault: Bool = false,
+        useUniqueDistinctId: Bool = false,
+        superProperties: Properties? = nil,
+        proxyServerConfig: ProxyServerConfig,
+        useGzipCompression: Bool = false,
+        trackAutomaticEvents: Bool = false
     ) -> MixpanelInstance {
-      return MixpanelManager.sharedInstance.initialize(
-        token: apiToken,
-        flushInterval: flushInterval,
-        instanceName: ((instanceName != nil) ? instanceName! : apiToken),
-        trackAutomaticEvents: trackAutomaticEvents,
-        optOutTrackingByDefault: optOutTrackingByDefault,
-        useUniqueDistinctId: useUniqueDistinctId,
-        superProperties: superProperties,
-        proxyServerConfig: proxyServerConfig,
-        useGzipCompression: useGzipCompression)
+        return MixpanelManager.sharedInstance.initialize(
+            token: apiToken,
+            flushInterval: flushInterval,
+            instanceName: ((instanceName != nil) ? instanceName! : apiToken),
+            trackAutomaticEvents: trackAutomaticEvents,
+            optOutTrackingByDefault: optOutTrackingByDefault,
+            useUniqueDistinctId: useUniqueDistinctId,
+            superProperties: superProperties,
+            proxyServerConfig: proxyServerConfig,
+            useGzipCompression: useGzipCompression)
     }
-  #endif  // os(OSX)
+    #endif  // os(OSX)
 
-  /**
-     Gets the mixpanel instance with the given name
-
-     - parameter name: the instance name
-
-     - returns: returns the mixpanel instance
-     */
-  open class func getInstance(name: String) -> MixpanelInstance? {
-    return MixpanelManager.sharedInstance.getInstance(name: name)
-  }
-
-  /**
-     Returns the main instance that was initialized.
-
-     If not specified explicitly, the main instance is always the last instance added
-
-     - returns: returns the main Mixpanel instance
-     */
-  open class func mainInstance() -> MixpanelInstance {
-    if let instance = MixpanelManager.sharedInstance.getMainInstance() {
-      return instance
-    } else {
-      #if !targetEnvironment(simulator)
-        assert(
-          false,
-          "You have to call initialize(token:trackAutomaticEvents:) before calling the main instance, "
-            + "or define a new main instance if removing the main one")
-      #endif
-
-      #if !os(OSX) && !os(watchOS)
-        return Mixpanel.initialize(token: "", trackAutomaticEvents: true)
-      #else
-        return Mixpanel.initialize(token: "")
-      #endif
-
+    /**
+       Gets the mixpanel instance with the given name
+    
+       - parameter name: the instance name
+    
+       - returns: returns the mixpanel instance
+       */
+    open class func getInstance(name: String) -> MixpanelInstance? {
+        return MixpanelManager.sharedInstance.getInstance(name: name)
     }
-  }
 
-  /// Returns the main Mixpanel instance if it has been initialized.
-  /// - Returns: An optional MixpanelInstance, or nil if not yet initialized.
-  public class func safeMainInstance() -> MixpanelInstance? {
-    if let instance = MixpanelManager.sharedInstance.getMainInstance() {
-      return instance
-    } else {
-      MixpanelLogger.warn(
-        message:
-          "WARNING: Mixpanel main instance is NOT initialized. Call Mixpanel.initialize(...) first."
-      )
-      return nil
+    /**
+       Returns the main instance that was initialized.
+    
+       If not specified explicitly, the main instance is always the last instance added
+    
+       - returns: returns the main Mixpanel instance
+       */
+    open class func mainInstance() -> MixpanelInstance {
+        if let instance = MixpanelManager.sharedInstance.getMainInstance() {
+            return instance
+        } else {
+            #if !targetEnvironment(simulator)
+            assert(
+                false,
+                "You have to call initialize(token:trackAutomaticEvents:) before calling the main instance, "
+                    + "or define a new main instance if removing the main one")
+            #endif
+
+            #if !os(OSX) && !os(watchOS)
+            return Mixpanel.initialize(token: "", trackAutomaticEvents: true)
+            #else
+            return Mixpanel.initialize(token: "")
+            #endif
+
+        }
     }
-  }
 
-  /**
-     Sets the main instance based on the instance name
+    /// Returns the main Mixpanel instance if it has been initialized.
+    /// - Returns: An optional MixpanelInstance, or nil if not yet initialized.
+    public class func safeMainInstance() -> MixpanelInstance? {
+        if let instance = MixpanelManager.sharedInstance.getMainInstance() {
+            return instance
+        } else {
+            MixpanelLogger.warn(
+                message:
+                    "WARNING: Mixpanel main instance is NOT initialized. Call Mixpanel.initialize(...) first."
+            )
+            return nil
+        }
+    }
 
-     - parameter name: the instance name
-     */
-  open class func setMainInstance(name: String) {
-    MixpanelManager.sharedInstance.setMainInstance(name: name)
-  }
+    /**
+       Sets the main instance based on the instance name
+    
+       - parameter name: the instance name
+       */
+    open class func setMainInstance(name: String) {
+        MixpanelManager.sharedInstance.setMainInstance(name: name)
+    }
 
-  /**
-     Removes an unneeded Mixpanel instance based on its name
-
-     - parameter name: the instance name
-     */
-  open class func removeInstance(name: String) {
-    MixpanelManager.sharedInstance.removeInstance(name: name)
-  }
+    /**
+       Removes an unneeded Mixpanel instance based on its name
+    
+       - parameter name: the instance name
+       */
+    open class func removeInstance(name: String) {
+        MixpanelManager.sharedInstance.removeInstance(name: name)
+    }
 }
 
 final class MixpanelManager {
 
-  static let sharedInstance = MixpanelManager()
-  private var instances: [String: MixpanelInstance]
-  private var mainInstance: MixpanelInstance?
-  private let readWriteLock: ReadWriteLock
-  private let instanceQueue: DispatchQueue
+    static let sharedInstance = MixpanelManager()
+    private var instances: [String: MixpanelInstance]
+    private var mainInstance: MixpanelInstance?
+    private let readWriteLock: ReadWriteLock
+    private let instanceQueue: DispatchQueue
 
-  init() {
-    instances = [String: MixpanelInstance]()
-    MixpanelLogger.addLogging(PrintLogging())
-    readWriteLock = ReadWriteLock(label: "com.mixpanel.instance.manager.lock")
-    instanceQueue = DispatchQueue(
-      label: "com.mixpanel.instance.manager.instance", qos: .utility,
-      autoreleaseFrequency: .workItem)
-  }
-
-  func initialize(options: MixpanelOptions) -> MixpanelInstance {
-    let instanceName = options.instanceName ?? options.token
-    return dequeueInstance(instanceName: instanceName) {
-      return MixpanelInstance(options: options)
+    init() {
+        instances = [String: MixpanelInstance]()
+        MixpanelLogger.addLogging(PrintLogging())
+        readWriteLock = ReadWriteLock(label: "com.mixpanel.instance.manager.lock")
+        instanceQueue = DispatchQueue(
+            label: "com.mixpanel.instance.manager.instance", qos: .utility,
+            autoreleaseFrequency: .workItem)
     }
-  }
 
-  func initialize(
-    token apiToken: String,
-    flushInterval: Double,
-    instanceName: String,
-    trackAutomaticEvents: Bool,
-    optOutTrackingByDefault: Bool = false,
-    useUniqueDistinctId: Bool = false,
-    superProperties: Properties? = nil,
-    serverURL: String? = nil,
-    useGzipCompression: Bool = false
-  ) -> MixpanelInstance {
-    return dequeueInstance(instanceName: instanceName) {
-      return MixpanelInstance(
-        apiToken: apiToken,
-        flushInterval: flushInterval,
-        name: instanceName,
-        trackAutomaticEvents: trackAutomaticEvents,
-        optOutTrackingByDefault: optOutTrackingByDefault,
-        useUniqueDistinctId: useUniqueDistinctId,
-        superProperties: superProperties,
-        serverURL: serverURL,
-        useGzipCompression: useGzipCompression)
+    func initialize(options: MixpanelOptions) -> MixpanelInstance {
+        let instanceName = options.instanceName ?? options.token
+        return dequeueInstance(instanceName: instanceName) {
+            return MixpanelInstance(options: options)
+        }
     }
-  }
 
-  func initialize(
-    token apiToken: String,
-    flushInterval: Double,
-    instanceName: String,
-    trackAutomaticEvents: Bool,
-    optOutTrackingByDefault: Bool = false,
-    useUniqueDistinctId: Bool = false,
-    superProperties: Properties? = nil,
-    proxyServerConfig: ProxyServerConfig,
-    useGzipCompression: Bool = false
-  ) -> MixpanelInstance {
-    return dequeueInstance(instanceName: instanceName) {
-      return MixpanelInstance(
-        apiToken: apiToken,
-        flushInterval: flushInterval,
-        name: instanceName,
-        trackAutomaticEvents: trackAutomaticEvents,
-        optOutTrackingByDefault: optOutTrackingByDefault,
-        useUniqueDistinctId: useUniqueDistinctId,
-        superProperties: superProperties,
-        proxyServerConfig: proxyServerConfig,
-        useGzipCompression: useGzipCompression)
+    func initialize(
+        token apiToken: String,
+        flushInterval: Double,
+        instanceName: String,
+        trackAutomaticEvents: Bool,
+        optOutTrackingByDefault: Bool = false,
+        useUniqueDistinctId: Bool = false,
+        superProperties: Properties? = nil,
+        serverURL: String? = nil,
+        useGzipCompression: Bool = false
+    ) -> MixpanelInstance {
+        return dequeueInstance(instanceName: instanceName) {
+            return MixpanelInstance(
+                apiToken: apiToken,
+                flushInterval: flushInterval,
+                name: instanceName,
+                trackAutomaticEvents: trackAutomaticEvents,
+                optOutTrackingByDefault: optOutTrackingByDefault,
+                useUniqueDistinctId: useUniqueDistinctId,
+                superProperties: superProperties,
+                serverURL: serverURL,
+                useGzipCompression: useGzipCompression)
+        }
     }
-  }
 
-  private func dequeueInstance(instanceName: String, instanceCreation: () -> MixpanelInstance)
-    -> MixpanelInstance
-  {
-    instanceQueue.sync {
-      var instance: MixpanelInstance?
-      if let instance = instances[instanceName] {
+    func initialize(
+        token apiToken: String,
+        flushInterval: Double,
+        instanceName: String,
+        trackAutomaticEvents: Bool,
+        optOutTrackingByDefault: Bool = false,
+        useUniqueDistinctId: Bool = false,
+        superProperties: Properties? = nil,
+        proxyServerConfig: ProxyServerConfig,
+        useGzipCompression: Bool = false
+    ) -> MixpanelInstance {
+        return dequeueInstance(instanceName: instanceName) {
+            return MixpanelInstance(
+                apiToken: apiToken,
+                flushInterval: flushInterval,
+                name: instanceName,
+                trackAutomaticEvents: trackAutomaticEvents,
+                optOutTrackingByDefault: optOutTrackingByDefault,
+                useUniqueDistinctId: useUniqueDistinctId,
+                superProperties: superProperties,
+                proxyServerConfig: proxyServerConfig,
+                useGzipCompression: useGzipCompression)
+        }
+    }
+
+    private func dequeueInstance(instanceName: String, instanceCreation: () -> MixpanelInstance)
+        -> MixpanelInstance
+    {
+        instanceQueue.sync {
+            var instance: MixpanelInstance?
+            if let instance = instances[instanceName] {
+                mainInstance = instance
+                return
+            }
+
+            instance = instanceCreation()
+            readWriteLock.write {
+                instances[instanceName] = instance!
+                mainInstance = instance!
+            }
+        }
+        return mainInstance!
+    }
+
+    func getInstance(name instanceName: String) -> MixpanelInstance? {
+        var instance: MixpanelInstance?
+        readWriteLock.read {
+            instance = instances[instanceName]
+        }
+        if instance == nil {
+            MixpanelLogger.warn(message: "no such instance: \(instanceName)")
+            return nil
+        }
+        return instance
+    }
+
+    func getMainInstance() -> MixpanelInstance? {
+        return mainInstance
+    }
+
+    func getAllInstances() -> [MixpanelInstance]? {
+        var allInstances: [MixpanelInstance]?
+        readWriteLock.read {
+            allInstances = Array(instances.values)
+        }
+        return allInstances
+    }
+
+    func setMainInstance(name instanceName: String) {
+        var instance: MixpanelInstance?
+        readWriteLock.read {
+            instance = instances[instanceName]
+        }
+        if instance == nil {
+            return
+        }
         mainInstance = instance
-        return
-      }
+    }
 
-      instance = instanceCreation()
-      readWriteLock.write {
-        instances[instanceName] = instance!
-        mainInstance = instance!
-      }
+    func removeInstance(name instanceName: String) {
+        readWriteLock.write {
+            if instances[instanceName] === mainInstance {
+                mainInstance = nil
+            }
+            instances[instanceName] = nil
+        }
     }
-    return mainInstance!
-  }
-
-  func getInstance(name instanceName: String) -> MixpanelInstance? {
-    var instance: MixpanelInstance?
-    readWriteLock.read {
-      instance = instances[instanceName]
-    }
-    if instance == nil {
-      MixpanelLogger.warn(message: "no such instance: \(instanceName)")
-      return nil
-    }
-    return instance
-  }
-
-  func getMainInstance() -> MixpanelInstance? {
-    return mainInstance
-  }
-
-  func getAllInstances() -> [MixpanelInstance]? {
-    var allInstances: [MixpanelInstance]?
-    readWriteLock.read {
-      allInstances = Array(instances.values)
-    }
-    return allInstances
-  }
-
-  func setMainInstance(name instanceName: String) {
-    var instance: MixpanelInstance?
-    readWriteLock.read {
-      instance = instances[instanceName]
-    }
-    if instance == nil {
-      return
-    }
-    mainInstance = instance
-  }
-
-  func removeInstance(name instanceName: String) {
-    readWriteLock.write {
-      if instances[instanceName] === mainInstance {
-        mainInstance = nil
-      }
-      instances[instanceName] = nil
-    }
-  }
 
 }

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -9,42 +9,42 @@
 import Foundation
 
 #if !os(OSX)
-  import UIKit
+import UIKit
 #else
-  import Cocoa
+import Cocoa
 #endif  // os(OSX)
 #if os(iOS)
-  import SystemConfiguration
+import SystemConfiguration
 #endif
 
 #if os(iOS)
-  import CoreTelephony
+import CoreTelephony
 #endif  // os(iOS)
 
 private let devicePrefix = "$device:"
 
 /// Delegate protocol for updating the Proxy Server API's network behavior.
 public protocol MixpanelProxyServerDelegate: AnyObject {
-  /**
-     Asks the delegate to return API resource items like query params & headers for proxy Server.
-  
-     - parameter mixpanel: The mixpanel instance
-  
-     - returns: return ServerProxyResource to give custom headers and query params.
-     */
-  func mixpanelResourceForProxyServer(_ name: String) -> ServerProxyResource?
+    /**
+       Asks the delegate to return API resource items like query params & headers for proxy Server.
+    
+       - parameter mixpanel: The mixpanel instance
+    
+       - returns: return ServerProxyResource to give custom headers and query params.
+       */
+    func mixpanelResourceForProxyServer(_ name: String) -> ServerProxyResource?
 }
 
 /// Delegate protocol for controlling the Mixpanel API's network behavior.
 public protocol MixpanelDelegate: AnyObject {
-  /**
-     Asks the delegate if data should be uploaded to the server.
-  
-     - parameter mixpanel: The mixpanel instance
-  
-     - returns: return true to upload now or false to defer until later
-     */
-  func mixpanelWillFlush(_ mixpanel: MixpanelInstance) -> Bool
+    /**
+       Asks the delegate if data should be uploaded to the server.
+    
+       - parameter mixpanel: The mixpanel instance
+    
+       - returns: return true to upload now or false to defer until later
+       */
+    func mixpanelWillFlush(_ mixpanel: MixpanelInstance) -> Bool
 }
 
 public typealias Properties = [String: MixpanelType]
@@ -52,1772 +52,1772 @@ typealias InternalProperties = [String: Any]
 typealias Queue = [InternalProperties]
 
 protocol AppLifecycle {
-  func applicationDidBecomeActive()
-  func applicationWillResignActive()
+    func applicationDidBecomeActive()
+    func applicationWillResignActive()
 }
 
 public struct ProxyServerConfig {
-  public init?(serverUrl: String, delegate: MixpanelProxyServerDelegate? = nil) {
-    /// check if proxy server is not same as default mixpanel API
-    /// if same, then fail the initializer
-    /// this is to avoid case where client might inadvertently use headers intended for the proxy server
-    /// on Mixpanel's default server, leading to unexpected behavior.
-    guard serverUrl != BasePath.DefaultMixpanelAPI else { return nil }
-    self.serverUrl = serverUrl
-    self.delegate = delegate
-  }
+    public init?(serverUrl: String, delegate: MixpanelProxyServerDelegate? = nil) {
+        /// check if proxy server is not same as default mixpanel API
+        /// if same, then fail the initializer
+        /// this is to avoid case where client might inadvertently use headers intended for the proxy server
+        /// on Mixpanel's default server, leading to unexpected behavior.
+        guard serverUrl != BasePath.DefaultMixpanelAPI else { return nil }
+        self.serverUrl = serverUrl
+        self.delegate = delegate
+    }
 
-  let serverUrl: String
-  let delegate: MixpanelProxyServerDelegate?
+    let serverUrl: String
+    let delegate: MixpanelProxyServerDelegate?
 }
 
 /// The class that represents the Mixpanel Instance
 open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDelegate,
-  MixpanelFlagDelegate
+    MixpanelFlagDelegate
 {
 
-  private let options: MixpanelOptions
+    private let options: MixpanelOptions
 
-  /// apiToken string that identifies the project to track data to
-  open var apiToken = ""
+    /// apiToken string that identifies the project to track data to
+    open var apiToken = ""
 
-  /// The a MixpanelDelegate object that gives control over Mixpanel network activity.
-  open weak var delegate: MixpanelDelegate?
+    /// The a MixpanelDelegate object that gives control over Mixpanel network activity.
+    open weak var delegate: MixpanelDelegate?
 
-  /// distinctId string that uniquely identifies the current user.
-  open var distinctId = ""
+    /// distinctId string that uniquely identifies the current user.
+    open var distinctId = ""
 
-  /// anonymousId string that uniquely identifies the device.
-  open var anonymousId: String?
+    /// anonymousId string that uniquely identifies the device.
+    open var anonymousId: String?
 
-  /// userId string that identify is called with.
-  open var userId: String?
+    /// userId string that identify is called with.
+    open var userId: String?
 
-  /// hadPersistedDistinctId is a boolean value which specifies that the stored distinct_id
-  /// already exists in persistence
-  open var hadPersistedDistinctId: Bool?
+    /// hadPersistedDistinctId is a boolean value which specifies that the stored distinct_id
+    /// already exists in persistence
+    open var hadPersistedDistinctId: Bool?
 
-  /// alias string that uniquely identifies the current user.
-  open var alias: String?
+    /// alias string that uniquely identifies the current user.
+    open var alias: String?
 
-  /// Accessor to the Mixpanel People API object.
-  open var people: People!
+    /// Accessor to the Mixpanel People API object.
+    open var people: People!
 
-  /// Accessor the Mixpanel Feature Flags API object.
-  open var flags: MixpanelFlags!
+    /// Accessor the Mixpanel Feature Flags API object.
+    open var flags: MixpanelFlags!
 
-  let mixpanelPersistence: MixpanelPersistence
+    let mixpanelPersistence: MixpanelPersistence
 
-  /// Accessor to the Mixpanel People API object.
-  var groups: [String: Group] = [:]
+    /// Accessor to the Mixpanel People API object.
+    var groups: [String: Group] = [:]
 
-  /// Controls whether to show spinning network activity indicator when flushing
-  /// data to the Mixpanel servers. Defaults to true.
-  open var showNetworkActivityIndicator = true
+    /// Controls whether to show spinning network activity indicator when flushing
+    /// data to the Mixpanel servers. Defaults to true.
+    open var showNetworkActivityIndicator = true
 
-  /// This allows enabling or disabling collecting common mobile events,
-  open var trackAutomaticEventsEnabled: Bool
+    /// This allows enabling or disabling collecting common mobile events,
+    open var trackAutomaticEventsEnabled: Bool
 
-  /// Flush timer's interval.
-  /// Setting a flush interval of 0 will turn off the flush timer and you need to call the flush() API manually
-  /// to upload queued data to the Mixpanel server.
-  open var flushInterval: Double {
-    get {
-      return flushInstance.flushInterval
-    }
-    set {
-      flushInstance.flushInterval = newValue
-    }
-  }
-
-  /// Control whether the library should flush data to Mixpanel when the app
-  /// enters the background. Defaults to true.
-  open var flushOnBackground: Bool {
-    get {
-      return flushInstance.flushOnBackground
-    }
-    set {
-      flushInstance.flushOnBackground = newValue
-    }
-  }
-
-  /// Controls whether to automatically send the client IP Address as part of
-  /// event tracking. With an IP address, the Mixpanel Dashboard will show you the users' city.
-  /// Defaults to true.
-  open var useIPAddressForGeoLocation: Bool {
-    get {
-      return flushInstance.useIPAddressForGeoLocation
-    }
-    set {
-      flushInstance.useIPAddressForGeoLocation = newValue
-    }
-  }
-
-  /// The `flushBatchSize` property determines the number of events sent in a single network request to the Mixpanel server.
-  /// By configuring this value, you can optimize network usage and manage the frequency of communication between the client
-  /// and the server. The maximum size is 50; any value over 50 will default to 50.
-  open var flushBatchSize: Int {
-    get {
-      return flushInstance.flushBatchSize
-    }
-    set {
-      flushInstance.flushBatchSize = min(newValue, APIConstants.maxBatchSize)
-    }
-  }
-
-  /// The base URL used for Mixpanel API requests.
-  /// Useful if you need to proxy Mixpanel requests. Defaults to
-  /// https://api.mixpanel.com.
-  open var serverURL = BasePath.DefaultMixpanelAPI {
-    didSet {
-      flushInstance.serverURL = serverURL
-    }
-  }
-
-  open var useGzipCompression: Bool = false {
-    didSet {
-      flushInstance.useGzipCompression = useGzipCompression
-    }
-  }
-
-  /// The a MixpanelProxyServerDelegate object that gives config control over Proxy Server's network activity.
-  open weak var proxyServerDelegate: MixpanelProxyServerDelegate? = nil
-
-  open var debugDescription: String {
-    return "Mixpanel(\n"
-      + "    Token: \(apiToken),\n"
-      + "    Distinct Id: \(distinctId)\n"
-      + ")"
-  }
-
-  /// This allows enabling or disabling of all Mixpanel logs at run time.
-  /// - Note: All logging is disabled by default. Usually, this is only required
-  ///         if you are running in to issues with the SDK and you need support.
-  open var loggingEnabled: Bool = false {
-    didSet {
-      if loggingEnabled {
-        MixpanelLogger.enableLevel(.debug)
-        MixpanelLogger.enableLevel(.info)
-        MixpanelLogger.enableLevel(.warning)
-        MixpanelLogger.enableLevel(.error)
-        MixpanelLogger.info(message: "MixpanelLogging Enabled")
-      } else {
-        MixpanelLogger.info(message: "MixpanelLogging Disabled")
-        MixpanelLogger.disableLevel(.debug)
-        MixpanelLogger.disableLevel(.info)
-        MixpanelLogger.disableLevel(.warning)
-        MixpanelLogger.disableLevel(.error)
-      }
-      #if DEBUG
-        var trackProps: Properties = ["MixpanelLogging Enabled": loggingEnabled]
-        if superProperties["mp_lib"] != nil {
-          trackProps["mp_lib"] = self.superProperties["mp_lib"] as! String
+    /// Flush timer's interval.
+    /// Setting a flush interval of 0 will turn off the flush timer and you need to call the flush() API manually
+    /// to upload queued data to the Mixpanel server.
+    open var flushInterval: Double {
+        get {
+            return flushInstance.flushInterval
         }
-        if superProperties["$lib_version"] != nil {
-          trackProps["$lib_version"] = self.superProperties["$lib_version"] as! String
+        set {
+            flushInstance.flushInterval = newValue
         }
-      #endif
     }
-  }
 
-  /// A unique identifier for this MixpanelInstance
-  public let name: String
+    /// Control whether the library should flush data to Mixpanel when the app
+    /// enters the background. Defaults to true.
+    open var flushOnBackground: Bool {
+        get {
+            return flushInstance.flushOnBackground
+        }
+        set {
+            flushInstance.flushOnBackground = newValue
+        }
+    }
 
-  /// The minimum session duration (ms) that is tracked in automatic events.
-  /// The default value is 10000 (10 seconds).
-  #if os(iOS) || os(tvOS) || os(visionOS) || os(macOS)
+    /// Controls whether to automatically send the client IP Address as part of
+    /// event tracking. With an IP address, the Mixpanel Dashboard will show you the users' city.
+    /// Defaults to true.
+    open var useIPAddressForGeoLocation: Bool {
+        get {
+            return flushInstance.useIPAddressForGeoLocation
+        }
+        set {
+            flushInstance.useIPAddressForGeoLocation = newValue
+        }
+    }
+
+    /// The `flushBatchSize` property determines the number of events sent in a single network request to the Mixpanel server.
+    /// By configuring this value, you can optimize network usage and manage the frequency of communication between the client
+    /// and the server. The maximum size is 50; any value over 50 will default to 50.
+    open var flushBatchSize: Int {
+        get {
+            return flushInstance.flushBatchSize
+        }
+        set {
+            flushInstance.flushBatchSize = min(newValue, APIConstants.maxBatchSize)
+        }
+    }
+
+    /// The base URL used for Mixpanel API requests.
+    /// Useful if you need to proxy Mixpanel requests. Defaults to
+    /// https://api.mixpanel.com.
+    open var serverURL = BasePath.DefaultMixpanelAPI {
+        didSet {
+            flushInstance.serverURL = serverURL
+        }
+    }
+
+    open var useGzipCompression: Bool = false {
+        didSet {
+            flushInstance.useGzipCompression = useGzipCompression
+        }
+    }
+
+    /// The a MixpanelProxyServerDelegate object that gives config control over Proxy Server's network activity.
+    open weak var proxyServerDelegate: MixpanelProxyServerDelegate? = nil
+
+    open var debugDescription: String {
+        return "Mixpanel(\n"
+            + "    Token: \(apiToken),\n"
+            + "    Distinct Id: \(distinctId)\n"
+            + ")"
+    }
+
+    /// This allows enabling or disabling of all Mixpanel logs at run time.
+    /// - Note: All logging is disabled by default. Usually, this is only required
+    ///         if you are running in to issues with the SDK and you need support.
+    open var loggingEnabled: Bool = false {
+        didSet {
+            if loggingEnabled {
+                MixpanelLogger.enableLevel(.debug)
+                MixpanelLogger.enableLevel(.info)
+                MixpanelLogger.enableLevel(.warning)
+                MixpanelLogger.enableLevel(.error)
+                MixpanelLogger.info(message: "MixpanelLogging Enabled")
+            } else {
+                MixpanelLogger.info(message: "MixpanelLogging Disabled")
+                MixpanelLogger.disableLevel(.debug)
+                MixpanelLogger.disableLevel(.info)
+                MixpanelLogger.disableLevel(.warning)
+                MixpanelLogger.disableLevel(.error)
+            }
+            #if DEBUG
+            var trackProps: Properties = ["MixpanelLogging Enabled": loggingEnabled]
+            if superProperties["mp_lib"] != nil {
+                trackProps["mp_lib"] = self.superProperties["mp_lib"] as! String
+            }
+            if superProperties["$lib_version"] != nil {
+                trackProps["$lib_version"] = self.superProperties["$lib_version"] as! String
+            }
+            #endif
+        }
+    }
+
+    /// A unique identifier for this MixpanelInstance
+    public let name: String
+
+    /// The minimum session duration (ms) that is tracked in automatic events.
+    /// The default value is 10000 (10 seconds).
+    #if os(iOS) || os(tvOS) || os(visionOS) || os(macOS)
     open var minimumSessionDuration: UInt64 {
-      get {
-        return automaticEvents.minimumSessionDuration
-      }
-      set {
-        automaticEvents.minimumSessionDuration = newValue
-      }
+        get {
+            return automaticEvents.minimumSessionDuration
+        }
+        set {
+            automaticEvents.minimumSessionDuration = newValue
+        }
     }
 
     /// The maximum session duration (ms) that is tracked in automatic events.
     /// The default value is UINT64_MAX (no maximum session duration).
     open var maximumSessionDuration: UInt64 {
-      get {
-        return automaticEvents.maximumSessionDuration
-      }
-      set {
-        automaticEvents.maximumSessionDuration = newValue
-      }
+        get {
+            return automaticEvents.maximumSessionDuration
+        }
+        set {
+            automaticEvents.maximumSessionDuration = newValue
+        }
     }
-  #endif
-  var superProperties = InternalProperties()
-  var trackingQueue: DispatchQueue
-  var networkQueue: DispatchQueue
-  var optOutStatus: Bool?
-  var useUniqueDistinctId: Bool
-  var timedEvents = InternalProperties()
+    #endif
+    var superProperties = InternalProperties()
+    var trackingQueue: DispatchQueue
+    var networkQueue: DispatchQueue
+    var optOutStatus: Bool?
+    var useUniqueDistinctId: Bool
+    var timedEvents = InternalProperties()
 
-  let readWriteLock: ReadWriteLock
-  #if os(iOS) && !targetEnvironment(macCatalyst)
+    let readWriteLock: ReadWriteLock
+    #if os(iOS) && !targetEnvironment(macCatalyst)
     var reachability: SCNetworkReachability?
     static let telephonyInfo = CTTelephonyNetworkInfo()
-  #endif
-  #if !os(OSX) && !os(watchOS)
+    #endif
+    #if !os(OSX) && !os(watchOS)
     var taskId = UIBackgroundTaskIdentifier.invalid
-  #endif  // os(OSX)
-  let sessionMetadata: SessionMetadata
-  let flushInstance: Flush
-  let trackInstance: Track
-  #if os(iOS) || os(tvOS) || os(visionOS) || os(macOS)
-    let automaticEvents = AutomaticEvents()
-  #endif
-  private let registerSuperPropertiesNotificationName = Notification.Name(
-    "com.mixpanel.properties.register")
-  private let unregisterSuperPropertiesNotificationName = Notification.Name(
-    "com.mixpanel.properties.unregister")
-
-  convenience init(options: MixpanelOptions) {
-    self.init(
-      apiToken: options.token,
-      flushInterval: options.flushInterval,
-      name: options.instanceName ?? options.token,
-      trackAutomaticEvents: options.trackAutomaticEvents,
-      optOutTrackingByDefault: options.optOutTrackingByDefault,
-      useUniqueDistinctId: options.useUniqueDistinctId,
-      superProperties: options.superProperties,
-      serverURL: options.serverURL,
-      proxyServerDelegate: options.proxyServerConfig?.delegate,
-      useGzipCompression: options.useGzipCompression,
-      options: options)
-  }
-
-  convenience init(
-    apiToken: String?,
-    flushInterval: Double,
-    name: String,
-    trackAutomaticEvents: Bool,
-    optOutTrackingByDefault: Bool = false,
-    useUniqueDistinctId: Bool = false,
-    superProperties: Properties? = nil,
-    proxyServerConfig: ProxyServerConfig,
-    useGzipCompression: Bool = false
-  ) {
-    self.init(
-      apiToken: apiToken,
-      flushInterval: flushInterval,
-      name: name,
-      trackAutomaticEvents: trackAutomaticEvents,
-      optOutTrackingByDefault: optOutTrackingByDefault,
-      useUniqueDistinctId: useUniqueDistinctId,
-      superProperties: superProperties,
-      serverURL: proxyServerConfig.serverUrl,
-      proxyServerDelegate: proxyServerConfig.delegate,
-      useGzipCompression: useGzipCompression)
-  }
-
-  convenience init(
-    apiToken: String?,
-    flushInterval: Double,
-    name: String,
-    trackAutomaticEvents: Bool,
-    optOutTrackingByDefault: Bool = false,
-    useUniqueDistinctId: Bool = false,
-    superProperties: Properties? = nil,
-    serverURL: String? = nil,
-    useGzipCompression: Bool = false
-  ) {
-    self.init(
-      apiToken: apiToken,
-      flushInterval: flushInterval,
-      name: name,
-      trackAutomaticEvents: trackAutomaticEvents,
-      optOutTrackingByDefault: optOutTrackingByDefault,
-      useUniqueDistinctId: useUniqueDistinctId,
-      superProperties: superProperties,
-      serverURL: serverURL,
-      proxyServerDelegate: nil,
-      useGzipCompression: useGzipCompression)
-  }
-
-  private init(
-    apiToken: String?,
-    flushInterval: Double,
-    name: String,
-    trackAutomaticEvents: Bool,
-    optOutTrackingByDefault: Bool = false,
-    useUniqueDistinctId: Bool = false,
-    superProperties: Properties? = nil,
-    serverURL: String? = nil,
-    proxyServerDelegate: MixpanelProxyServerDelegate? = nil,
-    useGzipCompression: Bool = false,
-    options: MixpanelOptions? = nil
-  ) {
-    // Store the config if provided, otherwise create one with the current values
-    self.options =
-      options
-      ?? MixpanelOptions(
-        token: apiToken ?? "",
-        flushInterval: flushInterval,
-        instanceName: name,
-        trackAutomaticEvents: trackAutomaticEvents,
-        optOutTrackingByDefault: optOutTrackingByDefault,
-        useUniqueDistinctId: useUniqueDistinctId,
-        superProperties: superProperties,
-        serverURL: serverURL,
-        useGzipCompression: useGzipCompression
-      )
-
-    if let apiToken = apiToken, !apiToken.isEmpty {
-      self.apiToken = apiToken
-    }
-    trackAutomaticEventsEnabled = trackAutomaticEvents
-    // Capture UI properties (screen size) that require main thread access.
-    // This is called here to ensure $ae_first_open event includes screen size.
-    AutomaticProperties.setUIProperties()
-
-    if let serverURL = serverURL {
-      self.serverURL = serverURL
-    }
-    self.useGzipCompression = useGzipCompression
-    self.proxyServerDelegate = proxyServerDelegate
-    let label = "com.mixpanel.\(self.apiToken)"
-    trackingQueue = DispatchQueue(
-      label: "\(label).tracking)", qos: .utility, autoreleaseFrequency: .workItem)
-    networkQueue = DispatchQueue(
-      label: "\(label).network)", qos: .utility, autoreleaseFrequency: .workItem)
-    self.name = name
-
-    mixpanelPersistence = MixpanelPersistence.init(instanceName: name)
-    mixpanelPersistence.migrate()
-    self.useUniqueDistinctId = useUniqueDistinctId
-
-    readWriteLock = ReadWriteLock(label: "com.mixpanel.globallock")
-    flushInstance = Flush(serverURL: self.serverURL, useGzipCompression: useGzipCompression)
-    sessionMetadata = SessionMetadata(trackingQueue: trackingQueue)
-    MixpanelInstance.warnIfStrippingLibProperties(self.options.excludeProperties)
-    trackInstance = Track(
-      apiToken: self.apiToken,
-      instanceName: self.name,
-      lock: self.readWriteLock,
-      metadata: sessionMetadata,
-      mixpanelPersistence: mixpanelPersistence,
-      excludeProperties: self.options.excludeProperties)
-    trackInstance.mixpanelInstance = self
-    #if os(iOS) && !targetEnvironment(macCatalyst)
-      // Extract hostname from serverURL and create reachability
-      if let url = URL(string: self.serverURL),
-         let host = url.host {
-        self.reachability = SCNetworkReachabilityCreateWithName(nil, host)
-      }
-      if let reachability = self.reachability {
-        var context = SCNetworkReachabilityContext(
-          version: 0, info: nil, retain: nil, release: nil, copyDescription: nil)
-        func reachabilityCallback(
-          reachability: SCNetworkReachability,
-          flags: SCNetworkReachabilityFlags,
-          unsafePointer: UnsafeMutableRawPointer?
-        ) {
-          let wifi =
-            flags.contains(SCNetworkReachabilityFlags.reachable)
-            && !flags.contains(SCNetworkReachabilityFlags.isWWAN)
-          AutomaticProperties.automaticPropertiesLock.write {
-            AutomaticProperties.properties["$wifi"] = wifi
-          }
-          MixpanelLogger.info(message: "reachability changed, wifi=\(wifi)")
-        }
-        if SCNetworkReachabilitySetCallback(reachability, reachabilityCallback, &context) {
-          if !SCNetworkReachabilitySetDispatchQueue(reachability, trackingQueue) {
-            // cleanup callback if setting dispatch queue failed
-            SCNetworkReachabilitySetCallback(reachability, nil, nil)
-          }
-        }
-      }
-    #endif
-    flushInstance.delegate = self
-    distinctId = devicePrefix + defaultDeviceId()
-    people = People(
-      apiToken: self.apiToken,
-      serialQueue: trackingQueue,
-      lock: self.readWriteLock,
-      metadata: sessionMetadata, mixpanelPersistence: mixpanelPersistence,
-      excludeProperties: self.options.excludeProperties)
-    people.mixpanelInstance = self
-    people.delegate = self
-    flushInstance.flushInterval = flushInterval
-    #if !os(watchOS)
-      setupListeners()
-    #endif
-    unarchive()
-
-    // Construct FeatureFlagManager AFTER unarchive() so the on-disk cache load (dispatched
-    // async by FeatureFlagManager.init when a caching policy is configured) reads the
-    // correct distinctId via `delegate.getDistinctId()`. Constructing earlier would race the
-    // async cache load against the synchronous distinctId initialization in unarchive() —
-    // a worker thread could pick up the cache-load block and read distinctId == "", computing
-    // the wrong fingerprint and silently ignoring an otherwise-valid cache. Nothing between
-    // here and `flags.loadFlags()` below references `flags`.
-    flags = FeatureFlagManager(
-      serverURL: self.serverURL,
-      trackingQueue: self.trackingQueue,
-      instanceName: self.name,
-      delegate: self
-    )
-
-    // check whether we should opt out by default
-    // note: we don't override opt out persistence here since opt-out default state is often
-    // used as an initial state while GDPR information is being collected
-    if optOutTrackingByDefault && (hasOptedOutTracking() || optOutStatus == nil) {
-      optOutTracking()
-    }
-
-    if let superProperties = superProperties {
-      registerSuperProperties(superProperties)
-    }
-
+    #endif  // os(OSX)
+    let sessionMetadata: SessionMetadata
+    let flushInstance: Flush
+    let trackInstance: Track
     #if os(iOS) || os(tvOS) || os(visionOS) || os(macOS)
-      if !MixpanelInstance.isiOSAppExtension() && trackAutomaticEvents {
-        automaticEvents.delegate = self
-        // Defer automatic events initialization to the next run loop iteration
-        // to avoid interfering with SwiftUI's accent color setup when
-        // Mixpanel.initialize() is called from a SwiftUI App's init().
-        // See: https://github.com/mixpanel/mixpanel-swift/issues/522
-        DispatchQueue.main.async { [weak self] in
-          guard let self = self else { return }
-          self.automaticEvents.initializeEvents(instanceName: self.name)
-        }
-      }
+    let automaticEvents = AutomaticEvents()
     #endif
-    if self.options.featureFlagOptions.prefetchFlags {
-      flags.loadFlags()
+    private let registerSuperPropertiesNotificationName = Notification.Name(
+        "com.mixpanel.properties.register")
+    private let unregisterSuperPropertiesNotificationName = Notification.Name(
+        "com.mixpanel.properties.unregister")
+
+    convenience init(options: MixpanelOptions) {
+        self.init(
+            apiToken: options.token,
+            flushInterval: options.flushInterval,
+            name: options.instanceName ?? options.token,
+            trackAutomaticEvents: options.trackAutomaticEvents,
+            optOutTrackingByDefault: options.optOutTrackingByDefault,
+            useUniqueDistinctId: options.useUniqueDistinctId,
+            superProperties: options.superProperties,
+            serverURL: options.serverURL,
+            proxyServerDelegate: options.proxyServerConfig?.delegate,
+            useGzipCompression: options.useGzipCompression,
+            options: options)
     }
-  }
 
-  public func getOptions() -> MixpanelOptions {
-    return options
-  }
+    convenience init(
+        apiToken: String?,
+        flushInterval: Double,
+        name: String,
+        trackAutomaticEvents: Bool,
+        optOutTrackingByDefault: Bool = false,
+        useUniqueDistinctId: Bool = false,
+        superProperties: Properties? = nil,
+        proxyServerConfig: ProxyServerConfig,
+        useGzipCompression: Bool = false
+    ) {
+        self.init(
+            apiToken: apiToken,
+            flushInterval: flushInterval,
+            name: name,
+            trackAutomaticEvents: trackAutomaticEvents,
+            optOutTrackingByDefault: optOutTrackingByDefault,
+            useUniqueDistinctId: useUniqueDistinctId,
+            superProperties: superProperties,
+            serverURL: proxyServerConfig.serverUrl,
+            proxyServerDelegate: proxyServerConfig.delegate,
+            useGzipCompression: useGzipCompression)
+    }
 
-  public func getDistinctId() -> String {
-    return distinctId
-  }
+    convenience init(
+        apiToken: String?,
+        flushInterval: Double,
+        name: String,
+        trackAutomaticEvents: Bool,
+        optOutTrackingByDefault: Bool = false,
+        useUniqueDistinctId: Bool = false,
+        superProperties: Properties? = nil,
+        serverURL: String? = nil,
+        useGzipCompression: Bool = false
+    ) {
+        self.init(
+            apiToken: apiToken,
+            flushInterval: flushInterval,
+            name: name,
+            trackAutomaticEvents: trackAutomaticEvents,
+            optOutTrackingByDefault: optOutTrackingByDefault,
+            useUniqueDistinctId: useUniqueDistinctId,
+            superProperties: superProperties,
+            serverURL: serverURL,
+            proxyServerDelegate: nil,
+            useGzipCompression: useGzipCompression)
+    }
 
-  public func getAnonymousId() -> String? {
-    return anonymousId
-  }
+    private init(
+        apiToken: String?,
+        flushInterval: Double,
+        name: String,
+        trackAutomaticEvents: Bool,
+        optOutTrackingByDefault: Bool = false,
+        useUniqueDistinctId: Bool = false,
+        superProperties: Properties? = nil,
+        serverURL: String? = nil,
+        proxyServerDelegate: MixpanelProxyServerDelegate? = nil,
+        useGzipCompression: Bool = false,
+        options: MixpanelOptions? = nil
+    ) {
+        // Store the config if provided, otherwise create one with the current values
+        self.options =
+            options
+            ?? MixpanelOptions(
+                token: apiToken ?? "",
+                flushInterval: flushInterval,
+                instanceName: name,
+                trackAutomaticEvents: trackAutomaticEvents,
+                optOutTrackingByDefault: optOutTrackingByDefault,
+                useUniqueDistinctId: useUniqueDistinctId,
+                superProperties: superProperties,
+                serverURL: serverURL,
+                useGzipCompression: useGzipCompression
+            )
 
-  #if !os(OSX) && !os(watchOS)
+        if let apiToken = apiToken, !apiToken.isEmpty {
+            self.apiToken = apiToken
+        }
+        trackAutomaticEventsEnabled = trackAutomaticEvents
+        // Capture UI properties (screen size) that require main thread access.
+        // This is called here to ensure $ae_first_open event includes screen size.
+        AutomaticProperties.setUIProperties()
+
+        if let serverURL = serverURL {
+            self.serverURL = serverURL
+        }
+        self.useGzipCompression = useGzipCompression
+        self.proxyServerDelegate = proxyServerDelegate
+        let label = "com.mixpanel.\(self.apiToken)"
+        trackingQueue = DispatchQueue(
+            label: "\(label).tracking)", qos: .utility, autoreleaseFrequency: .workItem)
+        networkQueue = DispatchQueue(
+            label: "\(label).network)", qos: .utility, autoreleaseFrequency: .workItem)
+        self.name = name
+
+        mixpanelPersistence = MixpanelPersistence.init(instanceName: name)
+        mixpanelPersistence.migrate()
+        self.useUniqueDistinctId = useUniqueDistinctId
+
+        readWriteLock = ReadWriteLock(label: "com.mixpanel.globallock")
+        flushInstance = Flush(serverURL: self.serverURL, useGzipCompression: useGzipCompression)
+        sessionMetadata = SessionMetadata(trackingQueue: trackingQueue)
+        MixpanelInstance.warnIfStrippingLibProperties(self.options.excludeProperties)
+        trackInstance = Track(
+            apiToken: self.apiToken,
+            instanceName: self.name,
+            lock: self.readWriteLock,
+            metadata: sessionMetadata,
+            mixpanelPersistence: mixpanelPersistence,
+            excludeProperties: self.options.excludeProperties)
+        trackInstance.mixpanelInstance = self
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        // Extract hostname from serverURL and create reachability
+        if let url = URL(string: self.serverURL),
+            let host = url.host
+        {
+            self.reachability = SCNetworkReachabilityCreateWithName(nil, host)
+        }
+        if let reachability = self.reachability {
+            var context = SCNetworkReachabilityContext(
+                version: 0, info: nil, retain: nil, release: nil, copyDescription: nil)
+            func reachabilityCallback(
+                reachability: SCNetworkReachability,
+                flags: SCNetworkReachabilityFlags,
+                unsafePointer: UnsafeMutableRawPointer?
+            ) {
+                let wifi =
+                    flags.contains(SCNetworkReachabilityFlags.reachable)
+                    && !flags.contains(SCNetworkReachabilityFlags.isWWAN)
+                AutomaticProperties.automaticPropertiesLock.write {
+                    AutomaticProperties.properties["$wifi"] = wifi
+                }
+                MixpanelLogger.info(message: "reachability changed, wifi=\(wifi)")
+            }
+            if SCNetworkReachabilitySetCallback(reachability, reachabilityCallback, &context) {
+                if !SCNetworkReachabilitySetDispatchQueue(reachability, trackingQueue) {
+                    // cleanup callback if setting dispatch queue failed
+                    SCNetworkReachabilitySetCallback(reachability, nil, nil)
+                }
+            }
+        }
+        #endif
+        flushInstance.delegate = self
+        distinctId = devicePrefix + defaultDeviceId()
+        people = People(
+            apiToken: self.apiToken,
+            serialQueue: trackingQueue,
+            lock: self.readWriteLock,
+            metadata: sessionMetadata, mixpanelPersistence: mixpanelPersistence,
+            excludeProperties: self.options.excludeProperties)
+        people.mixpanelInstance = self
+        people.delegate = self
+        flushInstance.flushInterval = flushInterval
+        #if !os(watchOS)
+        setupListeners()
+        #endif
+        unarchive()
+
+        // Construct FeatureFlagManager AFTER unarchive() so the on-disk cache load (dispatched
+        // async by FeatureFlagManager.init when a caching policy is configured) reads the
+        // correct distinctId via `delegate.getDistinctId()`. Constructing earlier would race the
+        // async cache load against the synchronous distinctId initialization in unarchive() —
+        // a worker thread could pick up the cache-load block and read distinctId == "", computing
+        // the wrong fingerprint and silently ignoring an otherwise-valid cache. Nothing between
+        // here and `flags.loadFlags()` below references `flags`.
+        flags = FeatureFlagManager(
+            serverURL: self.serverURL,
+            trackingQueue: self.trackingQueue,
+            instanceName: self.name,
+            delegate: self
+        )
+
+        // check whether we should opt out by default
+        // note: we don't override opt out persistence here since opt-out default state is often
+        // used as an initial state while GDPR information is being collected
+        if optOutTrackingByDefault && (hasOptedOutTracking() || optOutStatus == nil) {
+            optOutTracking()
+        }
+
+        if let superProperties = superProperties {
+            registerSuperProperties(superProperties)
+        }
+
+        #if os(iOS) || os(tvOS) || os(visionOS) || os(macOS)
+        if !MixpanelInstance.isiOSAppExtension() && trackAutomaticEvents {
+            automaticEvents.delegate = self
+            // Defer automatic events initialization to the next run loop iteration
+            // to avoid interfering with SwiftUI's accent color setup when
+            // Mixpanel.initialize() is called from a SwiftUI App's init().
+            // See: https://github.com/mixpanel/mixpanel-swift/issues/522
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.automaticEvents.initializeEvents(instanceName: self.name)
+            }
+        }
+        #endif
+        if self.options.featureFlagOptions.prefetchFlags {
+            flags.loadFlags()
+        }
+    }
+
+    public func getOptions() -> MixpanelOptions {
+        return options
+    }
+
+    public func getDistinctId() -> String {
+        return distinctId
+    }
+
+    public func getAnonymousId() -> String? {
+        return anonymousId
+    }
+
+    #if !os(OSX) && !os(watchOS)
     private func setupListeners() {
-      let notificationCenter = NotificationCenter.default
-      #if os(iOS) && !targetEnvironment(macCatalyst)
+        let notificationCenter = NotificationCenter.default
+        #if os(iOS) && !targetEnvironment(macCatalyst)
         setCurrentRadio()
-      // Temporarily remove the ability to monitor the radio change due to a crash issue might relate to the api from Apple
-      // https://openradar.appspot.com/46873673
-      //    notificationCenter.addObserver(self,
-      //                                   selector: #selector(setCurrentRadio),
-      //                                   name: .CTRadioAccessTechnologyDidChange,
-      //                                   object: nil)
-      #endif  // os(iOS)
-      if !MixpanelInstance.isiOSAppExtension() {
-        notificationCenter.addObserver(
-          self,
-          selector: #selector(applicationWillResignActive(_:)),
-          name: UIApplication.willResignActiveNotification,
-          object: nil)
-        notificationCenter.addObserver(
-          self,
-          selector: #selector(applicationDidBecomeActive(_:)),
-          name: UIApplication.didBecomeActiveNotification,
-          object: nil)
-        notificationCenter.addObserver(
-          self,
-          selector: #selector(applicationDidEnterBackground(_:)),
-          name: UIApplication.didEnterBackgroundNotification,
-          object: nil)
-        notificationCenter.addObserver(
-          self,
-          selector: #selector(applicationWillEnterForeground(_:)),
-          name: UIApplication.willEnterForegroundNotification,
-          object: nil)
-        notificationCenter.addObserver(
-          self,
-          selector: #selector(handleSuperPropertiesRegistrationNotification(_:)),
-          name: registerSuperPropertiesNotificationName,
-          object: nil
-        )
-        notificationCenter.addObserver(
-          self,
-          selector: #selector(handleSuperPropertiesRegistrationNotification(_:)),
-          name: unregisterSuperPropertiesNotificationName,
-          object: nil
-        )
-      }
+        // Temporarily remove the ability to monitor the radio change due to a crash issue might relate to the api from Apple
+        // https://openradar.appspot.com/46873673
+        //    notificationCenter.addObserver(self,
+        //                                   selector: #selector(setCurrentRadio),
+        //                                   name: .CTRadioAccessTechnologyDidChange,
+        //                                   object: nil)
+        #endif  // os(iOS)
+        if !MixpanelInstance.isiOSAppExtension() {
+            notificationCenter.addObserver(
+                self,
+                selector: #selector(applicationWillResignActive(_:)),
+                name: UIApplication.willResignActiveNotification,
+                object: nil)
+            notificationCenter.addObserver(
+                self,
+                selector: #selector(applicationDidBecomeActive(_:)),
+                name: UIApplication.didBecomeActiveNotification,
+                object: nil)
+            notificationCenter.addObserver(
+                self,
+                selector: #selector(applicationDidEnterBackground(_:)),
+                name: UIApplication.didEnterBackgroundNotification,
+                object: nil)
+            notificationCenter.addObserver(
+                self,
+                selector: #selector(applicationWillEnterForeground(_:)),
+                name: UIApplication.willEnterForegroundNotification,
+                object: nil)
+            notificationCenter.addObserver(
+                self,
+                selector: #selector(handleSuperPropertiesRegistrationNotification(_:)),
+                name: registerSuperPropertiesNotificationName,
+                object: nil
+            )
+            notificationCenter.addObserver(
+                self,
+                selector: #selector(handleSuperPropertiesRegistrationNotification(_:)),
+                name: unregisterSuperPropertiesNotificationName,
+                object: nil
+            )
+        }
     }
-  #elseif os(OSX)
+    #elseif os(OSX)
     private func setupListeners() {
-      let notificationCenter = NotificationCenter.default
-      notificationCenter.addObserver(
-        self,
-        selector: #selector(applicationWillResignActive(_:)),
-        name: NSApplication.willResignActiveNotification,
-        object: nil)
-      notificationCenter.addObserver(
-        self,
-        selector: #selector(applicationDidBecomeActive(_:)),
-        name: NSApplication.didBecomeActiveNotification,
-        object: nil)
+        let notificationCenter = NotificationCenter.default
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(applicationWillResignActive(_:)),
+            name: NSApplication.willResignActiveNotification,
+            object: nil)
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(applicationDidBecomeActive(_:)),
+            name: NSApplication.didBecomeActiveNotification,
+            object: nil)
     }
-  #endif  // os(OSX)
+    #endif  // os(OSX)
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-    #if os(iOS) && !os(watchOS) && !targetEnvironment(macCatalyst)
-      if let reachability = self.reachability {
-        if !SCNetworkReachabilitySetCallback(reachability, nil, nil) {
-          MixpanelLogger.error(message: "\(self) error unsetting reachability callback")
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        #if os(iOS) && !os(watchOS) && !targetEnvironment(macCatalyst)
+        if let reachability = self.reachability {
+            if !SCNetworkReachabilitySetCallback(reachability, nil, nil) {
+                MixpanelLogger.error(message: "\(self) error unsetting reachability callback")
+            }
+            if !SCNetworkReachabilitySetDispatchQueue(reachability, nil) {
+                MixpanelLogger.error(message: "\(self) error unsetting reachability dispatch queue")
+            }
         }
-        if !SCNetworkReachabilitySetDispatchQueue(reachability, nil) {
-          MixpanelLogger.error(message: "\(self) error unsetting reachability dispatch queue")
-        }
-      }
-    #endif
-  }
-
-  static func isiOSAppExtension() -> Bool {
-    return Bundle.main.bundlePath.hasSuffix(".appex")
-  }
-
-  private static func warnIfStrippingLibProperties(_ excludeProperties: Set<String>) {
-    if excludeProperties.contains("mp_lib") || excludeProperties.contains("$lib_version") {
-      MixpanelLogger.warn(
-        message:
-          "MixpanelOptions.excludeProperties is stripping 'mp_lib' and/or '$lib_version'. "
-          + "These are not required for ingestion or identity, but Mixpanel uses them to "
-          + "identify the SDK source and version of each event — stripping them is not "
-          + "recommended.")
+        #endif
     }
-  }
 
-  #if !os(OSX) && !os(watchOS)
+    static func isiOSAppExtension() -> Bool {
+        return Bundle.main.bundlePath.hasSuffix(".appex")
+    }
+
+    private static func warnIfStrippingLibProperties(_ excludeProperties: Set<String>) {
+        if excludeProperties.contains("mp_lib") || excludeProperties.contains("$lib_version") {
+            MixpanelLogger.warn(
+                message:
+                    "MixpanelOptions.excludeProperties is stripping 'mp_lib' and/or '$lib_version'. "
+                    + "These are not required for ingestion or identity, but Mixpanel uses them to "
+                    + "identify the SDK source and version of each event — stripping them is not "
+                    + "recommended.")
+        }
+    }
+
+    #if !os(OSX) && !os(watchOS)
     static func sharedUIApplication() -> UIApplication? {
-      guard
-        let sharedApplication =
-          UIApplication.perform(NSSelectorFromString("sharedApplication"))?.takeUnretainedValue()
-          as? UIApplication
-      else {
-        return nil
-      }
-      return sharedApplication
-    }
-  #endif  // !os(OSX)
-
-  @objc private func applicationDidBecomeActive(_ notification: Notification) {
-    flushInstance.applicationDidBecomeActive()
-  }
-
-  @objc private func applicationWillResignActive(_ notification: Notification) {
-    flushInstance.applicationWillResignActive()
-    #if os(OSX)
-      if flushOnBackground {
-        flush()
-      }
-
-    #endif
-  }
-
-  #if !os(OSX) && !os(watchOS)
-    @objc private func applicationDidEnterBackground(_ notification: Notification) {
-      guard let sharedApplication = MixpanelInstance.sharedUIApplication() else {
-        return
-      }
-
-      if hasOptedOutTracking() {
-        return
-      }
-
-      let completionHandler: () -> Void = { [weak self] in
-        guard let self = self else { return }
-
-        if self.taskId != UIBackgroundTaskIdentifier.invalid {
-          sharedApplication.endBackgroundTask(self.taskId)
-          self.taskId = UIBackgroundTaskIdentifier.invalid
+        guard
+            let sharedApplication =
+                UIApplication.perform(NSSelectorFromString("sharedApplication"))?.takeUnretainedValue()
+                as? UIApplication
+        else {
+            return nil
         }
-      }
+        return sharedApplication
+    }
+    #endif  // !os(OSX)
 
-      taskId = sharedApplication.beginBackgroundTask(expirationHandler: completionHandler)
+    @objc private func applicationDidBecomeActive(_ notification: Notification) {
+        flushInstance.applicationDidBecomeActive()
+    }
 
-      // Ensure that any session replay ID is cleared when the app enters the background
-      unregisterSuperProperty("$mp_replay_id")
+    @objc private func applicationWillResignActive(_ notification: Notification) {
+        flushInstance.applicationWillResignActive()
+        #if os(OSX)
+        if flushOnBackground {
+            flush()
+        }
 
-      if flushOnBackground {
-        flush(performFullFlush: true, completion: completionHandler)
-      }
+        #endif
+    }
+
+    #if !os(OSX) && !os(watchOS)
+    @objc private func applicationDidEnterBackground(_ notification: Notification) {
+        guard let sharedApplication = MixpanelInstance.sharedUIApplication() else {
+            return
+        }
+
+        if hasOptedOutTracking() {
+            return
+        }
+
+        let completionHandler: () -> Void = { [weak self] in
+            guard let self = self else { return }
+
+            if self.taskId != UIBackgroundTaskIdentifier.invalid {
+                sharedApplication.endBackgroundTask(self.taskId)
+                self.taskId = UIBackgroundTaskIdentifier.invalid
+            }
+        }
+
+        taskId = sharedApplication.beginBackgroundTask(expirationHandler: completionHandler)
+
+        // Ensure that any session replay ID is cleared when the app enters the background
+        unregisterSuperProperty("$mp_replay_id")
+
+        if flushOnBackground {
+            flush(performFullFlush: true, completion: completionHandler)
+        }
     }
 
     @objc private func applicationWillEnterForeground(_ notification: Notification) {
-      guard let sharedApplication = MixpanelInstance.sharedUIApplication() else {
-        return
-      }
-      sessionMetadata.applicationWillEnterForeground()
-
-      if taskId != UIBackgroundTaskIdentifier.invalid {
-        sharedApplication.endBackgroundTask(taskId)
-        taskId = UIBackgroundTaskIdentifier.invalid
-        #if os(iOS)
-          self.updateNetworkActivityIndicator(false)
-        #endif  // os(iOS)
-      }
-
-    }
-  #endif
-
-  func addPrefixToDeviceId(deviceId: String?) -> String {
-    if let temp = deviceId {
-      return devicePrefix + temp
-    }
-    return ""
-  }
-
-  func defaultDeviceId() -> String {
-    // Check if a custom device ID provider is set
-    if let provider = options.deviceIdProvider {
-      if let providedId = provider()?.trimmingCharacters(in: .whitespacesAndNewlines),
-        !providedId.isEmpty
-      {
-        return providedId
-      }
-      // Fall through to default behavior if nil or empty
-      MixpanelLogger.warn(
-        message: "deviceIdProvider returned nil or empty string, using default device ID")
-    }
-
-    // Default behavior: use IDFV or random UUID
-    let distinctId: String?
-    if useUniqueDistinctId {
-      distinctId = uniqueIdentifierForDevice()
-    } else {
-      #if MIXPANEL_UNIQUE_DISTINCT_ID
-        distinctId = uniqueIdentifierForDevice()
-      #else
-        distinctId = nil
-      #endif
-    }
-    return distinctId ?? UUID().uuidString  // use a random UUID by default
-  }
-
-  func uniqueIdentifierForDevice() -> String? {
-    var distinctId: String?
-    #if os(OSX)
-      distinctId = MixpanelInstance.macOSIdentifier()
-    #elseif !os(watchOS)
-      if NSClassFromString("UIDevice") != nil {
-        distinctId = UIDevice.current.identifierForVendor?.uuidString
-      } else {
-        distinctId = nil
-      }
-    #else
-      distinctId = nil
-    #endif
-    return distinctId
-  }
-
-  #if os(OSX)
-    static func macOSIdentifier() -> String? {
-      let platformExpert: io_service_t = IOServiceGetMatchingService(
-        kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice"))
-      let serialNumberAsCFString =
-        IORegistryEntryCreateCFProperty(
-          platformExpert, kIOPlatformSerialNumberKey as CFString, kCFAllocatorDefault, 0)
-      IOObjectRelease(platformExpert)
-      return (serialNumberAsCFString?.takeUnretainedValue() as? String)
-    }
-  #endif  // os(OSX)
-
-  #if os(iOS)
-    func updateNetworkActivityIndicator(_ on: Bool) {
-      if showNetworkActivityIndicator {
-        DispatchQueue.main.async { [on] in
-          MixpanelInstance.sharedUIApplication()?.isNetworkActivityIndicatorVisible = on
+        guard let sharedApplication = MixpanelInstance.sharedUIApplication() else {
+            return
         }
-      }
+        sessionMetadata.applicationWillEnterForeground()
+
+        if taskId != UIBackgroundTaskIdentifier.invalid {
+            sharedApplication.endBackgroundTask(taskId)
+            taskId = UIBackgroundTaskIdentifier.invalid
+            #if os(iOS)
+            self.updateNetworkActivityIndicator(false)
+            #endif  // os(iOS)
+        }
+
+    }
+    #endif
+
+    func addPrefixToDeviceId(deviceId: String?) -> String {
+        if let temp = deviceId {
+            return devicePrefix + temp
+        }
+        return ""
+    }
+
+    func defaultDeviceId() -> String {
+        // Check if a custom device ID provider is set
+        if let provider = options.deviceIdProvider {
+            if let providedId = provider()?.trimmingCharacters(in: .whitespacesAndNewlines),
+                !providedId.isEmpty
+            {
+                return providedId
+            }
+            // Fall through to default behavior if nil or empty
+            MixpanelLogger.warn(
+                message: "deviceIdProvider returned nil or empty string, using default device ID")
+        }
+
+        // Default behavior: use IDFV or random UUID
+        let distinctId: String?
+        if useUniqueDistinctId {
+            distinctId = uniqueIdentifierForDevice()
+        } else {
+            #if MIXPANEL_UNIQUE_DISTINCT_ID
+            distinctId = uniqueIdentifierForDevice()
+            #else
+            distinctId = nil
+            #endif
+        }
+        return distinctId ?? UUID().uuidString  // use a random UUID by default
+    }
+
+    func uniqueIdentifierForDevice() -> String? {
+        var distinctId: String?
+        #if os(OSX)
+        distinctId = MixpanelInstance.macOSIdentifier()
+        #elseif !os(watchOS)
+        if NSClassFromString("UIDevice") != nil {
+            distinctId = UIDevice.current.identifierForVendor?.uuidString
+        } else {
+            distinctId = nil
+        }
+        #else
+        distinctId = nil
+        #endif
+        return distinctId
+    }
+
+    #if os(OSX)
+    static func macOSIdentifier() -> String? {
+        let platformExpert: io_service_t = IOServiceGetMatchingService(
+            kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice"))
+        let serialNumberAsCFString =
+            IORegistryEntryCreateCFProperty(
+                platformExpert, kIOPlatformSerialNumberKey as CFString, kCFAllocatorDefault, 0)
+        IOObjectRelease(platformExpert)
+        return (serialNumberAsCFString?.takeUnretainedValue() as? String)
+    }
+    #endif  // os(OSX)
+
+    #if os(iOS)
+    func updateNetworkActivityIndicator(_ on: Bool) {
+        if showNetworkActivityIndicator {
+            DispatchQueue.main.async { [on] in
+                MixpanelInstance.sharedUIApplication()?.isNetworkActivityIndicatorVisible = on
+            }
+        }
     }
     #if os(iOS) && !targetEnvironment(macCatalyst)
-      @objc func setCurrentRadio() {
+    @objc func setCurrentRadio() {
         var radio = ""
         let prefix = "CTRadioAccessTechnology"
         if #available(iOS 12.0, *) {
-          if let radioDict = MixpanelInstance.telephonyInfo.serviceCurrentRadioAccessTechnology {
-            for (_, value) in radioDict where !value.isEmpty && value.hasPrefix(prefix) {
-              // the first should be the prefix, second the target
-              let components = value.components(separatedBy: prefix)
+            if let radioDict = MixpanelInstance.telephonyInfo.serviceCurrentRadioAccessTechnology {
+                for (_, value) in radioDict where !value.isEmpty && value.hasPrefix(prefix) {
+                    // the first should be the prefix, second the target
+                    let components = value.components(separatedBy: prefix)
 
-              // Something went wrong and we have more than prefix:target
-              guard components.count == 2 else {
-                continue
-              }
+                    // Something went wrong and we have more than prefix:target
+                    guard components.count == 2 else {
+                        continue
+                    }
 
-              // Safe to directly access by index since we confirmed count == 2 above
-              let radioValue = components[1]
+                    // Safe to directly access by index since we confirmed count == 2 above
+                    let radioValue = components[1]
 
-              // Send to parent
-              radio += radio.isEmpty ? radioValue : ", \(radioValue)"
+                    // Send to parent
+                    radio += radio.isEmpty ? radioValue : ", \(radioValue)"
+                }
+
+                radio = radio.isEmpty ? "None" : radio
             }
-
-            radio = radio.isEmpty ? "None" : radio
-          }
         } else {
-          radio = MixpanelInstance.telephonyInfo.currentRadioAccessTechnology ?? "None"
-          if radio.hasPrefix(prefix) {
-            radio = (radio as NSString).substring(from: prefix.count)
-          }
+            radio = MixpanelInstance.telephonyInfo.currentRadioAccessTechnology ?? "None"
+            if radio.hasPrefix(prefix) {
+                radio = (radio as NSString).substring(from: prefix.count)
+            }
         }
 
         trackingQueue.async {
-          AutomaticProperties.automaticPropertiesLock.write { [weak self, radio] in
-            AutomaticProperties.properties["$radio"] = radio
+            AutomaticProperties.automaticPropertiesLock.write { [weak self, radio] in
+                AutomaticProperties.properties["$radio"] = radio
 
-            guard self != nil else {
-              return
-            }
+                guard self != nil else {
+                    return
+                }
 
-            AutomaticProperties.properties["$carrier"] = ""
-            if #available(iOS 12.0, *) {
-              if let carrierName = MixpanelInstance.telephonyInfo
-                .serviceSubscriberCellularProviders?.first?.value.carrierName
-              {
-                AutomaticProperties.properties["$carrier"] = carrierName
-              }
-            } else {
-              if let carrierName = MixpanelInstance.telephonyInfo.subscriberCellularProvider?
-                .carrierName
-              {
-                AutomaticProperties.properties["$carrier"] = carrierName
-              }
+                AutomaticProperties.properties["$carrier"] = ""
+                if #available(iOS 12.0, *) {
+                    if let carrierName = MixpanelInstance.telephonyInfo
+                        .serviceSubscriberCellularProviders?.first?.value.carrierName
+                    {
+                        AutomaticProperties.properties["$carrier"] = carrierName
+                    }
+                } else {
+                    if let carrierName = MixpanelInstance.telephonyInfo.subscriberCellularProvider?
+                        .carrierName
+                    {
+                        AutomaticProperties.properties["$carrier"] = carrierName
+                    }
+                }
             }
-          }
         }
-      }
+    }
     #endif
-  #endif  // os(iOS)
+    #endif  // os(iOS)
 
-  @objc func handleSuperPropertiesRegistrationNotification(_ notification: Notification) {
-    guard let data = notification.userInfo else { return }
+    @objc func handleSuperPropertiesRegistrationNotification(_ notification: Notification) {
+        guard let data = notification.userInfo else { return }
 
-    if notification.name.rawValue == registerSuperPropertiesNotificationName.rawValue {
-      guard let properties = data as? Properties else { return }
-      registerSuperProperties(properties)
-    } else {
-      for (key, _) in data {
-        if let keyToUnregister = key as? String {
-          unregisterSuperProperty(keyToUnregister)
+        if notification.name.rawValue == registerSuperPropertiesNotificationName.rawValue {
+            guard let properties = data as? Properties else { return }
+            registerSuperProperties(properties)
+        } else {
+            for (key, _) in data {
+                if let keyToUnregister = key as? String {
+                    unregisterSuperProperty(keyToUnregister)
+                }
+            }
         }
-      }
     }
-  }
 }
 
 extension MixpanelInstance {
-  // MARK: - Identity
+    // MARK: - Identity
 
-  /**
-     Sets the distinct ID of the current user.
-  
-     Mixpanel uses a randomly generated persistent UUID  as the default local distinct ID.
-  
-     If you want to  use a unique persistent UUID, you can define the
-     <code>MIXPANEL_UNIQUE_DISTINCT_ID</code> flag in your <code>Active Compilation Conditions</code>
-     build settings. It then uses the IFV String (`UIDevice.current().identifierForVendor`) as
-     the default local distinct ID. This ID will identify a user across all apps by the same vendor, but cannot be
-     used to link the same user across apps from different vendors. If we are unable to get an IFV, we will fall
-     back to generating a random persistent UUID.
-  
-     For tracking events, you do not need to call `identify:`. However,
-     **Mixpanel User profiles always requires an explicit call to `identify:`.**
-     If calls are made to
-     `set:`, `increment` or other `People`
-     methods prior to calling `identify:`, then they are queued up and
-     flushed once `identify:` is called.
-  
-     If you'd like to use the default distinct ID for Mixpanel People as well
-     (recommended), call `identify:` using the current distinct ID:
-     `mixpanelInstance.identify(mixpanelInstance.distinctId)`.
-  
-     When the distinct ID actually changes, this method also resets feature-flag state
-     (in-memory variants, on-disk cache, and activated first-time-event set) before fetching
-     flags under the new identity. Any `flags.loadFlags(completion:)` callbacks pending from
-     a fetch that was in flight at the moment identify was called will fire with `false`
-     (so callers don't hang) — they will *not* receive the result of the new identity's fetch.
-
-     - parameter distinctId: string that uniquely identifies the current user
-     - parameter usePeople: boolean that controls whether or not to set the people distinctId to the event distinctId.
-     This should only be set to false if you wish to prevent people profile updates for that user.
-     - parameter completion: an optional completion handler for when the identify has completed.
-     */
-  public func identify(distinctId: String, usePeople: Bool = true, completion: (() -> Void)? = nil)
-  {
-    if hasOptedOutTracking() {
-      if let completion = completion {
-        DispatchQueue.main.async(execute: completion)
-      }
-      return
-    }
-    if distinctId.isEmpty {
-      MixpanelLogger.error(message: "\(self) cannot identify blank distinct id")
-      if let completion = completion {
-        DispatchQueue.main.async(execute: completion)
-      }
-      return
-    }
-    trackingQueue.async { [weak self, distinctId, usePeople] in
-      guard let self = self else { return }
-
-      // If there's no anonymousId assigned yet, that means distinctId is stored in the storage. Assigning already stored
-      // distinctId as anonymousId on identify and also setting a flag to notify that it might be previously logged in user
-      if self.anonymousId == nil {
-        self.anonymousId = self.distinctId
-        self.hadPersistedDistinctId = true
-      }
-
-      if self.userId == nil {
-        self.readWriteLock.write {
-          self.userId = distinctId
+    /**
+       Sets the distinct ID of the current user.
+    
+       Mixpanel uses a randomly generated persistent UUID  as the default local distinct ID.
+    
+       If you want to  use a unique persistent UUID, you can define the
+       <code>MIXPANEL_UNIQUE_DISTINCT_ID</code> flag in your <code>Active Compilation Conditions</code>
+       build settings. It then uses the IFV String (`UIDevice.current().identifierForVendor`) as
+       the default local distinct ID. This ID will identify a user across all apps by the same vendor, but cannot be
+       used to link the same user across apps from different vendors. If we are unable to get an IFV, we will fall
+       back to generating a random persistent UUID.
+    
+       For tracking events, you do not need to call `identify:`. However,
+       **Mixpanel User profiles always requires an explicit call to `identify:`.**
+       If calls are made to
+       `set:`, `increment` or other `People`
+       methods prior to calling `identify:`, then they are queued up and
+       flushed once `identify:` is called.
+    
+       If you'd like to use the default distinct ID for Mixpanel People as well
+       (recommended), call `identify:` using the current distinct ID:
+       `mixpanelInstance.identify(mixpanelInstance.distinctId)`.
+    
+       When the distinct ID actually changes, this method also resets feature-flag state
+       (in-memory variants, on-disk cache, and activated first-time-event set) before fetching
+       flags under the new identity. Any `flags.loadFlags(completion:)` callbacks pending from
+       a fetch that was in flight at the moment identify was called will fire with `false`
+       (so callers don't hang) — they will *not* receive the result of the new identity's fetch.
+    
+       - parameter distinctId: string that uniquely identifies the current user
+       - parameter usePeople: boolean that controls whether or not to set the people distinctId to the event distinctId.
+       This should only be set to false if you wish to prevent people profile updates for that user.
+       - parameter completion: an optional completion handler for when the identify has completed.
+       */
+    public func identify(distinctId: String, usePeople: Bool = true, completion: (() -> Void)? = nil) {
+        if hasOptedOutTracking() {
+            if let completion = completion {
+                DispatchQueue.main.async(execute: completion)
+            }
+            return
         }
-      }
-
-      if distinctId != self.distinctId {
-        let oldDistinctId = self.distinctId
-        self.readWriteLock.write {
-          self.alias = nil
-          self.distinctId = distinctId
-          self.userId = distinctId
+        if distinctId.isEmpty {
+            MixpanelLogger.error(message: "\(self) cannot identify blank distinct id")
+            if let completion = completion {
+                DispatchQueue.main.async(execute: completion)
+            }
+            return
         }
-        // Distinct ID just changed — clear in-memory feature-flag state and the on-disk
-        // cache from the prior identity (and bump the fetch generation so any in-flight
-        // fetch is discarded) before loading flags under the new identity. trackingQueue
-        // FIFO guarantees the reset runs before the loadFlags-driven fetch.
-        if let flagManager = self.flags as? FeatureFlagManager {
-          flagManager.reset()
-        }
-        self.flags.loadFlags()
-        self.track(event: "$identify", properties: ["$anon_distinct_id": oldDistinctId])
-      }
+        trackingQueue.async { [weak self, distinctId, usePeople] in
+            guard let self = self else { return }
 
-      if usePeople {
-        self.readWriteLock.write {
-          self.people.distinctId = distinctId
-        }
-        self.mixpanelPersistence.identifyPeople(token: self.apiToken)
-      } else {
-        self.people.distinctId = nil
-      }
+            // If there's no anonymousId assigned yet, that means distinctId is stored in the storage. Assigning already stored
+            // distinctId as anonymousId on identify and also setting a flag to notify that it might be previously logged in user
+            if self.anonymousId == nil {
+                self.anonymousId = self.distinctId
+                self.hadPersistedDistinctId = true
+            }
 
-      MixpanelPersistence.saveIdentity(
-        MixpanelIdentity.init(
-          distinctID: self.distinctId,
-          peopleDistinctID: self.people.distinctId,
-          anonymousId: self.anonymousId,
-          userId: self.userId,
-          alias: self.alias,
-          hadPersistedDistinctId: self.hadPersistedDistinctId), instanceName: self.name)
-      if let completion = completion {
-        DispatchQueue.main.async(execute: completion)
-      }
-    }
+            if self.userId == nil {
+                self.readWriteLock.write {
+                    self.userId = distinctId
+                }
+            }
 
-    if MixpanelInstance.isiOSAppExtension() {
-      flush()
-    }
-  }
+            if distinctId != self.distinctId {
+                let oldDistinctId = self.distinctId
+                self.readWriteLock.write {
+                    self.alias = nil
+                    self.distinctId = distinctId
+                    self.userId = distinctId
+                }
+                // Distinct ID just changed — clear in-memory feature-flag state and the on-disk
+                // cache from the prior identity (and bump the fetch generation so any in-flight
+                // fetch is discarded) before loading flags under the new identity. trackingQueue
+                // FIFO guarantees the reset runs before the loadFlags-driven fetch.
+                if let flagManager = self.flags as? FeatureFlagManager {
+                    flagManager.reset()
+                }
+                self.flags.loadFlags()
+                self.track(event: "$identify", properties: ["$anon_distinct_id": oldDistinctId])
+            }
 
-  /**
-     The alias method creates an alias which Mixpanel will use to remap one id to another.
-     Multiple aliases can point to the same identifier.
-  
-     Please note: With Mixpanel Identity Merge enabled, calling alias is no longer required
-     but can be used to merge two IDs in scenarios where identify() would fail
-  
-  
-     `mixpanelInstance.createAlias("New ID", distinctId: mixpanelInstance.distinctId)`
-  
-     You can add multiple id aliases to the existing id
-  
-     `mixpanelInstance.createAlias("Newer ID", distinctId: mixpanelInstance.distinctId)`
-  
-  
-     - parameter alias:      A unique identifier that you want to use as an identifier for this user.
-     - parameter distinctId: The current user identifier.
-     - parameter usePeople: boolean that controls whether or not to set the people distinctId to the event distinctId.
-     - parameter andIdentify: an optional boolean that controls whether or not to call 'identify' with your current
-     user identifier(not alias). Default to true for keeping your signup funnels working correctly in most cases.
-     - parameter completion: an optional completion handler for when the createAlias has completed.
-     This should only be set to false if you wish to prevent people profile updates for that user.
-     */
-  public func createAlias(
-    _ alias: String, distinctId: String, usePeople: Bool = true, andIdentify: Bool = true,
-    completion: (() -> Void)? = nil
-  ) {
-    if hasOptedOutTracking() {
-      if let completion = completion {
-        DispatchQueue.main.async(execute: completion)
-      }
-      return
-    }
+            if usePeople {
+                self.readWriteLock.write {
+                    self.people.distinctId = distinctId
+                }
+                self.mixpanelPersistence.identifyPeople(token: self.apiToken)
+            } else {
+                self.people.distinctId = nil
+            }
 
-    if distinctId.isEmpty {
-      MixpanelLogger.error(message: "\(self) cannot identify blank distinct id")
-      if let completion = completion {
-        DispatchQueue.main.async(execute: completion)
-      }
-      return
-    }
-
-    if alias.isEmpty {
-      MixpanelLogger.error(message: "\(self) create alias called with empty alias")
-      if let completion = completion {
-        DispatchQueue.main.async(execute: completion)
-      }
-      return
-    }
-
-    if alias != distinctId {
-      trackingQueue.async { [weak self, alias] in
-        guard let self = self else {
-          if let completion = completion {
-            DispatchQueue.main.async(execute: completion)
-          }
-          return
-        }
-        self.readWriteLock.write {
-          self.alias = alias
+            MixpanelPersistence.saveIdentity(
+                MixpanelIdentity.init(
+                    distinctID: self.distinctId,
+                    peopleDistinctID: self.people.distinctId,
+                    anonymousId: self.anonymousId,
+                    userId: self.userId,
+                    alias: self.alias,
+                    hadPersistedDistinctId: self.hadPersistedDistinctId), instanceName: self.name)
+            if let completion = completion {
+                DispatchQueue.main.async(execute: completion)
+            }
         }
 
-        var distinctIdSnapshot: String?
-        var peopleDistinctIDSnapshot: String?
-        var anonymousIdSnapshot: String?
-        var userIdSnapshot: String?
-        var aliasSnapshot: String?
-        var hadPersistedDistinctIdSnapshot: Bool?
+        if MixpanelInstance.isiOSAppExtension() {
+            flush()
+        }
+    }
 
-        self.readWriteLock.read {
-          distinctIdSnapshot = self.distinctId
-          peopleDistinctIDSnapshot = self.people.distinctId
-          anonymousIdSnapshot = self.anonymousId
-          userIdSnapshot = self.userId
-          aliasSnapshot = self.alias
-          hadPersistedDistinctIdSnapshot = self.hadPersistedDistinctId
+    /**
+       The alias method creates an alias which Mixpanel will use to remap one id to another.
+       Multiple aliases can point to the same identifier.
+    
+       Please note: With Mixpanel Identity Merge enabled, calling alias is no longer required
+       but can be used to merge two IDs in scenarios where identify() would fail
+    
+    
+       `mixpanelInstance.createAlias("New ID", distinctId: mixpanelInstance.distinctId)`
+    
+       You can add multiple id aliases to the existing id
+    
+       `mixpanelInstance.createAlias("Newer ID", distinctId: mixpanelInstance.distinctId)`
+    
+    
+       - parameter alias:      A unique identifier that you want to use as an identifier for this user.
+       - parameter distinctId: The current user identifier.
+       - parameter usePeople: boolean that controls whether or not to set the people distinctId to the event distinctId.
+       - parameter andIdentify: an optional boolean that controls whether or not to call 'identify' with your current
+       user identifier(not alias). Default to true for keeping your signup funnels working correctly in most cases.
+       - parameter completion: an optional completion handler for when the createAlias has completed.
+       This should only be set to false if you wish to prevent people profile updates for that user.
+       */
+    public func createAlias(
+        _ alias: String, distinctId: String, usePeople: Bool = true, andIdentify: Bool = true,
+        completion: (() -> Void)? = nil
+    ) {
+        if hasOptedOutTracking() {
+            if let completion = completion {
+                DispatchQueue.main.async(execute: completion)
+            }
+            return
         }
 
-        MixpanelPersistence.saveIdentity(
-          MixpanelIdentity.init(
-            distinctID: distinctIdSnapshot!,
-            peopleDistinctID: peopleDistinctIDSnapshot,
-            anonymousId: anonymousIdSnapshot,
-            userId: userIdSnapshot,
-            alias: aliasSnapshot,
-            hadPersistedDistinctId: hadPersistedDistinctIdSnapshot), instanceName: self.name)
-      }
-
-      let properties = ["distinct_id": distinctId, "alias": alias]
-      track(event: "$create_alias", properties: properties)
-      if andIdentify {
-        identify(distinctId: distinctId, usePeople: usePeople)
-      }
-      flush(completion: completion)
-    } else {
-      MixpanelLogger.error(
-        message: "alias: \(alias) matches distinctId: \(distinctId) - skipping api call.")
-      if let completion = completion {
-        DispatchQueue.main.async(execute: completion)
-      }
-    }
-  }
-
-  /**
-     Clears all stored properties including the distinct Id.
-     Useful if your app's user logs out.
-  
-     - parameter completion: an optional completion handler for when the reset has completed.
-     */
-  public func reset(completion: (() -> Void)? = nil) {
-    flush()
-    trackingQueue.async { [weak self] in
-      guard let self = self else {
-        return
-      }
-
-      MixpanelPersistence.deleteMPUserDefaultsData(instanceName: self.name)
-      self.readWriteLock.write {
-        self.timedEvents = InternalProperties()
-        self.anonymousId = self.defaultDeviceId()
-        self.distinctId = self.addPrefixToDeviceId(deviceId: self.anonymousId)
-        self.hadPersistedDistinctId = true
-        self.userId = nil
-        self.superProperties = InternalProperties()
-        self.people.distinctId = nil
-        self.alias = nil
-      }
-
-      self.mixpanelPersistence.resetEntities()
-      self.archive()
-
-      // reset() does not call identify(), so the loadFlags() call inside identify() never
-      // fires. Clear feature-flag state explicitly and refetch under the new identity if
-      // prefetching is enabled. Defer the user-facing completion until the flag-manager
-      // reset has actually drained — otherwise a customer calling a sync flag API from
-      // their completion handler could observe pre-reset variants (the inner reset is
-      // async on the same trackingQueue, so it'd run AFTER the outer block dispatched
-      // completion to main).
-      let flagManager = self.flags as? FeatureFlagManager
-      let fireUserCompletion: () -> Void = {
-        if let completion = completion {
-          DispatchQueue.main.async(execute: completion)
+        if distinctId.isEmpty {
+            MixpanelLogger.error(message: "\(self) cannot identify blank distinct id")
+            if let completion = completion {
+                DispatchQueue.main.async(execute: completion)
+            }
+            return
         }
-      }
-      if let flagManager = flagManager {
-        flagManager.reset {
-          if self.options.featureFlagOptions.prefetchFlags {
-            flagManager.loadFlags()
-          }
-          fireUserCompletion()
+
+        if alias.isEmpty {
+            MixpanelLogger.error(message: "\(self) create alias called with empty alias")
+            if let completion = completion {
+                DispatchQueue.main.async(execute: completion)
+            }
+            return
         }
-      } else {
-        fireUserCompletion()
-      }
-    }
-  }
-}
 
-extension MixpanelInstance {
-  // MARK: - Persistence
+        if alias != distinctId {
+            trackingQueue.async { [weak self, alias] in
+                guard let self = self else {
+                    if let completion = completion {
+                        DispatchQueue.main.async(execute: completion)
+                    }
+                    return
+                }
+                self.readWriteLock.write {
+                    self.alias = alias
+                }
 
-  public func archive() {
-    self.readWriteLock.read {
-      MixpanelPersistence.saveTimedEvents(timedEvents: timedEvents, instanceName: self.name)
-      MixpanelPersistence.saveSuperProperties(
-        superProperties: superProperties, instanceName: self.name)
-      MixpanelPersistence.saveIdentity(
-        MixpanelIdentity.init(
-          distinctID: distinctId,
-          peopleDistinctID: people.distinctId,
-          anonymousId: anonymousId,
-          userId: userId,
-          alias: alias,
-          hadPersistedDistinctId: hadPersistedDistinctId), instanceName: self.name)
-    }
-  }
+                var distinctIdSnapshot: String?
+                var peopleDistinctIDSnapshot: String?
+                var anonymousIdSnapshot: String?
+                var userIdSnapshot: String?
+                var aliasSnapshot: String?
+                var hadPersistedDistinctIdSnapshot: Bool?
 
-  func unarchive() {
-    let didCreateIdentity = self.readWriteLock.write {
-      optOutStatus = MixpanelPersistence.loadOptOutStatusFlag(instanceName: self.name)
-      superProperties = MixpanelPersistence.loadSuperProperties(instanceName: self.name)
-      timedEvents = MixpanelPersistence.loadTimedEvents(instanceName: self.name)
-      let mixpanelIdentity = MixpanelPersistence.loadIdentity(instanceName: self.name)
-      (distinctId, people.distinctId, anonymousId, userId, alias, hadPersistedDistinctId) = (
-        mixpanelIdentity.distinctID,
-        mixpanelIdentity.peopleDistinctID,
-        mixpanelIdentity.anonymousId,
-        mixpanelIdentity.userId,
-        mixpanelIdentity.alias,
-        mixpanelIdentity.hadPersistedDistinctId
-      )
-      if distinctId.isEmpty {
-        anonymousId = defaultDeviceId()
-        distinctId = addPrefixToDeviceId(deviceId: anonymousId)
-        hadPersistedDistinctId = true
-        userId = nil
-        return true
-      } else {
-        // Check if a deviceIdProvider is set and would return a different value
-        // than the persisted anonymousId. This helps detect potential identity
-        // discontinuity when adding a provider to an existing app.
-        if options.deviceIdProvider != nil,
-          let existingId = anonymousId,
-          !existingId.isEmpty
-        {
-          let providerValue = defaultDeviceId()
-          if providerValue != existingId {
+                self.readWriteLock.read {
+                    distinctIdSnapshot = self.distinctId
+                    peopleDistinctIDSnapshot = self.people.distinctId
+                    anonymousIdSnapshot = self.anonymousId
+                    userIdSnapshot = self.userId
+                    aliasSnapshot = self.alias
+                    hadPersistedDistinctIdSnapshot = self.hadPersistedDistinctId
+                }
+
+                MixpanelPersistence.saveIdentity(
+                    MixpanelIdentity.init(
+                        distinctID: distinctIdSnapshot!,
+                        peopleDistinctID: peopleDistinctIDSnapshot,
+                        anonymousId: anonymousIdSnapshot,
+                        userId: userIdSnapshot,
+                        alias: aliasSnapshot,
+                        hadPersistedDistinctId: hadPersistedDistinctIdSnapshot), instanceName: self.name)
+            }
+
+            let properties = ["distinct_id": distinctId, "alias": alias]
+            track(event: "$create_alias", properties: properties)
+            if andIdentify {
+                identify(distinctId: distinctId, usePeople: usePeople)
+            }
+            flush(completion: completion)
+        } else {
             MixpanelLogger.error(
-              message:
-                "deviceIdProvider returned '\(providerValue)' but existing anonymousId is '\(existingId)'. "
-                + "Using persisted value to preserve identity continuity. "
-                + "If you intended to change the device ID, call reset() after initialization.")
-          }
+                message: "alias: \(alias) matches distinctId: \(distinctId) - skipping api call.")
+            if let completion = completion {
+                DispatchQueue.main.async(execute: completion)
+            }
         }
-        return false
-      }
     }
 
-    if didCreateIdentity {
-      self.readWriteLock.read {
-        MixpanelPersistence.saveIdentity(
-          MixpanelIdentity.init(
-            distinctID: distinctId,
-            peopleDistinctID: people.distinctId,
-            anonymousId: anonymousId,
-            userId: userId,
-            alias: alias,
-            hadPersistedDistinctId: hadPersistedDistinctId), instanceName: self.name)
-      }
+    /**
+       Clears all stored properties including the distinct Id.
+       Useful if your app's user logs out.
+    
+       - parameter completion: an optional completion handler for when the reset has completed.
+       */
+    public func reset(completion: (() -> Void)? = nil) {
+        flush()
+        trackingQueue.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            MixpanelPersistence.deleteMPUserDefaultsData(instanceName: self.name)
+            self.readWriteLock.write {
+                self.timedEvents = InternalProperties()
+                self.anonymousId = self.defaultDeviceId()
+                self.distinctId = self.addPrefixToDeviceId(deviceId: self.anonymousId)
+                self.hadPersistedDistinctId = true
+                self.userId = nil
+                self.superProperties = InternalProperties()
+                self.people.distinctId = nil
+                self.alias = nil
+            }
+
+            self.mixpanelPersistence.resetEntities()
+            self.archive()
+
+            // reset() does not call identify(), so the loadFlags() call inside identify() never
+            // fires. Clear feature-flag state explicitly and refetch under the new identity if
+            // prefetching is enabled. Defer the user-facing completion until the flag-manager
+            // reset has actually drained — otherwise a customer calling a sync flag API from
+            // their completion handler could observe pre-reset variants (the inner reset is
+            // async on the same trackingQueue, so it'd run AFTER the outer block dispatched
+            // completion to main).
+            let flagManager = self.flags as? FeatureFlagManager
+            let fireUserCompletion: () -> Void = {
+                if let completion = completion {
+                    DispatchQueue.main.async(execute: completion)
+                }
+            }
+            if let flagManager = flagManager {
+                flagManager.reset {
+                    if self.options.featureFlagOptions.prefetchFlags {
+                        flagManager.loadFlags()
+                    }
+                    fireUserCompletion()
+                }
+            } else {
+                fireUserCompletion()
+            }
+        }
     }
-  }
 }
 
 extension MixpanelInstance {
-  // MARK: - Flush
+    // MARK: - Persistence
 
-  /**
-     Uploads queued data to the Mixpanel server.
-  
-     By default, queued data is flushed to the Mixpanel servers every minute (the
-     default for `flushInterval`), and on background (since
-     `flushOnBackground` is on by default). You only need to call this
-     method manually if you want to force a flush at a particular moment.
-  
-     - parameter performFullFlush: A optional boolean value indicating whether a full flush should be performed. If `true`, a full flush will be triggered, sending all events to the server. Default to `false`, a partial flush will be executed for reducing memory footprint.
-     - parameter completion: an optional completion handler for when the flush has completed.
-     */
-  public func flush(performFullFlush: Bool = false, completion: (() -> Void)? = nil) {
-    if hasOptedOutTracking() {
-      if let completion = completion {
-        DispatchQueue.main.async(execute: completion)
-      }
-      return
-    }
-    trackingQueue.async { [weak self, completion] in
-      guard let self = self else {
-        if let completion = completion {
-          DispatchQueue.main.async(execute: completion)
+    public func archive() {
+        self.readWriteLock.read {
+            MixpanelPersistence.saveTimedEvents(timedEvents: timedEvents, instanceName: self.name)
+            MixpanelPersistence.saveSuperProperties(
+                superProperties: superProperties, instanceName: self.name)
+            MixpanelPersistence.saveIdentity(
+                MixpanelIdentity.init(
+                    distinctID: distinctId,
+                    peopleDistinctID: people.distinctId,
+                    anonymousId: anonymousId,
+                    userId: userId,
+                    alias: alias,
+                    hadPersistedDistinctId: hadPersistedDistinctId), instanceName: self.name)
         }
-        return
-      }
+    }
 
-      if let shouldFlush = self.delegate?.mixpanelWillFlush(self), !shouldFlush {
-        if let completion = completion {
-          DispatchQueue.main.async(execute: completion)
+    func unarchive() {
+        let didCreateIdentity = self.readWriteLock.write {
+            optOutStatus = MixpanelPersistence.loadOptOutStatusFlag(instanceName: self.name)
+            superProperties = MixpanelPersistence.loadSuperProperties(instanceName: self.name)
+            timedEvents = MixpanelPersistence.loadTimedEvents(instanceName: self.name)
+            let mixpanelIdentity = MixpanelPersistence.loadIdentity(instanceName: self.name)
+            (distinctId, people.distinctId, anonymousId, userId, alias, hadPersistedDistinctId) = (
+                mixpanelIdentity.distinctID,
+                mixpanelIdentity.peopleDistinctID,
+                mixpanelIdentity.anonymousId,
+                mixpanelIdentity.userId,
+                mixpanelIdentity.alias,
+                mixpanelIdentity.hadPersistedDistinctId
+            )
+            if distinctId.isEmpty {
+                anonymousId = defaultDeviceId()
+                distinctId = addPrefixToDeviceId(deviceId: anonymousId)
+                hadPersistedDistinctId = true
+                userId = nil
+                return true
+            } else {
+                // Check if a deviceIdProvider is set and would return a different value
+                // than the persisted anonymousId. This helps detect potential identity
+                // discontinuity when adding a provider to an existing app.
+                if options.deviceIdProvider != nil,
+                    let existingId = anonymousId,
+                    !existingId.isEmpty
+                {
+                    let providerValue = defaultDeviceId()
+                    if providerValue != existingId {
+                        MixpanelLogger.error(
+                            message:
+                                "deviceIdProvider returned '\(providerValue)' but existing anonymousId is '\(existingId)'. "
+                                + "Using persisted value to preserve identity continuity. "
+                                + "If you intended to change the device ID, call reset() after initialization.")
+                    }
+                }
+                return false
+            }
         }
-        return
-      }
 
-      // automatic events will NOT be flushed until one of the flags is non-nil
-      let eventQueue = self.mixpanelPersistence.loadEntitiesInBatch(
-        type: self.persistenceTypeFromFlushType(.events),
-        batchSize: performFullFlush ? Int.max : self.flushBatchSize,
-        excludeAutomaticEvents: !self.trackAutomaticEventsEnabled
-      )
-      let peopleQueue = self.mixpanelPersistence.loadEntitiesInBatch(
-        type: self.persistenceTypeFromFlushType(.people),
-        batchSize: performFullFlush ? Int.max : self.flushBatchSize
-      )
-      let groupsQueue = self.mixpanelPersistence.loadEntitiesInBatch(
-        type: self.persistenceTypeFromFlushType(.groups),
-        batchSize: performFullFlush ? Int.max : self.flushBatchSize
-      )
-
-      self.networkQueue.async { [weak self, completion] in
-        guard let self = self else {
-          if let completion = completion {
-            DispatchQueue.main.async(execute: completion)
-          }
-          return
+        if didCreateIdentity {
+            self.readWriteLock.read {
+                MixpanelPersistence.saveIdentity(
+                    MixpanelIdentity.init(
+                        distinctID: distinctId,
+                        peopleDistinctID: people.distinctId,
+                        anonymousId: anonymousId,
+                        userId: userId,
+                        alias: alias,
+                        hadPersistedDistinctId: hadPersistedDistinctId), instanceName: self.name)
+            }
         }
-        self.flushQueue(eventQueue, type: .events)
-        self.flushQueue(peopleQueue, type: .people)
-        self.flushQueue(groupsQueue, type: .groups)
+    }
+}
 
-        if let completion = completion {
-          DispatchQueue.main.async(execute: completion)
+extension MixpanelInstance {
+    // MARK: - Flush
+
+    /**
+       Uploads queued data to the Mixpanel server.
+    
+       By default, queued data is flushed to the Mixpanel servers every minute (the
+       default for `flushInterval`), and on background (since
+       `flushOnBackground` is on by default). You only need to call this
+       method manually if you want to force a flush at a particular moment.
+    
+       - parameter performFullFlush: A optional boolean value indicating whether a full flush should be performed. If `true`, a full flush will be triggered, sending all events to the server. Default to `false`, a partial flush will be executed for reducing memory footprint.
+       - parameter completion: an optional completion handler for when the flush has completed.
+       */
+    public func flush(performFullFlush: Bool = false, completion: (() -> Void)? = nil) {
+        if hasOptedOutTracking() {
+            if let completion = completion {
+                DispatchQueue.main.async(execute: completion)
+            }
+            return
         }
-      }
-    }
-  }
+        trackingQueue.async { [weak self, completion] in
+            guard let self = self else {
+                if let completion = completion {
+                    DispatchQueue.main.async(execute: completion)
+                }
+                return
+            }
 
-  private func persistenceTypeFromFlushType(_ type: FlushType) -> PersistenceType {
-    switch type {
-    case .events:
-      return PersistenceType.events
-    case .people:
-      return PersistenceType.people
-    case .groups:
-      return PersistenceType.groups
-    }
-  }
+            if let shouldFlush = self.delegate?.mixpanelWillFlush(self), !shouldFlush {
+                if let completion = completion {
+                    DispatchQueue.main.async(execute: completion)
+                }
+                return
+            }
 
-  func flushQueue(_ queue: Queue, type: FlushType) {
-    if hasOptedOutTracking() {
-      return
-    }
-    let proxyServerResource = proxyServerDelegate?.mixpanelResourceForProxyServer(name)
-    let headers: [String: String] = proxyServerResource?.headers ?? [:]
-    let queryItems = proxyServerResource?.queryItems ?? []
+            // automatic events will NOT be flushed until one of the flags is non-nil
+            let eventQueue = self.mixpanelPersistence.loadEntitiesInBatch(
+                type: self.persistenceTypeFromFlushType(.events),
+                batchSize: performFullFlush ? Int.max : self.flushBatchSize,
+                excludeAutomaticEvents: !self.trackAutomaticEventsEnabled
+            )
+            let peopleQueue = self.mixpanelPersistence.loadEntitiesInBatch(
+                type: self.persistenceTypeFromFlushType(.people),
+                batchSize: performFullFlush ? Int.max : self.flushBatchSize
+            )
+            let groupsQueue = self.mixpanelPersistence.loadEntitiesInBatch(
+                type: self.persistenceTypeFromFlushType(.groups),
+                batchSize: performFullFlush ? Int.max : self.flushBatchSize
+            )
 
-    self.flushInstance.flushQueue(queue, type: type, headers: headers, queryItems: queryItems)
-  }
+            self.networkQueue.async { [weak self, completion] in
+                guard let self = self else {
+                    if let completion = completion {
+                        DispatchQueue.main.async(execute: completion)
+                    }
+                    return
+                }
+                self.flushQueue(eventQueue, type: .events)
+                self.flushQueue(peopleQueue, type: .people)
+                self.flushQueue(groupsQueue, type: .groups)
 
-  func flushSuccess(type: FlushType, ids: [Int32]) {
-    trackingQueue.async { [weak self] in
-      guard let self = self else {
-        return
-      }
-      self.mixpanelPersistence.removeEntitiesInBatch(
-        type: self.persistenceTypeFromFlushType(type), ids: ids)
+                if let completion = completion {
+                    DispatchQueue.main.async(execute: completion)
+                }
+            }
+        }
     }
-  }
+
+    private func persistenceTypeFromFlushType(_ type: FlushType) -> PersistenceType {
+        switch type {
+            case .events:
+                return PersistenceType.events
+            case .people:
+                return PersistenceType.people
+            case .groups:
+                return PersistenceType.groups
+        }
+    }
+
+    func flushQueue(_ queue: Queue, type: FlushType) {
+        if hasOptedOutTracking() {
+            return
+        }
+        let proxyServerResource = proxyServerDelegate?.mixpanelResourceForProxyServer(name)
+        let headers: [String: String] = proxyServerResource?.headers ?? [:]
+        let queryItems = proxyServerResource?.queryItems ?? []
+
+        self.flushInstance.flushQueue(queue, type: type, headers: headers, queryItems: queryItems)
+    }
+
+    func flushSuccess(type: FlushType, ids: [Int32]) {
+        trackingQueue.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.mixpanelPersistence.removeEntitiesInBatch(
+                type: self.persistenceTypeFromFlushType(type), ids: ids)
+        }
+    }
 
 }
 
 extension MixpanelInstance {
-  // MARK: - Track
+    // MARK: - Track
 
-  /**
-     Tracks an event with properties.
-     Properties are optional and can be added only if needed.
-  
-     Properties will allow you to segment your events in your Mixpanel reports.
-     Property keys must be String objects and the supported value types need to conform to MixpanelType.
-     MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
-     If the event is being timed, the timer will stop and be added as a property.
-  
-     - parameter event:      event name
-     - parameter properties: properties dictionary
-     */
-  public func track(event: String?, properties: Properties? = nil) {
-    let epochInterval = Date().timeIntervalSince1970
+    /**
+       Tracks an event with properties.
+       Properties are optional and can be added only if needed.
+    
+       Properties will allow you to segment your events in your Mixpanel reports.
+       Property keys must be String objects and the supported value types need to conform to MixpanelType.
+       MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
+       If the event is being timed, the timer will stop and be added as a property.
+    
+       - parameter event:      event name
+       - parameter properties: properties dictionary
+       */
+    public func track(event: String?, properties: Properties? = nil) {
+        let epochInterval = Date().timeIntervalSince1970
 
-    trackingQueue.async { [weak self, event, properties, epochInterval] in
-      guard let self else {
-        return
-      }
-      if self.hasOptedOutTracking() {
-        return
-      }
-      var shadowTimedEvents = InternalProperties()
-      var shadowSuperProperties = InternalProperties()
+        trackingQueue.async { [weak self, event, properties, epochInterval] in
+            guard let self else {
+                return
+            }
+            if self.hasOptedOutTracking() {
+                return
+            }
+            var shadowTimedEvents = InternalProperties()
+            var shadowSuperProperties = InternalProperties()
 
-      self.readWriteLock.read {
-        shadowTimedEvents = self.timedEvents
-        shadowSuperProperties = self.superProperties
-      }
+            self.readWriteLock.read {
+                shadowTimedEvents = self.timedEvents
+                shadowSuperProperties = self.superProperties
+            }
 
-      let mixpanelIdentity = MixpanelIdentity.init(
-        distinctID: self.distinctId,
-        peopleDistinctID: nil,
-        anonymousId: self.anonymousId,
-        userId: self.userId,
-        alias: nil,
-        hadPersistedDistinctId: self.hadPersistedDistinctId)
-      let timedEventsSnapshot = self.trackInstance.track(
-        event: event,
-        properties: properties,
-        timedEvents: shadowTimedEvents,
-        superProperties: shadowSuperProperties,
-        mixpanelIdentity: mixpanelIdentity,
-        epochInterval: epochInterval)
+            let mixpanelIdentity = MixpanelIdentity.init(
+                distinctID: self.distinctId,
+                peopleDistinctID: nil,
+                anonymousId: self.anonymousId,
+                userId: self.userId,
+                alias: nil,
+                hadPersistedDistinctId: self.hadPersistedDistinctId)
+            let timedEventsSnapshot = self.trackInstance.track(
+                event: event,
+                properties: properties,
+                timedEvents: shadowTimedEvents,
+                superProperties: shadowSuperProperties,
+                mixpanelIdentity: mixpanelIdentity,
+                epochInterval: epochInterval)
 
-      self.readWriteLock.write {
-        self.timedEvents = timedEventsSnapshot
-      }
-    }
-
-    if MixpanelInstance.isiOSAppExtension() {
-      flush()
-    }
-  }
-
-  /**
-     Tracks an event with properties and to specific groups.
-     Properties and groups are optional and can be added only if needed.
-  
-     Properties will allow you to segment your events in your Mixpanel reports.
-     Property and group keys must be String objects and the supported value types need to conform to MixpanelType.
-     MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
-     If the event is being timed, the timer will stop and be added as a property.
-  
-     - parameter event:      event name
-     - parameter properties: properties dictionary
-     - parameter groups:     groups dictionary
-     */
-  public func trackWithGroups(event: String?, properties: Properties? = nil, groups: Properties?) {
-    if hasOptedOutTracking() {
-      return
-    }
-
-    guard let properties = properties else {
-      self.track(event: event, properties: groups)
-      return
-    }
-
-    guard let groups = groups else {
-      self.track(event: event, properties: properties)
-      return
-    }
-
-    var mergedProperties = properties
-    for (groupKey, groupID) in groups {
-      mergedProperties[groupKey] = groupID
-    }
-    self.track(event: event, properties: mergedProperties)
-  }
-
-  public func getGroup(groupKey: String, groupID: MixpanelType) -> Group {
-    let key = makeMapKey(groupKey: groupKey, groupID: groupID)
-
-    var groupsShadow: [String: Group] = [:]
-
-    readWriteLock.read {
-      groupsShadow = groups
-    }
-
-    guard let group = groupsShadow[key] else {
-      readWriteLock.write {
-        groups[key] = Group(
-          apiToken: apiToken,
-          serialQueue: trackingQueue,
-          lock: self.readWriteLock,
-          groupKey: groupKey,
-          groupID: groupID,
-          metadata: sessionMetadata,
-          mixpanelPersistence: mixpanelPersistence,
-          mixpanelInstance: self)
-        groupsShadow = groups
-      }
-      return groupsShadow[key]!
-    }
-
-    if !(group.groupKey == groupKey && group.groupID.equals(rhs: groupID)) {
-      // we somehow hit a collision on the map key, return a new group with the correct key and ID
-      MixpanelLogger.info(message: "groups dictionary key collision: \(key)")
-      let newGroup = Group(
-        apiToken: apiToken,
-        serialQueue: trackingQueue,
-        lock: self.readWriteLock,
-        groupKey: groupKey,
-        groupID: groupID,
-        metadata: sessionMetadata,
-        mixpanelPersistence: mixpanelPersistence,
-        mixpanelInstance: self)
-      readWriteLock.write {
-        groups[key] = newGroup
-      }
-      return newGroup
-    }
-
-    return group
-  }
-
-  func removeCachedGroup(groupKey: String, groupID: MixpanelType) {
-    readWriteLock.write {
-      groups.removeValue(forKey: makeMapKey(groupKey: groupKey, groupID: groupID))
-    }
-  }
-
-  func makeMapKey(groupKey: String, groupID: MixpanelType) -> String {
-    return "\(groupKey)_\(groupID)"
-  }
-
-  /**
-     Starts a timer that will be stopped and added as a property when a
-     corresponding event is tracked.
-  
-     This method is intended to be used in advance of events that have
-     a duration. For example, if a developer were to track an "Image Upload" event
-     she might want to also know how long the upload took. Calling this method
-     before the upload code would implicitly cause the `track`
-     call to record its duration.
-  
-     - precondition:
-     // begin timing the image upload:
-     mixpanelInstance.time(event:"Image Upload")
-     // upload the image:
-     self.uploadImageWithSuccessHandler() { _ in
-     // track the event
-     mixpanelInstance.track("Image Upload")
-     }
-  
-     - parameter event: the event name to be timed
-  
-     */
-  public func time(event: String) {
-    let startTime = Date().timeIntervalSince1970
-    trackingQueue.async { [weak self, startTime, event] in
-      guard let self = self else { return }
-      let timedEvents = self.trackInstance.time(
-        event: event, timedEvents: self.timedEvents, startTime: startTime)
-      self.readWriteLock.write {
-        self.timedEvents = timedEvents
-      }
-      MixpanelPersistence.saveTimedEvents(timedEvents: timedEvents, instanceName: self.name)
-    }
-  }
-
-  /**
-     Retrieves the time elapsed for the named event since time(event:) was called.
-  
-     - parameter event: the name of the event to be tracked that was passed to time(event:)
-     */
-  public func eventElapsedTime(event: String) -> Double {
-    var timedEvents = InternalProperties()
-    self.readWriteLock.read {
-      timedEvents = self.timedEvents
-    }
-
-    if let startTime = timedEvents[event] as? TimeInterval {
-      return Date().timeIntervalSince1970 - startTime
-    }
-    return 0
-  }
-
-  /**
-     Clears all current event timers.
-     */
-  public func clearTimedEvents() {
-    trackingQueue.async { [weak self] in
-      guard let self = self else { return }
-      self.readWriteLock.write {
-        self.timedEvents = InternalProperties()
-      }
-      MixpanelPersistence.saveTimedEvents(
-        timedEvents: InternalProperties(), instanceName: self.name)
-    }
-  }
-
-  /**
-     Clears the event timer for the named event.
-  
-     - parameter event: the name of the event to clear the timer for
-     */
-  public func clearTimedEvent(event: String) {
-    trackingQueue.async { [weak self, event] in
-      guard let self = self else { return }
-
-      let updatedTimedEvents = self.trackInstance.clearTimedEvent(
-        event: event, timedEvents: self.timedEvents)
-      MixpanelPersistence.saveTimedEvents(timedEvents: updatedTimedEvents, instanceName: self.name)
-    }
-  }
-
-  /**
-     Returns the currently set super properties.
-  
-     - returns: the current super properties
-     */
-  public func currentSuperProperties() -> [String: Any] {
-    var properties = InternalProperties()
-    self.readWriteLock.read {
-      properties = superProperties
-    }
-    return properties
-  }
-
-  /**
-     Clears all currently set super properties.
-     */
-  public func clearSuperProperties() {
-    trackingQueue.async { [weak self] in
-      guard let self = self else { return }
-      self.superProperties = self.trackInstance.clearSuperProperties(self.superProperties)
-      MixpanelPersistence.saveSuperProperties(
-        superProperties: self.superProperties, instanceName: self.name)
-    }
-  }
-
-  /**
-     Registers super properties, overwriting ones that have already been set.
-  
-     Super properties, once registered, are automatically sent as properties for
-     all event tracking calls. They save you having to maintain and add a common
-     set of properties to your events.
-     Property keys must be String objects and the supported value types need to conform to MixpanelType.
-     MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
-  
-     - parameter properties: properties dictionary
-     */
-  public func registerSuperProperties(_ properties: Properties) {
-    trackingQueue.async { [weak self] in
-      guard let self = self else { return }
-      let updatedSuperProperties = self.trackInstance.registerSuperProperties(
-        properties,
-        superProperties: self.superProperties)
-      self.readWriteLock.write {
-        self.superProperties = updatedSuperProperties
-      }
-      self.readWriteLock.read {
-        MixpanelPersistence.saveSuperProperties(
-          superProperties: self.superProperties, instanceName: self.name)
-      }
-    }
-  }
-
-  /**
-     Registers super properties without overwriting ones that have already been set,
-     unless the existing value is equal to defaultValue. defaultValue is optional.
-  
-     Property keys must be String objects and the supported value types need to conform to MixpanelType.
-     MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
-  
-     - parameter properties:   properties dictionary
-     - parameter defaultValue: Optional. overwrite existing properties that have this value
-     */
-  public func registerSuperPropertiesOnce(
-    _ properties: Properties,
-    defaultValue: MixpanelType? = nil
-  ) {
-    trackingQueue.async { [weak self] in
-      guard let self = self else { return }
-      let updatedSuperProperties = self.trackInstance.registerSuperPropertiesOnce(
-        properties,
-        superProperties: self.superProperties,
-        defaultValue: defaultValue)
-      self.readWriteLock.write {
-        self.superProperties = updatedSuperProperties
-      }
-      self.readWriteLock.read {
-        MixpanelPersistence.saveSuperProperties(
-          superProperties: self.superProperties, instanceName: self.name)
-      }
-    }
-  }
-
-  /**
-     Removes a previously registered super property.
-  
-     As an alternative to clearing all properties, unregistering specific super
-     properties prevents them from being recorded on future events. This operation
-     does not affect the value of other super properties. Any property name that is
-     not registered is ignored.
-     Note that after removing a super property, events will show the attribute as
-     having the value `undefined` in Mixpanel until a new value is
-     registered.
-  
-     - parameter propertyName: array of property name strings to remove
-     */
-  public func unregisterSuperProperty(_ propertyName: String) {
-    trackingQueue.async { [weak self] in
-      guard let self = self else { return }
-      let updatedSuperProperties = self.trackInstance.unregisterSuperProperty(
-        propertyName,
-        superProperties: self.superProperties)
-      self.readWriteLock.write {
-        self.superProperties = updatedSuperProperties
-      }
-      self.readWriteLock.read {
-        MixpanelPersistence.saveSuperProperties(
-          superProperties: self.superProperties, instanceName: self.name)
-      }
-    }
-  }
-
-  /**
-     Updates a super property atomically. The update function
-  
-     - parameter update: closure to apply to super properties
-     */
-  func updateSuperProperty(
-    _ update: @escaping (_ superproperties: inout InternalProperties) -> Void
-  ) {
-    trackingQueue.async { [weak self] in
-      guard let self = self else { return }
-      var superPropertiesShadow = self.superProperties
-      self.trackInstance.updateSuperProperty(
-        update,
-        superProperties: &superPropertiesShadow)
-      self.readWriteLock.write {
-        self.superProperties = superPropertiesShadow
-      }
-      self.readWriteLock.read {
-        MixpanelPersistence.saveSuperProperties(
-          superProperties: self.superProperties, instanceName: self.name)
-      }
-    }
-  }
-
-  /**
-     Convenience method to set a single group the user belongs to.
-  
-     - parameter groupKey: The property name associated with this group type (must already have been set up).
-     - parameter groupID: The group the user belongs to.
-     */
-  public func setGroup(groupKey: String, groupID: MixpanelType) {
-    if hasOptedOutTracking() {
-      return
-    }
-
-    setGroup(groupKey: groupKey, groupIDs: [groupID])
-  }
-
-  /**
-     Set the groups this user belongs to.
-  
-     - parameter groupKey: The property name associated with this group type (must already have been set up).
-     - parameter groupIDs: The list of groups the user belongs to.
-     */
-  public func setGroup(groupKey: String, groupIDs: [MixpanelType]) {
-    if hasOptedOutTracking() {
-      return
-    }
-
-    let properties = [groupKey: groupIDs]
-    self.registerSuperProperties(properties)
-    people.set(properties: properties)
-  }
-
-  /**
-     Add a group to this user's membership for a particular group key
-  
-     - parameter groupKey: The property name associated with this group type (must already have been set up).
-     - parameter groupID: The new group the user belongs to.
-     */
-  public func addGroup(groupKey: String, groupID: MixpanelType) {
-    if hasOptedOutTracking() {
-      return
-    }
-
-    updateSuperProperty { superProperties in
-      guard let oldValue = superProperties[groupKey] else {
-        superProperties[groupKey] = [groupID]
-        self.people.set(properties: [groupKey: [groupID]])
-        return
-      }
-
-      if let oldValue = oldValue as? [MixpanelType] {
-        var vals = oldValue
-        if !vals.contains(where: { $0.equals(rhs: groupID) }) {
-          vals.append(groupID)
-          superProperties[groupKey] = vals
-        }
-      } else {
-        superProperties[groupKey] = [oldValue, groupID]
-      }
-
-      // This is a best effort--if the people property is not already a list, this call does nothing.
-      self.people.union(properties: [groupKey: [groupID]])
-    }
-  }
-
-  /**
-     Remove a group from this user's membership for a particular group key
-  
-     - parameter groupKey: The property name associated with this group type (must already have been set up).
-     - parameter groupID: The group value to remove.
-     */
-  public func removeGroup(groupKey: String, groupID: MixpanelType) {
-    if hasOptedOutTracking() {
-      return
-    }
-
-    updateSuperProperty { (superProperties) -> Void in
-      guard let oldValue = superProperties[groupKey] else {
-        return
-      }
-
-      guard let vals = oldValue as? [MixpanelType] else {
-        superProperties.removeValue(forKey: groupKey)
-        self.people.unset(properties: [groupKey])
-        return
-      }
-
-      if vals.count < 2 {
-        superProperties.removeValue(forKey: groupKey)
-        self.people.unset(properties: [groupKey])
-        return
-      }
-
-      superProperties[groupKey] = vals.filter { !$0.equals(rhs: groupID) }
-      self.people.remove(properties: [groupKey: groupID])
-    }
-  }
-
-  /**
-     Opt out tracking.
-  
-     This method is used to opt out tracking. This causes all events and people request no longer
-     to be sent back to the Mixpanel server.
-     */
-  public func optOutTracking() {
-    trackingQueue.async { [weak self] in
-      guard let self = self else { return }
-      if self.people.distinctId != nil {
-        self.people.deleteUser()
-        self.people.clearCharges()
-        self.flush()
-      }
-      self.readWriteLock.write { [weak self] in
-        guard let self = self else {
-          return
+            self.readWriteLock.write {
+                self.timedEvents = timedEventsSnapshot
+            }
         }
 
-        self.alias = nil
-        self.people.distinctId = nil
-        self.userId = nil
-        self.anonymousId = self.defaultDeviceId()
-        self.distinctId = self.addPrefixToDeviceId(deviceId: self.anonymousId)
-        self.hadPersistedDistinctId = true
-        self.superProperties = InternalProperties()
-        MixpanelPersistence.saveTimedEvents(
-          timedEvents: InternalProperties(), instanceName: self.name)
-      }
-      self.archive()
-      self.readWriteLock.write {
-        self.optOutStatus = true
-      }
-      self.readWriteLock.read {
-        MixpanelPersistence.saveOptOutStatusFlag(value: self.optOutStatus!, instanceName: self.name)
-      }
-
-      // Identity just changed (distinctId was regenerated above). Clear in-memory feature
-      // flag state and the on-disk cache from the prior identity so subsequent lookups
-      // don't serve stale variants. Mirrors `identify()` and `setContext()`. We deliberately
-      // do NOT call `loadFlags()` here — opt-out semantically means "stop tracking", and
-      // re-fetching flags under the new anon identity would defeat that intent. The next
-      // `optInTracking()` will restore the normal fetch flow.
-      if let flagManager = self.flags as? FeatureFlagManager {
-        flagManager.reset()
-      }
-    }
-  }
-
-  /**
-     Opt in tracking.
-  
-     Use this method to opt in an already opted out user from tracking. People updates and track calls will be
-     sent to Mixpanel after using this method.
-  
-     This method will internally track an opt in event to your project.
-  
-     - parameter distinctId: an optional string to use as the distinct ID for events
-     - parameter properties: an optional properties dictionary that could be passed to add properties to the opt-in event
-     that is sent to Mixpanel
-     */
-  public func optInTracking(distinctId: String? = nil, properties: Properties? = nil) {
-    trackingQueue.async { [weak self] in
-      guard let self = self else { return }
-      self.readWriteLock.write {
-        self.optOutStatus = false
-      }
-      self.readWriteLock.read {
-        MixpanelPersistence.saveOptOutStatusFlag(value: self.optOutStatus!, instanceName: self.name)
-      }
-      if let distinctId = distinctId {
-        self.identify(distinctId: distinctId)
-      }
-      self.track(event: "$opt_in", properties: properties)
+        if MixpanelInstance.isiOSAppExtension() {
+            flush()
+        }
     }
 
-  }
+    /**
+       Tracks an event with properties and to specific groups.
+       Properties and groups are optional and can be added only if needed.
+    
+       Properties will allow you to segment your events in your Mixpanel reports.
+       Property and group keys must be String objects and the supported value types need to conform to MixpanelType.
+       MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
+       If the event is being timed, the timer will stop and be added as a property.
+    
+       - parameter event:      event name
+       - parameter properties: properties dictionary
+       - parameter groups:     groups dictionary
+       */
+    public func trackWithGroups(event: String?, properties: Properties? = nil, groups: Properties?) {
+        if hasOptedOutTracking() {
+            return
+        }
 
-  /**
-     Returns if the current user has opted out tracking.
-  
-     - returns: the current super opted out tracking status
-     */
-  public func hasOptedOutTracking() -> Bool {
-    var optOutStatusShadow: Bool?
-    readWriteLock.read {
-      optOutStatusShadow = optOutStatus
+        guard let properties = properties else {
+            self.track(event: event, properties: groups)
+            return
+        }
+
+        guard let groups = groups else {
+            self.track(event: event, properties: properties)
+            return
+        }
+
+        var mergedProperties = properties
+        for (groupKey, groupID) in groups {
+            mergedProperties[groupKey] = groupID
+        }
+        self.track(event: event, properties: mergedProperties)
     }
-    return optOutStatusShadow ?? false
-  }
 
-  // MARK: - AEDelegate
-  func increment(property: String, by: Double) {
-    people?.increment(property: property, by: by)
-  }
+    public func getGroup(groupKey: String, groupID: MixpanelType) -> Group {
+        let key = makeMapKey(groupKey: groupKey, groupID: groupID)
 
-  func setOnce(properties: Properties) {
-    people?.setOnce(properties: properties)
-  }
+        var groupsShadow: [String: Group] = [:]
+
+        readWriteLock.read {
+            groupsShadow = groups
+        }
+
+        guard let group = groupsShadow[key] else {
+            readWriteLock.write {
+                groups[key] = Group(
+                    apiToken: apiToken,
+                    serialQueue: trackingQueue,
+                    lock: self.readWriteLock,
+                    groupKey: groupKey,
+                    groupID: groupID,
+                    metadata: sessionMetadata,
+                    mixpanelPersistence: mixpanelPersistence,
+                    mixpanelInstance: self)
+                groupsShadow = groups
+            }
+            return groupsShadow[key]!
+        }
+
+        if !(group.groupKey == groupKey && group.groupID.equals(rhs: groupID)) {
+            // we somehow hit a collision on the map key, return a new group with the correct key and ID
+            MixpanelLogger.info(message: "groups dictionary key collision: \(key)")
+            let newGroup = Group(
+                apiToken: apiToken,
+                serialQueue: trackingQueue,
+                lock: self.readWriteLock,
+                groupKey: groupKey,
+                groupID: groupID,
+                metadata: sessionMetadata,
+                mixpanelPersistence: mixpanelPersistence,
+                mixpanelInstance: self)
+            readWriteLock.write {
+                groups[key] = newGroup
+            }
+            return newGroup
+        }
+
+        return group
+    }
+
+    func removeCachedGroup(groupKey: String, groupID: MixpanelType) {
+        readWriteLock.write {
+            groups.removeValue(forKey: makeMapKey(groupKey: groupKey, groupID: groupID))
+        }
+    }
+
+    func makeMapKey(groupKey: String, groupID: MixpanelType) -> String {
+        return "\(groupKey)_\(groupID)"
+    }
+
+    /**
+       Starts a timer that will be stopped and added as a property when a
+       corresponding event is tracked.
+    
+       This method is intended to be used in advance of events that have
+       a duration. For example, if a developer were to track an "Image Upload" event
+       she might want to also know how long the upload took. Calling this method
+       before the upload code would implicitly cause the `track`
+       call to record its duration.
+    
+       - precondition:
+       // begin timing the image upload:
+       mixpanelInstance.time(event:"Image Upload")
+       // upload the image:
+       self.uploadImageWithSuccessHandler() { _ in
+       // track the event
+       mixpanelInstance.track("Image Upload")
+       }
+    
+       - parameter event: the event name to be timed
+    
+       */
+    public func time(event: String) {
+        let startTime = Date().timeIntervalSince1970
+        trackingQueue.async { [weak self, startTime, event] in
+            guard let self = self else { return }
+            let timedEvents = self.trackInstance.time(
+                event: event, timedEvents: self.timedEvents, startTime: startTime)
+            self.readWriteLock.write {
+                self.timedEvents = timedEvents
+            }
+            MixpanelPersistence.saveTimedEvents(timedEvents: timedEvents, instanceName: self.name)
+        }
+    }
+
+    /**
+       Retrieves the time elapsed for the named event since time(event:) was called.
+    
+       - parameter event: the name of the event to be tracked that was passed to time(event:)
+       */
+    public func eventElapsedTime(event: String) -> Double {
+        var timedEvents = InternalProperties()
+        self.readWriteLock.read {
+            timedEvents = self.timedEvents
+        }
+
+        if let startTime = timedEvents[event] as? TimeInterval {
+            return Date().timeIntervalSince1970 - startTime
+        }
+        return 0
+    }
+
+    /**
+       Clears all current event timers.
+       */
+    public func clearTimedEvents() {
+        trackingQueue.async { [weak self] in
+            guard let self = self else { return }
+            self.readWriteLock.write {
+                self.timedEvents = InternalProperties()
+            }
+            MixpanelPersistence.saveTimedEvents(
+                timedEvents: InternalProperties(), instanceName: self.name)
+        }
+    }
+
+    /**
+       Clears the event timer for the named event.
+    
+       - parameter event: the name of the event to clear the timer for
+       */
+    public func clearTimedEvent(event: String) {
+        trackingQueue.async { [weak self, event] in
+            guard let self = self else { return }
+
+            let updatedTimedEvents = self.trackInstance.clearTimedEvent(
+                event: event, timedEvents: self.timedEvents)
+            MixpanelPersistence.saveTimedEvents(timedEvents: updatedTimedEvents, instanceName: self.name)
+        }
+    }
+
+    /**
+       Returns the currently set super properties.
+    
+       - returns: the current super properties
+       */
+    public func currentSuperProperties() -> [String: Any] {
+        var properties = InternalProperties()
+        self.readWriteLock.read {
+            properties = superProperties
+        }
+        return properties
+    }
+
+    /**
+       Clears all currently set super properties.
+       */
+    public func clearSuperProperties() {
+        trackingQueue.async { [weak self] in
+            guard let self = self else { return }
+            self.superProperties = self.trackInstance.clearSuperProperties(self.superProperties)
+            MixpanelPersistence.saveSuperProperties(
+                superProperties: self.superProperties, instanceName: self.name)
+        }
+    }
+
+    /**
+       Registers super properties, overwriting ones that have already been set.
+    
+       Super properties, once registered, are automatically sent as properties for
+       all event tracking calls. They save you having to maintain and add a common
+       set of properties to your events.
+       Property keys must be String objects and the supported value types need to conform to MixpanelType.
+       MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
+    
+       - parameter properties: properties dictionary
+       */
+    public func registerSuperProperties(_ properties: Properties) {
+        trackingQueue.async { [weak self] in
+            guard let self = self else { return }
+            let updatedSuperProperties = self.trackInstance.registerSuperProperties(
+                properties,
+                superProperties: self.superProperties)
+            self.readWriteLock.write {
+                self.superProperties = updatedSuperProperties
+            }
+            self.readWriteLock.read {
+                MixpanelPersistence.saveSuperProperties(
+                    superProperties: self.superProperties, instanceName: self.name)
+            }
+        }
+    }
+
+    /**
+       Registers super properties without overwriting ones that have already been set,
+       unless the existing value is equal to defaultValue. defaultValue is optional.
+    
+       Property keys must be String objects and the supported value types need to conform to MixpanelType.
+       MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
+    
+       - parameter properties:   properties dictionary
+       - parameter defaultValue: Optional. overwrite existing properties that have this value
+       */
+    public func registerSuperPropertiesOnce(
+        _ properties: Properties,
+        defaultValue: MixpanelType? = nil
+    ) {
+        trackingQueue.async { [weak self] in
+            guard let self = self else { return }
+            let updatedSuperProperties = self.trackInstance.registerSuperPropertiesOnce(
+                properties,
+                superProperties: self.superProperties,
+                defaultValue: defaultValue)
+            self.readWriteLock.write {
+                self.superProperties = updatedSuperProperties
+            }
+            self.readWriteLock.read {
+                MixpanelPersistence.saveSuperProperties(
+                    superProperties: self.superProperties, instanceName: self.name)
+            }
+        }
+    }
+
+    /**
+       Removes a previously registered super property.
+    
+       As an alternative to clearing all properties, unregistering specific super
+       properties prevents them from being recorded on future events. This operation
+       does not affect the value of other super properties. Any property name that is
+       not registered is ignored.
+       Note that after removing a super property, events will show the attribute as
+       having the value `undefined` in Mixpanel until a new value is
+       registered.
+    
+       - parameter propertyName: array of property name strings to remove
+       */
+    public func unregisterSuperProperty(_ propertyName: String) {
+        trackingQueue.async { [weak self] in
+            guard let self = self else { return }
+            let updatedSuperProperties = self.trackInstance.unregisterSuperProperty(
+                propertyName,
+                superProperties: self.superProperties)
+            self.readWriteLock.write {
+                self.superProperties = updatedSuperProperties
+            }
+            self.readWriteLock.read {
+                MixpanelPersistence.saveSuperProperties(
+                    superProperties: self.superProperties, instanceName: self.name)
+            }
+        }
+    }
+
+    /**
+       Updates a super property atomically. The update function
+    
+       - parameter update: closure to apply to super properties
+       */
+    func updateSuperProperty(
+        _ update: @escaping (_ superproperties: inout InternalProperties) -> Void
+    ) {
+        trackingQueue.async { [weak self] in
+            guard let self = self else { return }
+            var superPropertiesShadow = self.superProperties
+            self.trackInstance.updateSuperProperty(
+                update,
+                superProperties: &superPropertiesShadow)
+            self.readWriteLock.write {
+                self.superProperties = superPropertiesShadow
+            }
+            self.readWriteLock.read {
+                MixpanelPersistence.saveSuperProperties(
+                    superProperties: self.superProperties, instanceName: self.name)
+            }
+        }
+    }
+
+    /**
+       Convenience method to set a single group the user belongs to.
+    
+       - parameter groupKey: The property name associated with this group type (must already have been set up).
+       - parameter groupID: The group the user belongs to.
+       */
+    public func setGroup(groupKey: String, groupID: MixpanelType) {
+        if hasOptedOutTracking() {
+            return
+        }
+
+        setGroup(groupKey: groupKey, groupIDs: [groupID])
+    }
+
+    /**
+       Set the groups this user belongs to.
+    
+       - parameter groupKey: The property name associated with this group type (must already have been set up).
+       - parameter groupIDs: The list of groups the user belongs to.
+       */
+    public func setGroup(groupKey: String, groupIDs: [MixpanelType]) {
+        if hasOptedOutTracking() {
+            return
+        }
+
+        let properties = [groupKey: groupIDs]
+        self.registerSuperProperties(properties)
+        people.set(properties: properties)
+    }
+
+    /**
+       Add a group to this user's membership for a particular group key
+    
+       - parameter groupKey: The property name associated with this group type (must already have been set up).
+       - parameter groupID: The new group the user belongs to.
+       */
+    public func addGroup(groupKey: String, groupID: MixpanelType) {
+        if hasOptedOutTracking() {
+            return
+        }
+
+        updateSuperProperty { superProperties in
+            guard let oldValue = superProperties[groupKey] else {
+                superProperties[groupKey] = [groupID]
+                self.people.set(properties: [groupKey: [groupID]])
+                return
+            }
+
+            if let oldValue = oldValue as? [MixpanelType] {
+                var vals = oldValue
+                if !vals.contains(where: { $0.equals(rhs: groupID) }) {
+                    vals.append(groupID)
+                    superProperties[groupKey] = vals
+                }
+            } else {
+                superProperties[groupKey] = [oldValue, groupID]
+            }
+
+            // This is a best effort--if the people property is not already a list, this call does nothing.
+            self.people.union(properties: [groupKey: [groupID]])
+        }
+    }
+
+    /**
+       Remove a group from this user's membership for a particular group key
+    
+       - parameter groupKey: The property name associated with this group type (must already have been set up).
+       - parameter groupID: The group value to remove.
+       */
+    public func removeGroup(groupKey: String, groupID: MixpanelType) {
+        if hasOptedOutTracking() {
+            return
+        }
+
+        updateSuperProperty { (superProperties) -> Void in
+            guard let oldValue = superProperties[groupKey] else {
+                return
+            }
+
+            guard let vals = oldValue as? [MixpanelType] else {
+                superProperties.removeValue(forKey: groupKey)
+                self.people.unset(properties: [groupKey])
+                return
+            }
+
+            if vals.count < 2 {
+                superProperties.removeValue(forKey: groupKey)
+                self.people.unset(properties: [groupKey])
+                return
+            }
+
+            superProperties[groupKey] = vals.filter { !$0.equals(rhs: groupID) }
+            self.people.remove(properties: [groupKey: groupID])
+        }
+    }
+
+    /**
+       Opt out tracking.
+    
+       This method is used to opt out tracking. This causes all events and people request no longer
+       to be sent back to the Mixpanel server.
+       */
+    public func optOutTracking() {
+        trackingQueue.async { [weak self] in
+            guard let self = self else { return }
+            if self.people.distinctId != nil {
+                self.people.deleteUser()
+                self.people.clearCharges()
+                self.flush()
+            }
+            self.readWriteLock.write { [weak self] in
+                guard let self = self else {
+                    return
+                }
+
+                self.alias = nil
+                self.people.distinctId = nil
+                self.userId = nil
+                self.anonymousId = self.defaultDeviceId()
+                self.distinctId = self.addPrefixToDeviceId(deviceId: self.anonymousId)
+                self.hadPersistedDistinctId = true
+                self.superProperties = InternalProperties()
+                MixpanelPersistence.saveTimedEvents(
+                    timedEvents: InternalProperties(), instanceName: self.name)
+            }
+            self.archive()
+            self.readWriteLock.write {
+                self.optOutStatus = true
+            }
+            self.readWriteLock.read {
+                MixpanelPersistence.saveOptOutStatusFlag(value: self.optOutStatus!, instanceName: self.name)
+            }
+
+            // Identity just changed (distinctId was regenerated above). Clear in-memory feature
+            // flag state and the on-disk cache from the prior identity so subsequent lookups
+            // don't serve stale variants. Mirrors `identify()` and `setContext()`. We deliberately
+            // do NOT call `loadFlags()` here — opt-out semantically means "stop tracking", and
+            // re-fetching flags under the new anon identity would defeat that intent. The next
+            // `optInTracking()` will restore the normal fetch flow.
+            if let flagManager = self.flags as? FeatureFlagManager {
+                flagManager.reset()
+            }
+        }
+    }
+
+    /**
+       Opt in tracking.
+    
+       Use this method to opt in an already opted out user from tracking. People updates and track calls will be
+       sent to Mixpanel after using this method.
+    
+       This method will internally track an opt in event to your project.
+    
+       - parameter distinctId: an optional string to use as the distinct ID for events
+       - parameter properties: an optional properties dictionary that could be passed to add properties to the opt-in event
+       that is sent to Mixpanel
+       */
+    public func optInTracking(distinctId: String? = nil, properties: Properties? = nil) {
+        trackingQueue.async { [weak self] in
+            guard let self = self else { return }
+            self.readWriteLock.write {
+                self.optOutStatus = false
+            }
+            self.readWriteLock.read {
+                MixpanelPersistence.saveOptOutStatusFlag(value: self.optOutStatus!, instanceName: self.name)
+            }
+            if let distinctId = distinctId {
+                self.identify(distinctId: distinctId)
+            }
+            self.track(event: "$opt_in", properties: properties)
+        }
+
+    }
+
+    /**
+       Returns if the current user has opted out tracking.
+    
+       - returns: the current super opted out tracking status
+       */
+    public func hasOptedOutTracking() -> Bool {
+        var optOutStatusShadow: Bool?
+        readWriteLock.read {
+            optOutStatusShadow = optOutStatus
+        }
+        return optOutStatusShadow ?? false
+    }
+
+    // MARK: - AEDelegate
+    func increment(property: String, by: Double) {
+        people?.increment(property: property, by: by)
+    }
+
+    func setOnce(properties: Properties) {
+        people?.setOnce(properties: properties)
+    }
 
 }

--- a/Sources/MixpanelLogger.swift
+++ b/Sources/MixpanelLogger.swift
@@ -11,150 +11,150 @@ import Foundation
 /// This defines the various levels of logging that a message may be tagged with. This allows hiding and
 /// showing different logging levels at run time depending on the environment
 public enum MixpanelLogLevel: String {
-  /// MixpanelLogging displays *all* logs and additional debug information that may be useful to a developer
-  case debug
+    /// MixpanelLogging displays *all* logs and additional debug information that may be useful to a developer
+    case debug
 
-  /// MixpanelLogging displays *all* logs (**except** debug)
-  case info
+    /// MixpanelLogging displays *all* logs (**except** debug)
+    case info
 
-  /// MixpanelLogging displays *only* warnings and above
-  case warning
+    /// MixpanelLogging displays *only* warnings and above
+    case warning
 
-  /// MixpanelLogging displays *only* errors and above
-  case error
+    /// MixpanelLogging displays *only* errors and above
+    case error
 }
 
 /// This holds all the data for each log message, since the formatting is up to each
 /// logging object. It is a simple bag of data
 public struct MixpanelLogMessage {
-  /// The file where this log message was created
-  public let file: String
+    /// The file where this log message was created
+    public let file: String
 
-  /// The function where this log message was created
-  public let function: String
+    /// The function where this log message was created
+    public let function: String
 
-  /// The text of the log message
-  public let text: String
+    /// The text of the log message
+    public let text: String
 
-  /// The level of the log message
-  public let level: MixpanelLogLevel
+    /// The level of the log message
+    public let level: MixpanelLogLevel
 
-  init(path: String, function: String, text: String, level: MixpanelLogLevel) {
-    if let file = path.components(separatedBy: "/").last {
-      self.file = file
-    } else {
-      self.file = path
+    init(path: String, function: String, text: String, level: MixpanelLogLevel) {
+        if let file = path.components(separatedBy: "/").last {
+            self.file = file
+        } else {
+            self.file = path
+        }
+        self.function = function
+        self.text = text
+        self.level = level
     }
-    self.function = function
-    self.text = text
-    self.level = level
-  }
 }
 
 /// Any object that conforms to this protocol may log messages
 public protocol MixpanelLogging {
-  func addMessage(message: MixpanelLogMessage)
+    func addMessage(message: MixpanelLogMessage)
 }
 
 public class MixpanelLogger {
-  private static var loggers = [MixpanelLogging]()
-  private static var enabledLevels = Set<MixpanelLogLevel>()
-  private static let readWriteLock: ReadWriteLock = ReadWriteLock(label: "loggerLock")
+    private static var loggers = [MixpanelLogging]()
+    private static var enabledLevels = Set<MixpanelLogLevel>()
+    private static let readWriteLock: ReadWriteLock = ReadWriteLock(label: "loggerLock")
 
-  /// Add a `MixpanelLogging` object to receive all log messages
-  public class func addLogging(_ logging: MixpanelLogging) {
-    readWriteLock.write {
-      loggers.append(logging)
+    /// Add a `MixpanelLogging` object to receive all log messages
+    public class func addLogging(_ logging: MixpanelLogging) {
+        readWriteLock.write {
+            loggers.append(logging)
+        }
     }
-  }
 
-  /// Enable log messages of a specific `LogLevel` to be added to the log
-  class func enableLevel(_ level: MixpanelLogLevel) {
-    readWriteLock.write {
-      enabledLevels.insert(level)
+    /// Enable log messages of a specific `LogLevel` to be added to the log
+    class func enableLevel(_ level: MixpanelLogLevel) {
+        readWriteLock.write {
+            enabledLevels.insert(level)
+        }
     }
-  }
 
-  /// Disable log messages of a specific `LogLevel` to prevent them from being logged
-  class func disableLevel(_ level: MixpanelLogLevel) {
-    readWriteLock.write {
-      enabledLevels.remove(level)
+    /// Disable log messages of a specific `LogLevel` to prevent them from being logged
+    class func disableLevel(_ level: MixpanelLogLevel) {
+        readWriteLock.write {
+            enabledLevels.remove(level)
+        }
     }
-  }
 
-  /// debug: Adds a debug message to the Mixpanel log
-  /// - Parameter message: The message to be added to the log
-  class func debug(
-    message: @autoclosure () -> Any, _ path: String = #file, _ function: String = #function
-  ) {
-    var enabledLevels = Set<MixpanelLogLevel>()
-    readWriteLock.read {
-      enabledLevels = self.enabledLevels
+    /// debug: Adds a debug message to the Mixpanel log
+    /// - Parameter message: The message to be added to the log
+    class func debug(
+        message: @autoclosure () -> Any, _ path: String = #file, _ function: String = #function
+    ) {
+        var enabledLevels = Set<MixpanelLogLevel>()
+        readWriteLock.read {
+            enabledLevels = self.enabledLevels
+        }
+        guard enabledLevels.contains(.debug) else { return }
+        forwardLogMessage(
+            MixpanelLogMessage(
+                path: path, function: function, text: "\(message())",
+                level: .debug))
     }
-    guard enabledLevels.contains(.debug) else { return }
-    forwardLogMessage(
-      MixpanelLogMessage(
-        path: path, function: function, text: "\(message())",
-        level: .debug))
-  }
 
-  /// info: Adds an informational message to the Mixpanel log
-  /// - Parameter message: The message to be added to the log
-  class func info(
-    message: @autoclosure () -> Any, _ path: String = #file, _ function: String = #function
-  ) {
-    var enabledLevels = Set<MixpanelLogLevel>()
-    readWriteLock.read {
-      enabledLevels = self.enabledLevels
+    /// info: Adds an informational message to the Mixpanel log
+    /// - Parameter message: The message to be added to the log
+    class func info(
+        message: @autoclosure () -> Any, _ path: String = #file, _ function: String = #function
+    ) {
+        var enabledLevels = Set<MixpanelLogLevel>()
+        readWriteLock.read {
+            enabledLevels = self.enabledLevels
+        }
+        guard enabledLevels.contains(.info) else { return }
+        forwardLogMessage(
+            MixpanelLogMessage(
+                path: path, function: function, text: "\(message())",
+                level: .info))
     }
-    guard enabledLevels.contains(.info) else { return }
-    forwardLogMessage(
-      MixpanelLogMessage(
-        path: path, function: function, text: "\(message())",
-        level: .info))
-  }
 
-  /// warn: Adds a warning message to the Mixpanel log
-  /// - Parameter message: The message to be added to the log
-  class func warn(
-    message: @autoclosure () -> Any, _ path: String = #file, _ function: String = #function
-  ) {
-    var enabledLevels = Set<MixpanelLogLevel>()
-    readWriteLock.read {
-      enabledLevels = self.enabledLevels
+    /// warn: Adds a warning message to the Mixpanel log
+    /// - Parameter message: The message to be added to the log
+    class func warn(
+        message: @autoclosure () -> Any, _ path: String = #file, _ function: String = #function
+    ) {
+        var enabledLevels = Set<MixpanelLogLevel>()
+        readWriteLock.read {
+            enabledLevels = self.enabledLevels
+        }
+        guard enabledLevels.contains(.warning) else { return }
+        forwardLogMessage(
+            MixpanelLogMessage(
+                path: path, function: function, text: "\(message())",
+                level: .warning))
     }
-    guard enabledLevels.contains(.warning) else { return }
-    forwardLogMessage(
-      MixpanelLogMessage(
-        path: path, function: function, text: "\(message())",
-        level: .warning))
-  }
 
-  /// error: Adds an error message to the Mixpanel log
-  /// - Parameter message: The message to be added to the log
-  class func error(
-    message: @autoclosure () -> Any, _ path: String = #file, _ function: String = #function
-  ) {
-    var enabledLevels = Set<MixpanelLogLevel>()
-    readWriteLock.read {
-      enabledLevels = self.enabledLevels
+    /// error: Adds an error message to the Mixpanel log
+    /// - Parameter message: The message to be added to the log
+    class func error(
+        message: @autoclosure () -> Any, _ path: String = #file, _ function: String = #function
+    ) {
+        var enabledLevels = Set<MixpanelLogLevel>()
+        readWriteLock.read {
+            enabledLevels = self.enabledLevels
+        }
+        guard enabledLevels.contains(.error) else { return }
+        forwardLogMessage(
+            MixpanelLogMessage(
+                path: path, function: function, text: "\(message())",
+                level: .error))
     }
-    guard enabledLevels.contains(.error) else { return }
-    forwardLogMessage(
-      MixpanelLogMessage(
-        path: path, function: function, text: "\(message())",
-        level: .error))
-  }
 
-  /// This forwards a `MixpanelLogMessage` to each logger that has been added
-  class private func forwardLogMessage(_ message: MixpanelLogMessage) {
-    // Forward the log message to every registered MixpanelLogging instance
-    var loggers = [MixpanelLogging]()
-    readWriteLock.read {
-      loggers = self.loggers
+    /// This forwards a `MixpanelLogMessage` to each logger that has been added
+    class private func forwardLogMessage(_ message: MixpanelLogMessage) {
+        // Forward the log message to every registered MixpanelLogging instance
+        var loggers = [MixpanelLogging]()
+        readWriteLock.read {
+            loggers = self.loggers
+        }
+        readWriteLock.write {
+            loggers.forEach { $0.addMessage(message: message) }
+        }
     }
-    readWriteLock.write {
-      loggers.forEach { $0.addMessage(message: message) }
-    }
-  }
 }

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -34,41 +34,41 @@ import Foundation
 /// If `identify` may be called with the same persisted distinctId (no change),
 /// call `mp.flags.loadFlags()` explicitly to ensure flags are fetched.
 public struct FeatureFlagOptions {
-  /// Whether feature flags are enabled. Defaults to `false`.
-  public let enabled: Bool
+    /// Whether feature flags are enabled. Defaults to `false`.
+    public let enabled: Bool
 
-  /// Custom context dictionary sent with flag fetch requests.
-  public let context: [String: Any]
+    /// Custom context dictionary sent with flag fetch requests.
+    public let context: [String: Any]
 
-  /// Whether the SDK should prefetch feature flags during initialization.
-  /// Defaults to `true`.
-  ///
-  /// Set to `false` if you need to call `identify` before the first flag fetch,
-  /// then manually trigger loading via `flags.loadFlags()`.
-  public let prefetchFlags: Bool
+    /// Whether the SDK should prefetch feature flags during initialization.
+    /// Defaults to `true`.
+    ///
+    /// Set to `false` if you need to call `identify` before the first flag fetch,
+    /// then manually trigger loading via `flags.loadFlags()`.
+    public let prefetchFlags: Bool
 
-  /// Strategy used to resolve flag variants relative to the on-disk persistence layer and
-  /// the network. Defaults to `.networkOnly` — variant lookups always wait for the network
-  /// call, matching behavior prior to the introduction of variant persistence.
-  ///
-  /// Persistence behavior is derived directly from this policy:
-  /// - `.networkOnly` — no persistence. The on-disk blob is also wiped at init if present
-  ///   (so toggling from a persisting policy back to `.networkOnly` cleans up after itself).
-  /// - `.persistenceUntilNetworkSuccess(persistenceTtl:)` / `.networkFirst(persistenceTtl:)` — successful
-  ///   fetches write to disk; persisted variants are read on init.
-  public let variantLookupPolicy: VariantLookupPolicy
+    /// Strategy used to resolve flag variants relative to the on-disk persistence layer and
+    /// the network. Defaults to `.networkOnly` — variant lookups always wait for the network
+    /// call, matching behavior prior to the introduction of variant persistence.
+    ///
+    /// Persistence behavior is derived directly from this policy:
+    /// - `.networkOnly` — no persistence. The on-disk blob is also wiped at init if present
+    ///   (so toggling from a persisting policy back to `.networkOnly` cleans up after itself).
+    /// - `.persistenceUntilNetworkSuccess(persistenceTtl:)` / `.networkFirst(persistenceTtl:)` — successful
+    ///   fetches write to disk; persisted variants are read on init.
+    public let variantLookupPolicy: VariantLookupPolicy
 
-  public init(
-    enabled: Bool = false,
-    context: [String: Any] = [:],
-    prefetchFlags: Bool = true,
-    variantLookupPolicy: VariantLookupPolicy = .networkOnly
-  ) {
-    self.enabled = enabled
-    self.context = context
-    self.prefetchFlags = prefetchFlags
-    self.variantLookupPolicy = variantLookupPolicy
-  }
+    public init(
+        enabled: Bool = false,
+        context: [String: Any] = [:],
+        prefetchFlags: Bool = true,
+        variantLookupPolicy: VariantLookupPolicy = .networkOnly
+    ) {
+        self.enabled = enabled
+        self.context = context
+        self.prefetchFlags = prefetchFlags
+        self.variantLookupPolicy = variantLookupPolicy
+    }
 }
 
 /// Strategy for resolving feature flag variants relative to the on-disk persistence layer
@@ -97,199 +97,200 @@ public struct FeatureFlagOptions {
 /// `defaultTTL` (24 hours) — equivalent to passing
 /// `persistenceTtl: VariantLookupPolicy.defaultTTL`.
 public enum VariantLookupPolicy {
-  case networkOnly
-  case persistenceUntilNetworkSuccess(persistenceTtl: TimeInterval)
-  case networkFirst(persistenceTtl: TimeInterval)
+    case networkOnly
+    case persistenceUntilNetworkSuccess(persistenceTtl: TimeInterval)
+    case networkFirst(persistenceTtl: TimeInterval)
 
-  /// Default time-to-live for persisted variants when no TTL is specified: 24 hours.
-  public static let defaultTTL: TimeInterval = 24 * 60 * 60
+    /// Default time-to-live for persisted variants when no TTL is specified: 24 hours.
+    public static let defaultTTL: TimeInterval = 24 * 60 * 60
 
-  /// Convenience constructor — equivalent to
-  /// `.persistenceUntilNetworkSuccess(persistenceTtl: VariantLookupPolicy.defaultTTL)`.
-  public static func persistenceUntilNetworkSuccess() -> VariantLookupPolicy {
-    return .persistenceUntilNetworkSuccess(persistenceTtl: defaultTTL)
-  }
-
-  /// Convenience constructor — equivalent to
-  /// `.networkFirst(persistenceTtl: VariantLookupPolicy.defaultTTL)`.
-  public static func networkFirst() -> VariantLookupPolicy {
-    return .networkFirst(persistenceTtl: defaultTTL)
-  }
-
-  /// Resolves the policy the SDK should actually use given what the developer configured.
-  /// Substitutes `.networkOnly` when the requested policy is a persisting one with non-
-  /// positive `persistenceTtl`, since "persist on every fetch but the TTL makes nothing ever
-  /// serve" does no useful work — the developer almost certainly meant "no persistence." Logs
-  /// a warning when the substitution happens.
-  ///
-  /// Called once at FeatureFlagManager init; downstream code can treat the returned policy
-  /// as canonical.
-  internal static func effective(_ requested: VariantLookupPolicy) -> VariantLookupPolicy {
-    let persistenceTtl: TimeInterval
-    switch requested {
-    case .networkOnly:
-      return requested
-    case .persistenceUntilNetworkSuccess(let t), .networkFirst(let t):
-      persistenceTtl = t
+    /// Convenience constructor — equivalent to
+    /// `.persistenceUntilNetworkSuccess(persistenceTtl: VariantLookupPolicy.defaultTTL)`.
+    public static func persistenceUntilNetworkSuccess() -> VariantLookupPolicy {
+        return .persistenceUntilNetworkSuccess(persistenceTtl: defaultTTL)
     }
-    if persistenceTtl <= 0 {
-      MixpanelLogger.warn(
-        message:
-          "Non-positive persistenceTtl (\(persistenceTtl)s) on \(requested); falling back to networkOnly since persistence with no meaningful TTL does no useful work.")
-      return .networkOnly
+
+    /// Convenience constructor — equivalent to
+    /// `.networkFirst(persistenceTtl: VariantLookupPolicy.defaultTTL)`.
+    public static func networkFirst() -> VariantLookupPolicy {
+        return .networkFirst(persistenceTtl: defaultTTL)
     }
-    return requested
-  }
+
+    /// Resolves the policy the SDK should actually use given what the developer configured.
+    /// Substitutes `.networkOnly` when the requested policy is a persisting one with non-
+    /// positive `persistenceTtl`, since "persist on every fetch but the TTL makes nothing ever
+    /// serve" does no useful work — the developer almost certainly meant "no persistence." Logs
+    /// a warning when the substitution happens.
+    ///
+    /// Called once at FeatureFlagManager init; downstream code can treat the returned policy
+    /// as canonical.
+    internal static func effective(_ requested: VariantLookupPolicy) -> VariantLookupPolicy {
+        let persistenceTtl: TimeInterval
+        switch requested {
+            case .networkOnly:
+                return requested
+            case .persistenceUntilNetworkSuccess(let t), .networkFirst(let t):
+                persistenceTtl = t
+        }
+        if persistenceTtl <= 0 {
+            MixpanelLogger.warn(
+                message:
+                    "Non-positive persistenceTtl (\(persistenceTtl)s) on \(requested); falling back to networkOnly since persistence with no meaningful TTL does no useful work."
+            )
+            return .networkOnly
+        }
+        return requested
+    }
 }
 
 public class MixpanelOptions {
-  /// Property keys that ingestion or identity resolution require and that will never be
-  /// stripped by ``excludeProperties``, even if a customer lists them. Single source of truth
-  /// for both the runtime filter (see `Track.applyExcludeProperties`) and the documentation.
-  public static let reservedPropertyKeys: Set<String> = [
-    "token", "time", "distinct_id", "$device_id", "$user_id", "$had_persisted_distinct_id",
-  ]
+    /// Property keys that ingestion or identity resolution require and that will never be
+    /// stripped by ``excludeProperties``, even if a customer lists them. Single source of truth
+    /// for both the runtime filter (see `Track.applyExcludeProperties`) and the documentation.
+    public static let reservedPropertyKeys: Set<String> = [
+        "token", "time", "distinct_id", "$device_id", "$user_id", "$had_persisted_distinct_id",
+    ]
 
-  public let token: String
-  public let flushInterval: Double
-  public let instanceName: String?
-  public let trackAutomaticEvents: Bool
-  public let optOutTrackingByDefault: Bool
-  public let useUniqueDistinctId: Bool
-  public let superProperties: Properties?
-  public let serverURL: String?
-  public let proxyServerConfig: ProxyServerConfig?
-  public let useGzipCompression: Bool
+    public let token: String
+    public let flushInterval: Double
+    public let instanceName: String?
+    public let trackAutomaticEvents: Bool
+    public let optOutTrackingByDefault: Bool
+    public let useUniqueDistinctId: Bool
+    public let superProperties: Properties?
+    public let serverURL: String?
+    public let proxyServerConfig: ProxyServerConfig?
+    public let useGzipCompression: Bool
 
-  /// Property keys that will be stripped from outgoing event and People payloads before they
-  /// are persisted and sent to Mixpanel. Defaults to empty (no filtering, zero per-payload
-  /// overhead).
-  ///
-  /// Use this to reduce payload size or to suppress properties the project has no interest in.
-  /// Matching is **exact and case-sensitive**.
-  ///
-  /// Keys in ``MixpanelOptions/reservedPropertyKeys`` are never stripped, even if listed —
-  /// they are required for ingestion and identity resolution.
-  ///
-  /// **Scope:**
-  /// - **Events** — applied at the persistence chokepoint, covering super properties, caller
-  ///   properties, and SDK auto-properties uniformly.
-  /// - **People `$set` and `$set_once`** — applied after the SDK merges
-  ///   `AutomaticProperties.peopleProperties` (the auto-injected `$ios_*` device keys) so
-  ///   those auto-injected keys are subject to the same exclude set as event auto-properties.
-  ///
-  /// **Not in scope:**
-  /// - Other People operators (`$add`, `$append`, `$union`, `$unset`, `$merge`, `$remove`,
-  ///   `$delete`) are pass-through. Their property keys are operands rather than a bag to
-  ///   mutate, and filtering inside them would silently change semantics (e.g. dropping a
-  ///   name from an `$unset` list).
-  /// - **Group updates** never merge auto-properties, so there is nothing the filter would
-  ///   contribute that the caller couldn't omit themselves.
-  /// - **`$mp_metadata`** is a sibling of `properties` in the event envelope and is
-  ///   structurally outside the filter's scope by design.
-  ///
-  /// **Recommended: do not strip `mp_lib` or `$lib_version`.** Mixpanel does not need them
-  /// for ingestion or identity resolution, so stripping them is permitted — but they are how
-  /// Mixpanel identifies which SDK (and which version) produced an event. Removing them
-  /// limits reporting accuracy (e.g. per-platform breakdowns) and makes it harder for support
-  /// to debug issues on your project. If either key is included here, the SDK logs a warning
-  /// at instance creation time.
-  public let excludeProperties: Set<String>
-  @available(*, deprecated, message: "Use featureFlagOptions.enabled instead")
-  public var featureFlagsEnabled: Bool { return featureFlagOptions.enabled }
+    /// Property keys that will be stripped from outgoing event and People payloads before they
+    /// are persisted and sent to Mixpanel. Defaults to empty (no filtering, zero per-payload
+    /// overhead).
+    ///
+    /// Use this to reduce payload size or to suppress properties the project has no interest in.
+    /// Matching is **exact and case-sensitive**.
+    ///
+    /// Keys in ``MixpanelOptions/reservedPropertyKeys`` are never stripped, even if listed —
+    /// they are required for ingestion and identity resolution.
+    ///
+    /// **Scope:**
+    /// - **Events** — applied at the persistence chokepoint, covering super properties, caller
+    ///   properties, and SDK auto-properties uniformly.
+    /// - **People `$set` and `$set_once`** — applied after the SDK merges
+    ///   `AutomaticProperties.peopleProperties` (the auto-injected `$ios_*` device keys) so
+    ///   those auto-injected keys are subject to the same exclude set as event auto-properties.
+    ///
+    /// **Not in scope:**
+    /// - Other People operators (`$add`, `$append`, `$union`, `$unset`, `$merge`, `$remove`,
+    ///   `$delete`) are pass-through. Their property keys are operands rather than a bag to
+    ///   mutate, and filtering inside them would silently change semantics (e.g. dropping a
+    ///   name from an `$unset` list).
+    /// - **Group updates** never merge auto-properties, so there is nothing the filter would
+    ///   contribute that the caller couldn't omit themselves.
+    /// - **`$mp_metadata`** is a sibling of `properties` in the event envelope and is
+    ///   structurally outside the filter's scope by design.
+    ///
+    /// **Recommended: do not strip `mp_lib` or `$lib_version`.** Mixpanel does not need them
+    /// for ingestion or identity resolution, so stripping them is permitted — but they are how
+    /// Mixpanel identifies which SDK (and which version) produced an event. Removing them
+    /// limits reporting accuracy (e.g. per-platform breakdowns) and makes it harder for support
+    /// to debug issues on your project. If either key is included here, the SDK logs a warning
+    /// at instance creation time.
+    public let excludeProperties: Set<String>
+    @available(*, deprecated, message: "Use featureFlagOptions.enabled instead")
+    public var featureFlagsEnabled: Bool { return featureFlagOptions.enabled }
 
-  @available(*, deprecated, message: "Use featureFlagOptions.context instead")
-  public var featureFlagsContext: [String: Any] { return featureFlagOptions.context }
+    @available(*, deprecated, message: "Use featureFlagOptions.context instead")
+    public var featureFlagsContext: [String: Any] { return featureFlagOptions.context }
 
-  /// Grouped configuration for feature flags behavior.
-  ///
-  /// When provided to the initializer, this takes precedence over the
-  /// `featureFlagsEnabled` and `featureFlagsContext` parameters.
-  public let featureFlagOptions: FeatureFlagOptions
+    /// Grouped configuration for feature flags behavior.
+    ///
+    /// When provided to the initializer, this takes precedence over the
+    /// `featureFlagsEnabled` and `featureFlagsContext` parameters.
+    public let featureFlagOptions: FeatureFlagOptions
 
-  /// A closure that provides a custom device ID.
-  ///
-  /// Use this to control device ID generation instead of relying on the SDK's default behavior
-  /// (random UUID or IDFV based on `useUniqueDistinctId`).
-  ///
-  /// **Important: Choose your device ID strategy up front.** This closure is called:
-  /// - Once during initialization (if no persisted identity exists)
-  /// - On each call to `reset()`
-  /// - On each call to `optOutTracking()`
-  ///
-  /// **Controlling Reset Behavior:**
-  /// - Return the **same value** each time = Device ID never changes (persistent identity)
-  /// - Return a **different value** each time = Device ID changes on reset (ephemeral identity)
-  /// - Return `nil` = Use SDK's default device ID (useful for error handling)
-  ///
-  /// **Thread Safety:** This closure is called synchronously while holding internal locks.
-  /// Keep implementations fast and non-blocking. For Keychain or network-fetched IDs,
-  /// retrieve and cache the value at app launch, then return the cached value from the provider.
-  ///
-  /// **Warning:** Adding a `deviceIdProvider` to an existing app that previously used the default
-  /// device ID may cause identity discontinuity. The SDK will log a warning if the provider
-  /// returns a value different from the persisted anonymous ID.
-  ///
-  /// **Example - Persistent Device ID (cached at launch):**
-  /// ```swift
-  /// // Cache the device ID at app launch (before Mixpanel init)
-  /// let cachedDeviceId = MyKeychainHelper.getOrCreatePersistentId()
-  ///
-  /// let options = MixpanelOptions(
-  ///     token: "YOUR_TOKEN",
-  ///     deviceIdProvider: { cachedDeviceId }  // Return cached value
-  /// )
-  /// ```
-  ///
-  /// **Example - Ephemeral Device ID (resets each time):**
-  /// ```swift
-  /// let options = MixpanelOptions(
-  ///     token: "YOUR_TOKEN",
-  ///     deviceIdProvider: {
-  ///         return UUID().uuidString
-  ///     }
-  /// )
-  /// ```
-  public let deviceIdProvider: (() -> String?)?
+    /// A closure that provides a custom device ID.
+    ///
+    /// Use this to control device ID generation instead of relying on the SDK's default behavior
+    /// (random UUID or IDFV based on `useUniqueDistinctId`).
+    ///
+    /// **Important: Choose your device ID strategy up front.** This closure is called:
+    /// - Once during initialization (if no persisted identity exists)
+    /// - On each call to `reset()`
+    /// - On each call to `optOutTracking()`
+    ///
+    /// **Controlling Reset Behavior:**
+    /// - Return the **same value** each time = Device ID never changes (persistent identity)
+    /// - Return a **different value** each time = Device ID changes on reset (ephemeral identity)
+    /// - Return `nil` = Use SDK's default device ID (useful for error handling)
+    ///
+    /// **Thread Safety:** This closure is called synchronously while holding internal locks.
+    /// Keep implementations fast and non-blocking. For Keychain or network-fetched IDs,
+    /// retrieve and cache the value at app launch, then return the cached value from the provider.
+    ///
+    /// **Warning:** Adding a `deviceIdProvider` to an existing app that previously used the default
+    /// device ID may cause identity discontinuity. The SDK will log a warning if the provider
+    /// returns a value different from the persisted anonymous ID.
+    ///
+    /// **Example - Persistent Device ID (cached at launch):**
+    /// ```swift
+    /// // Cache the device ID at app launch (before Mixpanel init)
+    /// let cachedDeviceId = MyKeychainHelper.getOrCreatePersistentId()
+    ///
+    /// let options = MixpanelOptions(
+    ///     token: "YOUR_TOKEN",
+    ///     deviceIdProvider: { cachedDeviceId }  // Return cached value
+    /// )
+    /// ```
+    ///
+    /// **Example - Ephemeral Device ID (resets each time):**
+    /// ```swift
+    /// let options = MixpanelOptions(
+    ///     token: "YOUR_TOKEN",
+    ///     deviceIdProvider: {
+    ///         return UUID().uuidString
+    ///     }
+    /// )
+    /// ```
+    public let deviceIdProvider: (() -> String?)?
 
-  public init(
-    token: String,
-    flushInterval: Double = 60,
-    instanceName: String? = nil,
-    trackAutomaticEvents: Bool = false,
-    optOutTrackingByDefault: Bool = false,
-    useUniqueDistinctId: Bool = false,
-    superProperties: Properties? = nil,
-    serverURL: String? = nil,
-    proxyServerConfig: ProxyServerConfig? = nil,
-    useGzipCompression: Bool = true,  // NOTE: This is a new default value!
-    featureFlagsEnabled: Bool = false,
-    featureFlagsContext: [String: Any] = [:],
-    deviceIdProvider: (() -> String?)? = nil,
-    featureFlagOptions: FeatureFlagOptions? = nil,
-    excludeProperties: Set<String> = []
-  ) {
-    self.token = token
-    self.flushInterval = flushInterval
-    self.instanceName = instanceName
-    self.trackAutomaticEvents = trackAutomaticEvents
-    self.optOutTrackingByDefault = optOutTrackingByDefault
-    self.useUniqueDistinctId = useUniqueDistinctId
-    self.superProperties = superProperties
-    self.serverURL = serverURL
-    self.proxyServerConfig = proxyServerConfig
-    self.useGzipCompression = useGzipCompression
-    self.deviceIdProvider = deviceIdProvider
-    self.excludeProperties = excludeProperties
+    public init(
+        token: String,
+        flushInterval: Double = 60,
+        instanceName: String? = nil,
+        trackAutomaticEvents: Bool = false,
+        optOutTrackingByDefault: Bool = false,
+        useUniqueDistinctId: Bool = false,
+        superProperties: Properties? = nil,
+        serverURL: String? = nil,
+        proxyServerConfig: ProxyServerConfig? = nil,
+        useGzipCompression: Bool = true,  // NOTE: This is a new default value!
+        featureFlagsEnabled: Bool = false,
+        featureFlagsContext: [String: Any] = [:],
+        deviceIdProvider: (() -> String?)? = nil,
+        featureFlagOptions: FeatureFlagOptions? = nil,
+        excludeProperties: Set<String> = []
+    ) {
+        self.token = token
+        self.flushInterval = flushInterval
+        self.instanceName = instanceName
+        self.trackAutomaticEvents = trackAutomaticEvents
+        self.optOutTrackingByDefault = optOutTrackingByDefault
+        self.useUniqueDistinctId = useUniqueDistinctId
+        self.superProperties = superProperties
+        self.serverURL = serverURL
+        self.proxyServerConfig = proxyServerConfig
+        self.useGzipCompression = useGzipCompression
+        self.deviceIdProvider = deviceIdProvider
+        self.excludeProperties = excludeProperties
 
-    // When featureFlagOptions is explicitly provided, it takes precedence
-    if let featureFlagOptions = featureFlagOptions {
-      self.featureFlagOptions = featureFlagOptions
-    } else {
-      self.featureFlagOptions = FeatureFlagOptions(
-        enabled: featureFlagsEnabled,
-        context: featureFlagsContext
-      )
+        // When featureFlagOptions is explicitly provided, it takes precedence
+        if let featureFlagOptions = featureFlagOptions {
+            self.featureFlagOptions = featureFlagOptions
+        } else {
+            self.featureFlagOptions = FeatureFlagOptions(
+                enabled: featureFlagsEnabled,
+                context: featureFlagsContext
+            )
+        }
     }
-  }
 }

--- a/Sources/MixpanelPersistence.swift
+++ b/Sources/MixpanelPersistence.swift
@@ -9,45 +9,45 @@
 import Foundation
 
 enum LegacyArchiveType: String {
-  case events
-  case people
-  case groups
-  case properties
-  case optOutStatus
+    case events
+    case people
+    case groups
+    case properties
+    case optOutStatus
 }
 
 enum PersistenceType: String, CaseIterable {
-  case events
-  case people
-  case groups
+    case events
+    case people
+    case groups
 }
 
 struct PersistenceConstant {
-  static let unIdentifiedFlag = true
+    static let unIdentifiedFlag = true
 }
 
 struct MixpanelIdentity {
-  let distinctID: String
-  let peopleDistinctID: String?
-  let anonymousId: String?
-  let userId: String?
-  let alias: String?
-  let hadPersistedDistinctId: Bool?
+    let distinctID: String
+    let peopleDistinctID: String?
+    let anonymousId: String?
+    let userId: String?
+    let alias: String?
+    let hadPersistedDistinctId: Bool?
 }
 
 struct MixpanelUserDefaultsKeys {
-  static let suiteName = "Mixpanel"
-  static let prefix = "mixpanel"
-  static let optOutStatus = "OptOutStatus"
-  static let timedEvents = "timedEvents"
-  static let superProperties = "superProperties"
-  static let distinctID = "MPDistinctID"
-  static let peopleDistinctID = "MPPeopleDistinctID"
-  static let anonymousId = "MPAnonymousId"
-  static let userID = "MPUserId"
-  static let alias = "MPAlias"
-  static let hadPersistedDistinctId = "MPHadPersistedDistinctId"
-  static let flagsPersistence = "MPFlagsPersistence"
+    static let suiteName = "Mixpanel"
+    static let prefix = "mixpanel"
+    static let optOutStatus = "OptOutStatus"
+    static let timedEvents = "timedEvents"
+    static let superProperties = "superProperties"
+    static let distinctID = "MPDistinctID"
+    static let peopleDistinctID = "MPPeopleDistinctID"
+    static let anonymousId = "MPAnonymousId"
+    static let userID = "MPUserId"
+    static let alias = "MPAlias"
+    static let hadPersistedDistinctId = "MPHadPersistedDistinctId"
+    static let flagsPersistence = "MPFlagsPersistence"
 }
 
 /// On-disk persistence blob for the most recent successful `/flags/` response.
@@ -57,559 +57,559 @@ struct MixpanelUserDefaultsKeys {
 /// shape changes self-heal — a parse failure on read just clears the blob and the next
 /// successful fetch overwrites with the current shape.
 struct FlagsPersistenceBlob {
-  /// Time the blob was originally written.
-  let persistedAt: Date
-  /// The distinctId the variants in `response` were evaluated under. Validated on read so a
-  /// freshly-identified user can't be served the prior user's variants.
-  let distinctId: String
-  /// Raw JSON string returned by the `/flags/` endpoint. Re-parsed on read.
-  let response: String
+    /// Time the blob was originally written.
+    let persistedAt: Date
+    /// The distinctId the variants in `response` were evaluated under. Validated on read so a
+    /// freshly-identified user can't be served the prior user's variants.
+    let distinctId: String
+    /// Raw JSON string returned by the `/flags/` endpoint. Re-parsed on read.
+    let response: String
 
-  func toDictionary() -> [String: Any] {
-    return [
-      "persistedAt": Int64(persistedAt.timeIntervalSince1970 * 1000),
-      "distinctId": distinctId,
-      "response": response,
-    ]
-  }
+    func toDictionary() -> [String: Any] {
+        return [
+            "persistedAt": Int64(persistedAt.timeIntervalSince1970 * 1000),
+            "distinctId": distinctId,
+            "response": response,
+        ]
+    }
 
-  static func from(dictionary: [String: Any]) -> FlagsPersistenceBlob? {
-    guard
-      let persistedAtMillis = dictionary["persistedAt"] as? Int64
-        ?? (dictionary["persistedAt"] as? NSNumber).map({ $0.int64Value }),
-      let distinctId = dictionary["distinctId"] as? String,
-      let response = dictionary["response"] as? String
-    else { return nil }
-    return FlagsPersistenceBlob(
-      persistedAt: Date(timeIntervalSince1970: TimeInterval(persistedAtMillis) / 1000.0),
-      distinctId: distinctId,
-      response: response
-    )
-  }
+    static func from(dictionary: [String: Any]) -> FlagsPersistenceBlob? {
+        guard
+            let persistedAtMillis = dictionary["persistedAt"] as? Int64
+                ?? (dictionary["persistedAt"] as? NSNumber).map({ $0.int64Value }),
+            let distinctId = dictionary["distinctId"] as? String,
+            let response = dictionary["response"] as? String
+        else { return nil }
+        return FlagsPersistenceBlob(
+            persistedAt: Date(timeIntervalSince1970: TimeInterval(persistedAtMillis) / 1000.0),
+            distinctId: distinctId,
+            response: response
+        )
+    }
 }
 
 class MixpanelPersistence {
 
-  let instanceName: String
-  let mpdb: MPDB
-  private static let archivedClasses = [
-    NSArray.self, NSDictionary.self, NSSet.self, NSString.self, NSDate.self, NSURL.self,
-    NSNumber.self, NSNull.self,
-  ]
+    let instanceName: String
+    let mpdb: MPDB
+    private static let archivedClasses = [
+        NSArray.self, NSDictionary.self, NSSet.self, NSString.self, NSDate.self, NSURL.self,
+        NSNumber.self, NSNull.self,
+    ]
 
-  init(instanceName: String) {
-    self.instanceName = instanceName
-    mpdb = MPDB.init(token: instanceName)
-  }
-
-  deinit {
-    mpdb.close()
-  }
-
-  func closeDB() {
-    mpdb.close()
-  }
-
-  func saveEntity(_ entity: InternalProperties, type: PersistenceType, flag: Bool = false) {
-    if let data = JSONHandler.serializeJSONObject(entity) {
-      mpdb.insertRow(type, data: data, flag: flag)
-    }
-  }
-
-  func saveEntities(_ entities: Queue, type: PersistenceType, flag: Bool = false) {
-    for entity in entities {
-      saveEntity(entity, type: type)
-    }
-  }
-
-  func loadEntitiesInBatch(
-    type: PersistenceType, batchSize: Int = Int.max, flag: Bool = false,
-    excludeAutomaticEvents: Bool = false
-  ) -> [InternalProperties] {
-    var entities = mpdb.readRows(type, numRows: batchSize, flag: flag)
-    if excludeAutomaticEvents && type == .events {
-      entities = entities.filter { !($0["event"] as! String).hasPrefix("$ae_") }
-    }
-    if type == PersistenceType.people {
-      let distinctId = MixpanelPersistence.loadIdentity(instanceName: instanceName).distinctID
-      return entities.map { entityWithDistinctId($0, distinctId: distinctId) }
-    }
-    return entities
-  }
-
-  private func entityWithDistinctId(_ entity: InternalProperties, distinctId: String)
-    -> InternalProperties
-  {
-    var result = entity
-    result["$distinct_id"] = distinctId
-    return result
-  }
-
-  func removeEntitiesInBatch(type: PersistenceType, ids: [Int32]) {
-    mpdb.deleteRows(type, ids: ids)
-  }
-
-  func identifyPeople(token: String) {
-    mpdb.updateRowsFlag(.people, newFlag: !PersistenceConstant.unIdentifiedFlag)
-  }
-
-  func resetEntities() {
-    for pType in PersistenceType.allCases {
-      mpdb.deleteRows(pType, isDeleteAll: true)
-    }
-  }
-
-  static func saveOptOutStatusFlag(value: Bool, instanceName: String) {
-    guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
-      return
-    }
-    let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
-    defaults.setValue(value, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.optOutStatus)")
-    defaults.synchronize()
-  }
-
-  static func loadOptOutStatusFlag(instanceName: String) -> Bool? {
-    guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
-      return nil
-    }
-    let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
-    return defaults.object(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.optOutStatus)") as? Bool
-  }
-
-  static func saveTimedEvents(timedEvents: InternalProperties, instanceName: String) {
-    guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
-      return
-    }
-    let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
-    do {
-      let timedEventsData = try NSKeyedArchiver.archivedData(
-        withRootObject: timedEvents, requiringSecureCoding: false)
-      defaults.set(timedEventsData, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.timedEvents)")
-      defaults.synchronize()
-    } catch {
-      MixpanelLogger.warn(message: "Failed to archive timed events")
-    }
-  }
-
-  static func loadTimedEvents(instanceName: String) -> InternalProperties {
-    guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
-      return InternalProperties()
-    }
-    let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
-    guard
-      let timedEventsData = defaults.data(
-        forKey: "\(prefix)\(MixpanelUserDefaultsKeys.timedEvents)")
-    else {
-      return InternalProperties()
-    }
-    do {
-      return try NSKeyedUnarchiver.unarchivedObject(
-        ofClasses: archivedClasses, from: timedEventsData) as? InternalProperties
-        ?? InternalProperties()
-    } catch {
-      MixpanelLogger.warn(message: "Failed to unarchive timed events")
-      return InternalProperties()
-    }
-  }
-
-  static func saveSuperProperties(superProperties: InternalProperties, instanceName: String) {
-    guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
-      return
-    }
-    let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
-    do {
-      let superPropertiesData = try NSKeyedArchiver.archivedData(
-        withRootObject: superProperties, requiringSecureCoding: false)
-      defaults.set(
-        superPropertiesData, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.superProperties)")
-      defaults.synchronize()
-    } catch {
-      MixpanelLogger.warn(message: "Failed to archive super properties")
-    }
-  }
-
-  static func loadSuperProperties(instanceName: String) -> InternalProperties {
-    guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
-      return InternalProperties()
-    }
-    let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
-    guard
-      let superPropertiesData = defaults.data(
-        forKey: "\(prefix)\(MixpanelUserDefaultsKeys.superProperties)")
-    else {
-      return InternalProperties()
-    }
-    do {
-      return try NSKeyedUnarchiver.unarchivedObject(
-        ofClasses: archivedClasses, from: superPropertiesData) as? InternalProperties
-        ?? InternalProperties()
-    } catch {
-      MixpanelLogger.warn(message: "Failed to unarchive super properties")
-      return InternalProperties()
-    }
-  }
-
-  // -- Feature Flag Variant Persistence --
-  // Wire format: a JSON-serialized dictionary stored under a single per-instance key in the
-  // shared "Mixpanel" UserDefaults suite. See `FlagsPersistenceBlob` for layout.
-
-  static func saveFlagsPersistence(_ blob: FlagsPersistenceBlob, instanceName: String) {
-    guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
-      return
-    }
-    let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
-    do {
-      let data = try JSONSerialization.data(withJSONObject: blob.toDictionary(), options: [])
-      defaults.set(data, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.flagsPersistence)")
-    } catch {
-      MixpanelLogger.warn(message: "Failed to serialize flags persistence blob: \(error)")
-    }
-  }
-
-  /// Reads and validates the persisted flags blob.
-  ///
-  /// Returns `nil` when nothing is persisted or the blob is unparseable. **Self-healing:**
-  /// malformed blobs are deleted as a side effect so the next successful fetch overwrites
-  /// with the current shape — no version field needed.
-  ///
-  /// distinctId and TTL validation are intentionally left to the caller (the manager) so
-  /// the persistence layer stays format-only and the manager can apply its own policy.
-  static func loadFlagsPersistence(instanceName: String) -> FlagsPersistenceBlob? {
-    guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
-      return nil
-    }
-    let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
-    let key = "\(prefix)\(MixpanelUserDefaultsKeys.flagsPersistence)"
-    guard let data = defaults.data(forKey: key) else {
-      return nil
-    }
-    do {
-      let parsed = try JSONSerialization.jsonObject(with: data, options: [])
-      guard let dict = parsed as? [String: Any],
-            let blob = FlagsPersistenceBlob.from(dictionary: dict)
-      else {
-        MixpanelLogger.warn(message: "Persisted flags blob has unexpected shape; clearing.")
-        defaults.removeObject(forKey: key)
-        return nil
-      }
-      return blob
-    } catch {
-      MixpanelLogger.warn(message: "Failed to parse persisted flags blob; clearing. \(error)")
-      defaults.removeObject(forKey: key)
-      return nil
-    }
-  }
-
-  static func deleteFlagsPersistence(instanceName: String) {
-    guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
-      return
-    }
-    let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
-    defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.flagsPersistence)")
-  }
-
-  static func saveIdentity(_ mixpanelIdentity: MixpanelIdentity, instanceName: String) {
-    guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
-      return
-    }
-    let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
-    defaults.set(
-      mixpanelIdentity.distinctID, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.distinctID)")
-    defaults.set(
-      mixpanelIdentity.peopleDistinctID,
-      forKey: "\(prefix)\(MixpanelUserDefaultsKeys.peopleDistinctID)")
-    defaults.set(
-      mixpanelIdentity.anonymousId, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.anonymousId)")
-    defaults.set(mixpanelIdentity.userId, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.userID)")
-    defaults.set(mixpanelIdentity.alias, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.alias)")
-    defaults.set(
-      mixpanelIdentity.hadPersistedDistinctId,
-      forKey: "\(prefix)\(MixpanelUserDefaultsKeys.hadPersistedDistinctId)")
-    defaults.synchronize()
-  }
-
-  static func loadIdentity(instanceName: String) -> MixpanelIdentity {
-    guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
-      return MixpanelIdentity.init(
-        distinctID: "",
-        peopleDistinctID: nil,
-        anonymousId: nil,
-        userId: nil,
-        alias: nil,
-        hadPersistedDistinctId: nil)
-    }
-    let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
-    return MixpanelIdentity.init(
-      distinctID: defaults.string(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.distinctID)") ?? "",
-      peopleDistinctID: defaults.string(
-        forKey: "\(prefix)\(MixpanelUserDefaultsKeys.peopleDistinctID)"),
-      anonymousId: defaults.string(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.anonymousId)"),
-      userId: defaults.string(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.userID)"),
-      alias: defaults.string(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.alias)"),
-      hadPersistedDistinctId: defaults.bool(
-        forKey: "\(prefix)\(MixpanelUserDefaultsKeys.hadPersistedDistinctId)"))
-  }
-
-  static func deleteMPUserDefaultsData(instanceName: String) {
-    guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
-      return
-    }
-    let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
-    defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.distinctID)")
-    defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.peopleDistinctID)")
-    defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.anonymousId)")
-    defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.userID)")
-    defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.alias)")
-    defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.hadPersistedDistinctId)")
-    defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.optOutStatus)")
-    defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.timedEvents)")
-    defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.superProperties)")
-    defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.flagsPersistence)")
-    defaults.synchronize()
-  }
-
-  // code for unarchiving from legacy archive files and migrating to SQLite / NSUserDefaults persistence
-  func migrate() {
-    if !needMigration() {
-      return
-    }
-    let (
-      eventsQueue,
-      peopleQueue,
-      groupsQueue,
-      superProperties,
-      timedEvents,
-      distinctId,
-      anonymousId,
-      userId,
-      alias,
-      hadPersistedDistinctId,
-      peopleDistinctId,
-      peopleUnidentifiedQueue,
-      optOutStatus
-    ) = unarchiveFromLegacy()
-    saveEntities(eventsQueue, type: PersistenceType.events)
-    saveEntities(
-      peopleUnidentifiedQueue, type: PersistenceType.people,
-      flag: PersistenceConstant.unIdentifiedFlag)
-    saveEntities(peopleQueue, type: PersistenceType.people)
-    saveEntities(groupsQueue, type: PersistenceType.groups)
-    MixpanelPersistence.saveSuperProperties(
-      superProperties: superProperties, instanceName: instanceName)
-    MixpanelPersistence.saveTimedEvents(timedEvents: timedEvents, instanceName: instanceName)
-    MixpanelPersistence.saveIdentity(
-      MixpanelIdentity.init(
-        distinctID: distinctId,
-        peopleDistinctID: peopleDistinctId,
-        anonymousId: anonymousId,
-        userId: userId,
-        alias: alias,
-        hadPersistedDistinctId: hadPersistedDistinctId), instanceName: instanceName)
-    if let optOutFlag = optOutStatus {
-      MixpanelPersistence.saveOptOutStatusFlag(value: optOutFlag, instanceName: instanceName)
-    }
-    return
-  }
-
-  private func filePathWithType(_ type: String) -> String? {
-    let filename = "mixpanel-\(instanceName)-\(type)"
-    let manager = FileManager.default
-
-    #if os(iOS)
-      let url = manager.urls(for: .libraryDirectory, in: .userDomainMask).last
-    #else
-      let url = manager.urls(for: .cachesDirectory, in: .userDomainMask).last
-    #endif  // os(iOS)
-    guard let urlUnwrapped = url?.appendingPathComponent(filename).path else {
-      return nil
+    init(instanceName: String) {
+        self.instanceName = instanceName
+        mpdb = MPDB.init(token: instanceName)
     }
 
-    return urlUnwrapped
-  }
-
-  private func unarchiveFromLegacy() -> (
-    eventsQueue: Queue,
-    peopleQueue: Queue,
-    groupsQueue: Queue,
-    superProperties: InternalProperties,
-    timedEvents: InternalProperties,
-    distinctId: String,
-    anonymousId: String?,
-    userId: String?,
-    alias: String?,
-    hadPersistedDistinctId: Bool?,
-    peopleDistinctId: String?,
-    peopleUnidentifiedQueue: Queue,
-    optOutStatus: Bool?
-  ) {
-    let eventsQueue = unarchiveEvents()
-    let peopleQueue = unarchivePeople()
-    let groupsQueue = unarchiveGroups()
-    let optOutStatus = unarchiveOptOutStatus()
-
-    let (
-      superProperties,
-      timedEvents,
-      distinctId,
-      anonymousId,
-      userId,
-      alias,
-      hadPersistedDistinctId,
-      peopleDistinctId,
-      peopleUnidentifiedQueue
-    ) = unarchiveProperties()
-
-    if let eventsFile = filePathWithType(PersistenceType.events.rawValue) {
-      removeArchivedFile(atPath: eventsFile)
-    }
-    if let peopleFile = filePathWithType(PersistenceType.people.rawValue) {
-      removeArchivedFile(atPath: peopleFile)
-    }
-    if let groupsFile = filePathWithType(PersistenceType.groups.rawValue) {
-      removeArchivedFile(atPath: groupsFile)
-    }
-    if let propsFile = filePathWithType("properties") {
-      removeArchivedFile(atPath: propsFile)
-    }
-    if let optOutFile = filePathWithType("optOutStatus") {
-      removeArchivedFile(atPath: optOutFile)
+    deinit {
+        mpdb.close()
     }
 
-    return (
-      eventsQueue,
-      peopleQueue,
-      groupsQueue,
-      superProperties,
-      timedEvents,
-      distinctId,
-      anonymousId,
-      userId,
-      alias,
-      hadPersistedDistinctId,
-      peopleDistinctId,
-      peopleUnidentifiedQueue,
-      optOutStatus
-    )
-  }
-
-  private func unarchiveWithFilePath(_ filePath: String) -> Any? {
-    if #available(iOS 11.0, macOS 10.13, watchOS 4.0, tvOS 11.0, *) {
-      guard let data = try? Data(contentsOf: URL(fileURLWithPath: filePath)),
-        let unarchivedData = try? NSKeyedUnarchiver.unarchivedObject(
-          ofClasses: MixpanelPersistence.archivedClasses, from: data)
-      else {
-        MixpanelLogger.info(message: "Unable to read file at path: \(filePath)")
-        removeArchivedFile(atPath: filePath)
-        return nil
-      }
-      return unarchivedData
-    } else {
-      guard let unarchivedData = NSKeyedUnarchiver.unarchiveObject(withFile: filePath) else {
-        MixpanelLogger.info(message: "Unable to read file at path: \(filePath)")
-        removeArchivedFile(atPath: filePath)
-        return nil
-      }
-      return unarchivedData
-    }
-  }
-
-  private func removeArchivedFile(atPath filePath: String) {
-    do {
-      try FileManager.default.removeItem(atPath: filePath)
-    } catch let err {
-      MixpanelLogger.info(message: "Unable to remove file at path: \(filePath), error: \(err)")
-    }
-  }
-
-  private func unarchiveEvents() -> Queue {
-    let data = unarchiveWithType(PersistenceType.events.rawValue)
-    return data as? Queue ?? []
-  }
-
-  private func unarchivePeople() -> Queue {
-    let data = unarchiveWithType(PersistenceType.people.rawValue)
-    return data as? Queue ?? []
-  }
-
-  private func unarchiveGroups() -> Queue {
-    let data = unarchiveWithType(PersistenceType.groups.rawValue)
-    return data as? Queue ?? []
-  }
-
-  private func unarchiveOptOutStatus() -> Bool? {
-    return unarchiveWithType("optOutStatus") as? Bool
-  }
-
-  private func unarchiveProperties() -> (
-    InternalProperties,
-    InternalProperties,
-    String,
-    String?,
-    String?,
-    String?,
-    Bool?,
-    String?,
-    Queue
-  ) {
-    let properties = unarchiveWithType("properties") as? InternalProperties
-    let superProperties =
-      properties?["superProperties"] as? InternalProperties ?? InternalProperties()
-    let timedEvents =
-      properties?["timedEvents"] as? InternalProperties ?? InternalProperties()
-    let distinctId =
-      properties?["distinctId"] as? String ?? ""
-    let anonymousId =
-      properties?["anonymousId"] as? String ?? nil
-    let userId =
-      properties?["userId"] as? String ?? nil
-    let alias =
-      properties?["alias"] as? String ?? nil
-    let hadPersistedDistinctId =
-      properties?["hadPersistedDistinctId"] as? Bool ?? nil
-    let peopleDistinctId =
-      properties?["peopleDistinctId"] as? String ?? nil
-    let peopleUnidentifiedQueue =
-      properties?["peopleUnidentifiedQueue"] as? Queue ?? Queue()
-
-    return (
-      superProperties,
-      timedEvents,
-      distinctId,
-      anonymousId,
-      userId,
-      alias,
-      hadPersistedDistinctId,
-      peopleDistinctId,
-      peopleUnidentifiedQueue
-    )
-  }
-
-  private func unarchiveWithType(_ type: String) -> Any? {
-    let filePath = filePathWithType(type)
-    guard let path = filePath else {
-      MixpanelLogger.info(message: "bad file path, cant fetch file")
-      return nil
+    func closeDB() {
+        mpdb.close()
     }
 
-    guard let unarchivedData = unarchiveWithFilePath(path) else {
-      MixpanelLogger.info(message: "can't unarchive file")
-      return nil
+    func saveEntity(_ entity: InternalProperties, type: PersistenceType, flag: Bool = false) {
+        if let data = JSONHandler.serializeJSONObject(entity) {
+            mpdb.insertRow(type, data: data, flag: flag)
+        }
     }
 
-    return unarchivedData
-  }
+    func saveEntities(_ entities: Queue, type: PersistenceType, flag: Bool = false) {
+        for entity in entities {
+            saveEntity(entity, type: type)
+        }
+    }
 
-  private func needMigration() -> Bool {
-    return fileExists(type: LegacyArchiveType.events.rawValue)
-      || fileExists(type: LegacyArchiveType.people.rawValue)
-      || fileExists(type: LegacyArchiveType.people.rawValue)
-      || fileExists(type: LegacyArchiveType.groups.rawValue)
-      || fileExists(type: LegacyArchiveType.properties.rawValue)
-      || fileExists(type: LegacyArchiveType.optOutStatus.rawValue)
-  }
+    func loadEntitiesInBatch(
+        type: PersistenceType, batchSize: Int = Int.max, flag: Bool = false,
+        excludeAutomaticEvents: Bool = false
+    ) -> [InternalProperties] {
+        var entities = mpdb.readRows(type, numRows: batchSize, flag: flag)
+        if excludeAutomaticEvents && type == .events {
+            entities = entities.filter { !($0["event"] as! String).hasPrefix("$ae_") }
+        }
+        if type == PersistenceType.people {
+            let distinctId = MixpanelPersistence.loadIdentity(instanceName: instanceName).distinctID
+            return entities.map { entityWithDistinctId($0, distinctId: distinctId) }
+        }
+        return entities
+    }
 
-  private func fileExists(type: String) -> Bool {
-    return FileManager.default.fileExists(atPath: filePathWithType(type) ?? "")
-  }
+    private func entityWithDistinctId(_ entity: InternalProperties, distinctId: String)
+        -> InternalProperties
+    {
+        var result = entity
+        result["$distinct_id"] = distinctId
+        return result
+    }
+
+    func removeEntitiesInBatch(type: PersistenceType, ids: [Int32]) {
+        mpdb.deleteRows(type, ids: ids)
+    }
+
+    func identifyPeople(token: String) {
+        mpdb.updateRowsFlag(.people, newFlag: !PersistenceConstant.unIdentifiedFlag)
+    }
+
+    func resetEntities() {
+        for pType in PersistenceType.allCases {
+            mpdb.deleteRows(pType, isDeleteAll: true)
+        }
+    }
+
+    static func saveOptOutStatusFlag(value: Bool, instanceName: String) {
+        guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
+            return
+        }
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
+        defaults.setValue(value, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.optOutStatus)")
+        defaults.synchronize()
+    }
+
+    static func loadOptOutStatusFlag(instanceName: String) -> Bool? {
+        guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
+            return nil
+        }
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
+        return defaults.object(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.optOutStatus)") as? Bool
+    }
+
+    static func saveTimedEvents(timedEvents: InternalProperties, instanceName: String) {
+        guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
+            return
+        }
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
+        do {
+            let timedEventsData = try NSKeyedArchiver.archivedData(
+                withRootObject: timedEvents, requiringSecureCoding: false)
+            defaults.set(timedEventsData, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.timedEvents)")
+            defaults.synchronize()
+        } catch {
+            MixpanelLogger.warn(message: "Failed to archive timed events")
+        }
+    }
+
+    static func loadTimedEvents(instanceName: String) -> InternalProperties {
+        guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
+            return InternalProperties()
+        }
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
+        guard
+            let timedEventsData = defaults.data(
+                forKey: "\(prefix)\(MixpanelUserDefaultsKeys.timedEvents)")
+        else {
+            return InternalProperties()
+        }
+        do {
+            return try NSKeyedUnarchiver.unarchivedObject(
+                ofClasses: archivedClasses, from: timedEventsData) as? InternalProperties
+                ?? InternalProperties()
+        } catch {
+            MixpanelLogger.warn(message: "Failed to unarchive timed events")
+            return InternalProperties()
+        }
+    }
+
+    static func saveSuperProperties(superProperties: InternalProperties, instanceName: String) {
+        guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
+            return
+        }
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
+        do {
+            let superPropertiesData = try NSKeyedArchiver.archivedData(
+                withRootObject: superProperties, requiringSecureCoding: false)
+            defaults.set(
+                superPropertiesData, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.superProperties)")
+            defaults.synchronize()
+        } catch {
+            MixpanelLogger.warn(message: "Failed to archive super properties")
+        }
+    }
+
+    static func loadSuperProperties(instanceName: String) -> InternalProperties {
+        guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
+            return InternalProperties()
+        }
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
+        guard
+            let superPropertiesData = defaults.data(
+                forKey: "\(prefix)\(MixpanelUserDefaultsKeys.superProperties)")
+        else {
+            return InternalProperties()
+        }
+        do {
+            return try NSKeyedUnarchiver.unarchivedObject(
+                ofClasses: archivedClasses, from: superPropertiesData) as? InternalProperties
+                ?? InternalProperties()
+        } catch {
+            MixpanelLogger.warn(message: "Failed to unarchive super properties")
+            return InternalProperties()
+        }
+    }
+
+    // -- Feature Flag Variant Persistence --
+    // Wire format: a JSON-serialized dictionary stored under a single per-instance key in the
+    // shared "Mixpanel" UserDefaults suite. See `FlagsPersistenceBlob` for layout.
+
+    static func saveFlagsPersistence(_ blob: FlagsPersistenceBlob, instanceName: String) {
+        guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
+            return
+        }
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
+        do {
+            let data = try JSONSerialization.data(withJSONObject: blob.toDictionary(), options: [])
+            defaults.set(data, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.flagsPersistence)")
+        } catch {
+            MixpanelLogger.warn(message: "Failed to serialize flags persistence blob: \(error)")
+        }
+    }
+
+    /// Reads and validates the persisted flags blob.
+    ///
+    /// Returns `nil` when nothing is persisted or the blob is unparseable. **Self-healing:**
+    /// malformed blobs are deleted as a side effect so the next successful fetch overwrites
+    /// with the current shape — no version field needed.
+    ///
+    /// distinctId and TTL validation are intentionally left to the caller (the manager) so
+    /// the persistence layer stays format-only and the manager can apply its own policy.
+    static func loadFlagsPersistence(instanceName: String) -> FlagsPersistenceBlob? {
+        guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
+            return nil
+        }
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
+        let key = "\(prefix)\(MixpanelUserDefaultsKeys.flagsPersistence)"
+        guard let data = defaults.data(forKey: key) else {
+            return nil
+        }
+        do {
+            let parsed = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let dict = parsed as? [String: Any],
+                let blob = FlagsPersistenceBlob.from(dictionary: dict)
+            else {
+                MixpanelLogger.warn(message: "Persisted flags blob has unexpected shape; clearing.")
+                defaults.removeObject(forKey: key)
+                return nil
+            }
+            return blob
+        } catch {
+            MixpanelLogger.warn(message: "Failed to parse persisted flags blob; clearing. \(error)")
+            defaults.removeObject(forKey: key)
+            return nil
+        }
+    }
+
+    static func deleteFlagsPersistence(instanceName: String) {
+        guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
+            return
+        }
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
+        defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.flagsPersistence)")
+    }
+
+    static func saveIdentity(_ mixpanelIdentity: MixpanelIdentity, instanceName: String) {
+        guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
+            return
+        }
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
+        defaults.set(
+            mixpanelIdentity.distinctID, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.distinctID)")
+        defaults.set(
+            mixpanelIdentity.peopleDistinctID,
+            forKey: "\(prefix)\(MixpanelUserDefaultsKeys.peopleDistinctID)")
+        defaults.set(
+            mixpanelIdentity.anonymousId, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.anonymousId)")
+        defaults.set(mixpanelIdentity.userId, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.userID)")
+        defaults.set(mixpanelIdentity.alias, forKey: "\(prefix)\(MixpanelUserDefaultsKeys.alias)")
+        defaults.set(
+            mixpanelIdentity.hadPersistedDistinctId,
+            forKey: "\(prefix)\(MixpanelUserDefaultsKeys.hadPersistedDistinctId)")
+        defaults.synchronize()
+    }
+
+    static func loadIdentity(instanceName: String) -> MixpanelIdentity {
+        guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
+            return MixpanelIdentity.init(
+                distinctID: "",
+                peopleDistinctID: nil,
+                anonymousId: nil,
+                userId: nil,
+                alias: nil,
+                hadPersistedDistinctId: nil)
+        }
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
+        return MixpanelIdentity.init(
+            distinctID: defaults.string(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.distinctID)") ?? "",
+            peopleDistinctID: defaults.string(
+                forKey: "\(prefix)\(MixpanelUserDefaultsKeys.peopleDistinctID)"),
+            anonymousId: defaults.string(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.anonymousId)"),
+            userId: defaults.string(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.userID)"),
+            alias: defaults.string(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.alias)"),
+            hadPersistedDistinctId: defaults.bool(
+                forKey: "\(prefix)\(MixpanelUserDefaultsKeys.hadPersistedDistinctId)"))
+    }
+
+    static func deleteMPUserDefaultsData(instanceName: String) {
+        guard let defaults = UserDefaults(suiteName: MixpanelUserDefaultsKeys.suiteName) else {
+            return
+        }
+        let prefix = "\(MixpanelUserDefaultsKeys.prefix)-\(instanceName)-"
+        defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.distinctID)")
+        defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.peopleDistinctID)")
+        defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.anonymousId)")
+        defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.userID)")
+        defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.alias)")
+        defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.hadPersistedDistinctId)")
+        defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.optOutStatus)")
+        defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.timedEvents)")
+        defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.superProperties)")
+        defaults.removeObject(forKey: "\(prefix)\(MixpanelUserDefaultsKeys.flagsPersistence)")
+        defaults.synchronize()
+    }
+
+    // code for unarchiving from legacy archive files and migrating to SQLite / NSUserDefaults persistence
+    func migrate() {
+        if !needMigration() {
+            return
+        }
+        let (
+            eventsQueue,
+            peopleQueue,
+            groupsQueue,
+            superProperties,
+            timedEvents,
+            distinctId,
+            anonymousId,
+            userId,
+            alias,
+            hadPersistedDistinctId,
+            peopleDistinctId,
+            peopleUnidentifiedQueue,
+            optOutStatus
+        ) = unarchiveFromLegacy()
+        saveEntities(eventsQueue, type: PersistenceType.events)
+        saveEntities(
+            peopleUnidentifiedQueue, type: PersistenceType.people,
+            flag: PersistenceConstant.unIdentifiedFlag)
+        saveEntities(peopleQueue, type: PersistenceType.people)
+        saveEntities(groupsQueue, type: PersistenceType.groups)
+        MixpanelPersistence.saveSuperProperties(
+            superProperties: superProperties, instanceName: instanceName)
+        MixpanelPersistence.saveTimedEvents(timedEvents: timedEvents, instanceName: instanceName)
+        MixpanelPersistence.saveIdentity(
+            MixpanelIdentity.init(
+                distinctID: distinctId,
+                peopleDistinctID: peopleDistinctId,
+                anonymousId: anonymousId,
+                userId: userId,
+                alias: alias,
+                hadPersistedDistinctId: hadPersistedDistinctId), instanceName: instanceName)
+        if let optOutFlag = optOutStatus {
+            MixpanelPersistence.saveOptOutStatusFlag(value: optOutFlag, instanceName: instanceName)
+        }
+        return
+    }
+
+    private func filePathWithType(_ type: String) -> String? {
+        let filename = "mixpanel-\(instanceName)-\(type)"
+        let manager = FileManager.default
+
+        #if os(iOS)
+        let url = manager.urls(for: .libraryDirectory, in: .userDomainMask).last
+        #else
+        let url = manager.urls(for: .cachesDirectory, in: .userDomainMask).last
+        #endif  // os(iOS)
+        guard let urlUnwrapped = url?.appendingPathComponent(filename).path else {
+            return nil
+        }
+
+        return urlUnwrapped
+    }
+
+    private func unarchiveFromLegacy() -> (
+        eventsQueue: Queue,
+        peopleQueue: Queue,
+        groupsQueue: Queue,
+        superProperties: InternalProperties,
+        timedEvents: InternalProperties,
+        distinctId: String,
+        anonymousId: String?,
+        userId: String?,
+        alias: String?,
+        hadPersistedDistinctId: Bool?,
+        peopleDistinctId: String?,
+        peopleUnidentifiedQueue: Queue,
+        optOutStatus: Bool?
+    ) {
+        let eventsQueue = unarchiveEvents()
+        let peopleQueue = unarchivePeople()
+        let groupsQueue = unarchiveGroups()
+        let optOutStatus = unarchiveOptOutStatus()
+
+        let (
+            superProperties,
+            timedEvents,
+            distinctId,
+            anonymousId,
+            userId,
+            alias,
+            hadPersistedDistinctId,
+            peopleDistinctId,
+            peopleUnidentifiedQueue
+        ) = unarchiveProperties()
+
+        if let eventsFile = filePathWithType(PersistenceType.events.rawValue) {
+            removeArchivedFile(atPath: eventsFile)
+        }
+        if let peopleFile = filePathWithType(PersistenceType.people.rawValue) {
+            removeArchivedFile(atPath: peopleFile)
+        }
+        if let groupsFile = filePathWithType(PersistenceType.groups.rawValue) {
+            removeArchivedFile(atPath: groupsFile)
+        }
+        if let propsFile = filePathWithType("properties") {
+            removeArchivedFile(atPath: propsFile)
+        }
+        if let optOutFile = filePathWithType("optOutStatus") {
+            removeArchivedFile(atPath: optOutFile)
+        }
+
+        return (
+            eventsQueue,
+            peopleQueue,
+            groupsQueue,
+            superProperties,
+            timedEvents,
+            distinctId,
+            anonymousId,
+            userId,
+            alias,
+            hadPersistedDistinctId,
+            peopleDistinctId,
+            peopleUnidentifiedQueue,
+            optOutStatus
+        )
+    }
+
+    private func unarchiveWithFilePath(_ filePath: String) -> Any? {
+        if #available(iOS 11.0, macOS 10.13, watchOS 4.0, tvOS 11.0, *) {
+            guard let data = try? Data(contentsOf: URL(fileURLWithPath: filePath)),
+                let unarchivedData = try? NSKeyedUnarchiver.unarchivedObject(
+                    ofClasses: MixpanelPersistence.archivedClasses, from: data)
+            else {
+                MixpanelLogger.info(message: "Unable to read file at path: \(filePath)")
+                removeArchivedFile(atPath: filePath)
+                return nil
+            }
+            return unarchivedData
+        } else {
+            guard let unarchivedData = NSKeyedUnarchiver.unarchiveObject(withFile: filePath) else {
+                MixpanelLogger.info(message: "Unable to read file at path: \(filePath)")
+                removeArchivedFile(atPath: filePath)
+                return nil
+            }
+            return unarchivedData
+        }
+    }
+
+    private func removeArchivedFile(atPath filePath: String) {
+        do {
+            try FileManager.default.removeItem(atPath: filePath)
+        } catch let err {
+            MixpanelLogger.info(message: "Unable to remove file at path: \(filePath), error: \(err)")
+        }
+    }
+
+    private func unarchiveEvents() -> Queue {
+        let data = unarchiveWithType(PersistenceType.events.rawValue)
+        return data as? Queue ?? []
+    }
+
+    private func unarchivePeople() -> Queue {
+        let data = unarchiveWithType(PersistenceType.people.rawValue)
+        return data as? Queue ?? []
+    }
+
+    private func unarchiveGroups() -> Queue {
+        let data = unarchiveWithType(PersistenceType.groups.rawValue)
+        return data as? Queue ?? []
+    }
+
+    private func unarchiveOptOutStatus() -> Bool? {
+        return unarchiveWithType("optOutStatus") as? Bool
+    }
+
+    private func unarchiveProperties() -> (
+        InternalProperties,
+        InternalProperties,
+        String,
+        String?,
+        String?,
+        String?,
+        Bool?,
+        String?,
+        Queue
+    ) {
+        let properties = unarchiveWithType("properties") as? InternalProperties
+        let superProperties =
+            properties?["superProperties"] as? InternalProperties ?? InternalProperties()
+        let timedEvents =
+            properties?["timedEvents"] as? InternalProperties ?? InternalProperties()
+        let distinctId =
+            properties?["distinctId"] as? String ?? ""
+        let anonymousId =
+            properties?["anonymousId"] as? String ?? nil
+        let userId =
+            properties?["userId"] as? String ?? nil
+        let alias =
+            properties?["alias"] as? String ?? nil
+        let hadPersistedDistinctId =
+            properties?["hadPersistedDistinctId"] as? Bool ?? nil
+        let peopleDistinctId =
+            properties?["peopleDistinctId"] as? String ?? nil
+        let peopleUnidentifiedQueue =
+            properties?["peopleUnidentifiedQueue"] as? Queue ?? Queue()
+
+        return (
+            superProperties,
+            timedEvents,
+            distinctId,
+            anonymousId,
+            userId,
+            alias,
+            hadPersistedDistinctId,
+            peopleDistinctId,
+            peopleUnidentifiedQueue
+        )
+    }
+
+    private func unarchiveWithType(_ type: String) -> Any? {
+        let filePath = filePathWithType(type)
+        guard let path = filePath else {
+            MixpanelLogger.info(message: "bad file path, cant fetch file")
+            return nil
+        }
+
+        guard let unarchivedData = unarchiveWithFilePath(path) else {
+            MixpanelLogger.info(message: "can't unarchive file")
+            return nil
+        }
+
+        return unarchivedData
+    }
+
+    private func needMigration() -> Bool {
+        return fileExists(type: LegacyArchiveType.events.rawValue)
+            || fileExists(type: LegacyArchiveType.people.rawValue)
+            || fileExists(type: LegacyArchiveType.people.rawValue)
+            || fileExists(type: LegacyArchiveType.groups.rawValue)
+            || fileExists(type: LegacyArchiveType.properties.rawValue)
+            || fileExists(type: LegacyArchiveType.optOutStatus.rawValue)
+    }
+
+    private func fileExists(type: String) -> Bool {
+        return FileManager.default.fileExists(atPath: filePathWithType(type) ?? "")
+    }
 
 }

--- a/Sources/MixpanelType.swift
+++ b/Sources/MixpanelType.swift
@@ -12,355 +12,355 @@ import Foundation
 /// MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
 /// Numbers are not NaN or infinity
 public protocol MixpanelType: Any {
-  /**
-     Checks if this object has nested object types that Mixpanel supports.
-     */
-  func isValidNestedTypeAndValue() -> Bool
+    /**
+       Checks if this object has nested object types that Mixpanel supports.
+       */
+    func isValidNestedTypeAndValue() -> Bool
 
-  func equals(rhs: MixpanelType) -> Bool
+    func equals(rhs: MixpanelType) -> Bool
 }
 
 extension Optional: MixpanelType {
-  /**
-     Checks if this object has nested object types that Mixpanel supports.
-     */
-  public func isValidNestedTypeAndValue() -> Bool {
-    guard let val = self else { return true }  // nil is valid
-    switch val {
-    case let v as MixpanelType:
-      return v.isValidNestedTypeAndValue()
-    default:
-      // non-nil but cannot be unwrapped to MixpanelType
-      return false
+    /**
+       Checks if this object has nested object types that Mixpanel supports.
+       */
+    public func isValidNestedTypeAndValue() -> Bool {
+        guard let val = self else { return true }  // nil is valid
+        switch val {
+            case let v as MixpanelType:
+                return v.isValidNestedTypeAndValue()
+            default:
+                // non-nil but cannot be unwrapped to MixpanelType
+                return false
+        }
     }
-  }
 
-  public func equals(rhs: MixpanelType) -> Bool {
-    if let v = self as? String, rhs is String {
-      return v == rhs as! String
-    } else if let v = self as? NSString, rhs is NSString {
-      return v == rhs as! NSString
-    } else if let v = self as? NSNumber, rhs is NSNumber {
-      return v.isEqual(to: rhs as! NSNumber)
-    } else if let v = self as? Int, rhs is Int {
-      return v == rhs as! Int
-    } else if let v = self as? UInt, rhs is UInt {
-      return v == rhs as! UInt
-    } else if let v = self as? Double, rhs is Double {
-      return v == rhs as! Double
-    } else if let v = self as? Float, rhs is Float {
-      return v == rhs as! Float
-    } else if let v = self as? Bool, rhs is Bool {
-      return v == rhs as! Bool
-    } else if let v = self as? Date, rhs is Date {
-      return v == rhs as! Date
-    } else if let v = self as? URL, rhs is URL {
-      return v == rhs as! URL
-    } else if self is NSNull && rhs is NSNull {
-      return true
+    public func equals(rhs: MixpanelType) -> Bool {
+        if let v = self as? String, rhs is String {
+            return v == rhs as! String
+        } else if let v = self as? NSString, rhs is NSString {
+            return v == rhs as! NSString
+        } else if let v = self as? NSNumber, rhs is NSNumber {
+            return v.isEqual(to: rhs as! NSNumber)
+        } else if let v = self as? Int, rhs is Int {
+            return v == rhs as! Int
+        } else if let v = self as? UInt, rhs is UInt {
+            return v == rhs as! UInt
+        } else if let v = self as? Double, rhs is Double {
+            return v == rhs as! Double
+        } else if let v = self as? Float, rhs is Float {
+            return v == rhs as! Float
+        } else if let v = self as? Bool, rhs is Bool {
+            return v == rhs as! Bool
+        } else if let v = self as? Date, rhs is Date {
+            return v == rhs as! Date
+        } else if let v = self as? URL, rhs is URL {
+            return v == rhs as! URL
+        } else if self is NSNull && rhs is NSNull {
+            return true
+        }
+        return false
     }
-    return false
-  }
 }
 extension String: MixpanelType {
-  /**
-     Checks if this object has nested object types that Mixpanel supports.
-     Will always return true.
-     */
-  public func isValidNestedTypeAndValue() -> Bool { return true }
+    /**
+       Checks if this object has nested object types that Mixpanel supports.
+       Will always return true.
+       */
+    public func isValidNestedTypeAndValue() -> Bool { return true }
 
-  public func equals(rhs: MixpanelType) -> Bool {
-    if rhs is String {
-      return self == rhs as! String
+    public func equals(rhs: MixpanelType) -> Bool {
+        if rhs is String {
+            return self == rhs as! String
+        }
+        return false
     }
-    return false
-  }
 }
 
 extension NSString: MixpanelType {
-  /**
-     Checks if this object has nested object types that Mixpanel supports.
-     Will always return true.
-     */
-  public func isValidNestedTypeAndValue() -> Bool { return true }
+    /**
+       Checks if this object has nested object types that Mixpanel supports.
+       Will always return true.
+       */
+    public func isValidNestedTypeAndValue() -> Bool { return true }
 
-  public func equals(rhs: MixpanelType) -> Bool {
-    if rhs is NSString {
-      return self == rhs as! NSString
+    public func equals(rhs: MixpanelType) -> Bool {
+        if rhs is NSString {
+            return self == rhs as! NSString
+        }
+        return false
     }
-    return false
-  }
 }
 
 extension NSNumber: MixpanelType {
-  /**
-     Checks if this object has nested object types that Mixpanel supports.
-     Will always return true.
-     */
-  public func isValidNestedTypeAndValue() -> Bool {
-    return !self.doubleValue.isInfinite && !self.doubleValue.isNaN
-  }
-
-  public func equals(rhs: MixpanelType) -> Bool {
-    if rhs is NSNumber {
-      return self.isEqual(rhs)
+    /**
+       Checks if this object has nested object types that Mixpanel supports.
+       Will always return true.
+       */
+    public func isValidNestedTypeAndValue() -> Bool {
+        return !self.doubleValue.isInfinite && !self.doubleValue.isNaN
     }
-    return false
-  }
+
+    public func equals(rhs: MixpanelType) -> Bool {
+        if rhs is NSNumber {
+            return self.isEqual(rhs)
+        }
+        return false
+    }
 }
 
 extension Int: MixpanelType {
-  /**
-     Checks if this object has nested object types that Mixpanel supports.
-     Will always return true.
-     */
-  public func isValidNestedTypeAndValue() -> Bool { return true }
+    /**
+       Checks if this object has nested object types that Mixpanel supports.
+       Will always return true.
+       */
+    public func isValidNestedTypeAndValue() -> Bool { return true }
 
-  public func equals(rhs: MixpanelType) -> Bool {
-    if rhs is Int {
-      return self == rhs as! Int
+    public func equals(rhs: MixpanelType) -> Bool {
+        if rhs is Int {
+            return self == rhs as! Int
+        }
+        return false
     }
-    return false
-  }
 }
 
 extension UInt: MixpanelType {
-  /**
-     Checks if this object has nested object types that Mixpanel supports.
-     Will always return true.
-     */
-  public func isValidNestedTypeAndValue() -> Bool { return true }
+    /**
+       Checks if this object has nested object types that Mixpanel supports.
+       Will always return true.
+       */
+    public func isValidNestedTypeAndValue() -> Bool { return true }
 
-  public func equals(rhs: MixpanelType) -> Bool {
-    if rhs is UInt {
-      return self == rhs as! UInt
+    public func equals(rhs: MixpanelType) -> Bool {
+        if rhs is UInt {
+            return self == rhs as! UInt
+        }
+        return false
     }
-    return false
-  }
 }
 extension Double: MixpanelType {
-  /**
-     Checks if this object has nested object types that Mixpanel supports.
-     Will always return true.
-     */
-  public func isValidNestedTypeAndValue() -> Bool {
-    return !self.isInfinite && !self.isNaN
-  }
-
-  public func equals(rhs: MixpanelType) -> Bool {
-    if rhs is Double {
-      return self == rhs as! Double
+    /**
+       Checks if this object has nested object types that Mixpanel supports.
+       Will always return true.
+       */
+    public func isValidNestedTypeAndValue() -> Bool {
+        return !self.isInfinite && !self.isNaN
     }
-    return false
-  }
+
+    public func equals(rhs: MixpanelType) -> Bool {
+        if rhs is Double {
+            return self == rhs as! Double
+        }
+        return false
+    }
 }
 extension Float: MixpanelType {
-  /**
-     Checks if this object has nested object types that Mixpanel supports.
-     Will always return true.
-     */
-  public func isValidNestedTypeAndValue() -> Bool {
-    return !self.isInfinite && !self.isNaN
-  }
-
-  public func equals(rhs: MixpanelType) -> Bool {
-    if rhs is Float {
-      return self == rhs as! Float
+    /**
+       Checks if this object has nested object types that Mixpanel supports.
+       Will always return true.
+       */
+    public func isValidNestedTypeAndValue() -> Bool {
+        return !self.isInfinite && !self.isNaN
     }
-    return false
-  }
+
+    public func equals(rhs: MixpanelType) -> Bool {
+        if rhs is Float {
+            return self == rhs as! Float
+        }
+        return false
+    }
 }
 extension Bool: MixpanelType {
-  /**
-     Checks if this object has nested object types that Mixpanel supports.
-     Will always return true.
-     */
-  public func isValidNestedTypeAndValue() -> Bool { return true }
+    /**
+       Checks if this object has nested object types that Mixpanel supports.
+       Will always return true.
+       */
+    public func isValidNestedTypeAndValue() -> Bool { return true }
 
-  public func equals(rhs: MixpanelType) -> Bool {
-    if rhs is Bool {
-      return self == rhs as! Bool
+    public func equals(rhs: MixpanelType) -> Bool {
+        if rhs is Bool {
+            return self == rhs as! Bool
+        }
+        return false
     }
-    return false
-  }
 }
 
 extension Date: MixpanelType {
-  /**
-     Checks if this object has nested object types that Mixpanel supports.
-     Will always return true.
-     */
-  public func isValidNestedTypeAndValue() -> Bool { return true }
+    /**
+       Checks if this object has nested object types that Mixpanel supports.
+       Will always return true.
+       */
+    public func isValidNestedTypeAndValue() -> Bool { return true }
 
-  public func equals(rhs: MixpanelType) -> Bool {
-    if rhs is Date {
-      return self == rhs as! Date
+    public func equals(rhs: MixpanelType) -> Bool {
+        if rhs is Date {
+            return self == rhs as! Date
+        }
+        return false
     }
-    return false
-  }
 }
 
 extension URL: MixpanelType {
-  /**
-     Checks if this object has nested object types that Mixpanel supports.
-     Will always return true.
-     */
-  public func isValidNestedTypeAndValue() -> Bool { return true }
+    /**
+       Checks if this object has nested object types that Mixpanel supports.
+       Will always return true.
+       */
+    public func isValidNestedTypeAndValue() -> Bool { return true }
 
-  public func equals(rhs: MixpanelType) -> Bool {
-    if rhs is URL {
-      return self == rhs as! URL
+    public func equals(rhs: MixpanelType) -> Bool {
+        if rhs is URL {
+            return self == rhs as! URL
+        }
+        return false
     }
-    return false
-  }
 }
 
 extension NSNull: MixpanelType {
-  /**
-     Checks if this object has nested object types that Mixpanel supports.
-     Will always return true.
-     */
-  public func isValidNestedTypeAndValue() -> Bool { return true }
+    /**
+       Checks if this object has nested object types that Mixpanel supports.
+       Will always return true.
+       */
+    public func isValidNestedTypeAndValue() -> Bool { return true }
 
-  public func equals(rhs: MixpanelType) -> Bool {
-    if rhs is NSNull {
-      return true
+    public func equals(rhs: MixpanelType) -> Bool {
+        if rhs is NSNull {
+            return true
+        }
+        return false
     }
-    return false
-  }
 }
 
 extension Array: MixpanelType {
-  /**
-     Checks if this object has nested object types that Mixpanel supports.
-     */
-  public func isValidNestedTypeAndValue() -> Bool {
-    for element in self {
-      guard element as? MixpanelType != nil else {
-        return false
-      }
-    }
-    return true
-  }
-
-  public func equals(rhs: MixpanelType) -> Bool {
-    if rhs is [MixpanelType] {
-      let rhs = rhs as! [MixpanelType]
-
-      if self.count != rhs.count {
-        return false
-      }
-
-      if !isValidNestedTypeAndValue() {
-        return false
-      }
-
-      let lhs = self as! [MixpanelType]
-      for (i, val) in lhs.enumerated() {
-        if !val.equals(rhs: rhs[i]) {
-          return false
+    /**
+       Checks if this object has nested object types that Mixpanel supports.
+       */
+    public func isValidNestedTypeAndValue() -> Bool {
+        for element in self {
+            guard element as? MixpanelType != nil else {
+                return false
+            }
         }
-      }
-      return true
+        return true
     }
-    return false
-  }
+
+    public func equals(rhs: MixpanelType) -> Bool {
+        if rhs is [MixpanelType] {
+            let rhs = rhs as! [MixpanelType]
+
+            if self.count != rhs.count {
+                return false
+            }
+
+            if !isValidNestedTypeAndValue() {
+                return false
+            }
+
+            let lhs = self as! [MixpanelType]
+            for (i, val) in lhs.enumerated() {
+                if !val.equals(rhs: rhs[i]) {
+                    return false
+                }
+            }
+            return true
+        }
+        return false
+    }
 }
 
 extension NSArray: MixpanelType {
-  /**
-     Checks if this object has nested object types that Mixpanel supports.
-     */
-  public func isValidNestedTypeAndValue() -> Bool {
-    for element in self {
-      guard element as? MixpanelType != nil else {
-        return false
-      }
-    }
-    return true
-  }
-
-  public func equals(rhs: MixpanelType) -> Bool {
-    if rhs is [MixpanelType] {
-      let rhs = rhs as! [MixpanelType]
-
-      if self.count != rhs.count {
-        return false
-      }
-
-      if !isValidNestedTypeAndValue() {
-        return false
-      }
-
-      let lhs = self as! [MixpanelType]
-      for (i, val) in lhs.enumerated() {
-        if !val.equals(rhs: rhs[i]) {
-          return false
+    /**
+       Checks if this object has nested object types that Mixpanel supports.
+       */
+    public func isValidNestedTypeAndValue() -> Bool {
+        for element in self {
+            guard element as? MixpanelType != nil else {
+                return false
+            }
         }
-      }
-      return true
+        return true
     }
-    return false
-  }
+
+    public func equals(rhs: MixpanelType) -> Bool {
+        if rhs is [MixpanelType] {
+            let rhs = rhs as! [MixpanelType]
+
+            if self.count != rhs.count {
+                return false
+            }
+
+            if !isValidNestedTypeAndValue() {
+                return false
+            }
+
+            let lhs = self as! [MixpanelType]
+            for (i, val) in lhs.enumerated() {
+                if !val.equals(rhs: rhs[i]) {
+                    return false
+                }
+            }
+            return true
+        }
+        return false
+    }
 }
 
 extension Dictionary: MixpanelType {
-  /**
-     Checks if this object has nested object types that Mixpanel supports.
-     */
-  public func isValidNestedTypeAndValue() -> Bool {
-    for (key, value) in self {
-      guard key as? String != nil, value as? MixpanelType != nil else {
-        return false
-      }
-    }
-    return true
-  }
-
-  public func equals(rhs: MixpanelType) -> Bool {
-    if rhs is [String: MixpanelType] {
-      let rhs = rhs as! [String: MixpanelType]
-
-      if self.keys.count != rhs.keys.count {
-        return false
-      }
-
-      if !isValidNestedTypeAndValue() {
-        return false
-      }
-
-      for (key, val) in self as! [String: MixpanelType] {
-        guard let rVal = rhs[key] else {
-          return false
+    /**
+       Checks if this object has nested object types that Mixpanel supports.
+       */
+    public func isValidNestedTypeAndValue() -> Bool {
+        for (key, value) in self {
+            guard key as? String != nil, value as? MixpanelType != nil else {
+                return false
+            }
         }
-
-        if !val.equals(rhs: rVal) {
-          return false
-        }
-      }
-      return true
+        return true
     }
-    return false
-  }
+
+    public func equals(rhs: MixpanelType) -> Bool {
+        if rhs is [String: MixpanelType] {
+            let rhs = rhs as! [String: MixpanelType]
+
+            if self.keys.count != rhs.keys.count {
+                return false
+            }
+
+            if !isValidNestedTypeAndValue() {
+                return false
+            }
+
+            for (key, val) in self as! [String: MixpanelType] {
+                guard let rVal = rhs[key] else {
+                    return false
+                }
+
+                if !val.equals(rhs: rVal) {
+                    return false
+                }
+            }
+            return true
+        }
+        return false
+    }
 }
 
 func assertPropertyTypes(_ properties: Properties?) {
-  if let properties = properties {
-    for (_, v) in properties {
-      MPAssert(
-        v.isValidNestedTypeAndValue(),
-        "Property values must be of valid type (MixpanelType) and valid value. Got \(type(of: v)) and Value \(v)"
-      )
+    if let properties = properties {
+        for (_, v) in properties {
+            MPAssert(
+                v.isValidNestedTypeAndValue(),
+                "Property values must be of valid type (MixpanelType) and valid value. Got \(type(of: v)) and Value \(v)"
+            )
+        }
     }
-  }
 }
 
 extension Dictionary {
-  func get<T>(key: Key, defaultValue: T) -> T {
-    if let value = self[key] as? T {
-      return value
-    }
+    func get<T>(key: Key, defaultValue: T) -> T {
+        if let value = self[key] as? T {
+            return value
+        }
 
-    return defaultValue
-  }
+        return defaultValue
+    }
 }

--- a/Sources/Network.swift
+++ b/Sources/Network.swift
@@ -9,136 +9,136 @@
 import Foundation
 
 struct BasePath {
-  static let DefaultMixpanelAPI = "https://api.mixpanel.com"
+    static let DefaultMixpanelAPI = "https://api.mixpanel.com"
 
-  static func buildURL(base: String, path: String, queryItems: [URLQueryItem]?) -> URL? {
-    guard let url = URL(string: base) else {
-      return nil
+    static func buildURL(base: String, path: String, queryItems: [URLQueryItem]?) -> URL? {
+        guard let url = URL(string: base) else {
+            return nil
+        }
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
+            return nil
+        }
+        components.path += path
+        components.queryItems = queryItems
+        // adding workaround to replece + for %2B as it's not done by default within URLComponents
+        components.percentEncodedQuery = components.percentEncodedQuery?.replacingOccurrences(
+            of: "+", with: "%2B")
+        return components.url
     }
-    guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
-      return nil
-    }
-    components.path += path
-    components.queryItems = queryItems
-    // adding workaround to replece + for %2B as it's not done by default within URLComponents
-    components.percentEncodedQuery = components.percentEncodedQuery?.replacingOccurrences(
-      of: "+", with: "%2B")
-    return components.url
-  }
 }
 
 enum RequestMethod: String {
-  case get
-  case post
+    case get
+    case post
 }
 
 struct Resource<A> {
-  let path: String
-  let method: RequestMethod
-  let requestBody: Data?
-  let queryItems: [URLQueryItem]?
-  let headers: [String: String]
-  let parse: (Data) -> A?
+    let path: String
+    let method: RequestMethod
+    let requestBody: Data?
+    let queryItems: [URLQueryItem]?
+    let headers: [String: String]
+    let parse: (Data) -> A?
 }
 
 enum Reason {
-  case parseError
-  case noData
-  case notOKStatusCode(statusCode: Int)
-  case other(Error)
+    case parseError
+    case noData
+    case notOKStatusCode(statusCode: Int)
+    case other(Error)
 }
 
 public struct ServerProxyResource {
-  public init(queryItems: [URLQueryItem]? = nil, headers: [String: String]) {
-    self.queryItems = queryItems
-    self.headers = headers
-  }
+    public init(queryItems: [URLQueryItem]? = nil, headers: [String: String]) {
+        self.queryItems = queryItems
+        self.headers = headers
+    }
 
-  public let queryItems: [URLQueryItem]?
-  public let headers: [String: String]
+    public let queryItems: [URLQueryItem]?
+    public let headers: [String: String]
 }
 
 class Network {
 
-  var serverURL: String
+    var serverURL: String
 
-  required init(serverURL: String) {
-    self.serverURL = serverURL
-  }
-
-  class func apiRequest<A>(
-    base: String,
-    resource: Resource<A>,
-    failure: @escaping (Reason, Data?, URLResponse?) -> Void,
-    success: @escaping (A, URLResponse?) -> Void
-  ) {
-    guard let request = buildURLRequest(base, resource: resource) else {
-      return
+    required init(serverURL: String) {
+        self.serverURL = serverURL
     }
 
-    URLSession.shared.dataTask(with: request) { (data, response, error) -> Void in
-      guard let httpResponse = response as? HTTPURLResponse else {
-
-        if let hasError = error {
-          failure(.other(hasError), data, response)
-        } else {
-          failure(.noData, data, response)
+    class func apiRequest<A>(
+        base: String,
+        resource: Resource<A>,
+        failure: @escaping (Reason, Data?, URLResponse?) -> Void,
+        success: @escaping (A, URLResponse?) -> Void
+    ) {
+        guard let request = buildURLRequest(base, resource: resource) else {
+            return
         }
-        return
-      }
-      guard httpResponse.statusCode == 200 else {
-        failure(.notOKStatusCode(statusCode: httpResponse.statusCode), data, response)
-        return
-      }
-      guard let responseData = data else {
-        failure(.noData, data, response)
-        return
-      }
-      guard let result = resource.parse(responseData) else {
-        failure(.parseError, data, response)
-        return
-      }
 
-      success(result, response)
-    }.resume()
-  }
+        URLSession.shared.dataTask(with: request) { (data, response, error) -> Void in
+            guard let httpResponse = response as? HTTPURLResponse else {
 
-  private class func buildURLRequest<A>(_ base: String, resource: Resource<A>) -> URLRequest? {
-    guard
-      let url = BasePath.buildURL(
-        base: base,
-        path: resource.path,
-        queryItems: resource.queryItems)
-    else {
-      return nil
+                if let hasError = error {
+                    failure(.other(hasError), data, response)
+                } else {
+                    failure(.noData, data, response)
+                }
+                return
+            }
+            guard httpResponse.statusCode == 200 else {
+                failure(.notOKStatusCode(statusCode: httpResponse.statusCode), data, response)
+                return
+            }
+            guard let responseData = data else {
+                failure(.noData, data, response)
+                return
+            }
+            guard let result = resource.parse(responseData) else {
+                failure(.parseError, data, response)
+                return
+            }
+
+            success(result, response)
+        }.resume()
     }
 
-    MixpanelLogger.debug(message: "Fetching URL")
-    MixpanelLogger.debug(message: url.absoluteURL)
-    var request = URLRequest(url: url)
-    request.httpMethod = resource.method.rawValue
-    request.httpBody = resource.requestBody
+    private class func buildURLRequest<A>(_ base: String, resource: Resource<A>) -> URLRequest? {
+        guard
+            let url = BasePath.buildURL(
+                base: base,
+                path: resource.path,
+                queryItems: resource.queryItems)
+        else {
+            return nil
+        }
 
-    for (k, v) in resource.headers {
-      request.setValue(v, forHTTPHeaderField: k)
+        MixpanelLogger.debug(message: "Fetching URL")
+        MixpanelLogger.debug(message: url.absoluteURL)
+        var request = URLRequest(url: url)
+        request.httpMethod = resource.method.rawValue
+        request.httpBody = resource.requestBody
+
+        for (k, v) in resource.headers {
+            request.setValue(v, forHTTPHeaderField: k)
+        }
+        return request as URLRequest
     }
-    return request as URLRequest
-  }
 
-  class func buildResource<A>(
-    path: String,
-    method: RequestMethod,
-    requestBody: Data? = nil,
-    queryItems: [URLQueryItem]? = nil,
-    headers: [String: String],
-    parse: @escaping (Data) -> A?
-  ) -> Resource<A> {
-    return Resource(
-      path: path,
-      method: method,
-      requestBody: requestBody,
-      queryItems: queryItems,
-      headers: headers,
-      parse: parse)
-  }
+    class func buildResource<A>(
+        path: String,
+        method: RequestMethod,
+        requestBody: Data? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        headers: [String: String],
+        parse: @escaping (Data) -> A?
+    ) -> Resource<A> {
+        return Resource(
+            path: path,
+            method: method,
+            requestBody: requestBody,
+            queryItems: queryItems,
+            headers: headers,
+            parse: parse)
+    }
 }

--- a/Sources/People.swift
+++ b/Sources/People.swift
@@ -12,279 +12,279 @@ import Foundation
 /// the main Mixpanel instance.
 open class People {
 
-  /// controls the $ignore_time property in any subsequent MixpanelPeople operation.
-  /// If the $ignore_time property is present and true in your request,
-  /// Mixpanel will not automatically update the "Last Seen" property of the profile.
-  /// Otherwise, Mixpanel will add a "Last Seen" property associated with the
-  /// current time for all $set, $append, and $add operations
-  open var ignoreTime = false
+    /// controls the $ignore_time property in any subsequent MixpanelPeople operation.
+    /// If the $ignore_time property is present and true in your request,
+    /// Mixpanel will not automatically update the "Last Seen" property of the profile.
+    /// Otherwise, Mixpanel will add a "Last Seen" property associated with the
+    /// current time for all $set, $append, and $add operations
+    open var ignoreTime = false
 
-  let apiToken: String
-  let serialQueue: DispatchQueue
-  let lock: ReadWriteLock
-  var distinctId: String?
-  weak var delegate: FlushDelegate?
-  let metadata: SessionMetadata
-  let mixpanelPersistence: MixpanelPersistence
-  let excludeProperties: Set<String>
-  weak var mixpanelInstance: MixpanelInstance?
+    let apiToken: String
+    let serialQueue: DispatchQueue
+    let lock: ReadWriteLock
+    var distinctId: String?
+    weak var delegate: FlushDelegate?
+    let metadata: SessionMetadata
+    let mixpanelPersistence: MixpanelPersistence
+    let excludeProperties: Set<String>
+    weak var mixpanelInstance: MixpanelInstance?
 
-  init(
-    apiToken: String,
-    serialQueue: DispatchQueue,
-    lock: ReadWriteLock,
-    metadata: SessionMetadata,
-    mixpanelPersistence: MixpanelPersistence,
-    excludeProperties: Set<String> = []
-  ) {
-    self.apiToken = apiToken
-    self.serialQueue = serialQueue
-    self.lock = lock
-    self.metadata = metadata
-    self.mixpanelPersistence = mixpanelPersistence
-    self.excludeProperties = excludeProperties
-  }
-
-  func addPeopleRecordToQueueWithAction(_ action: String, properties: InternalProperties) {
-    if mixpanelInstance?.hasOptedOutTracking() ?? false {
-      return
+    init(
+        apiToken: String,
+        serialQueue: DispatchQueue,
+        lock: ReadWriteLock,
+        metadata: SessionMetadata,
+        mixpanelPersistence: MixpanelPersistence,
+        excludeProperties: Set<String> = []
+    ) {
+        self.apiToken = apiToken
+        self.serialQueue = serialQueue
+        self.lock = lock
+        self.metadata = metadata
+        self.mixpanelPersistence = mixpanelPersistence
+        self.excludeProperties = excludeProperties
     }
-    let epochMilliseconds = round(Date().timeIntervalSince1970 * 1000)
-    let ignoreTimeCopy = ignoreTime
 
-    serialQueue.async { [weak self, action, properties] in
-      guard let self = self else { return }
-
-      var r = InternalProperties()
-      var p = InternalProperties()
-      r["$token"] = self.apiToken
-      r["$time"] = epochMilliseconds
-      if ignoreTimeCopy {
-        r["$ignore_time"] = ignoreTimeCopy ? 1 : 0
-      }
-      if action == "$unset" {
-        // $unset takes an array of property names which is supplied to this method
-        // in the properties parameter under the key "$properties"
-        r[action] = properties["$properties"]
-      } else {
-        if action == "$set" || action == "$set_once" {
-          AutomaticProperties.automaticPropertiesLock.read {
-            p += AutomaticProperties.peopleProperties
-          }
+    func addPeopleRecordToQueueWithAction(_ action: String, properties: InternalProperties) {
+        if mixpanelInstance?.hasOptedOutTracking() ?? false {
+            return
         }
-        p += properties
-        // Filter only the bag-style operators where the SDK merges peopleProperties
-        // ($set and $set_once on Swift — note: Android only merges into $set, so the
-        // Android port filters $set alone). The operand-style operators ($add,
-        // $append, $union, $unset, $merge, $delete) treat property keys as inputs
-        // rather than a bag to mutate, and filtering inside them would silently
-        // change semantics.
-        if action == "$set" || action == "$set_once" {
-          Track.applyExcludeProperties(&p, exclude: self.excludeProperties)
+        let epochMilliseconds = round(Date().timeIntervalSince1970 * 1000)
+        let ignoreTimeCopy = ignoreTime
+
+        serialQueue.async { [weak self, action, properties] in
+            guard let self = self else { return }
+
+            var r = InternalProperties()
+            var p = InternalProperties()
+            r["$token"] = self.apiToken
+            r["$time"] = epochMilliseconds
+            if ignoreTimeCopy {
+                r["$ignore_time"] = ignoreTimeCopy ? 1 : 0
+            }
+            if action == "$unset" {
+                // $unset takes an array of property names which is supplied to this method
+                // in the properties parameter under the key "$properties"
+                r[action] = properties["$properties"]
+            } else {
+                if action == "$set" || action == "$set_once" {
+                    AutomaticProperties.automaticPropertiesLock.read {
+                        p += AutomaticProperties.peopleProperties
+                    }
+                }
+                p += properties
+                // Filter only the bag-style operators where the SDK merges peopleProperties
+                // ($set and $set_once on Swift — note: Android only merges into $set, so the
+                // Android port filters $set alone). The operand-style operators ($add,
+                // $append, $union, $unset, $merge, $delete) treat property keys as inputs
+                // rather than a bag to mutate, and filtering inside them would silently
+                // change semantics.
+                if action == "$set" || action == "$set_once" {
+                    Track.applyExcludeProperties(&p, exclude: self.excludeProperties)
+                }
+                r[action] = p
+            }
+            self.metadata.toDict(isEvent: false).forEach { (k, v) in r[k] = v }
+
+            if let anonymousId = self.mixpanelInstance?.anonymousId {
+                r["$device_id"] = anonymousId
+            }
+
+            if let userId = self.mixpanelInstance?.userId {
+                r["$user_id"] = userId
+            }
+
+            if let hadPersistedDistinctId = self.mixpanelInstance?.hadPersistedDistinctId {
+                r["$had_persisted_distinct_id"] = hadPersistedDistinctId
+            }
+
+            if let distinctId = self.distinctId {
+                r["$distinct_id"] = distinctId
+                // identified
+                self.mixpanelPersistence.saveEntity(
+                    r, type: .people, flag: !PersistenceConstant.unIdentifiedFlag)
+            } else {
+                self.mixpanelPersistence.saveEntity(
+                    r, type: .people, flag: PersistenceConstant.unIdentifiedFlag)
+            }
         }
-        r[action] = p
-      }
-      self.metadata.toDict(isEvent: false).forEach { (k, v) in r[k] = v }
 
-      if let anonymousId = self.mixpanelInstance?.anonymousId {
-        r["$device_id"] = anonymousId
-      }
-
-      if let userId = self.mixpanelInstance?.userId {
-        r["$user_id"] = userId
-      }
-
-      if let hadPersistedDistinctId = self.mixpanelInstance?.hadPersistedDistinctId {
-        r["$had_persisted_distinct_id"] = hadPersistedDistinctId
-      }
-
-      if let distinctId = self.distinctId {
-        r["$distinct_id"] = distinctId
-        // identified
-        self.mixpanelPersistence.saveEntity(
-          r, type: .people, flag: !PersistenceConstant.unIdentifiedFlag)
-      } else {
-        self.mixpanelPersistence.saveEntity(
-          r, type: .people, flag: PersistenceConstant.unIdentifiedFlag)
-      }
+        if MixpanelInstance.isiOSAppExtension() {
+            delegate?.flush(performFullFlush: false, completion: nil)
+        }
     }
 
-    if MixpanelInstance.isiOSAppExtension() {
-      delegate?.flush(performFullFlush: false, completion: nil)
+    func merge(properties: InternalProperties) {
+        addPeopleRecordToQueueWithAction("$merge", properties: properties)
     }
-  }
 
-  func merge(properties: InternalProperties) {
-    addPeopleRecordToQueueWithAction("$merge", properties: properties)
-  }
+    // MARK: - People
 
-  // MARK: - People
-
-  /**
-     Set properties on the current user in Mixpanel People.
-
-     The properties will be set on the current user.
-     Property keys must be String objects and the supported value types need to conform to MixpanelType.
-     MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
-     You can override the current project token and distinct Id by
-     including the special properties: $token and $distinct_id. If the existing
-     user record on the server already has a value for a given property, the old
-     value is overwritten. Other existing properties will not be affected.
-
-     - precondition: You must identify for the set information to be linked to that user
-
-     - parameter properties: properties dictionary
-     */
-  open func set(properties: Properties) {
-    assertPropertyTypes(properties)
-    addPeopleRecordToQueueWithAction("$set", properties: properties)
-  }
-
-  /**
-     Convenience method for setting a single property in Mixpanel People.
-
-     Property keys must be String objects and the supported value types need to conform to MixpanelType.
-     MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
-
-     - parameter property: property name
-     - parameter to:       property value
-     */
-  open func set(property: String, to: MixpanelType) {
-    set(properties: [property: to])
-  }
-
-  /**
-     Set properties on the current user in Mixpanel People, but doesn't overwrite if
-     there is an existing value.
-
-     This method is identical to `set:` except it will only set
-     properties that are not already set. It is particularly useful for collecting
-     data about the user's initial experience and source, as well as dates
-     representing the first time something happened.
-
-     - parameter properties: properties dictionary
-     */
-  open func setOnce(properties: Properties) {
-    assertPropertyTypes(properties)
-    addPeopleRecordToQueueWithAction("$set_once", properties: properties)
-  }
-
-  /**
-     Remove a list of properties and their values from the current user's profile
-     in Mixpanel People.
-
-     The properties array must ony contain String names of properties. For properties
-     that don't exist there will be no effect.
-
-     - parameter properties: properties array
-     */
-  open func unset(properties: [String]) {
-    addPeopleRecordToQueueWithAction("$unset", properties: ["$properties": properties])
-  }
-
-  /**
-     Increment the given numeric properties by the given values.
-
-     Property keys must be String names of numeric properties. A property is
-     numeric if its current value is a number. If a property does not exist, it
-     will be set to the increment amount. Property values must be number objects.
-
-     - parameter properties: properties array
-     */
-  open func increment(properties: Properties) {
-    let filtered = properties.values.filter {
-      !($0 is Int || $0 is UInt || $0 is Double || $0 is Float)
+    /**
+       Set properties on the current user in Mixpanel People.
+    
+       The properties will be set on the current user.
+       Property keys must be String objects and the supported value types need to conform to MixpanelType.
+       MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
+       You can override the current project token and distinct Id by
+       including the special properties: $token and $distinct_id. If the existing
+       user record on the server already has a value for a given property, the old
+       value is overwritten. Other existing properties will not be affected.
+    
+       - precondition: You must identify for the set information to be linked to that user
+    
+       - parameter properties: properties dictionary
+       */
+    open func set(properties: Properties) {
+        assertPropertyTypes(properties)
+        addPeopleRecordToQueueWithAction("$set", properties: properties)
     }
-    if !filtered.isEmpty {
-      MPAssert(false, "increment property values should be numbers")
+
+    /**
+       Convenience method for setting a single property in Mixpanel People.
+    
+       Property keys must be String objects and the supported value types need to conform to MixpanelType.
+       MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
+    
+       - parameter property: property name
+       - parameter to:       property value
+       */
+    open func set(property: String, to: MixpanelType) {
+        set(properties: [property: to])
     }
-    addPeopleRecordToQueueWithAction("$add", properties: properties)
-  }
 
-  /**
-     Convenience method for incrementing a single numeric property by the specified
-     amount.
-
-     - parameter property: property name
-     - parameter by:       amount to increment by
-     */
-  open func increment(property: String, by: Double) {
-    increment(properties: [property: by])
-  }
-
-  /**
-     Append values to list properties.
-
-     Property keys must be String objects and the supported value types need to conform to MixpanelType.
-     MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
-
-     - parameter properties: mapping of list property names to values to append
-     */
-  open func append(properties: Properties) {
-    assertPropertyTypes(properties)
-    addPeopleRecordToQueueWithAction("$append", properties: properties)
-  }
-
-  /**
-     Removes list properties.
-
-     Property keys must be String objects and the supported value types need to conform to MixpanelType.
-     MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
-
-     - parameter properties: mapping of list property names to values to remove
-     */
-  open func remove(properties: Properties) {
-    assertPropertyTypes(properties)
-    addPeopleRecordToQueueWithAction("$remove", properties: properties)
-  }
-
-  /**
-     Union list properties.
-
-     Property values must be array objects.
-
-     - parameter properties: mapping of list property names to lists to union
-     */
-  open func union(properties: Properties) {
-    let filtered = properties.values.filter {
-      !($0 is [MixpanelType])
+    /**
+       Set properties on the current user in Mixpanel People, but doesn't overwrite if
+       there is an existing value.
+    
+       This method is identical to `set:` except it will only set
+       properties that are not already set. It is particularly useful for collecting
+       data about the user's initial experience and source, as well as dates
+       representing the first time something happened.
+    
+       - parameter properties: properties dictionary
+       */
+    open func setOnce(properties: Properties) {
+        assertPropertyTypes(properties)
+        addPeopleRecordToQueueWithAction("$set_once", properties: properties)
     }
-    if !filtered.isEmpty {
-      MPAssert(false, "union property values should be an array")
+
+    /**
+       Remove a list of properties and their values from the current user's profile
+       in Mixpanel People.
+    
+       The properties array must ony contain String names of properties. For properties
+       that don't exist there will be no effect.
+    
+       - parameter properties: properties array
+       */
+    open func unset(properties: [String]) {
+        addPeopleRecordToQueueWithAction("$unset", properties: ["$properties": properties])
     }
-    addPeopleRecordToQueueWithAction("$union", properties: properties)
-  }
 
-  /**
-     Track money spent by the current user for revenue analytics and associate
-     properties with the charge. Properties is optional.
-
-     Charge properties allow you to segment on types of revenue. For instance, you
-     could record a product ID with each charge so that you could segement on it in
-     revenue analytics to see which products are generating the most revenue.
-
-     - parameter amount:     amount of revenue received
-     - parameter properties: Optional. properties dictionary
-     */
-  open func trackCharge(amount: Double, properties: Properties? = nil) {
-    var transaction: InternalProperties = ["$amount": amount, "$time": Date()]
-    if let properties = properties {
-      transaction += properties
+    /**
+       Increment the given numeric properties by the given values.
+    
+       Property keys must be String names of numeric properties. A property is
+       numeric if its current value is a number. If a property does not exist, it
+       will be set to the increment amount. Property values must be number objects.
+    
+       - parameter properties: properties array
+       */
+    open func increment(properties: Properties) {
+        let filtered = properties.values.filter {
+            !($0 is Int || $0 is UInt || $0 is Double || $0 is Float)
+        }
+        if !filtered.isEmpty {
+            MPAssert(false, "increment property values should be numbers")
+        }
+        addPeopleRecordToQueueWithAction("$add", properties: properties)
     }
-    append(properties: ["$transactions": transaction])
-  }
 
-  /**
-     Delete current user's revenue history.
-     */
-  open func clearCharges() {
-    set(properties: ["$transactions": [] as [Any]])
-  }
+    /**
+       Convenience method for incrementing a single numeric property by the specified
+       amount.
+    
+       - parameter property: property name
+       - parameter by:       amount to increment by
+       */
+    open func increment(property: String, by: Double) {
+        increment(properties: [property: by])
+    }
 
-  /**
-     Delete current user's record from Mixpanel People.
-     */
-  open func deleteUser() {
-    addPeopleRecordToQueueWithAction("$delete", properties: [:])
-  }
+    /**
+       Append values to list properties.
+    
+       Property keys must be String objects and the supported value types need to conform to MixpanelType.
+       MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
+    
+       - parameter properties: mapping of list property names to values to append
+       */
+    open func append(properties: Properties) {
+        assertPropertyTypes(properties)
+        addPeopleRecordToQueueWithAction("$append", properties: properties)
+    }
+
+    /**
+       Removes list properties.
+    
+       Property keys must be String objects and the supported value types need to conform to MixpanelType.
+       MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
+    
+       - parameter properties: mapping of list property names to values to remove
+       */
+    open func remove(properties: Properties) {
+        assertPropertyTypes(properties)
+        addPeopleRecordToQueueWithAction("$remove", properties: properties)
+    }
+
+    /**
+       Union list properties.
+    
+       Property values must be array objects.
+    
+       - parameter properties: mapping of list property names to lists to union
+       */
+    open func union(properties: Properties) {
+        let filtered = properties.values.filter {
+            !($0 is [MixpanelType])
+        }
+        if !filtered.isEmpty {
+            MPAssert(false, "union property values should be an array")
+        }
+        addPeopleRecordToQueueWithAction("$union", properties: properties)
+    }
+
+    /**
+       Track money spent by the current user for revenue analytics and associate
+       properties with the charge. Properties is optional.
+    
+       Charge properties allow you to segment on types of revenue. For instance, you
+       could record a product ID with each charge so that you could segement on it in
+       revenue analytics to see which products are generating the most revenue.
+    
+       - parameter amount:     amount of revenue received
+       - parameter properties: Optional. properties dictionary
+       */
+    open func trackCharge(amount: Double, properties: Properties? = nil) {
+        var transaction: InternalProperties = ["$amount": amount, "$time": Date()]
+        if let properties = properties {
+            transaction += properties
+        }
+        append(properties: ["$transactions": transaction])
+    }
+
+    /**
+       Delete current user's revenue history.
+       */
+    open func clearCharges() {
+        set(properties: ["$transactions": [] as [Any]])
+    }
+
+    /**
+       Delete current user's record from Mixpanel People.
+       */
+    open func deleteUser() {
+        addPeopleRecordToQueueWithAction("$delete", properties: [:])
+    }
 }

--- a/Sources/PrintLogging.swift
+++ b/Sources/PrintLogging.swift
@@ -10,19 +10,19 @@ import Foundation
 
 /// Simply formats and prints the object by calling `print`
 class PrintLogging: MixpanelLogging {
-  func addMessage(message: MixpanelLogMessage) {
-    print(
-      "[Mixpanel - \(message.file) - func \(message.function)] (\(message.level.rawValue)) - \(message.text)"
-    )
-  }
+    func addMessage(message: MixpanelLogMessage) {
+        print(
+            "[Mixpanel - \(message.file) - func \(message.function)] (\(message.level.rawValue)) - \(message.text)"
+        )
+    }
 }
 
 /// Simply formats and prints the object by calling `debugPrint`, this makes things a bit easier if you
 /// need to print data that may be quoted for instance.
 class PrintDebugLogging: MixpanelLogging {
-  func addMessage(message: MixpanelLogMessage) {
-    debugPrint(
-      "[Mixpanel - \(message.file) - func \(message.function)] (\(message.level.rawValue)) - \(message.text)"
-    )
-  }
+    func addMessage(message: MixpanelLogMessage) {
+        debugPrint(
+            "[Mixpanel - \(message.file) - func \(message.function)] (\(message.level.rawValue)) - \(message.text)"
+        )
+    }
 }

--- a/Sources/ReadWriteLock.swift
+++ b/Sources/ReadWriteLock.swift
@@ -8,23 +8,23 @@
 import Foundation
 
 class ReadWriteLock {
-  private let concurrentQueue: DispatchQueue
+    private let concurrentQueue: DispatchQueue
 
-  init(label: String) {
-    concurrentQueue = DispatchQueue(
-      label: label, qos: .utility, attributes: .concurrent, autoreleaseFrequency: .workItem)
-  }
-
-  func read(closure: () -> Void) {
-    concurrentQueue.sync {
-      closure()
+    init(label: String) {
+        concurrentQueue = DispatchQueue(
+            label: label, qos: .utility, attributes: .concurrent, autoreleaseFrequency: .workItem)
     }
-  }
-  func write<T>(closure: () -> T) -> T {
-    concurrentQueue.sync(
-      flags: .barrier,
-      execute: {
-        closure()
-      })
-  }
+
+    func read(closure: () -> Void) {
+        concurrentQueue.sync {
+            closure()
+        }
+    }
+    func write<T>(closure: () -> T) -> T {
+        concurrentQueue.sync(
+            flags: .barrier,
+            execute: {
+                closure()
+            })
+    }
 }

--- a/Sources/SessionMetadata.swift
+++ b/Sources/SessionMetadata.swift
@@ -9,43 +9,43 @@
 import Foundation
 
 class SessionMetadata {
-  var eventsCounter: UInt64 = 0
-  var peopleCounter: UInt64 = 0
-  var sessionID: String = String.randomId()
-  var sessionStartEpoch: UInt64 = 0
-  var trackingQueue: DispatchQueue
+    var eventsCounter: UInt64 = 0
+    var peopleCounter: UInt64 = 0
+    var sessionID: String = String.randomId()
+    var sessionStartEpoch: UInt64 = 0
+    var trackingQueue: DispatchQueue
 
-  init(trackingQueue: DispatchQueue) {
-    self.trackingQueue = trackingQueue
-  }
-
-  func applicationWillEnterForeground() {
-    trackingQueue.async { [weak self] in
-      guard let self = self else { return }
-
-      self.eventsCounter = 0
-      self.peopleCounter = 0
-      self.sessionID = String.randomId()
-      self.sessionStartEpoch = UInt64(Date().timeIntervalSince1970)
+    init(trackingQueue: DispatchQueue) {
+        self.trackingQueue = trackingQueue
     }
-  }
 
-  func toDict(isEvent: Bool = true) -> InternalProperties {
-    let dict: [String: Any] = [
-      "$mp_metadata": [
-        "$mp_event_id": String.randomId(),
-        "$mp_session_id": sessionID,
-        "$mp_session_seq_id": (isEvent ? eventsCounter : peopleCounter),
-        "$mp_session_start_sec": sessionStartEpoch,
-      ] as [String: Any]
-    ]
-    isEvent ? (eventsCounter += 1) : (peopleCounter += 1)
-    return dict
-  }
+    func applicationWillEnterForeground() {
+        trackingQueue.async { [weak self] in
+            guard let self = self else { return }
+
+            self.eventsCounter = 0
+            self.peopleCounter = 0
+            self.sessionID = String.randomId()
+            self.sessionStartEpoch = UInt64(Date().timeIntervalSince1970)
+        }
+    }
+
+    func toDict(isEvent: Bool = true) -> InternalProperties {
+        let dict: [String: Any] = [
+            "$mp_metadata": [
+                "$mp_event_id": String.randomId(),
+                "$mp_session_id": sessionID,
+                "$mp_session_seq_id": (isEvent ? eventsCounter : peopleCounter),
+                "$mp_session_start_sec": sessionStartEpoch,
+            ] as [String: Any]
+        ]
+        isEvent ? (eventsCounter += 1) : (peopleCounter += 1)
+        return dict
+    }
 }
 
 extension String {
-  fileprivate static func randomId() -> String {
-    return String(format: "%08x%08x", arc4random(), arc4random())
-  }
+    fileprivate static func randomId() -> String {
+        return String(format: "%08x%08x", arc4random(), arc4random())
+    }
 }

--- a/Sources/Track.swift
+++ b/Sources/Track.swift
@@ -10,206 +10,207 @@ import Foundation
 import MixpanelSwiftCommon
 
 func += <K, V>(left: inout [K: V], right: [K: V]) {
-  for (k, v) in right {
-    left.updateValue(v, forKey: k)
-  }
+    for (k, v) in right {
+        left.updateValue(v, forKey: k)
+    }
 }
 
 class Track {
-  let instanceName: String
-  let apiToken: String
-  let lock: ReadWriteLock
-  let metadata: SessionMetadata
-  let mixpanelPersistence: MixpanelPersistence
-  let excludeProperties: Set<String>
-  weak var mixpanelInstance: MixpanelInstance?
+    let instanceName: String
+    let apiToken: String
+    let lock: ReadWriteLock
+    let metadata: SessionMetadata
+    let mixpanelPersistence: MixpanelPersistence
+    let excludeProperties: Set<String>
+    weak var mixpanelInstance: MixpanelInstance?
 
-  init(
-    apiToken: String, instanceName: String, lock: ReadWriteLock, metadata: SessionMetadata,
-    mixpanelPersistence: MixpanelPersistence, excludeProperties: Set<String> = []
-  ) {
-    self.instanceName = instanceName
-    self.apiToken = apiToken
-    self.lock = lock
-    self.metadata = metadata
-    self.mixpanelPersistence = mixpanelPersistence
-    self.excludeProperties = excludeProperties
-  }
-
-  /// Removes any key in `exclude` from `properties`, skipping keys in
-  /// ``MixpanelOptions/reservedPropertyKeys`` that ingestion or identity require.
-  /// `internal` so it can be unit-tested directly. No-op on an empty exclude set.
-  static func applyExcludeProperties(
-    _ properties: inout InternalProperties, exclude: Set<String>
-  ) {
-    if exclude.isEmpty { return }
-    for key in exclude {
-      if MixpanelOptions.reservedPropertyKeys.contains(key) { continue }
-      properties.removeValue(forKey: key)
-    }
-  }
-
-  func track(
-    event: String?,
-    properties: Properties? = nil,
-    timedEvents: InternalProperties,
-    superProperties: InternalProperties,
-    mixpanelIdentity: MixpanelIdentity,
-    epochInterval: Double
-  ) -> InternalProperties {
-    var ev = "mp_event"
-    if let event = event {
-      ev = event
-    } else {
-      MixpanelLogger.info(
-        message: "mixpanel track called with empty event parameter. using 'mp_event'")
-    }
-    if !(mixpanelInstance?.trackAutomaticEventsEnabled ?? false) && ev.hasPrefix("$ae_") {
-      return timedEvents
-    }
-    assertPropertyTypes(properties)
-    let epochMilliseconds = round(epochInterval * 1000)
-    let eventStartTime = timedEvents[ev] as? Double
-    var p = InternalProperties()
-    AutomaticProperties.automaticPropertiesLock.read {
-      p += AutomaticProperties.properties
-    }
-    p["token"] = apiToken
-    p["time"] = epochMilliseconds
-    var shadowTimedEvents = timedEvents
-    if let eventStartTime = eventStartTime {
-      shadowTimedEvents.removeValue(forKey: ev)
-      p["$duration"] = Double(String(format: "%.3f", epochInterval - eventStartTime))
-    }
-    p["distinct_id"] = mixpanelIdentity.distinctID
-    if mixpanelIdentity.anonymousId != nil {
-      p["$device_id"] = mixpanelIdentity.anonymousId
-    }
-    if mixpanelIdentity.userId != nil {
-      p["$user_id"] = mixpanelIdentity.userId
-    }
-    if mixpanelIdentity.hadPersistedDistinctId != nil {
-      p["$had_persisted_distinct_id"] = mixpanelIdentity.hadPersistedDistinctId
+    init(
+        apiToken: String, instanceName: String, lock: ReadWriteLock, metadata: SessionMetadata,
+        mixpanelPersistence: MixpanelPersistence, excludeProperties: Set<String> = []
+    ) {
+        self.instanceName = instanceName
+        self.apiToken = apiToken
+        self.lock = lock
+        self.metadata = metadata
+        self.mixpanelPersistence = mixpanelPersistence
+        self.excludeProperties = excludeProperties
     }
 
-    p += superProperties
-    if let properties = properties {
-      p += properties
+    /// Removes any key in `exclude` from `properties`, skipping keys in
+    /// ``MixpanelOptions/reservedPropertyKeys`` that ingestion or identity require.
+    /// `internal` so it can be unit-tested directly. No-op on an empty exclude set.
+    static func applyExcludeProperties(
+        _ properties: inout InternalProperties, exclude: Set<String>
+    ) {
+        if exclude.isEmpty { return }
+        for key in exclude {
+            if MixpanelOptions.reservedPropertyKeys.contains(key) { continue }
+            properties.removeValue(forKey: key)
+        }
     }
 
-    // Notify event bridge listeners (non-blocking)
-    if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) {
-      MixpanelEventBridge.shared.notifyListeners(
-        eventName: ev,
-        properties: p
-      )
+    func track(
+        event: String?,
+        properties: Properties? = nil,
+        timedEvents: InternalProperties,
+        superProperties: InternalProperties,
+        mixpanelIdentity: MixpanelIdentity,
+        epochInterval: Double
+    ) -> InternalProperties {
+        var ev = "mp_event"
+        if let event = event {
+            ev = event
+        } else {
+            MixpanelLogger.info(
+                message: "mixpanel track called with empty event parameter. using 'mp_event'")
+        }
+        if !(mixpanelInstance?.trackAutomaticEventsEnabled ?? false) && ev.hasPrefix("$ae_") {
+            return timedEvents
+        }
+        assertPropertyTypes(properties)
+        let epochMilliseconds = round(epochInterval * 1000)
+        let eventStartTime = timedEvents[ev] as? Double
+        var p = InternalProperties()
+        AutomaticProperties.automaticPropertiesLock.read {
+            p += AutomaticProperties.properties
+        }
+        p["token"] = apiToken
+        p["time"] = epochMilliseconds
+        var shadowTimedEvents = timedEvents
+        if let eventStartTime = eventStartTime {
+            shadowTimedEvents.removeValue(forKey: ev)
+            p["$duration"] = Double(String(format: "%.3f", epochInterval - eventStartTime))
+        }
+        p["distinct_id"] = mixpanelIdentity.distinctID
+        if mixpanelIdentity.anonymousId != nil {
+            p["$device_id"] = mixpanelIdentity.anonymousId
+        }
+        if mixpanelIdentity.userId != nil {
+            p["$user_id"] = mixpanelIdentity.userId
+        }
+        if mixpanelIdentity.hadPersistedDistinctId != nil {
+            p["$had_persisted_distinct_id"] = mixpanelIdentity.hadPersistedDistinctId
+        }
+
+        p += superProperties
+        if let properties = properties {
+            p += properties
+        }
+
+        // Notify event bridge listeners (non-blocking)
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) {
+            MixpanelEventBridge.shared.notifyListeners(
+                eventName: ev,
+                properties: p
+            )
+        }
+
+        // Check for first-time event matches
+        if let mixpanelInstance = mixpanelInstance,
+            let flagManager = mixpanelInstance.flags as? FeatureFlagManager
+        {
+            flagManager.checkFirstTimeEvents(eventName: ev, properties: p)
+        }
+
+        // Filter just before persistence so internal observers above (event bridge,
+        // first-time-events check) still see the full property set, matching Android's
+        // network-send chokepoint.
+        Track.applyExcludeProperties(&p, exclude: excludeProperties)
+
+        var trackEvent: InternalProperties = ["event": ev, "properties": p]
+        metadata.toDict().forEach { (k, v) in trackEvent[k] = v }
+
+        self.mixpanelPersistence.saveEntity(trackEvent, type: .events)
+        MixpanelPersistence.saveTimedEvents(timedEvents: shadowTimedEvents, instanceName: instanceName)
+        return shadowTimedEvents
     }
 
-    // Check for first-time event matches
-    if let mixpanelInstance = mixpanelInstance,
-       let flagManager = mixpanelInstance.flags as? FeatureFlagManager {
-      flagManager.checkFirstTimeEvents(eventName: ev, properties: p)
+    func registerSuperProperties(
+        _ properties: Properties,
+        superProperties: InternalProperties
+    ) -> InternalProperties {
+        if mixpanelInstance?.hasOptedOutTracking() ?? false {
+            return superProperties
+        }
+
+        var updatedSuperProperties = superProperties
+        assertPropertyTypes(properties)
+        updatedSuperProperties += properties
+
+        return updatedSuperProperties
     }
 
-    // Filter just before persistence so internal observers above (event bridge,
-    // first-time-events check) still see the full property set, matching Android's
-    // network-send chokepoint.
-    Track.applyExcludeProperties(&p, exclude: excludeProperties)
+    func registerSuperPropertiesOnce(
+        _ properties: Properties,
+        superProperties: InternalProperties,
+        defaultValue: MixpanelType?
+    ) -> InternalProperties {
+        if mixpanelInstance?.hasOptedOutTracking() ?? false {
+            return superProperties
+        }
 
-    var trackEvent: InternalProperties = ["event": ev, "properties": p]
-    metadata.toDict().forEach { (k, v) in trackEvent[k] = v }
+        var updatedSuperProperties = superProperties
+        assertPropertyTypes(properties)
+        _ = properties.map {
+            let val = updatedSuperProperties[$0.key]
+            if val == nil || (defaultValue != nil && (val as? NSObject == defaultValue as? NSObject)) {
+                updatedSuperProperties[$0.key] = $0.value
+            }
+        }
 
-    self.mixpanelPersistence.saveEntity(trackEvent, type: .events)
-    MixpanelPersistence.saveTimedEvents(timedEvents: shadowTimedEvents, instanceName: instanceName)
-    return shadowTimedEvents
-  }
-
-  func registerSuperProperties(
-    _ properties: Properties,
-    superProperties: InternalProperties
-  ) -> InternalProperties {
-    if mixpanelInstance?.hasOptedOutTracking() ?? false {
-      return superProperties
+        return updatedSuperProperties
     }
 
-    var updatedSuperProperties = superProperties
-    assertPropertyTypes(properties)
-    updatedSuperProperties += properties
-
-    return updatedSuperProperties
-  }
-
-  func registerSuperPropertiesOnce(
-    _ properties: Properties,
-    superProperties: InternalProperties,
-    defaultValue: MixpanelType?
-  ) -> InternalProperties {
-    if mixpanelInstance?.hasOptedOutTracking() ?? false {
-      return superProperties
+    func unregisterSuperProperty(
+        _ propertyName: String,
+        superProperties: InternalProperties
+    ) -> InternalProperties {
+        var updatedSuperProperties = superProperties
+        updatedSuperProperties.removeValue(forKey: propertyName)
+        return updatedSuperProperties
     }
 
-    var updatedSuperProperties = superProperties
-    assertPropertyTypes(properties)
-    _ = properties.map {
-      let val = updatedSuperProperties[$0.key]
-      if val == nil || (defaultValue != nil && (val as? NSObject == defaultValue as? NSObject)) {
-        updatedSuperProperties[$0.key] = $0.value
-      }
+    func clearSuperProperties(_ superProperties: InternalProperties) -> InternalProperties {
+        var updatedSuperProperties = superProperties
+        updatedSuperProperties.removeAll()
+        return updatedSuperProperties
     }
 
-    return updatedSuperProperties
-  }
-
-  func unregisterSuperProperty(
-    _ propertyName: String,
-    superProperties: InternalProperties
-  ) -> InternalProperties {
-    var updatedSuperProperties = superProperties
-    updatedSuperProperties.removeValue(forKey: propertyName)
-    return updatedSuperProperties
-  }
-
-  func clearSuperProperties(_ superProperties: InternalProperties) -> InternalProperties {
-    var updatedSuperProperties = superProperties
-    updatedSuperProperties.removeAll()
-    return updatedSuperProperties
-  }
-
-  func updateSuperProperty(
-    _ update: (_ superProperties: inout InternalProperties) -> Void,
-    superProperties: inout InternalProperties
-  ) {
-    update(&superProperties)
-  }
-
-  func time(event: String?, timedEvents: InternalProperties, startTime: Double)
-    -> InternalProperties
-  {
-    if mixpanelInstance?.hasOptedOutTracking() ?? false {
-      return timedEvents
+    func updateSuperProperty(
+        _ update: (_ superProperties: inout InternalProperties) -> Void,
+        superProperties: inout InternalProperties
+    ) {
+        update(&superProperties)
     }
-    var updatedTimedEvents = timedEvents
-    guard let event = event, !event.isEmpty else {
-      MixpanelLogger.error(message: "mixpanel cannot time an empty event")
-      return updatedTimedEvents
-    }
-    updatedTimedEvents[event] = startTime
-    return updatedTimedEvents
-  }
 
-  func clearTimedEvents(_ timedEvents: InternalProperties) -> InternalProperties {
-    var updatedTimedEvents = timedEvents
-    updatedTimedEvents.removeAll()
-    return updatedTimedEvents
-  }
-
-  func clearTimedEvent(event: String?, timedEvents: InternalProperties) -> InternalProperties {
-    var updatedTimedEvents = timedEvents
-    guard let event = event, !event.isEmpty else {
-      MixpanelLogger.error(message: "mixpanel cannot clear an empty timed event")
-      return updatedTimedEvents
+    func time(event: String?, timedEvents: InternalProperties, startTime: Double)
+        -> InternalProperties
+    {
+        if mixpanelInstance?.hasOptedOutTracking() ?? false {
+            return timedEvents
+        }
+        var updatedTimedEvents = timedEvents
+        guard let event = event, !event.isEmpty else {
+            MixpanelLogger.error(message: "mixpanel cannot time an empty event")
+            return updatedTimedEvents
+        }
+        updatedTimedEvents[event] = startTime
+        return updatedTimedEvents
     }
-    updatedTimedEvents.removeValue(forKey: event)
-    return updatedTimedEvents
-  }
+
+    func clearTimedEvents(_ timedEvents: InternalProperties) -> InternalProperties {
+        var updatedTimedEvents = timedEvents
+        updatedTimedEvents.removeAll()
+        return updatedTimedEvents
+    }
+
+    func clearTimedEvent(event: String?, timedEvents: InternalProperties) -> InternalProperties {
+        var updatedTimedEvents = timedEvents
+        guard let event = event, !event.isEmpty else {
+            MixpanelLogger.error(message: "mixpanel cannot clear an empty timed event")
+            return updatedTimedEvents
+        }
+        updatedTimedEvents.removeValue(forKey: event)
+        return updatedTimedEvents
+    }
 }


### PR DESCRIPTION
 The changes represent a complete reformatting of the entire Swift codebase from 2-space to 4-space indentation.                                                                   
                  
  Key Changes:                                                                                                                                                                      
                  
  1. .swift-format configuration - Updated indentation settings:                                                                                                                    
    - spaces: 2 → spaces: 4
    - tabWidth: 2 → tabWidth: 4                                                                                                                                                     
  2. All Swift files reformatted - 66 files modified across:
    - Core library (Sources/ directory)                                                                                                                                             
    - Demo applications (iOS, macOS, tvOS, watchOS)
    - All test suites                                                                                                                                                               
  3. No functional changes - This is purely a code style/formatting change. The logic, functionality, and behavior of the code remain identical.

SDK-104