### PR TITLE
fix: consolidate MixpanelOptions into single cross-platform initializer

### DIFF
--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -267,11 +267,8 @@ public class MixpanelOptions {
     /// ```
     ///
     /// **Note:** Autocapture is only available on iOS.
-    #if os(iOS)
     public let autocaptureOptions: AutocaptureOptions?
-    #endif
 
-    #if os(iOS)
     public init(
         token: String,
         flushInterval: Double = 60,
@@ -302,7 +299,11 @@ public class MixpanelOptions {
         self.useGzipCompression = useGzipCompression
         self.deviceIdProvider = deviceIdProvider
         self.excludeProperties = excludeProperties
+        #if os(iOS)
         self.autocaptureOptions = autocaptureOptions
+        #else
+        self.autocaptureOptions = nil
+        #endif
 
         if let featureFlagOptions = featureFlagOptions {
             self.featureFlagOptions = featureFlagOptions
@@ -313,45 +314,4 @@ public class MixpanelOptions {
             )
         }
     }
-    #else
-    public init(
-        token: String,
-        flushInterval: Double = 60,
-        instanceName: String? = nil,
-        trackAutomaticEvents: Bool = false,
-        optOutTrackingByDefault: Bool = false,
-        useUniqueDistinctId: Bool = false,
-        superProperties: Properties? = nil,
-        serverURL: String? = nil,
-        proxyServerConfig: ProxyServerConfig? = nil,
-        useGzipCompression: Bool = true,
-        featureFlagsEnabled: Bool = false,
-        featureFlagsContext: [String: Any] = [:],
-        deviceIdProvider: (() -> String?)? = nil,
-        featureFlagOptions: FeatureFlagOptions? = nil,
-        excludeProperties: Set<String> = []
-    ) {
-        self.token = token
-        self.flushInterval = flushInterval
-        self.instanceName = instanceName
-        self.trackAutomaticEvents = trackAutomaticEvents
-        self.optOutTrackingByDefault = optOutTrackingByDefault
-        self.useUniqueDistinctId = useUniqueDistinctId
-        self.superProperties = superProperties
-        self.serverURL = serverURL
-        self.proxyServerConfig = proxyServerConfig
-        self.useGzipCompression = useGzipCompression
-        self.deviceIdProvider = deviceIdProvider
-        self.excludeProperties = excludeProperties
-
-        if let featureFlagOptions = featureFlagOptions {
-            self.featureFlagOptions = featureFlagOptions
-        } else {
-            self.featureFlagOptions = FeatureFlagOptions(
-                enabled: featureFlagsEnabled,
-                context: featureFlagsContext
-            )
-        }
-    }
-    #endif
 }


### PR DESCRIPTION
## Summary

- Replaces the two platform-conditional `MixpanelOptions.init` variants (`#if os(iOS)` / `#else`) with a single initializer
- The `autocaptureOptions` parameter is now accepted on all platforms but silently set to `nil` on non-iOS, via a `#if os(iOS)` guard inside the init body
- Removes ~40 lines of duplicated init code that had to be kept in sync across platforms

## Motivation

The previous approach duplicated the entire initializer behind `#if os(iOS)` / `#else` blocks — one with `autocaptureOptions` and one without. This meant every new parameter added to `MixpanelOptions` had to be added in two places, risking drift. Moving the platform guard inside the body keeps a single source of truth.

## Test plan

- [x] Build and run MixpanelDemo on iOS simulator — autocapture initializes correctly
- [ ] Verify non-iOS targets (macOS, tvOS, watchOS) compile with `autocaptureOptions` parameter present but ignored