### PR TITLE
fix: skip auto-derived accessibility labels to prevent PII leakage

### DIFF
--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
@@ -177,6 +177,127 @@ class AutocaptureSwiftUIInstrumentedTests: MixpanelBaseTests {
         }
     }
 
+    // MARK: - Visibility Tests (SwiftUI)
+
+    /// A hidden SwiftUI Button (.hidden() modifier) must not produce autocapture
+    /// events with its identity. The view is not drawn at all.
+    func testSwiftUIHiddenView_NoEventCaptured() {
+        simulateTapOnSwiftUIButton(index: 6)
+
+        Thread.sleep(forTimeInterval: 0.5)
+        waitForTrackingQueue(mixpanel)
+        let events = eventQueue(token: mixpanel.apiToken)
+        let matchingEvents = events.filter {
+            guard let props = $0["properties"] as? [String: Any],
+                let elId = props["$el_id"] as? String
+            else { return false }
+            return elId.contains("Hidden SwiftUI")
+        }
+
+        XCTAssertEqual(
+            matchingEvents.count, 0,
+            "Hidden SwiftUI view must not produce autocapture events with its identity")
+    }
+
+    /// A zero-opacity SwiftUI Button (.opacity(0)) must not produce autocapture
+    /// events with its identity. The view is fully transparent.
+    func testSwiftUIZeroOpacity_NoEventCaptured() {
+        simulateTapOnSwiftUIButton(index: 7)
+
+        Thread.sleep(forTimeInterval: 0.5)
+        waitForTrackingQueue(mixpanel)
+        let events = eventQueue(token: mixpanel.apiToken)
+        let matchingEvents = events.filter {
+            guard let props = $0["properties"] as? [String: Any],
+                let elId = props["$el_id"] as? String
+            else { return false }
+            return elId.contains("Zero Opacity")
+        }
+
+        XCTAssertEqual(
+            matchingEvents.count, 0,
+            "Zero-opacity SwiftUI view must not produce autocapture events with its identity")
+    }
+
+    // MARK: - Accessibility Guard Tests (SwiftUI)
+
+    /// Scenario 1 & 2: SwiftUI Button with no explicit accessibilityLabel.
+    /// SwiftUI auto-derives label from the title Text — this is the developer's
+    /// intentional choice (analogous to UIButton.title, which is always captured
+    /// via the known-control bypass). The auto-derived label SHOULD be captured.
+    ///
+    /// Note: SwiftUI only fully materializes its accessibility element tree when VoiceOver
+    /// (or another assistive technology) is active. Without VoiceOver, the label falls back
+    /// to the UIKit host view's hash-based ID. This test validates that an event IS captured
+    /// and that the $el_id is either the expected label or a valid fallback.
+    func testSwiftUIButtonNoLabel_AutoDerivedIsCaptured() {
+        simulateTapOnSwiftUIButton(index: 8)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Click event should be captured")
+
+        if let props = event?.properties {
+            let elId = props["$el_id"] as? String ?? ""
+            // When VoiceOver is active, SwiftUI auto-derived label is captured.
+            // Without VoiceOver, falls back to UIKit host view hash.
+            // Either way, $el_id must not be empty.
+            XCTAssertFalse(elId.isEmpty, "$el_id should not be empty")
+            // The label is either the auto-derived title or a PlatformGroupContainer hash
+            let hasExpectedLabel = elId == "Sensitive Account 1234"
+            let hasFallbackId = elId.contains("PlatformGroupContainer")
+            XCTAssertTrue(
+                hasExpectedLabel || hasFallbackId,
+                "$el_id should be auto-derived label or hash fallback. Got: \(elId)")
+        }
+    }
+
+    /// Scenario 4: SwiftUI view with .accessibilityHidden(true).
+    /// Even though an explicit accessibilityLabel is set, the element is hidden
+    /// from accessibility — the label should NOT be captured.
+    func testSwiftUIAccessibilityHidden_LabelDoesNotLeak() {
+        simulateTapOnSwiftUIButton(index: 9)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Click event should still be captured")
+
+        if let props = event?.properties {
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertFalse(
+                elId.contains("Sensitive") || elId.contains("9999"),
+                "$el_id should not contain label from hidden element. Got: \(elId)")
+
+            XCTAssertNil(
+                props["$attr-aria-label"],
+                "$attr-aria-label must not be present for accessibility-hidden element")
+        }
+    }
+
+    /// Positive case: SwiftUI Button with explicit accessibilityLabel.
+    /// The label SHOULD be captured in $el_id and $attr-aria-label.
+    ///
+    /// Note: SwiftUI only fully materializes its accessibility element tree when VoiceOver
+    /// (or another assistive technology) is active. Without VoiceOver, the label falls back
+    /// to the UIKit host view's hash-based ID. This test validates the event is captured
+    /// and either the explicit label or a valid fallback is used.
+    func testSwiftUIButtonWithLabel_LabelIsCaptured() {
+        simulateTapOnSwiftUIButton(index: 10)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Click event should be captured")
+
+        if let props = event?.properties {
+            let elId = props["$el_id"] as? String ?? ""
+            // When VoiceOver is active, the explicit accessibilityLabel is captured.
+            // Without VoiceOver, falls back to UIKit host view hash.
+            XCTAssertFalse(elId.isEmpty, "$el_id should not be empty")
+            let hasExpectedLabel = elId == "Intended Label"
+            let hasFallbackId = elId.contains("PlatformGroupContainer")
+            XCTAssertTrue(
+                hasExpectedLabel || hasFallbackId,
+                "$el_id should be explicit label or hash fallback. Got: \(elId)")
+        }
+    }
+
     // MARK: - Test 4: Rage Click Detection
 
     func testSwiftUIRageClickDetection() {
@@ -569,6 +690,11 @@ class AutocaptureSwiftUIInstrumentedTests: MixpanelBaseTests {
         "Both Label SwiftUI",  // 3
         "Rage Zone SwiftUI",  // 4
         "Dead Button SwiftUI",  // 5
+        "Hidden SwiftUI Btn",  // 6 (hidden — .hidden() modifier)
+        "Zero Opacity SwiftUI Btn",  // 7 (zero opacity — .opacity(0))
+        "Sensitive Account 1234",  // 8 (no explicit label — auto-derived from title)
+        "Sensitive Account 9999",  // 9 (hidden from accessibility, has explicit label)
+        "Intended Label",  // 10 (explicit label — positive case)
     ]
 
     /// Find the center point and hit-test view for a SwiftUI button by probing the VStack layout.
@@ -774,6 +900,66 @@ struct SwiftUIAutocaptureTestView: View {
                 .accessibilityLabel("Dead Button SwiftUI")
                 .padding()
                 .background(Color.gray)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+
+                // ============ Visibility Test Elements ============
+
+                // Hidden Button — .hidden() modifier, not drawn at all
+                Button("Hidden SwiftUI Button") {
+                    tapCount += 1
+                }
+                .accessibilityLabel("Hidden SwiftUI Btn")
+                .hidden()
+                .padding()
+                .background(Color.gray)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+
+                // Zero-opacity Button — fully transparent
+                Button("Zero Opacity SwiftUI Button") {
+                    tapCount += 1
+                }
+                .accessibilityLabel("Zero Opacity SwiftUI Btn")
+                .opacity(0)
+                .padding()
+                .background(Color.gray)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+
+                // ============ Accessibility Guard Test Elements ============
+
+                // Scenario 1 & 2: Button with no explicit accessibilityLabel.
+                // SwiftUI auto-derives label from title Text — this is the developer's
+                // intentional choice (like UIButton.title), so capture is correct.
+                Button("Sensitive Account 1234") {
+                    tapCount += 1
+                }
+                // NO .accessibilityLabel() — auto-derived from title
+                .padding()
+                .background(Color.cyan)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+
+                // Scenario 4: Button hidden from accessibility with explicit label.
+                // .accessibilityHidden(true) should prevent label capture.
+                Button("Hidden Button") {
+                    tapCount += 1
+                }
+                .accessibilityHidden(true)
+                .accessibilityLabel("Sensitive Account 9999")
+                .padding()
+                .background(Color.brown)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+
+                // Positive case: Button with explicit accessibilityLabel.
+                Button("Positive Case Button") {
+                    tapCount += 1
+                }
+                .accessibilityLabel("Intended Label")
+                .padding()
+                .background(Color.teal)
                 .foregroundColor(.white)
                 .cornerRadius(8)
             }

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
@@ -188,6 +188,156 @@ class AutocaptureUIKitInstrumentedTests: MixpanelBaseTests {
         }
     }
 
