### PR TITLE
feat: extend Source.fallback with FallbackReason (SDK-79)

### DIFF
--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
@@ -206,7 +206,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
 
     func testFallbackVariantsHaveFallbackSource() {
         let fallback = MixpanelFlagVariant(value: "default")
-        if case .fallback = fallback.source {
+        if case .fallback(_) = fallback.source {
         } else {
             XCTFail("developer-supplied variants should carry .fallback source")
         }
@@ -567,7 +567,7 @@ class FeatureFlagPersistenceTests: XCTestCase {
         let result = manager.getVariantSync("flag_a", fallback: fallback)
 
         XCTAssertEqual(result.value as? String, "fallback_value")
-        if case .fallback = result.source {
+        if case .fallback(_) = result.source {
         } else {
             XCTFail("served fallback should carry .fallback source")
         }

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelFeatureFlagPersistenceTests.swift
@@ -212,6 +212,66 @@ class FeatureFlagPersistenceTests: XCTestCase {
         }
     }
 
+    // MARK: - FallbackReason distinctions (SDK-79)
+
+    /// `getVariantSync` before any load has happened must stamp `.notReady`, not
+    /// `.flagNotFound` — the two are distinct signals for the OpenFeature wrapper.
+    func testGetVariantSyncReturnsNotReadyWhenFlagsNeverLoaded() throws {
+        let mock = makeMockManager(distinctId: "user_a", context: [:], policy: .networkOnly)
+        waitForTrackingQueue(manager: mock)
+        // `flags` is nil at this point — no load has been attempted synchronously.
+        XCTAssertFalse(mock.areFlagsReady(), "precondition: flags must not be ready")
+
+        let result = mock.getVariantSync("any-flag", fallback: MixpanelFlagVariant(value: "fb"))
+        guard case .fallback(let reason) = result.source else {
+            XCTFail("expected .fallback source, got \(result.source)")
+            return
+        }
+        XCTAssertEqual(reason, .notReady, "sync lookup before load must be .notReady, not .flagNotFound")
+    }
+
+    /// `getVariantSync` after flags have loaded but the requested key isn't present must
+    /// stamp `.flagNotFound`, distinguishing "flag doesn't exist" from "flags never loaded".
+    func testGetVariantSyncReturnsFlagNotFoundWhenKeyMissing() throws {
+        let mock = makeMockManager(distinctId: "user_a", context: [:], policy: .networkOnly)
+        waitForTrackingQueue(manager: mock)
+        // Populate `flags` as an empty (but non-nil) map to simulate "loaded, no matching key".
+        mock.flagsLock.write { mock.flags = [:] }
+        XCTAssertTrue(mock.areFlagsReady(), "precondition: flags must be ready (empty is still ready)")
+
+        let result = mock.getVariantSync("missing-flag", fallback: MixpanelFlagVariant(value: "fb"))
+        guard case .fallback(let reason) = result.source else {
+            XCTFail("expected .fallback source, got \(result.source)")
+            return
+        }
+        XCTAssertEqual(reason, .flagNotFound, "loaded-but-missing key must be .flagNotFound")
+    }
+
+    /// Async `getVariant` after a failed network fetch with no cached/persisted data must
+    /// stamp `.backendError` — distinguishes "fetch failed" from "flags never loaded"
+    /// so the OpenFeature wrapper can map to GENERAL_ERROR instead of PROVIDER_NOT_READY.
+    func testGetVariantAsyncReturnsBackendErrorWhenFetchFailsWithoutCache() throws {
+        let mock = makeMockManager(distinctId: "user_a", context: [:], policy: .networkOnly)
+        waitForTrackingQueue(manager: mock)
+        mock.simulatedFetchResult = (success: false, flags: nil)
+        mock.simulatedNetworkDelay = 0
+        XCTAssertFalse(mock.areFlagsReady(), "precondition: no cache")
+
+        let done = expectation(description: "async lookup completes after failed fetch")
+        var observed: MixpanelFlagVariant?
+        mock.getVariant("any-flag", fallback: MixpanelFlagVariant(value: "fb")) { variant in
+            observed = variant
+            done.fulfill()
+        }
+        wait(for: [done], timeout: 2.0)
+
+        guard let result = observed, case .fallback(let reason) = result.source else {
+            XCTFail("expected .fallback source, got \(String(describing: observed?.source))")
+            return
+        }
+        XCTAssertEqual(reason, .backendError, "fetch-failed with no cache must be .backendError, not .notReady")
+    }
+
     // MARK: - Default TTL
 
     /// `VariantLookupPolicy.defaultTTL` is 24 hours, and the zero-arg static factories

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -70,11 +70,15 @@ public struct MixpanelFlagVariant: Decodable {
     /// cooperation — both surface as `.flagNotFound` for now. Future server changes
     /// can add a more specific reason without breaking callers that already switch
     /// on this enum.
-    public enum FallbackReason {
+    public enum FallbackReason: Equatable, Hashable, Sendable {
         /// Flag key was not present in the cache or network response.
         case flagNotFound
         /// Flags were not ready when the sync lookup happened.
         case notReady
+        /// Network fetch failed and no cached/persisted variant was available.
+        /// Only surfaced on the async `getVariant` path — `getVariantSync` cannot
+        /// distinguish "network error" from "flags never loaded."
+        case backendError
     }
 
     enum CodingKeys: String, CodingKey {
@@ -740,11 +744,20 @@ class FeatureFlagManager: MixpanelFlags {
                 // the fallback.
                 MixpanelLogger.debug(
                     message: "Flags not yet servable, attempting fetch for getVariant '\(flagName)'...")
-                self._fetchFlagsIfNeeded { _ in
+                self._fetchFlagsIfNeeded { fetchOk in
                     // Hop back to the tracking queue so we can read flags + run the tracking check
                     // atomically. Whether the fetch succeeded or not, _getVariantSyncImpl returns the
                     // variant from `flags` if present (persisted or network) else the fallback.
                     self.trackingQueue.async {
+                        if !fetchOk, !self.areFlagsReady() {
+                            // Fetch failed and we have no cached/persisted flags to fall back on —
+                            // distinguish this from "flags never loaded" (.notReady) so callers
+                            // (e.g., the OpenFeature wrapper) can surface a backend/general error
+                            // rather than a not-ready state.
+                            let result = fallback.withSource(.fallback(reason: .backendError))
+                            DispatchQueue.main.async { completion(result) }
+                            return
+                        }
                         let result = self._getVariantSyncImpl(flagName, fallback: fallback)
                         DispatchQueue.main.async { completion(result) }
                     }

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -60,11 +60,7 @@ public struct MixpanelFlagVariant: Decodable {
         /// ready. Previously a Fallback meant only "not a real variant," which collapsed
         /// several distinct outcomes into one (SDK-79). Callers — especially the OpenFeature
         /// wrapper — can dispatch on the reason to surface the correct user-facing error code.
-        ///
-        /// `.unspecified` is the default for developer-constructed fallbacks; the SDK
-        /// stamps a more specific reason before returning so callers should rarely
-        /// observe it on a returned variant.
-        case fallback(reason: FallbackReason = .unspecified)
+        case fallback(reason: FallbackReason)
     }
 
     /// Why the SDK returned the developer fallback.
@@ -75,9 +71,6 @@ public struct MixpanelFlagVariant: Decodable {
     /// can add a more specific reason without breaking callers that already switch
     /// on this enum.
     public enum FallbackReason {
-        /// Developer-constructed default. The SDK stamps a more specific reason
-        /// before returning, so callers should rarely observe this value.
-        case unspecified
         /// Flag key was not present in the cache or network response.
         case flagNotFound
         /// Flags were not ready when the sync lookup happened.
@@ -110,7 +103,7 @@ public struct MixpanelFlagVariant: Decodable {
         // Decoded variants are immediately re-stamped via `withSource` before being placed in
         // `flags`, so the customer never observes `.fallback` here. Defaulting to `.fallback`
         // keeps `source` non-optional without needing a sentinel "unstamped" case.
-        source = .fallback()
+        source = .fallback(reason: .flagNotFound)
     }
 
     // Helper initializer with fallbacks, value defaults to key if nil
@@ -127,7 +120,7 @@ public struct MixpanelFlagVariant: Decodable {
         self.experimentID = experimentID
         self.isExperimentActive = isExperimentActive
         self.isQATester = isQATester
-        self.source = .fallback()
+        self.source = .fallback(reason: .flagNotFound)
     }
 
     /// Initializer that stamps a served (or fallback) variant with its origin.
@@ -730,9 +723,8 @@ class FeatureFlagManager: MixpanelFlags {
                 }
                 // Flags are loaded (not network-first-awaiting, not stale), but this key
                 // isn't in `currentFlags` (or its persisted variant was expired). Stamp
-                // the fallback as `.flagNotFound` so the OpenFeature wrapper can map to
-                // `FLAG_NOT_FOUND` instead of letting a bare `.fallback(.unspecified)`
-                // through — same treatment the sync impl applies in _getVariantSyncImpl.
+                // the fallback as `.flagNotFound` — same treatment the sync impl applies
+                // in _getVariantSyncImpl.
                 let result = flagVariant ?? fallback.withSource(.fallback(reason: .flagNotFound))
                 if flagVariant != nil, needsTrackingCheck {
                     // Perform atomic check-and-track

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -54,9 +54,34 @@ public struct MixpanelFlagVariant: Decodable {
         /// Variant loaded from the on-disk persistence layer. `persistedAt` is the time the
         /// variant set was originally written to disk.
         case persistence(persistedAt: Date)
-        /// Developer-supplied fallback returned because the SDK had no value to serve (flag
-        /// not in the loaded set, flags never loaded, fetch failed under NetworkFirst, etc.).
-        case fallback
+        /// Developer-supplied fallback returned because the SDK had no value to serve.
+        ///
+        /// `reason` explains *why* — flag missing from the cache/response, or flags not yet
+        /// ready. Previously a Fallback meant only "not a real variant," which collapsed
+        /// several distinct outcomes into one (SDK-79). Callers — especially the OpenFeature
+        /// wrapper — can dispatch on the reason to surface the correct user-facing error code.
+        ///
+        /// `.unspecified` is the default for developer-constructed fallbacks; the SDK
+        /// stamps a more specific reason before returning so callers should rarely
+        /// observe it on a returned variant.
+        case fallback(reason: FallbackReason = .unspecified)
+    }
+
+    /// Why the SDK returned the developer fallback.
+    ///
+    /// Network/cache SDKs (like the iOS/macOS Mixpanel SDK) cannot distinguish
+    /// "flag does not exist" from "user is not in any rollout" without server-side
+    /// cooperation — both surface as `.flagNotFound` for now. Future server changes
+    /// can add a more specific reason without breaking callers that already switch
+    /// on this enum.
+    public enum FallbackReason {
+        /// Developer-constructed default. The SDK stamps a more specific reason
+        /// before returning, so callers should rarely observe this value.
+        case unspecified
+        /// Flag key was not present in the cache or network response.
+        case flagNotFound
+        /// Flags were not ready when the sync lookup happened.
+        case notReady
     }
 
     enum CodingKeys: String, CodingKey {
@@ -85,7 +110,7 @@ public struct MixpanelFlagVariant: Decodable {
         // Decoded variants are immediately re-stamped via `withSource` before being placed in
         // `flags`, so the customer never observes `.fallback` here. Defaulting to `.fallback`
         // keeps `source` non-optional without needing a sentinel "unstamped" case.
-        source = .fallback
+        source = .fallback()
     }
 
     // Helper initializer with fallbacks, value defaults to key if nil
@@ -102,16 +127,18 @@ public struct MixpanelFlagVariant: Decodable {
         self.experimentID = experimentID
         self.isExperimentActive = isExperimentActive
         self.isQATester = isQATester
-        self.source = .fallback
+        self.source = .fallback()
     }
 
-    /// Internal initializer used when stamping a served variant with its origin.
-    internal init(
+    /// Initializer that stamps a served (or fallback) variant with its origin.
+    /// Used both internally (by `withSource` when re-tagging a decoded variant)
+    /// and by tests/callers constructing variants with explicit source metadata.
+    public init(
         key: String,
         value: Any?,
-        experimentID: String?,
-        isExperimentActive: Bool?,
-        isQATester: Bool?,
+        experimentID: String? = nil,
+        isExperimentActive: Bool? = nil,
+        isQATester: Bool? = nil,
         source: Source
     ) {
         self.key = key
@@ -123,7 +150,11 @@ public struct MixpanelFlagVariant: Decodable {
     }
 
     /// Returns a copy of this variant stamped with the given source. Other fields are preserved.
-    internal func withSource(_ source: Source) -> MixpanelFlagVariant {
+    ///
+    /// Public so callers (and tests) can re-tag variants with explicit source
+    /// metadata — the SDK uses this internally to stamp the reason a developer-supplied
+    /// fallback was returned.
+    public func withSource(_ source: Source) -> MixpanelFlagVariant {
         return MixpanelFlagVariant(
             key: self.key,
             value: self.value,
@@ -644,7 +675,12 @@ class FeatureFlagManager: MixpanelFlags {
             return foundVariant
         } else {
             MixpanelLogger.info(message: "Flag '\(flagName)' not found or flags not ready. Returning fallback.")
-            return fallback
+            // Stamp the fallback with a reason so callers (e.g., the OpenFeature
+            // wrapper) can tell why we fell back — distinguish "flag missing /
+            // user not in cohort" from "flags never loaded" (SDK-79).
+            let reason: MixpanelFlagVariant.FallbackReason =
+                areFlagsReady() ? .flagNotFound : .notReady
+            return fallback.withSource(.fallback(reason: reason))
         }
     }
 
@@ -692,7 +728,12 @@ class FeatureFlagManager: MixpanelFlags {
                 {
                     self._fetchFlagsIfNeeded(completion: nil)
                 }
-                let result = flagVariant ?? fallback
+                // Flags are loaded (not network-first-awaiting, not stale), but this key
+                // isn't in `currentFlags` (or its persisted variant was expired). Stamp
+                // the fallback as `.flagNotFound` so the OpenFeature wrapper can map to
+                // `FLAG_NOT_FOUND` instead of letting a bare `.fallback(.unspecified)`
+                // through — same treatment the sync impl applies in _getVariantSyncImpl.
+                let result = flagVariant ?? fallback.withSource(.fallback(reason: .flagNotFound))
                 if flagVariant != nil, needsTrackingCheck {
                     // Perform atomic check-and-track
                     self._trackFlagIfNeeded(flagName: flagName, variant: result)
@@ -1366,7 +1407,7 @@ class FeatureFlagManager: MixpanelFlags {
                 if let ttl = self.persistenceTtlSeconds() {
                     properties["$ttl_in_ms"] = Int(ttl * 1000)
                 }
-            case .fallback:
+            case .fallback(_):
                 break
         }
 


### PR DESCRIPTION
## Summary

- **`MixpanelFlagVariant.Source.fallback` now carries an associated `FallbackReason`**: `.flagNotFound` | `.notReady` | `.backendError`. `getVariantSync` stamps `.notReady` when flags haven't loaded and `.flagNotFound` when the key is absent from the loaded set. Async `getVariant` upgrades to `.backendError` when a network fetch fails and no cached/persisted flags are available.
- `FallbackReason` conforms to `Equatable, Hashable, Sendable` for testing, Swift 6 concurrency, and downstream collection use.
- `MixpanelFlagVariant.withSource(_:)` is now `public` so callers (and the openfeature provider) can stamp source metadata.
- New public init lets callers construct variants with an explicit `Source`.

## ⚠ Breaking change

`Source.fallback` gained an associated value. External code that pattern-matches or switches on the case will not compile as-is:

```swift
// Before
switch variant.source { case .fallback: ... }
if case .fallback = variant.source { ... }
MixpanelFlagVariant(..., source: .fallback())

// After
switch variant.source { case .fallback(let reason): ... }   // or .fallback(_)
if case .fallback(_) = variant.source { ... }               // or bind the reason
MixpanelFlagVariant(..., source: .fallback(reason: .flagNotFound))
```

The default-associated-value trick (`case fallback(reason: FallbackReason = .unspecified)`) was tried and dropped in this branch — it lets `.fallback()` compile at construction sites but doesn't rescue exhaustive `switch` statements or `if case` patterns, so it was misleading half-coverage. Ripping the default off forces every callsite to name an explicit reason, which is the actionable behavior we want.

## Why

Today the OpenFeature wrapper (in [mixpanel-swift-openfeature](https://github.com/mixpanel/mixpanel-swift-openfeature)) collapses every fallback to `FLAG_NOT_FOUND`, sending callers debugging a default value chasing the flag name when the real cause was usually `.notReady` or a backend failure. The new `FallbackReason` lets the wrapper map each case to the spec-correct error code.

Discriminated union (`Source.fallback(reason:)`) rather than two flat fields because Swift's enums model this naturally; invalid states like "successful evaluation with a fallback reason" are unrepresentable — mirroring the existing `.persistence(persistedAt:)` case's design. Reason names align with the Android SDK-79 shape ([mixpanel-android#981](https://github.com/mixpanel/mixpanel-android/pull/981) uses `Source.Fallback` with a `Reason` field); the dynamic-typed SDKs (JS, PHP) use a sibling flat `fallback_reason` string field with matching values.

Cross-SDK fix tracked at [Linear SDK-79](https://linear.app/mixpanel/issue/SDK-79).

## Server-side note

`.flagNotFound` today still collapses "flag does not exist" with "user not in any rollout" because the `/flags` response can't tell them apart. This change preps the SDK to surface the distinction once the server returns it; no behavioral change for that case until then.

## Follow-up PR

[mixpanel-swift-openfeature](https://github.com/mixpanel/mixpanel-swift-openfeature) needs a matching update to dispatch on `Source.fallback`'s reason — that PR depends on this one shipping in a new `mixpanel-swift` release first (the openfeature package consumes the released SPM dep). It'll come right after release.

## Test plan

- [x] `swift build` succeeds
- [x] Three new `FeatureFlagPersistenceTests` cover the reason distinction end-to-end and pass locally on `iPhone 17 Pro`:
  - `testGetVariantSyncReturnsNotReadyWhenFlagsNeverLoaded`
  - `testGetVariantSyncReturnsFlagNotFoundWhenKeyMissing`
  - `testGetVariantAsyncReturnsBackendErrorWhenFetchFailsWithoutCache`
- [x] All 8 `FeatureFlagPersistenceTests` that flaked on the prior CI run pass locally in 0.125s total — no reproducible regression from this branch
- [ ] Wrapper PR pending base SDK release (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)