### PR TITLE
fix: add Autocapture.swift to podspec base_source_files

### DIFF
--- a/Mixpanel-swift.podspec
+++ b/Mixpanel-swift.podspec
@@ -23,7 +23,8 @@ Pod::Spec.new do |s|
     'Sources/Constants.swift', 'Sources/MixpanelType.swift', 'Sources/Mixpanel.swift', 'Sources/MixpanelInstance.swift',
     'Sources/Flush.swift', 'Sources/Track.swift', 'Sources/People.swift', 'Sources/AutomaticEvents.swift',
     'Sources/Group.swift', 'Sources/ReadWriteLock.swift', 'Sources/SessionMetadata.swift', 'Sources/MPDB.swift', 'Sources/MixpanelPersistence.swift', 
-    'Sources/Data+Compression.swift', 'Sources/MixpanelOptions.swift', 'Sources/FeatureFlags.swift']
+    'Sources/Data+Compression.swift', 'Sources/MixpanelOptions.swift', 'Sources/FeatureFlags.swift',
+    'Sources/Autocapture.swift']
   s.tvos.deployment_target = '12.0'
   s.tvos.frameworks = 'UIKit', 'Foundation'
   s.tvos.pod_target_xcconfig = {


### PR DESCRIPTION
## Summary
- 6.5.0's SPM release job fails at `pod lib lint` on every subspec/platform combo except `Complete/ios` with `cannot find type 'Autocapture' in scope` at `Sources/MixpanelInstance.swift:107` and `:524`.
- Root cause: the podspec's `base_source_files` is a hand-maintained whitelist. `Sources/Autocapture.swift` was added for 6.5.0 (commit ae3aefb6) but was never added to that list, while `MixpanelInstance.swift` uses `Autocapture` unconditionally (no `#if os(iOS)` guard).
- Failing run: https://github.com/mixpanel/mixpanel-swift/actions/runs/28819557855/job/85467528474
- Only `Complete/ios` (line 44) works because it uses the `Sources/*.swift` glob; `Core` on all platforms and `Complete` on tvOS/macOS/watchOS use `base_source_files` and break.

## Test plan
- [ ] `pod lib lint Mixpanel-swift.podspec --allow-warnings` passes locally
- [ ] Release SPM workflow's "Validate podspec" job passes on this branch

## Follow-up (not in this PR)
Consider replacing all six `source_files` assignments with the `['Sources/*.swift']` glob so a future added file can't reintroduce this class of bug. Nothing under `Sources/` is currently platform-specific — platform variance is handled inside files with `#if os(...)` (e.g. `MixpanelInstance.swift:527`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)