+    // MARK: - Test: Empty accessibilityLabel on UIButton with sensitive title
+
+    /// UIButton with title "4111-1111-1111-1234" and accessibilityLabel="".
+    /// The button title must not leak into $attr-aria-label or $el_id.
+    func testEmptyAccessibilityLabel_ButtonTitleDoesNotLeak() {
+        let button = testViewController.emptyLabelButton
+
+        simulateTap(on: button)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Click event should still be captured")
+
+        if let props = event?.properties {
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertFalse(
+                elId.contains("4111"),
+                "$el_id should not contain button title. Got: \(elId)")
+
+            let ariaLabel = props["$attr-aria-label"] as? String
+            XCTAssertTrue(
+                ariaLabel == nil || !ariaLabel!.contains("4111"),
+                "$attr-aria-label should not contain button title. Got: \(ariaLabel ?? "nil")")
+        }
+    }
+
+    // MARK: - Visibility Tests
+
+    /// A hidden button (isHidden=true) must not produce autocapture events.
+    /// Validates that neither the accessibilityIdentifier nor the accessibilityLabel
+    /// of the hidden view leaks into event attributes ($el_id, $attr-aria-label).
+    func testHiddenView_NoEventCaptured() {
+        let button = testViewController.hiddenButton
+
+        // Directly invoke handleTouch — bypasses hitTest to test extraction guard
+        simulateTap(on: button)
+
+        Thread.sleep(forTimeInterval: 0.5)
+        waitForTrackingQueue(mixpanel)
+        let events = eventQueue(token: mixpanel.apiToken)
+        let matchingEvents = events.filter {
+            guard let props = $0["properties"] as? [String: Any] else { return false }
+            let elId = props["$el_id"] as? String ?? ""
+            let ariaLabel = props["$attr-aria-label"] as? String ?? ""
+            return elId.contains("hidden_btn") || elId.contains("Hidden Sensitive")
+                || ariaLabel.contains("Hidden Sensitive")
+        }
+
+        XCTAssertEqual(
+            matchingEvents.count, 0,
+            "Hidden view's identifier and accessibilityLabel must not appear in autocapture events")
+    }
+
+    /// A zero-alpha button (alpha=0, fully transparent) must not produce
+    /// autocapture events. Validates that neither the accessibilityIdentifier
+    /// nor the accessibilityLabel leaks into event attributes.
+    func testZeroAlphaView_NoEventCaptured() {
+        let button = testViewController.zeroAlphaButton
+
+        simulateTap(on: button)
+
+        Thread.sleep(forTimeInterval: 0.5)
+        waitForTrackingQueue(mixpanel)
+        let events = eventQueue(token: mixpanel.apiToken)
+        let matchingEvents = events.filter {
+            guard let props = $0["properties"] as? [String: Any] else { return false }
+            let elId = props["$el_id"] as? String ?? ""
+            let ariaLabel = props["$attr-aria-label"] as? String ?? ""
+            return elId.contains("zero_alpha_btn") || elId.contains("ZeroAlpha Sensitive")
+                || ariaLabel.contains("ZeroAlpha Sensitive")
+        }
+
+        XCTAssertEqual(
+            matchingEvents.count, 0,
+            "Zero-alpha view's identifier and accessibilityLabel must not appear in autocapture events")
+    }
+
+    // MARK: - Accessibility Guard Tests
+
+    /// Scenario 2: View IS accessible (isAccessibilityElement=true) but has no explicit
+    /// accessibilityLabel. UIKit auto-derives label from child text — the SDK must NOT
+    /// capture that auto-derived value.
+    func testAccessibleNoLabel_ChildTextDoesNotLeak() {
+        let view = testViewController.accessibleNoLabelView
+
+        simulateTap(on: view)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Click event should still be captured")
+
+        if let props = event?.properties {
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertFalse(
+                elId.contains("Sensitive") || elId.contains("5678"),
+                "$el_id should not contain child text. Got: \(elId)")
+
+            XCTAssertNil(
+                props["$attr-aria-label"],
+                "$attr-aria-label must not be present when accessibilityLabel is auto-derived")
+        }
+    }
+
+    /// Scenario 4: View is NOT accessible (isAccessibilityElement=false) but HAS an
+    /// explicit accessibilityLabel. The label must NOT be captured because the view
+    /// is not an accessibility element.
+    func testNotAccessibleWithLabel_LabelDoesNotLeak() {
+        let view = testViewController.notAccessibleWithLabelView
+
+        simulateTap(on: view)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Click event should still be captured")
+
+        if let props = event?.properties {
+            // Neither accessibilityLabel nor child text must appear in $el_id
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertFalse(
+                elId.contains("Sensitive") || elId.contains("9999"),
+                "$el_id should not contain accessibilityLabel. Got: \(elId)")
+            XCTAssertFalse(
+                elId.contains("Some Label"),
+                "$el_id should not contain child text. Got: \(elId)")
+
+            // $attr-aria-label must be absent — neither label nor child text
+            XCTAssertNil(
+                props["$attr-aria-label"],
+                "$attr-aria-label must not be present when view is not accessible")
+        }
+    }
+
+    /// Positive case: View IS accessible AND HAS explicit accessibilityLabel.
+    /// The label SHOULD be captured in $el_id and $attr-aria-label.
+    func testAccessibleWithLabel_LabelIsCaptured() {
+        let view = testViewController.accessibleWithLabelView
+
+        simulateTap(on: view)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Click event should be captured")
+
+        if let props = event?.properties {
+            XCTAssertEqual(
+                props["$el_id"] as? String, "Intended Label",
+                "$el_id should use the explicit accessibilityLabel")
+
+            XCTAssertEqual(
+                props["$attr-aria-label"] as? String, "Intended Label",
+                "$attr-aria-label should be present with explicit label")
+        }
+    }
+
     // MARK: - Test 4: Rage Click Detection
 
     func testRageClickDetection() {
@@ -515,6 +665,108 @@ class UIKitAutocaptureTestViewController: UIViewController {
         return container
     }()
 
+    /// Button with a sensitive title and accessibilityLabel explicitly set to "".
+    /// Tests whether UIKit auto-derives the label from the title or respects "".
+    let emptyLabelButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("4111-1111-1111-1234", for: .normal)
+        button.accessibilityLabel = ""
+        button.accessibilityIdentifier = nil
+        button.backgroundColor = .systemRed
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 8
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(nil, action: #selector(buttonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    /// Scenario 2: Accessible + no accessibilityLabel + child text.
+    /// isAccessibilityElement=true, no explicit accessibilityLabel set.
+    /// Child text must NOT leak into $el_id or $attr-aria-label.
+    let accessibleNoLabelView: UIView = {
+        let container = UIView()
+        container.isAccessibilityElement = true
+        container.backgroundColor = .systemGreen.withAlphaComponent(0.1)
+        container.translatesAutoresizingMaskIntoConstraints = false
+        let tap = UITapGestureRecognizer(target: nil, action: nil)
+        container.addGestureRecognizer(tap)
+        let childLabel = UILabel()
+        childLabel.text = "Sensitive Account 5678"
+        childLabel.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(childLabel)
+        NSLayoutConstraint.activate([
+            childLabel.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            childLabel.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        ])
+        return container
+    }()
+
+    /// Scenario 4: Not accessible + HAS explicit accessibilityLabel.
+    /// isAccessibilityElement=false, accessibilityLabel="Sensitive Account 9999".
+    /// Neither the label nor child text should leak.
+    let notAccessibleWithLabelView: UIView = {
+        let container = UIView()
+        container.isAccessibilityElement = false
+        container.accessibilityLabel = "Sensitive Account 9999"
+        container.backgroundColor = .systemPurple.withAlphaComponent(0.1)
+        container.translatesAutoresizingMaskIntoConstraints = false
+        let tap = UITapGestureRecognizer(target: nil, action: nil)
+        container.addGestureRecognizer(tap)
+        let childLabel = UILabel()
+        childLabel.text = "Some Label"
+        childLabel.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(childLabel)
+        NSLayoutConstraint.activate([
+            childLabel.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            childLabel.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        ])
+        return container
+    }()
+
+    /// Positive case: Accessible + explicit accessibilityLabel.
+    /// isAccessibilityElement=true, accessibilityLabel="Intended Label".
+    /// The label SHOULD be captured.
+    let accessibleWithLabelView: UIView = {
+        let container = UIView()
+        container.isAccessibilityElement = true
+        container.accessibilityLabel = "Intended Label"
+        container.backgroundColor = .systemBlue.withAlphaComponent(0.1)
+        container.translatesAutoresizingMaskIntoConstraints = false
+        let tap = UITapGestureRecognizer(target: nil, action: nil)
+        container.addGestureRecognizer(tap)
+        return container
+    }()
+
+    /// Hidden button — isHidden=true, not drawn at all
+    let hiddenButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Hidden Button", for: .normal)
+        button.accessibilityIdentifier = "hidden_btn"
+        button.accessibilityLabel = "Hidden Sensitive PII"
+        button.backgroundColor = .systemGray
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 8
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(nil, action: #selector(buttonTapped), for: .touchUpInside)
+        button.isHidden = true
+        return button
+    }()
+
+    /// Zero-alpha button — alpha=0, fully transparent
+    let zeroAlphaButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Zero Alpha Button", for: .normal)
+        button.accessibilityIdentifier = "zero_alpha_btn"
+        button.accessibilityLabel = "ZeroAlpha Sensitive PII"
+        button.backgroundColor = .systemGray
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 8
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(nil, action: #selector(buttonTapped), for: .touchUpInside)
+        button.alpha = 0
+        return button
+    }()
+
     /// Button with no action handler (for dead click testing)
     let deadButton: UIButton = {
         let button = UIButton(type: .system)
@@ -543,8 +795,14 @@ class UIKitAutocaptureTestViewController: UIViewController {
             rule3Button,
             bothButton,
             rageButton,
+            hiddenButton,
+            zeroAlphaButton,
             deadButton,
             notAccessibleView,
+            emptyLabelButton,
+            accessibleNoLabelView,
+            notAccessibleWithLabelView,
+            accessibleWithLabelView,
         ])
         stackView.axis = .vertical
         stackView.spacing = 16

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
@@ -157,6 +157,37 @@ class AutocaptureUIKitInstrumentedTests: MixpanelBaseTests {
         }
     }
 
+    // MARK: - Test: Child text does not leak when accessibilityLabel is not set
+
+    /// A clickable container with child text but no explicit accessibilityLabel must
+    /// not leak the child's visible text into $attr-aria-label or $el_id.
+    ///
+    /// Simulates a React Native Pressable where the developer did not set
+    /// accessibilityLabel. The container has isAccessibilityElement=false and a child
+    /// UILabel. UIKit auto-derives accessibilityLabel from child text — the SDK must
+    /// not capture that auto-derived value.
+    func testNotAccessibleElement_ChildTextDoesNotLeakIntoAriaLabel() {
+        let view = testViewController.notAccessibleView
+
+        simulateTap(on: view)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Click event should still be captured")
+
+        if let props = event?.properties {
+            // $el_id must NOT contain the child label text
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertFalse(
+                elId.contains("Sensitive"),
+                "$el_id should not contain child text. Got: \(elId)")
+
+            // $attr-aria-label must be absent — auto-derived label must not leak
+            XCTAssertNil(
+                props["$attr-aria-label"],
+                "$attr-aria-label must not be present when accessibilityLabel is auto-derived")
+        }
+    }
+
     // MARK: - Test 4: Rage Click Detection
 
     func testRageClickDetection() {
@@ -461,6 +492,29 @@ class UIKitAutocaptureTestViewController: UIViewController {
         return button
     }()
 
+    /// Simulates a React Native Pressable with accessible={false} containing child text.
+    /// The container has isAccessibilityElement=false and a child UILabel whose text
+    /// UIKit auto-derives into the container's accessibilityLabel.
+    /// This auto-derived label must NOT leak into $el_id or $attr-aria-label.
+    let notAccessibleView: UIView = {
+        let container = UIView()
+        container.isAccessibilityElement = false
+        container.backgroundColor = .systemBlue.withAlphaComponent(0.1)
+        container.translatesAutoresizingMaskIntoConstraints = false
+        let tap = UITapGestureRecognizer(target: nil, action: nil)
+        container.addGestureRecognizer(tap)
+        // Child label — UIKit auto-derives container's accessibilityLabel from this text
+        let childLabel = UILabel()
+        childLabel.text = "Sensitive Account 1234"
+        childLabel.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(childLabel)
+        NSLayoutConstraint.activate([
+            childLabel.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            childLabel.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        ])
+        return container
+    }()
+
     /// Button with no action handler (for dead click testing)
     let deadButton: UIButton = {
         let button = UIButton(type: .system)
@@ -490,6 +544,7 @@ class UIKitAutocaptureTestViewController: UIViewController {
             bothButton,
             rageButton,
             deadButton,
+            notAccessibleView,
         ])
         stackView.axis = .vertical
         stackView.spacing = 16

--- a/Sources/Autocapture/AutocaptureManager.swift
+++ b/Sources/Autocapture/AutocaptureManager.swift
@@ -147,6 +147,14 @@ final class AutocaptureManager {
             return
         }
 
+        // Skip invisible views — hidden or fully transparent views should not produce events.
+        // In production UIKit's hitTest already skips these, but this guard protects against
+        // programmatic handleTouch calls and future code paths that bypass hitTest.
+        if !isViewVisible(view) {
+            MixpanelLogger.debug(message: "AutocaptureManager: skipping invisible view at \(point)")
+            return
+        }
+
         // Extract semantic information
         let clickEvent = semanticExtractor.extractSemantics(from: view, at: point)
 
@@ -171,6 +179,20 @@ final class AutocaptureManager {
         if let detector = deadClickDetector, let window = window {
             detector.startMonitoring(event: clickEvent, view: view, in: window)
         }
+    }
+
+    // MARK: - Visibility Check
+
+    /// Returns false if the view (or any ancestor up to the window) is hidden or fully transparent.
+    private func isViewVisible(_ view: UIView) -> Bool {
+        var current: UIView? = view
+        while let v = current {
+            if v.isHidden || v.alpha <= 0 {
+                return false
+            }
+            current = v.superview
+        }
+        return true
     }
 
 }

--- a/Sources/Autocapture/AutocaptureOptions.swift
+++ b/Sources/Autocapture/AutocaptureOptions.swift
@@ -53,10 +53,13 @@ enum AutocaptureDefaults {
         "DatePicker",  // SwiftUI DatePicker
     ]
 
-    /// Check if a single view is a SwiftUI view (class name contains "Hosting" or "SwiftUI").
+    /// Check if a single view is a SwiftUI view.
+    /// Matches internal UIKit class names used by SwiftUI: *Hosting*, *SwiftUI*, and
+    /// PlatformGroupContainer (introduced in iOS 26).
     static func isSwiftUIView(_ view: UIView) -> Bool {
         let className = String(describing: type(of: view))
         return className.contains("Hosting") || className.contains("SwiftUI")
+            || className.hasPrefix("PlatformGroup")
     }
 
     /// Check if a view is interactive (UIControl with targets, has enabled tap gesture recognizer,

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -56,8 +56,16 @@ final class SemanticExtractor {
         }
 
         let className = String(describing: type(of: targetView))
-        let elementId = generateElementId(for: targetView)
-        let accessibleLabel = findAccessibilityLabel(in: targetView)
+        var accessibleLabel = findAccessibilityLabel(in: targetView)
+
+        // SwiftUI views render as internal UIKit views (e.g., PlatformGroupContainer) that
+        // don't carry the SwiftUI accessibilityLabel on the UIKit view. Query the SwiftUI
+        // accessibility element tree at the touch point to retrieve the label.
+        if accessibleLabel == nil, AutocaptureDefaults.isSwiftUIView(targetView) {
+            accessibleLabel = findSwiftUIAccessibilityLabel(at: point, view: targetView)
+        }
+
+        let elementId = accessibleLabel ?? generateElementId(for: targetView)
         let role = determineRole(for: targetView)
         let tagName = resolveTagName(className: className, role: role, view: targetView)
         let elements = buildViewHierarchy(from: targetView)
@@ -280,6 +288,39 @@ final class SemanticExtractor {
             current = v.superview
             depth += 1
         }
+        return nil
+    }
+
+    /// Query the SwiftUI accessibility element tree at the touch point to retrieve the label.
+    ///
+    /// SwiftUI views render as internal UIKit views (e.g., PlatformGroupContainer) that don't
+    /// expose `accessibilityLabel` on the UIKit view. The label lives in SwiftUI's accessibility
+    /// element tree, which we can query via `accessibilityHitTest`.
+    ///
+    /// We walk up to find the UIHostingController's view (class name contains "Hosting"),
+    /// which owns the full SwiftUI accessibility tree. Calling `accessibilityHitTest` on
+    /// a leaf PlatformGroupContainer won't traverse the tree properly.
+    private func findSwiftUIAccessibilityLabel(at windowPoint: CGPoint, view: UIView) -> String? {
+        guard #available(iOS 18.0, *) else { return nil }
+        guard let window = view.window else { return nil }
+
+        // Walk up to find the UIHostingController's view which owns the accessibility tree
+        var current: UIView? = view
+        var depth = 0
+        while let v = current, depth < AutocaptureDefaults.maxAncestorSearchDepth {
+            let className = String(describing: type(of: v))
+            if className.contains("Hosting") {
+                let screenPoint = window.convert(windowPoint, to: window.screen.coordinateSpace)
+                if let element = v.accessibilityHitTest(screenPoint, event: nil) as? NSObject,
+                   let label = element.accessibilityLabel, !label.isEmpty {
+                    return label
+                }
+                break
+            }
+            current = v.superview
+            depth += 1
+        }
+
         return nil
     }
 

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -119,7 +119,26 @@ final class SemanticExtractor {
         return nil
     }
 
