### PR TITLE
feat: add pluggable ElementIdExtractor for $el_id resolution

### DIFF
--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -77,6 +77,8 @@
 		A18176D6C7255FA1611B3BF1 /* SemanticExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06325D1AC34056FFA59B35DF /* SemanticExtractor.swift */; };
 		A5507733A1B4945D84E53B33 /* SemanticExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DC0B63B575B53F8DE3BF79 /* SemanticExtractor.swift */; };
 		A9364BC8EBB564C53ADC5156 /* AutocaptureOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60F434067003D809DE25DFE /* AutocaptureOptions.swift */; };
+		1A2B3C4D5E6F70819AB0C001 /* ElementIdExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70819AB0C004 /* ElementIdExtractor.swift */; };
+		1A2B3C4D5E6F70819AB0C002 /* ElementIdExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70819AB0C003 /* ElementIdExtractor.swift */; };
 		BB9614171F3BB87700C3EF3E /* ReadWriteLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9614161F3BB87700C3EF3E /* ReadWriteLock.swift */; };
 		C694CF0F56D88BC591A0054A /* DeadClickDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99155E36042EDC3C22F18B45 /* DeadClickDetector.swift */; };
 		E10D118D1EC0F30900195CCD /* AutomaticEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E151FA371E70DFB5002EF53D /* AutomaticEvents.swift */; };
@@ -144,6 +146,7 @@
 		1728208D2BA8BDE4002CD973 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Sources/Mixpanel/PrivacyInfo.xcprivacy; sourceTree = SOURCE_ROOT; };
 		1CD6F1660CF2314121E328BE /* DeadClickDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DeadClickDetector.swift; path = Sources/Autocapture/DeadClickDetector.swift; sourceTree = "<group>"; };
 		38B29F5E5066FADE60A88040 /* AutocaptureOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AutocaptureOptions.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F70819AB0C003 /* ElementIdExtractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ElementIdExtractor.swift; sourceTree = "<group>"; };
 		51DD56791D306B740045D3DB /* MixpanelLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MixpanelLogger.swift; sourceTree = "<group>"; };
 		51DD56801D306B7B0045D3DB /* PrintLogging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrintLogging.swift; sourceTree = "<group>"; };
 		51DD56811D306B7B0045D3DB /* FileLogging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileLogging.swift; sourceTree = "<group>"; };
@@ -162,6 +165,7 @@
 		A6AFC14475BD4DC3722712CA /* AutocaptureManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AutocaptureManager.swift; path = Sources/Autocapture/AutocaptureManager.swift; sourceTree = "<group>"; };
 		BB9614161F3BB87700C3EF3E /* ReadWriteLock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadWriteLock.swift; sourceTree = "<group>"; };
 		D60F434067003D809DE25DFE /* AutocaptureOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AutocaptureOptions.swift; path = Sources/Autocapture/AutocaptureOptions.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F70819AB0C004 /* ElementIdExtractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElementIdExtractor.swift; path = Sources/Autocapture/ElementIdExtractor.swift; sourceTree = "<group>"; };
 		E115947D1CFF1491007F8B4F /* Mixpanel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mixpanel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E11594821CFF1491007F8B4F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Info.plist; sourceTree = "<group>"; };
 		E115948A1CFF1538007F8B4F /* Mixpanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mixpanel.swift; sourceTree = "<group>"; };
@@ -247,6 +251,7 @@
 				CC6DD07E38E5B14C184263E3 /* Model */,
 				99F9956D2BF2A5F6398C0A59 /* AutocaptureManager.swift */,
 				38B29F5E5066FADE60A88040 /* AutocaptureOptions.swift */,
+				1A2B3C4D5E6F70819AB0C003 /* ElementIdExtractor.swift */,
 				99155E36042EDC3C22F18B45 /* DeadClickDetector.swift */,
 				53AF035597E8943FA5E9E2F0 /* RageClickTracker.swift */,
 				06325D1AC34056FFA59B35DF /* SemanticExtractor.swift */,
@@ -656,6 +661,7 @@
 				E115948B1CFF1538007F8B4F /* Mixpanel.swift in Sources */,
 				48D1B82CD01A008022E3D759 /* AutocaptureManager.swift in Sources */,
 				A9364BC8EBB564C53ADC5156 /* AutocaptureOptions.swift in Sources */,
+				1A2B3C4D5E6F70819AB0C001 /* ElementIdExtractor.swift in Sources */,
 				662C13B6649508B946312234 /* DeadClickDetector.swift in Sources */,
 				5C6E56DD87033A7A76E027E7 /* RageClickTracker.swift in Sources */,
 				A5507733A1B4945D84E53B33 /* SemanticExtractor.swift in Sources */,
@@ -663,6 +669,7 @@
 				EA0C3E40CD32AC89419401FF /* ClickEvent.swift in Sources */,
 				4FB79FD4199BD2C1AEA83B1C /* AutocaptureManager.swift in Sources */,
 				2A5D30DD0C468327425DC577 /* AutocaptureOptions.swift in Sources */,
+				1A2B3C4D5E6F70819AB0C002 /* ElementIdExtractor.swift in Sources */,
 				C694CF0F56D88BC591A0054A /* DeadClickDetector.swift in Sources */,
 				E2281F33D7C441677B124788 /* RageClickTracker.swift in Sources */,
 				A18176D6C7255FA1611B3BF1 /* SemanticExtractor.swift in Sources */,

--- a/MixpanelDemo/MixpanelDemo/SceneDelegate.swift
+++ b/MixpanelDemo/MixpanelDemo/SceneDelegate.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+}

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
@@ -144,8 +144,6 @@ class AutocaptureSwiftUIInstrumentedTests: MixpanelBaseTests {
         }
     }
 
