### PR TITLE
fix: address autocapture review feedback (threading, constants, Swift 6)

### DIFF
--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
@@ -234,20 +234,14 @@ class AutocaptureUIKitInstrumentedTests: MixpanelBaseTests {
         // When: Simulate tap
         simulateTap(on: button)
 
-        // Wait and check event queue for full properties
-        waitForTrackingQueue(mixpanel)
+        // Wait for the event rather than reading the queue straight after the tap: autocapture
+        // hands click processing to a background queue, so emission no longer happens inline with
+        // the touch. waitForEvent polls and drains the tracking queue on each attempt.
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should have autocapture events in queue")
 
         // Then: Should have standard Mixpanel properties
-        let events = eventQueue(token: mixpanel.apiToken)
-        let clickEvents = events.filter {
-            ($0["event"] as? String)?.hasPrefix("$mp_") == true
-        }
-
-        XCTAssertFalse(clickEvents.isEmpty, "Should have autocapture events in queue")
-
-        if let firstEvent = clickEvents.first,
-            let props = firstEvent["properties"] as? [String: Any]
-        {
+        if let props = event?.properties {
             XCTAssertNotNil(props["distinct_id"], "Should have distinct_id")
             XCTAssertNotNil(props["token"], "Should have token")
         }

--- a/Sources/Autocapture/AutocaptureManager.swift
+++ b/Sources/Autocapture/AutocaptureManager.swift
@@ -24,6 +24,15 @@ final class AutocaptureManager {
     private let deadClickDetector: DeadClickDetector?
     private let touchInterceptor = TouchInterceptor()
 
+    /// Serial queue for the non-UI part of touch handling.
+    ///
+    /// Touches arrive on the main thread, and the parts of processing that must read the view
+    /// hierarchy stay there. Everything after that — rage click bookkeeping and event emission —
+    /// is pure computation, so it is handed off here to keep SDK work off the main thread.
+    /// Serial so that clicks are processed in the order the user made them, which rage click
+    /// detection depends on.
+    private let processingQueue = DispatchQueue(label: "com.mixpanel.autocapture.processing")
+
     // MARK: - Autocapture Reference
 
     /// Reference to the Autocapture instance for event tracking.
@@ -147,29 +156,40 @@ final class AutocaptureManager {
             return
         }
 
-        // Extract semantic information
+        // Extract semantic information. Reads the view hierarchy, so it has to run here on the
+        // main thread, synchronously with the touch.
         let clickEvent = semanticExtractor.extractSemantics(from: view, at: point)
 
-        // Check for rage click
-        let rageClickResult = rageClickTracker?.trackClick(x: point.x, y: point.y)
-
-        // Emit click event
-        if options.clickOptions.enabled {
-            autocapture?.trackClick(clickEvent)
-            MixpanelLogger.debug(
-                message: "AutocaptureManager: emitted $mp_click for \(clickEvent.elementId)")
-        }
-
-        // Emit rage click event (independent of regular click)
-        if rageClickResult?.isRageClick == true {
-            autocapture?.trackRageClick(clickEvent)
-            MixpanelLogger.debug(
-                message: "AutocaptureManager: emitted $mp_rage_click for \(clickEvent.elementId)")
-        }
-
-        // Start dead click monitoring
+        // Start dead click monitoring. Also main-thread and synchronous by necessity: it captures
+        // a baseline snapshot of the window that must be taken before the app's click handler can
+        // change the UI, otherwise a fast response is absorbed into the baseline and the click
+        // looks dead.
         if let detector = deadClickDetector, let window = window {
             detector.startMonitoring(event: clickEvent, view: view, in: window)
+        }
+
+        // Everything below is pure computation over values already extracted — no UIKit access —
+        // so it runs off the main thread.
+        processingQueue.async { [weak self] in
+            guard let self = self else { return }
+
+            // Check for rage click
+            let rageClickResult = self.rageClickTracker?.trackClick(x: point.x, y: point.y)
+
+            // Emit click event
+            if self.options.clickOptions.enabled {
+                self.autocapture?.trackClick(clickEvent)
+                MixpanelLogger.debug(
+                    message: "AutocaptureManager: emitted $mp_click for \(clickEvent.elementId)")
+            }
+
+            // Emit rage click event (independent of regular click)
+            if rageClickResult?.isRageClick == true {
+                self.autocapture?.trackRageClick(clickEvent)
+                MixpanelLogger.debug(
+                    message:
+                        "AutocaptureManager: emitted $mp_rage_click for \(clickEvent.elementId)")
+            }
         }
     }
 

--- a/Sources/Autocapture/AutocaptureOptions.swift
+++ b/Sources/Autocapture/AutocaptureOptions.swift
@@ -20,6 +20,12 @@ enum AutocaptureDefaults {
     static let maxAncestorSearchDepth = 20
     static let maxRecursionDepth = 20
 
+    /// Number of recent clicks the rage click tracker keeps before pruning entries that have
+    /// aged out of the time window. Only a bound on memory: clicks outside the window are
+    /// already ignored when counting, so this never affects detection. Sized well above the
+    /// default threshold of 4 so that a burst of taps cannot evict clicks still in the window.
+    static let maxTrackedClicks = 20
+
     #if os(iOS)
     /// UIKit controls with inherent visual feedback that should be excluded from
     /// dead click detection. These controls always produce a visible UI response

--- a/Sources/Autocapture/DeadClickDetector.swift
+++ b/Sources/Autocapture/DeadClickDetector.swift
@@ -141,8 +141,12 @@ final class DeadClickDetector {
             checkTask = Task { [weak self] in
                 try? await Task.sleep(nanoseconds: UInt64(timeWindow) * 1_000_000)
                 guard !Task.isCancelled else { return }
-                await MainActor.run {
-                    self?.performFinalCheck()
+                // Bind before hopping to the main actor: referencing the captured `weak var`
+                // from inside the concurrently-executing closure is a warning under Swift 5 and
+                // an error in the Swift 6 language mode.
+                guard let self = self else { return }
+                await MainActor.run { [self] in
+                    self.performFinalCheck()
                 }
             }
         } else {

--- a/Sources/Autocapture/Model/ClickEvent.swift
+++ b/Sources/Autocapture/Model/ClickEvent.swift
@@ -14,7 +14,10 @@ import UIKit
 /// Contains all semantic information about the clicked element and its context.
 /// Create a `ClickEvent` and pass it to `mixpanel.autocapture.trackClick(_:)` to
 /// track click events with full element metadata.
-public struct ClickEvent {
+/// All stored properties are value types (`CGFloat`, `String`, `Bool`), so the event can safely
+/// cross threads — it is handed from the main thread, where it is extracted, to the queue that
+/// emits it.
+public struct ClickEvent: Sendable {
     // MARK: - Position
 
     /// Touch X coordinate in the window's coordinate space (points).

--- a/Sources/Autocapture/RageClickTracker.swift
+++ b/Sources/Autocapture/RageClickTracker.swift
@@ -93,7 +93,7 @@ final class RageClickTracker {
         let isRageClick = nearbyCount >= (clickThreshold - 1)
 
         // Clean old clicks to prevent memory growth
-        if recentClicks.count > 20 {
+        if recentClicks.count > AutocaptureDefaults.maxTrackedClicks {
             cleanOldClicks(currentTime: now)
         }
 


### PR DESCRIPTION
## Summary

Addresses @ketanmixpanel's review comments on #746, on its own branch so that PR's diff stays about the feature. Stacked: this merges into `feature/ios-autocapture-phase1`.

| Comment | Status |
|---|---|
| [`trackClick` runs on the main thread; hand the work off](https://github.com/mixpanel/mixpanel-swift/pull/746#discussion_r3803105530) | Fixed |
| [Use a constant instead of hardcoding `20`](https://github.com/mixpanel/mixpanel-swift/pull/746#discussion_r3803055409) | Fixed |
| [Swift 6 warning: captured var `self`](https://github.com/mixpanel/mixpanel-swift/pull/746#discussion_r3803237102) | Fixed |
| [`accessibleLabel` → `accessibilityLabel`](https://github.com/mixpanel/mixpanel-swift/pull/746#discussion_r3796345336) | Declined for now — see below |

## Non-UI touch processing moved off the main thread

Touches arrive on the main thread and `AutocaptureManager` did all of its work there. Only part of it has to be:

- `extractSemantics` reads the view hierarchy — **stays on main**
- `DeadClickDetector.startMonitoring` — **stays on main and synchronous**, because it captures a baseline snapshot of the window that must be taken before the app's click handler can change the UI; otherwise a fast response is absorbed into the baseline and the click looks dead

Everything after that is pure computation over already-extracted values, so rage click bookkeeping and `$mp_click` / `$mp_rage_click` emission now run on a serial `com.mixpanel.autocapture.processing` queue. Serial so clicks stay in the order the user made them, which rage click detection depends on.

`RageClickTracker` keeps its synchronous, `NSLock`-guarded API — no call-site or test churn, and it was already safe to call from another thread.

**Worth knowing:** click emission is no longer inline with the touch, so the event's timestamp moves by roughly a millisecond, and anything reading the event queue immediately after a tap must now wait. `testClickEventHasTokenProperty` did exactly that; it now waits via `waitForEvent`, which polls and drains the tracking queue. Its assertions are unchanged.

Honest scope note: the rage click math is microseconds, and it sits behind `extractSemantics`, which is the dominant main-thread cost on the touch path and cannot move because it touches `UIView`. This change is about the SDK doing no non-UI work on the main thread, not about measurable latency.

## Rage click history bound is now a constant

`AutocaptureDefaults.maxTrackedClicks`, alongside the other autocapture tunables, documented for what it does and does not affect: it bounds memory only, since clicks outside the time window are already ignored when counting.

## Swift 6 capture warning

`self` is bound before the hop to the main actor, so the concurrently-executing closure captures an immutable binding rather than the captured `weak var`. Verified with `SWIFT_STRICT_CONCURRENCY=complete` — before:

```
DeadClickDetector.swift:145:21: warning: reference to captured var 'self' in concurrently-executing code; this is an error in the Swift 6 language mode
```

after: gone.

`ClickEvent` is also declared `Sendable` (all stored properties are value types), so handing it to the processing queue adds no new concurrency warnings. One remains at the new `processingQueue.async` — `capture of 'self' with non-Sendable type 'AutocaptureManager?'` — which is the same family as three warnings already present in that class (lines 25, 104, 119). Making the autocapture types `Sendable` / `@MainActor` is a real piece of work and I did not want to assert `@unchecked Sendable` on these classes as a drive-by; happy to take it as a follow-up if you want the module strict-concurrency clean.

## `accessibleLabel` naming

Left as `accessibleLabel` for now. It is named for parity with Android's `ClickEvent.accessibleLabel`, and the property serialises to `$attr-aria-label` either way, so the event payload is identical. If we would rather match UIKit's spelling, the right move is renaming both SDKs together — happy to do that as a pair.

## Testing

35 tests pass on an iPhone 17 simulator: `AutocaptureUIKitInstrumentedTests`, `AutocaptureSwiftUIInstrumentedTests`, `RageClickTrackerTests`, `AutocaptureOptionsTests`, `ClickEventTests`. The rage and dead click instrumented tests are the meaningful check on the threading change, since emission is now asynchronous.

Unrelated snag for anyone running the demo app on this branch: `MixpanelDemo.xcodeproj` references `MixpanelDemo/MixpanelDemo/SceneDelegate.swift`, which is not committed, so the app target does not build without it. I created it locally to run the tests but deliberately left it out of this PR — it belongs to #746 or to whoever added the project reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)