### PR TITLE
fix: Reduce flush and DB memory spikes

### DIFF
--- a/Sources/Flush.swift
+++ b/Sources/Flush.swift
@@ -10,7 +10,7 @@ import Foundation
 
 protocol FlushDelegate: AnyObject {
     func flush(performFullFlush: Bool, completion: (() -> Void)?)
-    func flushSuccess(type: FlushType, ids: [Int32])
+    func removeProcessedEntities(type: FlushType, ids: [Int32])
 
     #if os(iOS)
     func updateNetworkActivityIndicator(_ on: Bool)
@@ -142,32 +142,40 @@ class Flush: AppLifecycle {
 
                 batch = []
 
-                if let requestData = requestData {
-                    #if os(iOS)
-                    if !MixpanelInstance.isiOSAppExtension() {
-                        delegate?.updateNetworkActivityIndicator(true)
-                    }
-                    #endif  // os(iOS)
-                    let success = flushRequest.sendRequest(
-                        requestData,
-                        type: type,
-                        useIP: useIPAddressForGeoLocation,
-                        headers: headers,
-                        queryItems: queryItems, useGzipCompression: useGzipCompression)
-                    #if os(iOS)
-                    if !MixpanelInstance.isiOSAppExtension() {
-                        delegate?.updateNetworkActivityIndicator(false)
-                    }
-                    #endif  // os(iOS)
-                    if success {
-                        delegate?.flushSuccess(type: type, ids: ids)
-                        mutableQueue = self.removeProcessedBatch(
-                            batchSize: batchSize,
-                            queue: mutableQueue,
-                            type: type)
-                    } else {
-                        shouldBreak = true
-                    }
+                guard let requestData = requestData else {
+                    MixpanelLogger.warn(message: "Failed to serialize batch, dropping \(ids.count) events")
+                    delegate?.removeProcessedEntities(type: type, ids: ids)
+                    mutableQueue = self.removeProcessedBatch(
+                        batchSize: batchSize,
+                        queue: mutableQueue,
+                        type: type)
+                    return
+                }
+
+                #if os(iOS)
+                if !MixpanelInstance.isiOSAppExtension() {
+                    delegate?.updateNetworkActivityIndicator(true)
+                }
+                #endif  // os(iOS)
+                let success = flushRequest.sendRequest(
+                    requestData,
+                    type: type,
+                    useIP: useIPAddressForGeoLocation,
+                    headers: headers,
+                    queryItems: queryItems, useGzipCompression: useGzipCompression)
+                #if os(iOS)
+                if !MixpanelInstance.isiOSAppExtension() {
+                    delegate?.updateNetworkActivityIndicator(false)
+                }
+                #endif  // os(iOS)
+                if success {
+                    delegate?.removeProcessedEntities(type: type, ids: ids)
+                    mutableQueue = self.removeProcessedBatch(
+                        batchSize: batchSize,
+                        queue: mutableQueue,
+                        type: type)
+                } else {
+                    shouldBreak = true
                 }
             }
             if shouldBreak {

--- a/Sources/Flush.swift
+++ b/Sources/Flush.swift
@@ -128,43 +128,50 @@ class Flush: AppLifecycle {
     ) {
         var mutableQueue = queue
         while !mutableQueue.isEmpty {
-            let batchSize = min(mutableQueue.count, flushBatchSize)
-            let range = 0..<batchSize
-            let batch = Array(mutableQueue[range])
-            let ids: [Int32] = batch.map { entity in
-                (entity["id"] as? Int32) ?? 0
+            var shouldBreak = false
+            autoreleasepool {
+                let batchSize = min(mutableQueue.count, flushBatchSize)
+                let range = 0..<batchSize
+                var batch = Array(mutableQueue[range])
+                let ids: [Int32] = batch.map { entity in
+                    (entity["id"] as? Int32) ?? 0
+                }
+                MixpanelLogger.debug(message: "Sending batch of data")
+                MixpanelLogger.debug(message: batch as Any)
+                let requestData = JSONHandler.encodeAPIData(batch)
+
+                batch = []
+
+                if let requestData = requestData {
+                    #if os(iOS)
+                    if !MixpanelInstance.isiOSAppExtension() {
+                        delegate?.updateNetworkActivityIndicator(true)
+                    }
+                    #endif  // os(iOS)
+                    let success = flushRequest.sendRequest(
+                        requestData,
+                        type: type,
+                        useIP: useIPAddressForGeoLocation,
+                        headers: headers,
+                        queryItems: queryItems, useGzipCompression: useGzipCompression)
+                    #if os(iOS)
+                    if !MixpanelInstance.isiOSAppExtension() {
+                        delegate?.updateNetworkActivityIndicator(false)
+                    }
+                    #endif  // os(iOS)
+                    if success {
+                        delegate?.flushSuccess(type: type, ids: ids)
+                        mutableQueue = self.removeProcessedBatch(
+                            batchSize: batchSize,
+                            queue: mutableQueue,
+                            type: type)
+                    } else {
+                        shouldBreak = true
+                    }
+                }
             }
-            // Log data payload sent
-            MixpanelLogger.debug(message: "Sending batch of data")
-            MixpanelLogger.debug(message: batch as Any)
-            let requestData = JSONHandler.encodeAPIData(batch)
-            if let requestData = requestData {
-                #if os(iOS)
-                if !MixpanelInstance.isiOSAppExtension() {
-                    delegate?.updateNetworkActivityIndicator(true)
-                }
-                #endif  // os(iOS)
-                let success = flushRequest.sendRequest(
-                    requestData,
-                    type: type,
-                    useIP: useIPAddressForGeoLocation,
-                    headers: headers,
-                    queryItems: queryItems, useGzipCompression: useGzipCompression)
-                #if os(iOS)
-                if !MixpanelInstance.isiOSAppExtension() {
-                    delegate?.updateNetworkActivityIndicator(false)
-                }
-                #endif  // os(iOS)
-                if success {
-                    // remove
-                    delegate?.flushSuccess(type: type, ids: ids)
-                    mutableQueue = self.removeProcessedBatch(
-                        batchSize: batchSize,
-                        queue: mutableQueue,
-                        type: type)
-                } else {
-                    break
-                }
+            if shouldBreak {
+                break
             }
         }
     }

--- a/Sources/MPDB.swift
+++ b/Sources/MPDB.swift
@@ -270,19 +270,21 @@ class MPDB {
             var rowsRead: Int = 0
             if sqlite3_prepare_v2(db, selectString, -1, &selectStatement, nil) == SQLITE_OK {
                 while sqlite3_step(selectStatement) == SQLITE_ROW {
-                    if let blob = sqlite3_column_blob(selectStatement, 1) {
-                        let blobLength = sqlite3_column_bytes(selectStatement, 1)
-                        let data = Data(bytes: blob, count: Int(blobLength))
-                        let id = sqlite3_column_int(selectStatement, 0)
+                    autoreleasepool {
+                        if let blob = sqlite3_column_blob(selectStatement, 1) {
+                            let blobLength = sqlite3_column_bytes(selectStatement, 1)
+                            let data = Data(bytes: blob, count: Int(blobLength))
+                            let id = sqlite3_column_int(selectStatement, 0)
 
-                        if let jsonObject = JSONHandler.deserializeData(data) as? InternalProperties {
-                            var entity = jsonObject
-                            entity["id"] = id
-                            rows.append(entity)
+                            if let jsonObject = JSONHandler.deserializeData(data) as? InternalProperties {
+                                var entity = jsonObject
+                                entity["id"] = id
+                                rows.append(entity)
+                            }
+                            rowsRead += 1
+                        } else {
+                            logSqlError(message: "No blob found in data column for row in \(tableName)")
                         }
-                        rowsRead += 1
-                    } else {
-                        logSqlError(message: "No blob found in data column for row in \(tableName)")
                     }
                 }
                 if rowsRead > 0 {

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -1252,7 +1252,7 @@ extension MixpanelInstance {
         self.flushInstance.flushQueue(queue, type: type, headers: headers, queryItems: queryItems)
     }
 
-    func flushSuccess(type: FlushType, ids: [Int32]) {
+    func removeProcessedEntities(type: FlushType, ids: [Int32]) {
         trackingQueue.async { [weak self] in
             guard let self = self else {
                 return


### PR DESCRIPTION
## Summary                                                                                                                                        
         
  - Fix `NSMallocException` crash during flush by adding `autoreleasepool` to batch processing loops in `MPDB.readRows` and `Flush.flushQueueInBatches`                                                                                                                       
  - Reduce peak memory by releasing batch array immediately after JSON encoding                                                                     
                                                                                                                                                    
  ## The Crash
                                                                                                                                                    
  Users are experiencing a `NSMallocException` crash during the Mixpanel flush cycle. The crash occurs inside Foundation's JSON parser  (`JSONSerialization.jsonObject`) when deserializing event data read from the SQLite database.
                                                                                                                                                    
  **Crash stack:**          
```
  NSMallocException
    CoreFoundation    _NSDictionaryI_new
    Foundation        newJSONObject      
    Foundation        newJSONValue 
    Foundation        -[NSJSONReader parseData:options:error:]
    Mixpanel          JSONHandler.deserializeData(:)      ← JSONHandler.swift:29                                                                    
    Mixpanel          MPDB.readRows(:numRows:flag:)       ← MPDB.swift:277      
    Mixpanel          MixpanelPersistence.loadEntitiesInBatch(...)                                                                                  
    Mixpanel          MixpanelInstance.flush(...)                                                                                                   
```
   
  ## Root Cause                                                                                                                                     
                                                                                                                                                    
  The crash seems to be  caused due to **memory accumulation from objects** during batch processing.                                                                                                   
 
  **In `MPDB.readRows`:** Each iteration of the SQLite row-reading loop creates temporary objects — `Data` buffers, deserialized dictionaries, intermediate JSON parser allocations. Without an `autoreleasepool`, these temporaries are not released until the entire loop completes. When reading hundreds of rows (especially during a full flush on background where `batchSize` is `Int.max`), the accumulated autoreleased objects  exhaust available memory. The Nth call to `JSONSerialization.jsonObject` then fails to allocate a dictionary, throwing `NSMallocException`.

  **In `Flush.flushQueueInBatches`:** Similarly, each batch iteration creates temporary objects (batch array copies, JSON-encoded strings, network response objects) that accumulate across iterations without being released.
                                                                                                                                                    
  ## The Fix                

  1. **`MPDB.readRows`** — Wrap the SQLite row-reading loop body in `autoreleasepool`. This releases each row's temporary objects (`Data` buffer,  JSON parsing intermediates, deserialized dictionary) immediately after the row is processed, before the next row begins. Peak memory drops from  `O(N)` temporaries to `O(1)`.                                                                                                                     
                            
  2. **`Flush.flushQueueInBatches`** — Wrap the batch processing loop body in `autoreleasepool`. This releases each batch iteration's temporaries (batch array, JSON string, network objects) before the next iteration. Additionally, the batch array is explicitly cleared after JSON encoding  since only the `ids` array is needed for cleanup.                                                                                                 

  3. **`Flush.flushQueueInBatches`** — Fix infinite loop when `JSONHandler.encodeAPIData` returns `nil` (e.g., non-serializable values in the batch). Previously, a `nil` payload caused the `while !mutableQueue.isEmpty` loop to spin forever — no items were removed and no break was triggered. Now, unserializable batches are logged, removed from the in-memory queue, and their corresponding rows are deleted from the database via `removeProcessedEntities`, allowing the loop to continue with the remaining batches.

  4. **Rename `flushSuccess` → `removeProcessedEntities`** — The method deletes flushed rows from the database. The old name was misleading now that it is also called when dropping unserializable batches, not just on successful network sends.

  ## Why This Is Sufficient

  - Events are ~1.5KB each — well within normal size                                                                                                
  - `JSONHandler.deserializeData` already has try-catch error handling for malformed data
  - The crash seems to be purely from autorelease pool exhaustion during batch iteration, not from any single event                                          
  - With the `autoreleasepool` fix, each iteration's memory footprint is bounded regardless of total batch size                                     
   
  ## Test Plan                                                                                                                                      
                            
  - [ ] Verify flush works correctly with small event queues (< 50 events)                                                                          
  - [ ] Verify full flush on background with large event queues (500+ events)
  - [ ] Verify failed network requests still break out of the batch loop correctly                                                                  
  - [ ] Verify successful batches are deleted from the database after sending                                                                       
  - [ ] Monitor memory usage during flush with Instruments to confirm reduced peak memory

## Memory Profiling — Instruments Allocations Results

**Device:** iPhone 16 Pro (iOS 18)  
**Events:** 2,000 queued events with nested dictionary payloads

| Metric | Without fix | With fix | Delta |
|---|---|---|---|
| Peak live bytes | 73.05 MiB | 32.51 MiB | **-55.5%** |
| Total bytes throughput | 1.29 GiB | 1.22 GiB | -5.4% |
| Transient allocations | 1,08,38,961 | 1,02,11,942 | -6,27,019 |
| `UnknownObjectType` transient | 6,61,589 | 3,83,542 | **-42%** |
| Persistent bytes | 14.68 MiB | 14.67 MiB | negligible |

### Allocation curve

**Without fix:** continuously climbing ramp throughout flush. Parser intermediates from all previously processed rows accumulate simultaneously with no release between rows — O(N) peak, scales linearly with queue depth.

**With fix:** flat plateau from flush start to finish. Each row's temporaries drain before the next row begins — O(1) peak, bounded regardless of queue depth.

### Key signal: `UnknownObjectType` -42%

These are `_NSJSONReader`'s internal working objects (scanner state, intermediate containers, buffer nodes) — short-lived by design but held alive across the entire loop without `autoreleasepool`. Persistent allocations (`__NSDictionaryI`, `CFString`, heap buckets) are identical between both runs, confirming the fix changes only *when* temporaries are released, not what the SDK retains.

### Why this matters at scale

At 2,000 events on a high-RAM device, peak is 73 MiB without the fix. On older devices under memory pressure with other SDKs active, the same O(N) accumulation exhausts malloc headroom as queue depth grows, can cause `__NSArrayM_new` to fail inside `_NSJSONReader` and raise an `NSMallocException` that Swift's `do/catch` cannot intercept.

</div>

<img width="1050" height="997" alt="Screenshot 2026-07-15 at 1 38 57 PM" src="https://github.com/user-attachments/assets/b7831ca9-14dd-4e58-a200-85f58bf5e522" />
<img width="1170" height="999" alt="Screenshot 2026-07-15 at 1 38 34 PM" src="https://github.com/user-attachments/assets/b9b42744-8eb7-4e19-9bba-d4cb11eecb94" />


Fixes SDK-91