-    // MARK: - Test 2: accessibilityIdentifier fallback
-
     func testSwiftUIElementIdResolutionRule2() {
         // In SwiftUI, accessibilityLabel is primary
         simulateTapOnSwiftUIButton(index: 1, setAccessibility: "Rule Two SwiftUI")
@@ -964,6 +962,310 @@ struct SwiftUIAutocaptureTestView: View {
                 .cornerRadius(8)
             }
             .padding()
+        }
+    }
+}
+
+// MARK: - SwiftUI accessibilityLabel Auto-Derivation Verification Tests
+
+/// These tests verify how SwiftUI controls expose accessibilityLabel on their
+/// UIKit backing views when no explicit .accessibilityLabel() modifier is set.
+///
+/// SwiftUI renders through internal UIKit views (PlatformGroupContainer, _UIGraphicsView, etc.).
+/// We host each SwiftUI view, find the UIKit backing view via hitTest, and check
+/// whether view.accessibilityLabel is populated or nil.
+@available(iOS 14.0, *)
+class SwiftUIAccessibilityLabelDerivationTests: XCTestCase {
+
+    private var testWindow: UIWindow!
+
+    override func setUp() {
+        super.setUp()
+        let setupExpectation = expectation(description: "Setup")
+        DispatchQueue.main.async {
+            self.testWindow = UIWindow(frame: UIScreen.main.bounds)
+            self.testWindow.makeKeyAndVisible()
+            setupExpectation.fulfill()
+        }
+        wait(for: [setupExpectation], timeout: 2)
+    }
+
+    override func tearDown() {
+        let teardownExpectation = expectation(description: "Teardown")
+        DispatchQueue.main.async {
+            self.testWindow?.isHidden = true
+            self.testWindow = nil
+            teardownExpectation.fulfill()
+        }
+        wait(for: [teardownExpectation], timeout: 2)
+        super.tearDown()
+    }
+
+    /// Host a SwiftUI view and return the UIKit backing view at the center point.
+    private func hostAndFindBackingView<V: View>(_ swiftUIView: V) -> UIView? {
+        var result: UIView?
+        let exp = expectation(description: "Host view")
+
+        DispatchQueue.main.async {
+            let hostingController = UIHostingController(rootView: swiftUIView)
+            hostingController.view.frame = self.testWindow.bounds
+            self.testWindow.rootViewController = hostingController
+            self.testWindow.makeKeyAndVisible()
+
+            // Force layout
+            hostingController.view.setNeedsLayout()
+            hostingController.view.layoutIfNeeded()
+
+            // Allow SwiftUI rendering to complete
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                let center = hostingController.view.center
+                let hitView = hostingController.view.hitTest(center, with: nil)
+                result = hitView
+                exp.fulfill()
+            }
+        }
+
+        wait(for: [exp], timeout: 3)
+        return result
+    }
+
+    // MARK: - Button
+
+    func testSwiftUIButton_NoLabel_CheckDerivation() {
+        let view = hostAndFindBackingView(
+            Button("Card 4111-1111-1111-1234") {}
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI Button backing view: \(className)")
+            print("SwiftUI Button accessibilityLabel (no modifier): \(label ?? "nil")")
+            print("SwiftUI Button isAccessibilityElement: \(view.isAccessibilityElement)")
+        }
+    }
+
+    func testSwiftUIButton_WithLabel_CheckDerivation() {
+        let view = hostAndFindBackingView(
+            Button("Card 4111-1111-1111-1234") {}
+                .accessibilityLabel("Safe Label")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI Button (with label) backing view: \(className)")
+            print("SwiftUI Button (with label) accessibilityLabel: \(label ?? "nil")")
+        }
+    }
+
+    // MARK: - Text
+
+    func testSwiftUIText_NoLabel_CheckDerivation() {
+        let view = hostAndFindBackingView(
+            Text("Account 9876-5432")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI Text backing view: \(className)")
+            print("SwiftUI Text accessibilityLabel (no modifier): \(label ?? "nil")")
+            print("SwiftUI Text isAccessibilityElement: \(view.isAccessibilityElement)")
+        }
+    }
+
+    // MARK: - Toggle (equivalent of UISwitch)
+
+    func testSwiftUIToggle_NoLabel_CheckDerivation() {
+        let view = hostAndFindBackingView(
+            Toggle("Enable notifications", isOn: .constant(true))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding()
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI Toggle backing view: \(className)")
+            print("SwiftUI Toggle accessibilityLabel (no modifier): \(label ?? "nil")")
+            print("SwiftUI Toggle isAccessibilityElement: \(view.isAccessibilityElement)")
+        }
+    }
+
+    // MARK: - Slider
+
+    func testSwiftUISlider_NoLabel_CheckDerivation() {
+        let view = hostAndFindBackingView(
+            Slider(value: .constant(0.5))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding()
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI Slider backing view: \(className)")
+            print("SwiftUI Slider accessibilityLabel (no modifier): \(label ?? "nil")")
+        }
+    }
+
+    // MARK: - TextField
+
+    func testSwiftUITextField_NoLabel_WithTypedText() {
+        let view = hostAndFindBackingView(
+            TextField("Enter email", text: .constant("john.doe@example.com"))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding()
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let value = view.accessibilityValue
+            let className = String(describing: type(of: view))
+            print("SwiftUI TextField backing view: \(className)")
+            print("SwiftUI TextField accessibilityLabel: \(label ?? "nil")")
+            print("SwiftUI TextField accessibilityValue: \(value ?? "nil")")
+            if let label = label {
+                let typedTextLeaks = label.contains("john.doe") || label.contains("example.com")
+                print("SwiftUI TextField typed text leaks into label: \(typedTextLeaks)")
+            }
+        }
+    }
+
+    // MARK: - TextEditor (equivalent of UITextView)
+
+    func testSwiftUITextEditor_NoLabel_WithText() {
+        let view = hostAndFindBackingView(
+            TextEditor(text: .constant("SSN: 123-45-6789"))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding()
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let value = view.accessibilityValue
+            let className = String(describing: type(of: view))
+            print("SwiftUI TextEditor backing view: \(className)")
+            print("SwiftUI TextEditor accessibilityLabel: \(label ?? "nil")")
+            print("SwiftUI TextEditor accessibilityValue: \(value ?? "nil")")
+        }
+    }
+
+    // MARK: - Picker (equivalent of UISegmentedControl)
+
+    func testSwiftUIPicker_Segmented_NoLabel_CheckDerivation() {
+        let view = hostAndFindBackingView(
+            Picker("Account Type", selection: .constant(0)) {
+                Text("Personal").tag(0)
+                Text("Business").tag(1)
+                Text("Account 1234").tag(2)
+            }
+            .pickerStyle(.segmented)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding()
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI Picker (segmented) backing view: \(className)")
+            print("SwiftUI Picker accessibilityLabel: \(label ?? "nil")")
+        }
+    }
+
+    // MARK: - Stepper
+
+    func testSwiftUIStepper_NoLabel_CheckDerivation() {
+        let view = hostAndFindBackingView(
+            Stepper("Quantity", value: .constant(5), in: 0...10)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding()
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI Stepper backing view: \(className)")
+            print("SwiftUI Stepper accessibilityLabel: \(label ?? "nil")")
+        }
+    }
+
+    // MARK: - Image
+
+    func testSwiftUIImage_NoLabel_CheckDerivation() {
+        let view = hostAndFindBackingView(
+            Image(systemName: "star.fill")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI Image backing view: \(className)")
+            print("SwiftUI Image accessibilityLabel: \(label ?? "nil")")
+        }
+    }
+
+    // MARK: - VStack with child Text (container scenario)
+
+    func testSwiftUIVStack_WithChildText_NoLabel() {
+        let view = hostAndFindBackingView(
+            VStack {
+                Text("Sensitive Account 1234")
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .onTapGesture {}
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI VStack (tappable) backing view: \(className)")
+            print("SwiftUI VStack accessibilityLabel: \(label ?? "nil")")
+            print("SwiftUI VStack isAccessibilityElement: \(view.isAccessibilityElement)")
+            if let label = label {
+                let childTextLeaks = label.contains("Sensitive") || label.contains("1234")
+                print("SwiftUI VStack child text leaks: \(childTextLeaks)")
+            }
+        }
+    }
+
+    // MARK: - List row (common pattern for PII display)
+
+    func testSwiftUIListRow_WithSensitiveText() {
+        let view = hostAndFindBackingView(
+            List {
+                HStack {
+                    Text("Card ending")
+                    Spacer()
+                    Text("4111-1111-1111-1234")
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI List row backing view: \(className)")
+            print("SwiftUI List row accessibilityLabel: \(label ?? "nil")")
+            print("SwiftUI List row isAccessibilityElement: \(view.isAccessibilityElement)")
         }
     }
 }

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
@@ -144,8 +144,35 @@ class AutocaptureSwiftUIInstrumentedTests: MixpanelBaseTests {
         }
     }
 
+    // MARK: - Test 2a: accessibilityIdentifier outranks accessibilityLabel
+
+    /// On a SwiftUI-rendered view (`PlatformGroupContainer`), an accessibilityIdentifier must win
+    /// $el_id over the label: it is developer-assigned and never user-visible, so it cannot carry
+    /// PII the way a label can. The label still travels as $attr-aria-label.
+    ///
+    /// Note both properties are stamped onto the backing UIView here, exactly as the other SwiftUI
+    /// tests do. SwiftUI keeps `.accessibilityIdentifier(…)` / `.accessibilityLabel(…)` in its own
+    /// accessibility element tree, which is only populated while an accessibility client is
+    /// attached — never in this test host, where `accessibilityHitTest` returns nil.
+    func testSwiftUIElementIdIdentifierWinsOverLabel() {
+        setSwiftUIButtonAccessibility(
+            index: 3, identifier: "swiftui_both_id", label: "Both Label SwiftUI")
+
+        simulateTapOnSwiftUIButton(index: 3)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event")
+
+        if let props = event?.properties {
+            XCTAssertEqual(props["$el_id"] as? String, "swiftui_both_id")
+            XCTAssertEqual(props["$attr-aria-label"] as? String, "Both Label SwiftUI")
+        }
+    }
+
+    // MARK: - Test 2: accessibilityLabel fallback (no identifier on the view)
+
     func testSwiftUIElementIdResolutionRule2() {
-        // In SwiftUI, accessibilityLabel is primary
+        // With no accessibilityIdentifier on the backing view, the label is next in line.
         simulateTapOnSwiftUIButton(index: 1, setAccessibility: "Rule Two SwiftUI")
 
         let event = waitForEvent(named: "$mp_click", timeout: 5)

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
@@ -74,6 +74,18 @@ class AutocaptureOptionsTests: XCTestCase {
         XCTAssertTrue(options.deadClickOptions.enabled)
     }
 
+    func testAutocaptureOptionsDefaultToNoElementIdExtractor() {
+        XCTAssertNil(AutocaptureOptions().elementIdExtractor)
+    }
+
+    func testAutocaptureOptionsRetainTheElementIdExtractor() {
+        let extractor = ConstantElementIdExtractor("custom_el_id")
+        let options = AutocaptureOptions(elementIdExtractor: extractor)
+
+        XCTAssertNotNil(options.elementIdExtractor)
+        XCTAssertEqual(options.elementIdExtractor?.extractElementId(from: UIView()), "custom_el_id")
+    }
+
     func testAutocaptureOptionsIsEnabledWhenAnyFeatureEnabled() {
         // Only click enabled
         let clickOnly = AutocaptureOptions(
@@ -308,6 +320,486 @@ class ClickEventTests: XCTestCase {
         XCTAssertNil(props["$attr-aria-label"])
         XCTAssertNil(props["$attr-role"])
         XCTAssertNil(props["$elements"])
+    }
+}
+
+// MARK: - Element ID Resolution Order
+
+/// Stands in for React Native's `RCTView`: an `@objc` `nativeID` property makes `responds(to:)` and
+/// `value(forKey:)` behave exactly as they do on a real React Native view.
+private final class FakeReactNativeView: UIView {
+    @objc var nativeID: String?
+}
+
+/// Returns a fixed identifier for every view.
+private final class ConstantElementIdExtractor: ElementIdExtractor {
+    let identifier: String?
+
+    init(_ identifier: String?) {
+        self.identifier = identifier
+    }
+
+    func extractElementId(from view: UIView) -> String? {
+        return identifier
+    }
+}
+
+/// Tests the `$el_id` resolution order implemented by `DefaultElementIdExtractor`:
+/// React Native `nativeID` > `accessibilityIdentifier` > `accessibilityLabel` > `<ClassName>_<hash>`.
+class DefaultElementIdExtractorTests: XCTestCase {
+
+    /// Matches the anonymous fallback: ClassName_hexHash.
+    private let hashIdPattern = "^[A-Za-z0-9_]+_[0-9a-f]+$"
+
+    private let extractor = DefaultElementIdExtractor.shared
+
+    private func assertMatchesHashFallback(_ elementId: String, _ message: String = "") {
+        XCTAssertNotNil(
+            elementId.range(of: hashIdPattern, options: .regularExpression),
+            "Expected <ClassName>_<hash>, got: \(elementId). \(message)")
+    }
+
+    // MARK: - Priority 1: React Native nativeID
+
+    func testNativeIdWinsOverIdentifierAndLabel() {
+        let view = FakeReactNativeView()
+        view.nativeID = "rn_checkout_button"
+        view.accessibilityIdentifier = "checkout_identifier"
+        view.isAccessibilityElement = true
+        view.accessibilityLabel = "Checkout"
+
+        XCTAssertEqual(extractor.extractElementId(from: view), "rn_checkout_button")
+    }
+
+    func testEmptyNativeIdFallsThroughToIdentifier() {
+        let view = FakeReactNativeView()
+        view.nativeID = ""
+        view.accessibilityIdentifier = "checkout_identifier"
+
+        XCTAssertEqual(extractor.extractElementId(from: view), "checkout_identifier")
+    }
+
+    func testViewWithoutNativeIdPropertyIsHandled() {
+        // A plain UIView does not declare `nativeID`; the KVC probe must not throw.
+        let view = UIView()
+        view.accessibilityIdentifier = "plain_view"
+
+        XCTAssertEqual(extractor.extractElementId(from: view), "plain_view")
+    }
+
+    // MARK: - Priority 2: accessibilityIdentifier
+
+    func testIdentifierWinsOverLabel() {
+        // The identifier is stable and never user-visible, so it outranks the label.
+        let button = UIButton()
+        button.accessibilityIdentifier = "checkout_identifier"
+        button.accessibilityLabel = "Checkout"
+
+        XCTAssertEqual(extractor.extractElementId(from: button), "checkout_identifier")
+    }
+
+    func testEmptyIdentifierFallsThroughToLabel() {
+        let button = UIButton()
+        button.accessibilityIdentifier = ""
+        button.accessibilityLabel = "Checkout"
+
+        XCTAssertEqual(extractor.extractElementId(from: button), "Checkout")
+    }
+
+    func testInternalIdentifiersAreSkipped() {
+        for internalIdentifier in ["_privateThing", "AXID-42", "UITransitionView-1"] {
+            let button = UIButton()
+            button.accessibilityIdentifier = internalIdentifier
+            button.accessibilityLabel = "Checkout"
+
+            XCTAssertEqual(
+                extractor.extractElementId(from: button), "Checkout",
+                "Framework-internal identifier \(internalIdentifier) should be skipped")
+        }
+    }
+
+    // MARK: - Priority 3: accessibilityLabel
+
+    func testLabelUsedWhenNothingElseResolves() {
+        let label = UILabel()
+        label.accessibilityLabel = "Order Total"
+
+        XCTAssertEqual(extractor.extractElementId(from: label), "Order Total")
+    }
+
+    func testLabelOnGenericContainerIgnoredUnlessAccessibilityElement() {
+        // UIKit auto-derives container labels from child text, which can carry user data. A generic
+        // container (e.g. React Native's RCTView) is only trusted when the developer marked it as an
+        // accessibility element — `accessible={true}` in React Native.
+        let container = UIView()
+        container.accessibilityLabel = "Account ending 4321"
+        container.isAccessibilityElement = false
+
+        let elementId = extractor.extractElementId(from: container) ?? ""
+        assertMatchesHashFallback(elementId)
+        XCTAssertFalse(elementId.contains("4321"), "Derived label must not leak into $el_id")
+    }
+
+    func testLabelOnGenericContainerUsedWhenAccessibilityElement() {
+        let container = UIView()
+        container.accessibilityLabel = "Explicit Label"
+        container.isAccessibilityElement = true
+
+        XCTAssertEqual(extractor.extractElementId(from: container), "Explicit Label")
+    }
+
+    func testEmptyLabelFallsThroughToHash() {
+        let button = UIButton()
+        button.accessibilityLabel = ""
+
+        assertMatchesHashFallback(extractor.extractElementId(from: button) ?? "")
+    }
+
+    // MARK: - Priority 4: hash fallback
+
+    func testHashFallbackUsesClassName() {
+        let elementId = extractor.extractElementId(from: UIButton()) ?? ""
+
+        XCTAssertNotNil(
+            elementId.range(of: "^UIButton_[0-9a-f]+$", options: .regularExpression),
+            "Expected UIButton_<hash>, got: \(elementId)")
+    }
+
+    func testHashFallbackIsStablePerViewAndDistinctAcrossViews() {
+        let first = UIButton()
+        let second = UIButton()
+
+        XCTAssertEqual(
+            extractor.extractElementId(from: first), extractor.extractElementId(from: first),
+            "Same view must resolve to the same id")
+        XCTAssertNotEqual(
+            extractor.extractElementId(from: first), extractor.extractElementId(from: second),
+            "Different views must resolve to different ids")
+    }
+
+    func testAnonymousIdMatchesTheDefaultChainFallback() {
+        // resolveElementId() hands a nil-returning custom extractor over to anonymousId(); both
+        // paths must produce the same shape.
+        let view = UIButton()
+
+        XCTAssertEqual(
+            extractor.extractElementId(from: view),
+            DefaultElementIdExtractor.anonymousId(for: view))
+    }
+
+    // MARK: - SwiftUI fallbacks (values read from the accessibility element tree)
+
+    func testIdentifierFallbackUsedWhenViewHasNoIdentifier() {
+        let view = UIView()
+
+        XCTAssertEqual(
+            extractor.elementId(
+                for: view,
+                accessibilityIdentifierFallback: "swiftui_checkout",
+                accessibilityLabelFallback: "Checkout From Tree"),
+            "swiftui_checkout",
+            "Identifier fallback must outrank the label fallback")
+    }
+
+    func testViewIdentifierWinsOverIdentifierFallback() {
+        let view = UIView()
+        view.accessibilityIdentifier = "own_identifier"
+
+        XCTAssertEqual(
+            extractor.elementId(
+                for: view,
+                accessibilityIdentifierFallback: "tree_identifier",
+                accessibilityLabelFallback: nil),
+            "own_identifier")
+    }
+
+    func testLabelFallbackUsedWhenNoIdentifierAnywhere() {
+        let view = UIView()
+
+        XCTAssertEqual(
+            extractor.elementId(
+                for: view,
+                accessibilityIdentifierFallback: nil,
+                accessibilityLabelFallback: "Checkout From Tree"),
+            "Checkout From Tree")
+    }
+
+    func testInternalIdentifierFallbackIsSkipped() {
+        let view = UIView()
+
+        let elementId = extractor.elementId(
+            for: view,
+            accessibilityIdentifierFallback: "_UIKitInternal",
+            accessibilityLabelFallback: nil)
+
+        assertMatchesHashFallback(elementId)
+    }
+
+    func testEmptyFallbacksResolveToHash() {
+        let view = UIView()
+
+        assertMatchesHashFallback(
+            extractor.elementId(
+                for: view, accessibilityIdentifierFallback: "", accessibilityLabelFallback: ""))
+    }
+}
+
+/// Verifies that `AutocaptureOptions.elementIdExtractor` actually governs the `$el_id` that reaches
+/// the `ClickEvent` — the integration point between the option and the hit-test path.
+class SemanticExtractorElementIdTests: XCTestCase {
+
+    private let point = CGPoint(x: 10, y: 20)
+
+    private func elementId(for view: UIView, options: AutocaptureOptions) -> String {
+        return SemanticExtractor(autocaptureOptions: options)
+            .extractSemantics(from: view, at: point)
+            .elementId
+    }
+
+    func testDefaultResolutionUsedWhenNoExtractorProvided() {
+        let button = UIButton()
+        button.accessibilityIdentifier = "checkout_identifier"
+        button.accessibilityLabel = "Checkout"
+
+        XCTAssertEqual(
+            elementId(for: button, options: AutocaptureOptions()), "checkout_identifier")
+    }
+
+    func testCustomExtractorReplacesDefaultResolution() {
+        let button = UIButton()
+        button.accessibilityIdentifier = "checkout_identifier"
+
+        let options = AutocaptureOptions(
+            elementIdExtractor: ConstantElementIdExtractor("custom_el_id"))
+
+        XCTAssertEqual(elementId(for: button, options: options), "custom_el_id")
+    }
+
+    func testCustomExtractorReturningNilFallsBackToAnonymousId() {
+        // Returning nil means "report nothing identifying" — the SDK must not quietly fall back to
+        // metadata the developer declined to expose.
+        let button = UIButton()
+        button.accessibilityIdentifier = "checkout_identifier"
+        button.accessibilityLabel = "Checkout"
+
+        let options = AutocaptureOptions(elementIdExtractor: ConstantElementIdExtractor(nil))
+        let resolved = elementId(for: button, options: options)
+
+        XCTAssertEqual(resolved, DefaultElementIdExtractor.anonymousId(for: button))
+        XCTAssertFalse(resolved.contains("checkout_identifier"))
+        XCTAssertFalse(resolved.contains("Checkout"))
+    }
+
+    func testCustomExtractorReturningEmptyStringFallsBackToAnonymousId() {
+        let button = UIButton()
+        button.accessibilityIdentifier = "checkout_identifier"
+
+        let options = AutocaptureOptions(elementIdExtractor: ConstantElementIdExtractor(""))
+
+        XCTAssertEqual(
+            elementId(for: button, options: options),
+            DefaultElementIdExtractor.anonymousId(for: button))
+    }
+
+    func testAccessibilityLabelStillReportedSeparatelyFromElementId() {
+        // The identifier wins $el_id, but the label must still travel as $attr-aria-label.
+        let button = UIButton()
+        button.accessibilityIdentifier = "checkout_identifier"
+        button.accessibilityLabel = "Checkout"
+
+        let event = SemanticExtractor(autocaptureOptions: AutocaptureOptions())
+            .extractSemantics(from: button, at: point)
+
+        XCTAssertEqual(event.elementId, "checkout_identifier")
+        XCTAssertEqual(event.accessibleLabel, "Checkout")
+    }
+}
+
+/// End-to-end coverage for the extractor: an implementation handed to `MixpanelOptions` must survive
+/// SDK initialization and govern the `$el_id` of a `$mp_click` produced by a real touch.
+class ElementIdExtractorEndToEndTests: MixpanelBaseTests {
+
+    private var testWindow: UIWindow!
+    private var testViewController: UIViewController!
+    private var button: UIButton!
+    private var mixpanel: MixpanelInstance!
+
+    override func setUp() {
+        super.setUp()
+
+        let setupExpectation = expectation(description: "Setup complete")
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            self.button = UIButton(type: .system)
+            self.button.setTitle("Checkout", for: .normal)
+            self.button.accessibilityIdentifier = "checkout_identifier"
+            self.button.accessibilityLabel = "Checkout"
+            self.button.frame = CGRect(x: 20, y: 100, width: 200, height: 44)
+            self.button.addTarget(self, action: #selector(self.buttonTapped), for: .touchUpInside)
+
+            self.testViewController = UIViewController()
+            self.testViewController.view.addSubview(self.button)
+
+            self.testWindow = UIWindow(frame: UIScreen.main.bounds)
+            self.testWindow.rootViewController = self.testViewController
+            self.testWindow.makeKeyAndVisible()
+            self.testWindow.layoutIfNeeded()
+
+            setupExpectation.fulfill()
+        }
+        wait(for: [setupExpectation], timeout: 5)
+    }
+
+    override func tearDown() {
+        let teardownExpectation = expectation(description: "Teardown complete")
+        DispatchQueue.main.async { [weak self] in
+            self?.testWindow?.isHidden = true
+            self?.testWindow = nil
+            self?.testViewController = nil
+            self?.button = nil
+            teardownExpectation.fulfill()
+        }
+        wait(for: [teardownExpectation], timeout: 5)
+
+        if let token = mixpanel?.apiToken {
+            removeDBfile(token)
+        }
+        mixpanel = nil
+        super.tearDown()
+    }
+
+    @objc private func buttonTapped() {}
+
+    func testCustomExtractorGovernsElementIdEndToEnd() {
+        startMixpanel(extractor: ConstantElementIdExtractor("custom_el_id"))
+
+        simulateTap()
+
+        let properties = waitForClickProperties()
+        XCTAssertNotNil(properties, "Should capture $mp_click event")
+        XCTAssertEqual(properties?["$el_id"] as? String, "custom_el_id")
+    }
+
+    func testExtractorReturningNilYieldsAnonymousIdEndToEnd() {
+        startMixpanel(extractor: ConstantElementIdExtractor(nil))
+
+        simulateTap()
+
+        let properties = waitForClickProperties()
+        XCTAssertNotNil(properties, "Should capture $mp_click event")
+        let elementId = properties?["$el_id"] as? String ?? ""
+        XCTAssertNotNil(
+            elementId.range(of: "^UIButton_[0-9a-f]+$", options: .regularExpression),
+            "Expected the anonymous id, got: \(elementId)")
+        XCTAssertFalse(
+            elementId.contains("checkout_identifier"),
+            "Suppressed identifier must not leak into $el_id")
+    }
+
+    func testDefaultResolutionEndToEndWithoutExtractor() {
+        startMixpanel(extractor: nil)
+
+        simulateTap()
+
+        let properties = waitForClickProperties()
+        XCTAssertNotNil(properties, "Should capture $mp_click event")
+        XCTAssertEqual(properties?["$el_id"] as? String, "checkout_identifier")
+    }
+
+    /// A React Native view exposes the JS-side `nativeID` prop as an `@objc` property; it must win
+    /// $el_id over the accessibility metadata React Native also sets.
+    func testReactNativeNativeIdWinsEndToEnd() {
+        startMixpanel(extractor: nil)
+
+        let setupExpectation = expectation(description: "RN view added")
+        let rnView = FakeReactNativeView()
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            rnView.nativeID = "rn_checkout_button"
+            rnView.accessibilityIdentifier = "rn_view_identifier"
+            rnView.isAccessibilityElement = true
+            rnView.accessibilityLabel = "Checkout"
+            rnView.frame = CGRect(x: 20, y: 200, width: 200, height: 44)
+            // React Native attaches touch handling via gesture recognizers; one is enough to make
+            // the view read as interactive so the hit test stops here instead of walking up.
+            rnView.addGestureRecognizer(
+                UITapGestureRecognizer(target: self, action: #selector(self.buttonTapped)))
+            self.testViewController.view.addSubview(rnView)
+            self.testWindow.layoutIfNeeded()
+            setupExpectation.fulfill()
+        }
+        wait(for: [setupExpectation], timeout: 5)
+
+        let tapExpectation = expectation(description: "Tap simulated")
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self, let window = self.testWindow else {
+                tapExpectation.fulfill()
+                return
+            }
+            let center = rnView.superview?.convert(rnView.center, to: window) ?? rnView.center
+            self.mixpanel.autocaptureManager?.handleTouch(at: center, view: rnView, window: window)
+            tapExpectation.fulfill()
+        }
+        wait(for: [tapExpectation], timeout: 2)
+
+        let properties = waitForClickProperties()
+        XCTAssertNotNil(properties, "Should capture $mp_click event")
+        XCTAssertEqual(properties?["$el_id"] as? String, "rn_checkout_button")
+    }
+
+    // MARK: - Helpers
+
+    private func startMixpanel(extractor: ElementIdExtractor?) {
+        let token = randomId()
+        let options = MixpanelOptions(
+            token: token,
+            flushInterval: 60,
+            instanceName: token,
+            trackAutomaticEvents: false,
+            optOutTrackingByDefault: false,
+            serverURL: kFakeServerUrl,
+            autocaptureOptions: AutocaptureOptions(
+                clickOptions: ClickOptions(enabled: true),
+                rageClickOptions: RageClickOptions(enabled: false),
+                deadClickOptions: DeadClickOptions(enabled: false),
+                elementIdExtractor: extractor
+            )
+        )
+
+        mixpanel = Mixpanel.initialize(options: options)
+        waitForAsyncTasks()
+    }
+
+    private func simulateTap() {
+        let tapExpectation = expectation(description: "Tap simulated")
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self, let window = self.testWindow, let button = self.button else {
+                tapExpectation.fulfill()
+                return
+            }
+            let center = button.superview?.convert(button.center, to: window) ?? button.center
+            self.mixpanel.autocaptureManager?.handleTouch(at: center, view: button, window: window)
+            tapExpectation.fulfill()
+        }
+        wait(for: [tapExpectation], timeout: 2)
+    }
+
+    private func waitForClickProperties(timeout: TimeInterval = 5) -> [String: Any]? {
+        let startTime = Date()
+        while Date().timeIntervalSince(startTime) < timeout {
+            waitForTrackingQueue(mixpanel)
+
+            let events = eventQueue(token: mixpanel.apiToken)
+            if let match = events.first(where: { ($0["event"] as? String) == "$mp_click" }),
+                let properties = match["properties"] as? [String: Any]
+            {
+                return properties
+            }
+
+            RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.1))
+        }
+        return nil
     }
 }
 #endif

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
@@ -851,4 +851,247 @@ private class MockUITouch: UITouch {
     }
 }
 
