### PR TITLE
chore: document that screenName must be non-empty in trackScreenView/trackScreenLeave

### DIFF
--- a/Sources/Autocapture.swift
+++ b/Sources/Autocapture.swift
@@ -15,14 +15,12 @@ open class Autocapture {
 
     weak var mixpanelInstance: MixpanelInstance?
 
-    /**
-       Track a screen view event. This is a convenience method for tracking when users view
-       a screen/page in your application.
-    
-       - parameter screenName: The name of the screen/page being viewed. Must be non-empty;
-         if an empty or whitespace-only string is passed, the event is silently dropped.
-       - parameter properties: Optional properties to include with this event
-       */
+    /// Track a screen view event. This is a convenience method for tracking when users view
+    /// a screen/page in your application.
+    ///
+    /// - parameter screenName: The name of the screen/page being viewed. Must be non-empty;
+    ///   if an empty or whitespace-only string is passed, the event is silently dropped.
+    /// - parameter properties: Optional properties to include with this event
     open func trackScreenView(screenName: String, properties: Properties? = nil) {
         guard let mixpanelInstance = mixpanelInstance else { return }
         guard !screenName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -46,14 +44,12 @@ open class Autocapture {
         mixpanelInstance.track(event: "$mp_page_view", properties: mergedProperties)
     }
 
-    /**
-       Track a screen leave event. This is a convenience method for tracking when users leave
-       a screen/page in your application.
-    
-       - parameter screenName: The name of the screen/page being left. Must be non-empty;
-         if an empty or whitespace-only string is passed, the event is silently dropped.
-       - parameter properties: Optional properties to include with this event
-       */
+    /// Track a screen leave event. This is a convenience method for tracking when users leave
+    /// a screen/page in your application.
+    ///
+    /// - parameter screenName: The name of the screen/page being left. Must be non-empty;
+    ///   if an empty or whitespace-only string is passed, the event is silently dropped.
+    /// - parameter properties: Optional properties to include with this event
     open func trackScreenLeave(screenName: String, properties: Properties? = nil) {
         guard let mixpanelInstance = mixpanelInstance else { return }
         guard !screenName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {

--- a/Sources/Autocapture.swift
+++ b/Sources/Autocapture.swift
@@ -19,7 +19,8 @@ open class Autocapture {
        Track a screen view event. This is a convenience method for tracking when users view
        a screen/page in your application.
     
-       - parameter screenName: The name of the screen/page being viewed
+       - parameter screenName: The name of the screen/page being viewed. Must be non-empty;
+         if an empty or whitespace-only string is passed, the event is silently dropped.
        - parameter properties: Optional properties to include with this event
        */
     open func trackScreenView(screenName: String, properties: Properties? = nil) {
@@ -49,7 +50,8 @@ open class Autocapture {
        Track a screen leave event. This is a convenience method for tracking when users leave
        a screen/page in your application.
     
-       - parameter screenName: The name of the screen/page being left
+       - parameter screenName: The name of the screen/page being left. Must be non-empty;
+         if an empty or whitespace-only string is passed, the event is silently dropped.
        - parameter properties: Optional properties to include with this event
        */
     open func trackScreenLeave(screenName: String, properties: Properties? = nil) {

--- a/Sources/Autocapture.swift
+++ b/Sources/Autocapture.swift
@@ -18,7 +18,7 @@ open class Autocapture {
     /**
        Track a screen view event. This is a convenience method for tracking when users view
        a screen/page in your application.
-    
+
        - parameter screenName: The name of the screen/page being viewed. Must be non-empty;
          if an empty or whitespace-only string is passed, the event is silently dropped.
        - parameter properties: Optional properties to include with this event
@@ -49,7 +49,7 @@ open class Autocapture {
     /**
        Track a screen leave event. This is a convenience method for tracking when users leave
        a screen/page in your application.
-    
+
        - parameter screenName: The name of the screen/page being left. Must be non-empty;
          if an empty or whitespace-only string is passed, the event is silently dropped.
        - parameter properties: Optional properties to include with this event

--- a/Sources/Autocapture.swift
+++ b/Sources/Autocapture.swift
@@ -15,12 +15,14 @@ open class Autocapture {
 
     weak var mixpanelInstance: MixpanelInstance?
 
-    /// Track a screen view event. This is a convenience method for tracking when users view
-    /// a screen/page in your application.
-    ///
-    /// - parameter screenName: The name of the screen/page being viewed. Must be non-empty;
-    ///   if an empty or whitespace-only string is passed, the event is silently dropped.
-    /// - parameter properties: Optional properties to include with this event
+    /**
+       Track a screen view event. This is a convenience method for tracking when users view
+       a screen/page in your application.
+    
+       - parameter screenName: The name of the screen/page being viewed. Must be non-empty;
+         if an empty or whitespace-only string is passed, the event is silently dropped.
+       - parameter properties: Optional properties to include with this event
+       */
     open func trackScreenView(screenName: String, properties: Properties? = nil) {
         guard let mixpanelInstance = mixpanelInstance else { return }
         guard !screenName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -44,12 +46,14 @@ open class Autocapture {
         mixpanelInstance.track(event: "$mp_page_view", properties: mergedProperties)
     }
 
-    /// Track a screen leave event. This is a convenience method for tracking when users leave
-    /// a screen/page in your application.
-    ///
-    /// - parameter screenName: The name of the screen/page being left. Must be non-empty;
-    ///   if an empty or whitespace-only string is passed, the event is silently dropped.
-    /// - parameter properties: Optional properties to include with this event
+    /**
+       Track a screen leave event. This is a convenience method for tracking when users leave
+       a screen/page in your application.
+    
+       - parameter screenName: The name of the screen/page being left. Must be non-empty;
+         if an empty or whitespace-only string is passed, the event is silently dropped.
+       - parameter properties: Optional properties to include with this event
+       */
     open func trackScreenLeave(screenName: String, properties: Properties? = nil) {
         guard let mixpanelInstance = mixpanelInstance else { return }
         guard !screenName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {


### PR DESCRIPTION
## Summary
- Update doc comments on `screenName` parameter for `trackScreenView` and `trackScreenLeave` in `Autocapture.swift` to state it must be non-empty and the event is silently dropped if empty/whitespace-only.

## Test plan
- [ ] Verify doc comments render correctly in Xcode Quick Help

SDK-142