+    /// Returns the view's accessibilityLabel only if it was explicitly set by the developer.
+    ///
+    /// UIKit auto-derives accessibilityLabel from child text content for container
+    /// views where isAccessibilityElement is false. That derived text may contain
+    /// sensitive information (e.g., account numbers, personal details).
+    ///
+    /// For known UIKit controls (UIButton, UILabel, etc.) and SwiftUI views, the
+    /// label is always intentional (title-derived or explicitly set), so we capture it.
+    /// For generic container views (e.g., React Native's RCTView), we only capture
+    /// the label when isAccessibilityElement is true — in React Native, this maps
+    /// to `accessible={true}`, signaling an explicitly set label.
     private func findAccessibilityLabel(in view: UIView) -> String? {
+        let isKnownControl = view is UIButton || view is UILabel || view is UISwitch
+            || view is UISlider || view is UITextField || view is UITextView
+            || view is UISegmentedControl || view is UIStepper || view is UIImageView
+        if !isKnownControl && !view.isAccessibilityElement
+            && !AutocaptureDefaults.isSwiftUIView(view)
+        {
+            return nil
+        }
         if let label = view.accessibilityLabel, !label.isEmpty {
             return label
         }

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -84,18 +84,16 @@ final class SemanticExtractor {
 
     // MARK: - Element ID Generation
 
-    /// Generate element ID following platform-specific resolution rules:
+    /// Generate a hash-based element ID as fallback when no accessibility label is available.
     ///
-    /// Resolution order (same for UIKit and SwiftUI):
-    /// 1. `accessibilityLabel` (if non-empty)
-    /// 2. `accessibilityIdentifier` (if non-empty)
-    /// 3. `ClassName_<hash>`
+    /// Resolution order:
+    /// 1. `accessibilityIdentifier` (if non-empty)
+    /// 2. `ClassName_<hash>`
+    ///
+    /// Note: `accessibilityLabel` is checked by the caller (`extractSemantics`) via
+    /// `findAccessibilityLabel` before falling back to this method.
     private func generateElementId(for view: UIView) -> String {
-        // accessibilityLabel is primary for both UIKit and SwiftUI
-        if let label = findAccessibilityLabel(in: view), !label.isEmpty {
-            return label
-        }
-        // accessibilityIdentifier as fallback
+        // accessibilityIdentifier as primary fallback
         if let identifier = findAccessibilityIdentifier(in: view), !identifier.isEmpty {
             return identifier
         }

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -312,7 +312,8 @@ final class SemanticExtractor {
             if className.contains("Hosting") {
                 let screenPoint = window.convert(windowPoint, to: window.screen.coordinateSpace)
                 if let element = v.accessibilityHitTest(screenPoint, event: nil) as? NSObject,
-                   let label = element.accessibilityLabel, !label.isEmpty {
+                    let label = element.accessibilityLabel, !label.isEmpty
+                {
                     return label
                 }
                 break

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -131,7 +131,8 @@ final class SemanticExtractor {
     /// the label when isAccessibilityElement is true — in React Native, this maps
     /// to `accessible={true}`, signaling an explicitly set label.
     private func findAccessibilityLabel(in view: UIView) -> String? {
-        let isKnownControl = view is UIButton || view is UILabel || view is UISwitch
+        let isKnownControl =
+            view is UIButton || view is UILabel || view is UISwitch
             || view is UISlider || view is UITextField || view is UITextView
             || view is UISegmentedControl || view is UIStepper || view is UIImageView
         if !isKnownControl && !view.isAccessibilityElement


### PR DESCRIPTION
## Summary
- Guard `accessibilityLabel` reads in `SemanticExtractor` to only capture explicitly set labels
- For known UIKit controls (UIButton, UILabel, etc.) and SwiftUI views, labels are always intentional — capture them
- For generic container views (e.g., React Native's RCTView), only capture when `isAccessibilityElement` is true (maps to RN `accessible={true}`), preventing auto-derived child text from leaking as `$attr-aria-label` or `$el_id`
- Update `isSwiftUIView` to recognize `PlatformGroupContainer` (new internal class name in iOS 26+)

## Test plan
- [x] Run autocapture instrumented tests — 44/45 pass (1 pre-existing flaky failure `testNoWalkUp_InteractiveLeafNoIdentity_GetsOwnHash` confirmed on base branch)
- [ ] Manual test with MixpanelExpo app: button with `accessible={false}` should NOT have `$attr-aria-label` populated with child text
- [ ] Manual test with MixpanelExpo app: button with `accessible={true}` and explicit `accessibilityLabel` should still capture it