+// MARK: - UIKit accessibilityLabel Auto-Derivation Verification Tests
+
+/// These tests verify UIKit's auto-derivation behavior for each control type listed
+/// in SemanticExtractor.findAccessibilityLabel's known-control bypass.
+///
+/// For each control, we check:
+/// 1. When accessibilityLabel is nil (not set), does UIKit auto-derive it from visible text?
+/// 2. When accessibilityLabel is "" (explicitly empty), does UIKit respect the empty value?
+///
+/// This documents the actual runtime behavior to inform PII-safe extraction decisions.
+class UIKitAccessibilityLabelDerivationTests: XCTestCase {
+
+    // MARK: - UIButton
+
+    func testUIButton_NilLabel_DoesNotDeriveFromTitle() {
+        let button = UIButton(type: .system)
+        button.setTitle("Card 4111-1111-1111-1234", for: .normal)
+        // accessibilityLabel is NOT set (nil by default)
+
+        let label = button.accessibilityLabel
+        // UIButton does NOT auto-derive accessibilityLabel from title at the property level.
+        // VoiceOver reads the title, but view.accessibilityLabel remains nil.
+        XCTAssertNil(label, "UIButton should NOT auto-derive accessibilityLabel from title")
+    }
+
+    func testUIButton_EmptyLabel_DoesNotDeriveFromTitle() {
+        let button = UIButton(type: .system)
+        button.setTitle("Card 4111-1111-1111-1234", for: .normal)
+        button.accessibilityLabel = ""
+
+        let label = button.accessibilityLabel
+        // Check whether UIKit respects empty string or falls back to title
+        let isEmpty = (label == nil || label!.isEmpty)
+        XCTAssertTrue(
+            isEmpty,
+            "UIButton with accessibilityLabel='' should not derive from title. Got: \(label ?? "nil")")
+    }
+
+    // MARK: - UILabel
+
+    func testUILabel_NilLabel_DoesNotDeriveFromText() {
+        let uiLabel = UILabel()
+        uiLabel.text = "Account 9876-5432"
+        // accessibilityLabel is NOT set
+
+        let label = uiLabel.accessibilityLabel
+        // UILabel does NOT auto-derive accessibilityLabel from text at the property level.
+        // VoiceOver reads the text, but view.accessibilityLabel remains nil.
+        XCTAssertNil(label, "UILabel should NOT auto-derive accessibilityLabel from text")
+    }
+
+    func testUILabel_EmptyLabel_DoesNotDeriveFromText() {
+        let uiLabel = UILabel()
+        uiLabel.text = "Account 9876-5432"
+        uiLabel.accessibilityLabel = ""
+
+        let label = uiLabel.accessibilityLabel
+        let isEmpty = (label == nil || label!.isEmpty)
+        XCTAssertTrue(
+            isEmpty,
+            "UILabel with accessibilityLabel='' should not derive from text. Got: \(label ?? "nil")")
+    }
+
+    // MARK: - UISwitch
+
+    func testUISwitch_NilLabel_CheckDerivation() {
+        let toggle = UISwitch()
+        toggle.isOn = true
+        // accessibilityLabel is NOT set
+
+        let label = toggle.accessibilityLabel
+        // UISwitch has no visible text — document whether label is nil or has a default
+        // (This test documents behavior, not asserts a specific value)
+        if let label = label, !label.isEmpty {
+            // If non-nil, it should NOT contain user data (switch has no text input)
+            XCTAssertFalse(
+                label.contains("Account") || label.contains("1234"),
+                "UISwitch should not contain user data. Got: \(label)")
+        }
+        // Record the actual value for documentation
+        print("UISwitch default accessibilityLabel: \(label ?? "nil")")
+    }
+
+    // MARK: - UISlider
+
+    func testUISlider_NilLabel_CheckDerivation() {
+        let slider = UISlider()
+        slider.minimumValue = 0
+        slider.maximumValue = 100
+        slider.value = 50
+        // accessibilityLabel is NOT set
+
+        let label = slider.accessibilityLabel
+        if let label = label, !label.isEmpty {
+            XCTAssertFalse(
+                label.contains("Account") || label.contains("1234"),
+                "UISlider should not contain user data. Got: \(label)")
+        }
+        print("UISlider default accessibilityLabel: \(label ?? "nil")")
+    }
+
+    // MARK: - UITextField
+
+    func testUITextField_NilLabel_WithTypedText() {
+        let textField = UITextField()
+        textField.text = "john.doe@example.com"
+        textField.placeholder = "Enter email"
+        // accessibilityLabel is NOT set
+
+        let label = textField.accessibilityLabel
+        // Critical: does the TYPED TEXT leak into accessibilityLabel?
+        if let label = label, !label.isEmpty {
+            let typedTextLeaks = label.contains("john.doe") || label.contains("example.com")
+            print("UITextField accessibilityLabel with typed text: \(label)")
+            print("UITextField typed text leaks into accessibilityLabel: \(typedTextLeaks)")
+        } else {
+            print("UITextField default accessibilityLabel: nil/empty")
+        }
+    }
+
+    func testUITextField_NilLabel_WithPlaceholderOnly() {
+        let textField = UITextField()
+        textField.text = nil
+        textField.placeholder = "Enter email"
+        // accessibilityLabel is NOT set
+
+        let label = textField.accessibilityLabel
+        print("UITextField accessibilityLabel with placeholder only: \(label ?? "nil")")
+    }
+
+    func testUITextField_NilLabel_CheckAccessibilityValue() {
+        let textField = UITextField()
+        textField.text = "john.doe@example.com"
+        textField.placeholder = "Enter email"
+
+        let label = textField.accessibilityLabel
+        let value = textField.accessibilityValue
+        print("UITextField accessibilityLabel: \(label ?? "nil")")
+        print("UITextField accessibilityValue: \(value ?? "nil")")
+        // Document whether typed text goes to label, value, or both
+    }
+
+    // MARK: - UITextView
+
+    func testUITextView_NilLabel_WithTypedText() {
+        let textView = UITextView()
+        textView.text = "SSN: 123-45-6789"
+        // accessibilityLabel is NOT set
+
+        let label = textView.accessibilityLabel
+        if let label = label, !label.isEmpty {
+            let typedTextLeaks = label.contains("123-45") || label.contains("6789")
+            print("UITextView accessibilityLabel with typed text: \(label)")
+            print("UITextView typed text leaks into accessibilityLabel: \(typedTextLeaks)")
+        } else {
+            print("UITextView default accessibilityLabel: nil/empty")
+        }
+    }
+
+    func testUITextView_NilLabel_CheckAccessibilityValue() {
+        let textView = UITextView()
+        textView.text = "SSN: 123-45-6789"
+
+        let label = textView.accessibilityLabel
+        let value = textView.accessibilityValue
+        print("UITextView accessibilityLabel: \(label ?? "nil")")
+        print("UITextView accessibilityValue: \(value ?? "nil")")
+    }
+
+    // MARK: - UISegmentedControl
+
+    func testUISegmentedControl_NilLabel_DerivesFromSegments() {
+        let segControl = UISegmentedControl(items: ["Personal", "Business", "Account 1234"])
+        segControl.selectedSegmentIndex = 0
+        // accessibilityLabel is NOT set
+
+        let label = segControl.accessibilityLabel
+        print("UISegmentedControl accessibilityLabel: \(label ?? "nil")")
+        // Check if segment titles leak into the overall control's label
+        if let label = label, !label.isEmpty {
+            let segmentTextLeaks = label.contains("Personal") || label.contains("1234")
+            print("UISegmentedControl segment text leaks: \(segmentTextLeaks)")
+        }
+    }
+
+    // MARK: - UIStepper
+
+    func testUIStepper_NilLabel_CheckDerivation() {
+        let stepper = UIStepper()
+        stepper.value = 5
+        stepper.minimumValue = 0
+        stepper.maximumValue = 10
+        // accessibilityLabel is NOT set
+
+        let label = stepper.accessibilityLabel
+        print("UIStepper default accessibilityLabel: \(label ?? "nil")")
+    }
+
+    // MARK: - UIImageView
+
+    func testUIImageView_NilLabel_CheckDerivation() {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "star.fill")
+        imageView.accessibilityLabel = nil
+        // accessibilityLabel is NOT set
+
+        let label = imageView.accessibilityLabel
+        print("UIImageView default accessibilityLabel: \(label ?? "nil")")
+        // UIImageView has no text — label should be nil unless derived from image name
+    }
+
+    // MARK: - UIScrollView (not a known control, but in role detection)
+
+    func testUIScrollView_NilLabel_CheckDerivation() {
+        let scrollView = UIScrollView()
+        let childLabel = UILabel()
+        childLabel.text = "Secret Data 9999"
+        scrollView.addSubview(childLabel)
+
+        let label = scrollView.accessibilityLabel
+        print("UIScrollView default accessibilityLabel: \(label ?? "nil")")
+        if let label = label, !label.isEmpty {
+            let childTextLeaks = label.contains("Secret") || label.contains("9999")
+            print("UIScrollView child text leaks: \(childTextLeaks)")
+        }
+    }
+
+    // MARK: - UITableViewCell (common clickable container with child text)
+
+    func testUITableViewCell_NilLabel_WithChildText() {
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+        cell.textLabel?.text = "Card ending 1234"
+        // accessibilityLabel is NOT set
+
+        let label = cell.accessibilityLabel
+        print("UITableViewCell accessibilityLabel: \(label ?? "nil")")
+        if let label = label, !label.isEmpty {
+            let childTextLeaks = label.contains("1234")
+            print("UITableViewCell child text leaks: \(childTextLeaks)")
+        }
+    }
+}
+
 #endif

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
@@ -118,6 +118,25 @@ class AutocaptureUIKitInstrumentedTests: MixpanelBaseTests {
         }
     }
 
+    // MARK: - Test 1a: accessibilityIdentifier outranks accessibilityLabel
+
+    /// When a view carries both, the identifier wins $el_id — it is developer-assigned and never
+    /// user-visible, so unlike a label it cannot carry PII. The label still travels as
+    /// $attr-aria-label.
+    func testElementIdIdentifierWinsOverLabel() {
+        let button = testViewController.bothButton
+
+        simulateTap(on: button)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event")
+
+        if let props = event?.properties {
+            XCTAssertEqual(props["$el_id"] as? String, "both_id")
+            XCTAssertEqual(props["$attr-aria-label"] as? String, "Both Label")
+        }
+    }
+
     // MARK: - Test 2: Element ID Resolution Rule 2 (accessibilityLabel fallback)
 
     func testElementIdResolutionRule2() {

--- a/Sources/Autocapture/AutocaptureOptions.swift
+++ b/Sources/Autocapture/AutocaptureOptions.swift
@@ -211,11 +211,36 @@ public struct AutocaptureOptions {
     /// Configuration for dead click detection.
     public let deadClickOptions: DeadClickOptions
 
+    #if os(iOS)
+    /// Optional custom resolver for the `$el_id` reported on autocaptured interactions.
+    ///
+    /// When `nil` (the default), the SDK resolves `$el_id` internally: React Native `nativeID`,
+    /// then `accessibilityIdentifier`, then `accessibilityLabel`, then an anonymous `<ClassName>_<hash>`
+    /// identifier. Supply an implementation to control exactly which identifier is reported and to
+    /// keep personally identifiable information out of the payload.
+    ///
+    /// - SeeAlso: ``ElementIdExtractor``
+    public let elementIdExtractor: ElementIdExtractor?
+    #endif
+
     /// Returns `true` if any autocapture feature is enabled.
     public var isEnabled: Bool {
         return clickOptions.enabled || rageClickOptions.enabled || deadClickOptions.enabled
     }
 
+    #if os(iOS)
+    public init(
+        clickOptions: ClickOptions = ClickOptions(),
+        rageClickOptions: RageClickOptions = RageClickOptions(),
+        deadClickOptions: DeadClickOptions = DeadClickOptions(),
+        elementIdExtractor: ElementIdExtractor? = nil
+    ) {
+        self.clickOptions = clickOptions
+        self.rageClickOptions = rageClickOptions
+        self.deadClickOptions = deadClickOptions
+        self.elementIdExtractor = elementIdExtractor
+    }
+    #else
     public init(
         clickOptions: ClickOptions = ClickOptions(),
         rageClickOptions: RageClickOptions = RageClickOptions(),
@@ -225,4 +250,5 @@ public struct AutocaptureOptions {
         self.rageClickOptions = rageClickOptions
         self.deadClickOptions = deadClickOptions
     }
+    #endif
 }

--- a/Sources/Autocapture/ElementIdExtractor.swift
+++ b/Sources/Autocapture/ElementIdExtractor.swift
@@ -1,0 +1,194 @@
+//
+//  ElementIdExtractor.swift
+//  Mixpanel
+//
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+// MARK: - ElementIdExtractor
+
+/// Resolves the `$el_id` property reported for an autocaptured interaction.
+///
+/// Provide an implementation via `AutocaptureOptions(elementIdExtractor:)` to take full control
+/// over which identifier the SDK reports for a tapped view. This is the recommended way to keep
+/// personally identifiable information out of autocapture events: the SDK only ever reports what
+/// this method returns.
+///
+/// When no extractor is provided, the SDK falls back to an internal default implementation that
+/// resolves the identifier from the React Native `nativeID`, then `accessibilityIdentifier`, then
+/// `accessibilityLabel`.
+///
+/// **Example:**
+/// ```swift
+/// final class TrackingIdExtractor: ElementIdExtractor {
+///     func extractElementId(from view: UIView) -> String? {
+///         // Only report identifiers the team explicitly opted into.
+///         guard let id = view.accessibilityIdentifier, id.hasPrefix("track_") else { return nil }
+///         return id
+///     }
+/// }
+///
+/// let options = MixpanelOptions(
+///     token: "YOUR_TOKEN",
+///     autocaptureOptions: AutocaptureOptions(elementIdExtractor: TrackingIdExtractor())
+/// )
+/// ```
+///
+/// **Threading:** `extractElementId(from:)` is called on the main thread immediately after the hit
+/// test that resolved the tapped view. Keep the implementation fast and side-effect free.
+public protocol ElementIdExtractor {
+    /// Returns the `$el_id` to report for the given view.
+    ///
+    /// - Parameter view: The view resolved by the autocapture hit test.
+    /// - Returns: The identifier to report, or `nil` to let the SDK report an anonymous
+    ///   `<ClassName>_<hash>` identifier instead. Empty strings are treated as `nil`.
+    func extractElementId(from view: UIView) -> String?
+}
+
+// MARK: - DefaultElementIdExtractor
+
+/// Default `ElementIdExtractor` used when the host app does not supply its own.
+///
+/// Resolution priority:
+/// 1. **React Native `nativeID`** — read through the Objective-C runtime so the SDK carries no
+///    compile-time dependency on React Native. Skipped for SwiftUI views: React Native renders
+///    through UIKit, never SwiftUI, so the probe could only ever be wasted work there.
+/// 2. **`accessibilityIdentifier`** — stable, developer-assigned, and not user-visible. Internal
+///    framework identifiers (e.g. `_UIKit…`, `AXID-…`) are skipped.
+/// 3. **`accessibilityLabel`** — only when the label was intentionally set (see
+///    `intentionalAccessibilityLabel(for:)`), so framework-derived text that may contain user data
+///    is not reported.
+/// 4. **Anonymous fallback** — `<ClassName>_<hash>` derived from the view's class and hash.
+///
+/// For SwiftUI, steps 1–3 collapse to `accessibilityIdentifier` > `accessibilityLabel` > hash. Both
+/// of those properties live in SwiftUI's accessibility element tree rather than on the backing
+/// `UIView`, so `SemanticExtractor` resolves them from that tree and passes them in as the
+/// `accessibilityIdentifierFallback` / `accessibilityLabelFallback` arguments below.
+final class DefaultElementIdExtractor: ElementIdExtractor {
+
+    static let shared = DefaultElementIdExtractor()
+
+    /// Framework-internal identifier prefixes that carry no product meaning.
+    private static let internalIdentifierPrefixes = [
+        "_",  // Private Apple identifiers
+        "AXID-",  // Accessibility internal
+        "UITransitionView",
+        "UILayoutContainerView",
+    ]
+
+    func extractElementId(from view: UIView) -> String? {
+        return elementId(
+            for: view, accessibilityIdentifierFallback: nil, accessibilityLabelFallback: nil)
+    }
+
+    /// Resolution with optional precomputed values used at priority steps 2 and 3.
+    ///
+    /// SwiftUI renders its views as internal UIKit views that carry neither
+    /// `accessibilityIdentifier` nor `accessibilityLabel` on the UIKit view itself; the caller
+    /// resolves those from SwiftUI's accessibility element tree and passes them here so SwiftUI
+    /// elements still get a meaningful `$el_id`. Each fallback is consulted only after the view's
+    /// own property for that step, so an identifier always outranks any label.
+    func elementId(
+        for view: UIView,
+        accessibilityIdentifierFallback: String?,
+        accessibilityLabelFallback: String?
+    ) -> String {
+        // 1. React Native nativeID (UIKit-backed views only)
+        if let nativeId = reactNativeId(for: view) {
+            return nativeId
+        }
+
+        // 2. accessibilityIdentifier
+        if let identifier = view.accessibilityIdentifier,
+            !identifier.isEmpty,
+            !DefaultElementIdExtractor.isInternalIdentifier(identifier)
+        {
+            return identifier
+        }
+        if let fallbackIdentifier = accessibilityIdentifierFallback,
+            !fallbackIdentifier.isEmpty,
+            !DefaultElementIdExtractor.isInternalIdentifier(fallbackIdentifier)
+        {
+            return fallbackIdentifier
+        }
+
+        // 3. accessibilityLabel (only when intentionally set)
+        if let label = intentionalAccessibilityLabel(for: view) {
+            return label
+        }
+        if let fallbackLabel = accessibilityLabelFallback, !fallbackLabel.isEmpty {
+            return fallbackLabel
+        }
+
+        // 4. Anonymous fallback
+        return DefaultElementIdExtractor.anonymousId(for: view)
+    }
+
+    // MARK: - React Native
+
+    /// Reads React Native's `nativeID` property through the Objective-C runtime.
+    ///
+    /// `RCTView` (and friends) expose `nativeID` as an Objective-C property carrying the JS-side
+    /// `nativeID` prop. `responds(to:)` is checked first so KVC never throws on views that do not
+    /// declare the key.
+    ///
+    /// Skipped entirely for SwiftUI views — React Native renders through the UIKit view hierarchy,
+    /// so a SwiftUI view can never carry a `nativeID`.
+    private func reactNativeId(for view: UIView) -> String? {
+        guard !AutocaptureDefaults.isSwiftUIView(view) else { return nil }
+        let selector = NSSelectorFromString("nativeID")
+        guard view.responds(to: selector) else { return nil }
+        guard let nativeId = view.value(forKey: "nativeID") as? String, !nativeId.isEmpty else {
+            return nil
+        }
+        return nativeId
+    }
+
+    // MARK: - Accessibility
+
+    /// Returns the view's `accessibilityLabel` only when it was intentionally set.
+    ///
+    /// UIKit auto-derives `accessibilityLabel` from child text for container views whose
+    /// `isAccessibilityElement` is false, and that derived text may contain sensitive information
+    /// (account numbers, personal details). Known UIKit controls and SwiftUI views always carry an
+    /// intentional (title-derived or explicitly set) label, so they are trusted; generic containers
+    /// — e.g. React Native's `RCTView` — are trusted only when `isAccessibilityElement` is true,
+    /// which in React Native maps to `accessible={true}`.
+    private func intentionalAccessibilityLabel(for view: UIView) -> String? {
+        let isKnownControl =
+            view is UIButton || view is UILabel || view is UISwitch
+            || view is UISlider || view is UITextField || view is UITextView
+            || view is UISegmentedControl || view is UIStepper || view is UIImageView
+        if !isKnownControl && !view.isAccessibilityElement
+            && !AutocaptureDefaults.isSwiftUIView(view)
+        {
+            return nil
+        }
+        if let label = view.accessibilityLabel, !label.isEmpty {
+            return label
+        }
+        return nil
+    }
+
+    private static func isInternalIdentifier(_ identifier: String) -> Bool {
+        for prefix in internalIdentifierPrefixes where identifier.hasPrefix(prefix) {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Anonymous Fallback
+
+    /// The anonymous, PII-free identifier used when nothing else resolves:
+    /// `<ClassName>_<hash>` (e.g. `UIButton_3f2a1b`).
+    static func anonymousId(for view: UIView) -> String {
+        let className = String(describing: type(of: view))
+        // abs(Int.min) traps, so map it to Int.max.
+        let safeHash = view.hash == Int.min ? Int.max : abs(view.hash)
+        return "\(className)_\(String(safeHash, radix: 16))"
+    }
+}
+#endif

--- a/Sources/Autocapture/Model/ClickEvent.swift
+++ b/Sources/Autocapture/Model/ClickEvent.swift
@@ -33,10 +33,16 @@ public struct ClickEvent {
 
     /// A stable identifier for the tapped element, used to group clicks in analytics.
     ///
-    /// Recommended sources (in order of preference):
-    /// - `accessibilityLabel` — human-readable, consistent across UIKit and SwiftUI
+    /// Autocapture resolves this in the following order (see `DefaultElementIdExtractor`), and the
+    /// same preferences apply when tracking manually:
+    /// - React Native `nativeID` — the JS-side prop, read through the Objective-C runtime
+    ///   (skipped for SwiftUI views, which React Native never renders)
     /// - `accessibilityIdentifier` — stable and not user-visible
-    /// - A custom string like `"buy_button"` or `"settings_cell_notifications"`
+    /// - `accessibilityLabel` — human-readable, and only when intentionally set
+    /// - `<ClassName>_<hash>` as a last resort
+    ///
+    /// Supply an `ElementIdExtractor` through `AutocaptureOptions` to override this entirely — for
+    /// example a custom string like `"buy_button"` or `"settings_cell_notifications"`.
     ///
     /// Avoid dynamic values (e.g., cell index, timestamp) — they prevent meaningful grouping.
     public let elementId: String

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -65,7 +65,18 @@ final class SemanticExtractor {
             accessibleLabel = findSwiftUIAccessibilityLabel(at: point, view: targetView)
         }
 
-        let elementId = accessibleLabel ?? generateElementId(for: targetView)
+        // SwiftUI's .accessibilityIdentifier("…") never reaches the backing UIKit view either —
+        // it lives in the same accessibility element tree as the label. Query it only for SwiftUI
+        // views that carry no identifier of their own, so pure UIKit hierarchies pay nothing.
+        var derivedIdentifier: String? = nil
+        if AutocaptureDefaults.isSwiftUIView(targetView),
+            (targetView.accessibilityIdentifier ?? "").isEmpty
+        {
+            derivedIdentifier = findSwiftUIAccessibilityIdentifier(at: point, view: targetView)
+        }
+
+        let elementId = resolveElementId(
+            for: targetView, derivedIdentifier: derivedIdentifier, derivedLabel: accessibleLabel)
         let role = determineRole(for: targetView)
         let tagName = resolveTagName(className: className, role: role, view: targetView)
         let elements = buildViewHierarchy(from: targetView)
@@ -82,48 +93,41 @@ final class SemanticExtractor {
         )
     }
 
-    // MARK: - Element ID Generation
+    // MARK: - Element ID Resolution
 
-    /// Generate a hash-based element ID as fallback when no accessibility label is available.
+    /// Resolve the `$el_id` for the target view.
     ///
-    /// Resolution order:
-    /// 1. `accessibilityIdentifier` (if non-empty)
-    /// 2. `ClassName_<hash>`
+    /// When the host app supplied an ``ElementIdExtractor`` through `AutocaptureOptions`, that
+    /// extractor is the only source of the identifier: a `nil`/empty return yields the anonymous
+    /// `<ClassName>_<hash>` identifier rather than silently falling back to view metadata the developer
+    /// chose not to expose.
     ///
-    /// Note: `accessibilityLabel` is checked by the caller (`extractSemantics`) via
-    /// `findAccessibilityLabel` before falling back to this method.
-    private func generateElementId(for view: UIView) -> String {
-        // accessibilityIdentifier as primary fallback
-        if let identifier = findAccessibilityIdentifier(in: view), !identifier.isEmpty {
-            return identifier
+    /// Otherwise `DefaultElementIdExtractor` resolves it (React Native `nativeID` >
+    /// `accessibilityIdentifier` > `accessibilityLabel` > `<ClassName>_<hash>`; for SwiftUI the
+    /// `nativeID` step is skipped).
+    ///
+    /// - Parameters:
+    ///   - derivedIdentifier: Identifier read from SwiftUI's accessibility element tree, used at the
+    ///     `accessibilityIdentifier` priority step when the view carries none itself.
+    ///   - derivedLabel: The accessibility label already resolved by `extractSemantics`, including
+    ///     labels read from SwiftUI's accessibility element tree. Used at the `accessibilityLabel`
+    ///     priority step.
+    private func resolveElementId(
+        for view: UIView, derivedIdentifier: String?, derivedLabel: String?
+    ) -> String {
+        if let custom = autocaptureOptions.elementIdExtractor {
+            if let customId = custom.extractElementId(from: view), !customId.isEmpty {
+                return customId
+            }
+            return DefaultElementIdExtractor.anonymousId(for: view)
         }
-
-        // Fallback: ClassName_<hex hash>
-        let className = String(describing: type(of: view))
-        let safeHash = view.hash == Int.min ? Int.max : abs(view.hash)
-        return "\(className)_\(String(safeHash, radix: 16))"
+        return DefaultElementIdExtractor.shared.elementId(
+            for: view,
+            accessibilityIdentifierFallback: derivedIdentifier,
+            accessibilityLabelFallback: derivedLabel)
     }
 
     // MARK: - Accessibility Property Discovery
-
-    private func findAccessibilityIdentifier(
-        in view: UIView, maxLevels: Int = SemanticExtractor.maxHierarchyDepth
-    ) -> String? {
-        var currentView: UIView? = view
-        var level = 0
-
-        while let v = currentView, level < maxLevels {
-            if let identifier = v.accessibilityIdentifier, !identifier.isEmpty {
-                if !isInternalIdentifier(identifier) {
-                    return identifier
-                }
-            }
-            currentView = v.superview
-            level += 1
-        }
-
-        return nil
-    }
 
     /// Returns the view's accessibilityLabel only if it was explicitly set by the developer.
     ///
@@ -150,24 +154,6 @@ final class SemanticExtractor {
             return label
         }
         return nil
-    }
-
-    /// Check if an identifier is an internal framework identifier that should be skipped
-    private func isInternalIdentifier(_ identifier: String) -> Bool {
-        let internalPrefixes = [
-            "_",  // Private Apple identifiers
-            "AXID-",  // Accessibility internal
-            "UITransitionView",
-            "UILayoutContainerView",
-        ]
-
-        for prefix in internalPrefixes {
-            if identifier.hasPrefix(prefix) {
-                return true
-            }
-        }
-
-        return false
     }
 
     // MARK: - Role Detection
@@ -313,6 +299,45 @@ final class SemanticExtractor {
                     let label = element.accessibilityLabel, !label.isEmpty
                 {
                     return label
+                }
+                break
+            }
+            current = v.superview
+            depth += 1
+        }
+
+        return nil
+    }
+
+    /// Query the SwiftUI accessibility element tree at the touch point to retrieve the identifier
+    /// set by `.accessibilityIdentifier("…")`.
+    ///
+    /// Same mechanism (and same constraints) as `findSwiftUIAccessibilityLabel(at:view:)`: SwiftUI
+    /// keeps both the label and the identifier in its own accessibility element tree rather than on
+    /// the backing UIKit view, and only the `UIHostingController`'s view owns a tree that
+    /// `accessibilityHitTest` will traverse.
+    ///
+    /// Note SwiftUI only materializes that tree while an accessibility client is attached, so this
+    /// returns nil in an XCTest host — both this and the label helper are exercised on device, not
+    /// by the instrumented tests. `DefaultElementIdExtractorTests` covers what happens with the
+    /// values once resolved.
+    private func findSwiftUIAccessibilityIdentifier(at windowPoint: CGPoint, view: UIView) -> String?
+    {
+        guard #available(iOS 18.0, *) else { return nil }
+        guard let window = view.window else { return nil }
+
+        var current: UIView? = view
+        var depth = 0
+        while let v = current, depth < AutocaptureDefaults.maxAncestorSearchDepth {
+            let className = String(describing: type(of: v))
+            if className.contains("Hosting") {
+                let screenPoint = window.convert(windowPoint, to: window.screen.coordinateSpace)
+                if let element = v.accessibilityHitTest(screenPoint, event: nil) as? NSObject,
+                    let identifier = (element as? UIAccessibilityIdentification)?
+                        .accessibilityIdentifier,
+                    !identifier.isEmpty
+                {
+                    return identifier
                 }
                 break
             }

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -321,8 +321,7 @@ final class SemanticExtractor {
     /// returns nil in an XCTest host — both this and the label helper are exercised on device, not
     /// by the instrumented tests. `DefaultElementIdExtractorTests` covers what happens with the
     /// values once resolved.
-    private func findSwiftUIAccessibilityIdentifier(at windowPoint: CGPoint, view: UIView) -> String?
-    {
+    private func findSwiftUIAccessibilityIdentifier(at windowPoint: CGPoint, view: UIView) -> String? {
         guard #available(iOS 18.0, *) else { return nil }
         guard let window = view.window else { return nil }
 


### PR DESCRIPTION
## Summary

Adds a public `ElementIdExtractor` protocol so host apps decide exactly which identifier autocapture reports as `$el_id` — the main lever for keeping PII out of autocapture payloads. With no extractor supplied, an internal `DefaultElementIdExtractor` resolves it.

Companion PR: the same API on Android (`mixpanel-android`, branch `feature/custom-element-id-extractor`).

## Resolution order

**UIKit / React Native**

1. React Native `nativeID` — read through the Objective-C runtime (`responds(to:)` then `value(forKey:)`), so the SDK carries no compile-time React Native dependency
2. `accessibilityIdentifier` — stable, developer-assigned, never user-visible; framework-internal identifiers (`_…`, `AXID-…`) are skipped
3. `accessibilityLabel` — only when intentionally set. Known UIKit controls and SwiftUI views are trusted; a generic container (e.g. React Native's `RCTView`) only when `isAccessibilityElement` is true, which maps to `accessible={true}` — so UIKit's auto-derived container labels cannot leak
4. `<ClassName>_<hash>`

**SwiftUI** collapses to `accessibilityIdentifier` > `accessibilityLabel` > hash. The `nativeID` probe is skipped, since React Native renders through UIKit and never SwiftUI. Neither `.accessibilityIdentifier(…)` nor `.accessibilityLabel(…)` reaches the backing `UIView`, so `SemanticExtractor` resolves both from SwiftUI's accessibility element tree — the new `findSwiftUIAccessibilityIdentifier(at:view:)` mirrors the existing label helper — and passes them in as fallback arguments, each consulted only after the view's own property for that step.

## Behavior changes

- `accessibilityIdentifier` now outranks `accessibilityLabel` (previously reversed). The label is unaffected as `$attr-aria-label` — only `$el_id` changed.
- A custom extractor is authoritative: a `nil`/empty return yields the anonymous `<ClassName>_<hash>` rather than falling back to view metadata the developer declined to expose.

`AutocaptureOptions.elementIdExtractor` is declared under `#if os(iOS)` with a split init, so tvOS/macOS/watchOS still compile (`swift build` verified).

## Testing

78 tests pass on an iPhone 17 simulator:

- `DefaultElementIdExtractorTests` (18) — each priority step, the priority pairs, the internal-identifier skip, the container label guard in both directions, empty strings, the SwiftUI fallback parameters, hash shape/stability. Uses a `FakeReactNativeView` with an `@objc nativeID` so `responds(to:)`/`value(forKey:)` behave exactly as on a real `RCTView`.
- `SemanticExtractorElementIdTests` (5) — the options-to-`ClickEvent` wiring, including that a nil-returning extractor does not leak the suppressed identifier.
- `ElementIdExtractorEndToEndTests` (4) — real touches through `Mixpanel.initialize`, covering a React Native `nativeID` view end to end.
- One new test each in the UIKit and SwiftUI instrumented suites pinning identifier-over-label on a real tap.

Also verified in a real app: `mixpanel-react-native`'s `MixpanelStarter` sample, built against this checkout as a local pod, reports `"$el_id":"checkout_button"` for a button with `nativeID="checkout_button"` while `$attr-aria-label` still carries its accessibility label.

## Notes for reviewers

- The two SwiftUI accessibility-tree helpers cannot be covered by tests: SwiftUI only materializes that tree while an accessibility client is attached, so `accessibilityHitTest` returns nil in an XCTest host. Verified against the leaf view, `HostingScrollView`, `_UIHostingView` and the window, in both coordinate spaces. The caveat is documented on the helper; the existing label helper has the same constraint.
- The first commit on this branch is pre-existing WIP (accessibilityLabel auto-derivation verification tests plus `SceneDelegate.swift`) that was carried over from the base branch and had to be restored for the demo app to build. It is committed separately so this feature stays reviewable on its own.
- `xcodebuild test` on the demo project needs `IPHONEOS_DEPLOYMENT_TARGET=15.0`; without it the test target builds for iOS 12 against the iOS 15 app module and fails. Pre-existing project config, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)