### PR TITLE
fix: never use accessibilityLabel as $el_id, and drop $attr-aria-label

### DIFF
--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
@@ -137,8 +137,10 @@ class AutocaptureSwiftUIInstrumentedTests: MixpanelBaseTests {
         XCTAssertNotNil(event, "Should capture $mp_click event")
 
         if let props = event?.properties {
-            // SwiftUI uses accessibilityLabel as primary element ID
-            XCTAssertEqual(props["$el_id"] as? String, "SwiftUI Rule 1")
+            // The label is not an identity source: identity falls back to the structural hash.
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertFalse(elId.contains("SwiftUI Rule 1"), "Label must not leak into $el_id")
+            XCTAssertNil(props["$attr-aria-label"], "Labels are never reported")
             XCTAssertNotNil(props["$x"], "Should have $x coordinate")
             XCTAssertNotNil(props["$y"], "Should have $y coordinate")
         }
@@ -165,22 +167,24 @@ class AutocaptureSwiftUIInstrumentedTests: MixpanelBaseTests {
 
         if let props = event?.properties {
             XCTAssertEqual(props["$el_id"] as? String, "swiftui_both_id")
-            XCTAssertEqual(props["$attr-aria-label"] as? String, "Both Label SwiftUI")
+            XCTAssertNil(props["$attr-aria-label"], "Labels are never reported")
         }
     }
 
     // MARK: - Test 2: accessibilityLabel fallback (no identifier on the view)
 
-    func testSwiftUIElementIdResolutionRule2() {
-        // With no accessibilityIdentifier on the backing view, the label is next in line.
+    func testSwiftUIElementIdResolutionRule2_LabelIsNotUsed() {
+        // With no accessibilityIdentifier on the backing view, resolution falls to the structural
+        // hash — a localized label cannot serve as a stable identifier.
         simulateTapOnSwiftUIButton(index: 1, setAccessibility: "Rule Two SwiftUI")
 
         let event = waitForEvent(named: "$mp_click", timeout: 5)
         XCTAssertNotNil(event, "Should capture $mp_click event")
 
         if let props = event?.properties {
-            // Should use accessibilityLabel as ID
-            XCTAssertEqual(props["$el_id"] as? String, "Rule Two SwiftUI")
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertFalse(elId.contains("Rule Two"), "Label must not leak into $el_id")
+            XCTAssertNil(props["$attr-aria-label"], "Labels are never reported")
         }
     }
 

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
@@ -291,7 +291,6 @@ class ClickEventTests: XCTestCase {
             y: 200,
             elementId: "test_button",
             tagName: "UIButton",
-            accessibleLabel: "Test Button",
             role: "Button",
             elements: "UIButton > UIView"
         )
@@ -302,7 +301,7 @@ class ClickEventTests: XCTestCase {
         XCTAssertEqual(props["$y"] as? Int, 200)
         XCTAssertEqual(props["$el_id"] as? String, "test_button")
         XCTAssertEqual(props["$el_tag_name"] as? String, "UIButton")
-        XCTAssertEqual(props["$attr-aria-label"] as? String, "Test Button")
+        XCTAssertNil(props["$attr-aria-label"], "Accessibility labels are never reported")
         XCTAssertEqual(props["$attr-role"] as? String, "Button")
         XCTAssertEqual(props["$elements"] as? String, "UIButton > UIView")
     }
@@ -345,7 +344,8 @@ private final class ConstantElementIdExtractor: ElementIdExtractor {
 }
 
 /// Tests the `$el_id` resolution order implemented by `DefaultElementIdExtractor`:
-/// React Native `nativeID` > `accessibilityIdentifier` > `accessibilityLabel` > `<ClassName>_<hash>`.
+/// React Native `nativeID` > `accessibilityIdentifier` > `<ClassName>_<hash>`. Accessibility labels
+/// are never a source: they are localized and can carry user data.
 class DefaultElementIdExtractorTests: XCTestCase {
 
     /// Matches the anonymous fallback: ClassName_hexHash.
@@ -389,8 +389,8 @@ class DefaultElementIdExtractorTests: XCTestCase {
 
     // MARK: - Priority 2: accessibilityIdentifier
 
-    func testIdentifierWinsOverLabel() {
-        // The identifier is stable and never user-visible, so it outranks the label.
+    func testIdentifierIsUsedAndLabelIsIgnored() {
+        // The identifier is stable and never user-visible; the label is neither.
         let button = UIButton()
         button.accessibilityIdentifier = "checkout_identifier"
         button.accessibilityLabel = "Checkout"
@@ -398,61 +398,42 @@ class DefaultElementIdExtractorTests: XCTestCase {
         XCTAssertEqual(extractor.extractElementId(from: button), "checkout_identifier")
     }
 
-    func testEmptyIdentifierFallsThroughToLabel() {
+    func testEmptyIdentifierFallsThroughToTheStructuralHash() {
         let button = UIButton()
         button.accessibilityIdentifier = ""
         button.accessibilityLabel = "Checkout"
 
-        XCTAssertEqual(extractor.extractElementId(from: button), "Checkout")
+        let elementId = extractor.extractElementId(from: button) ?? ""
+        assertMatchesHashFallback(elementId)
+        XCTAssertFalse(elementId.contains("Checkout"), "Labels are never used as identity")
     }
 
     func testInternalIdentifiersAreSkipped() {
         for internalIdentifier in ["_privateThing", "AXID-42", "UITransitionView-1"] {
             let button = UIButton()
             button.accessibilityIdentifier = internalIdentifier
-            button.accessibilityLabel = "Checkout"
 
-            XCTAssertEqual(
-                extractor.extractElementId(from: button), "Checkout",
+            assertMatchesHashFallback(
+                extractor.extractElementId(from: button) ?? "",
                 "Framework-internal identifier \(internalIdentifier) should be skipped")
         }
     }
 
-    // MARK: - Priority 3: accessibilityLabel
+    // MARK: - Accessibility labels are never used
 
-    func testLabelUsedWhenNothingElseResolves() {
-        let label = UILabel()
-        label.accessibilityLabel = "Order Total"
+    func testLabelIsNeverUsedAsIdentity() {
+        // Localized text would give the same element a different id per language, and a label can
+        // carry user data, so no view shape may resolve to it.
+        for view in [UILabel(), UIButton(), UIView()] as [UIView] {
+            view.isAccessibilityElement = true
+            view.accessibilityLabel = "Account ending 4321"
 
-        XCTAssertEqual(extractor.extractElementId(from: label), "Order Total")
-    }
-
-    func testLabelOnGenericContainerIgnoredUnlessAccessibilityElement() {
-        // UIKit auto-derives container labels from child text, which can carry user data. A generic
-        // container (e.g. React Native's RCTView) is only trusted when the developer marked it as an
-        // accessibility element — `accessible={true}` in React Native.
-        let container = UIView()
-        container.accessibilityLabel = "Account ending 4321"
-        container.isAccessibilityElement = false
-
-        let elementId = extractor.extractElementId(from: container) ?? ""
-        assertMatchesHashFallback(elementId)
-        XCTAssertFalse(elementId.contains("4321"), "Derived label must not leak into $el_id")
-    }
-
-    func testLabelOnGenericContainerUsedWhenAccessibilityElement() {
-        let container = UIView()
-        container.accessibilityLabel = "Explicit Label"
-        container.isAccessibilityElement = true
-
-        XCTAssertEqual(extractor.extractElementId(from: container), "Explicit Label")
-    }
-
-    func testEmptyLabelFallsThroughToHash() {
-        let button = UIButton()
-        button.accessibilityLabel = ""
-
-        assertMatchesHashFallback(extractor.extractElementId(from: button) ?? "")
+            let elementId = extractor.extractElementId(from: view) ?? ""
+            assertMatchesHashFallback(elementId)
+            XCTAssertFalse(
+                elementId.contains("4321"),
+                "\(type(of: view)) leaked its label into $el_id")
+        }
     }
 
     // MARK: - Priority 4: hash fallback
@@ -465,16 +446,34 @@ class DefaultElementIdExtractorTests: XCTestCase {
             "Expected UIButton_<hash>, got: \(elementId)")
     }
 
-    func testHashFallbackIsStablePerViewAndDistinctAcrossViews() {
-        let first = UIButton()
-        let second = UIButton()
+    func testHashFallbackIsStableForTheSameStructure() {
+        // The hash describes where the view sits, not which instance it is, so an identical layout
+        // built twice — as on every launch — resolves to the same id.
+        func buildLeaf() -> UIView {
+            let root = UIView()
+            let row = UIView()
+            let leaf = UIButton()
+            row.addSubview(leaf)
+            root.addSubview(row)
+            return leaf
+        }
 
         XCTAssertEqual(
-            extractor.extractElementId(from: first), extractor.extractElementId(from: first),
-            "Same view must resolve to the same id")
+            extractor.extractElementId(from: buildLeaf()),
+            extractor.extractElementId(from: buildLeaf()),
+            "The same structure must resolve to the same id")
+    }
+
+    func testHashFallbackDistinguishesSiblingPositions() {
+        let root = UIView()
+        let first = UIButton()
+        let second = UIButton()
+        root.addSubview(first)
+        root.addSubview(second)
+
         XCTAssertNotEqual(
             extractor.extractElementId(from: first), extractor.extractElementId(from: second),
-            "Different views must resolve to different ids")
+            "Siblings at different positions must resolve to different ids")
     }
 
     func testAnonymousIdMatchesTheDefaultChainFallback() {
@@ -494,11 +493,9 @@ class DefaultElementIdExtractorTests: XCTestCase {
 
         XCTAssertEqual(
             extractor.elementId(
-                for: view,
-                accessibilityIdentifierFallback: "swiftui_checkout",
-                accessibilityLabelFallback: "Checkout From Tree"),
+                for: view, accessibilityIdentifierFallback: "swiftui_checkout"),
             "swiftui_checkout",
-            "Identifier fallback must outrank the label fallback")
+            "The SwiftUI identifier read from the accessibility tree is used")
     }
 
     func testViewIdentifierWinsOverIdentifierFallback() {
@@ -506,41 +503,31 @@ class DefaultElementIdExtractorTests: XCTestCase {
         view.accessibilityIdentifier = "own_identifier"
 
         XCTAssertEqual(
-            extractor.elementId(
-                for: view,
-                accessibilityIdentifierFallback: "tree_identifier",
-                accessibilityLabelFallback: nil),
+            extractor.elementId(for: view, accessibilityIdentifierFallback: "tree_identifier"),
             "own_identifier")
     }
 
-    func testLabelFallbackUsedWhenNoIdentifierAnywhere() {
+    func testStructuralHashUsedWhenNoIdentifierAnywhere() {
         let view = UIView()
 
-        XCTAssertEqual(
-            extractor.elementId(
-                for: view,
-                accessibilityIdentifierFallback: nil,
-                accessibilityLabelFallback: "Checkout From Tree"),
-            "Checkout From Tree")
+        assertMatchesHashFallback(
+            extractor.elementId(for: view, accessibilityIdentifierFallback: nil))
     }
 
     func testInternalIdentifierFallbackIsSkipped() {
         let view = UIView()
 
         let elementId = extractor.elementId(
-            for: view,
-            accessibilityIdentifierFallback: "_UIKitInternal",
-            accessibilityLabelFallback: nil)
+            for: view, accessibilityIdentifierFallback: "_UIKitInternal")
 
         assertMatchesHashFallback(elementId)
     }
 
-    func testEmptyFallbacksResolveToHash() {
+    func testEmptyIdentifierFallbackResolvesToHash() {
         let view = UIView()
 
         assertMatchesHashFallback(
-            extractor.elementId(
-                for: view, accessibilityIdentifierFallback: "", accessibilityLabelFallback: ""))
+            extractor.elementId(for: view, accessibilityIdentifierFallback: ""))
     }
 }
 
@@ -601,8 +588,8 @@ class SemanticExtractorElementIdTests: XCTestCase {
             DefaultElementIdExtractor.anonymousId(for: button))
     }
 
-    func testAccessibilityLabelStillReportedSeparatelyFromElementId() {
-        // The identifier wins $el_id, but the label must still travel as $attr-aria-label.
+    func testAccessibilityLabelIsNeverReported() {
+        // The identifier wins $el_id, and the label is not reported anywhere.
         let button = UIButton()
         button.accessibilityIdentifier = "checkout_identifier"
         button.accessibilityLabel = "Checkout"
@@ -611,7 +598,9 @@ class SemanticExtractorElementIdTests: XCTestCase {
             .extractSemantics(from: button, at: point)
 
         XCTAssertEqual(event.elementId, "checkout_identifier")
-        XCTAssertEqual(event.accessibleLabel, "Checkout")
+        XCTAssertNil(
+            event.toProperties()["$attr-aria-label"],
+            "Accessibility labels are localized and can carry user data — never reported")
     }
 }
 

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
@@ -122,7 +122,7 @@ class AutocaptureUIKitInstrumentedTests: MixpanelBaseTests {
 
     /// When a view carries both, the identifier wins $el_id — it is developer-assigned and never
     /// user-visible, so unlike a label it cannot carry PII. The label still travels as
-    /// $attr-aria-label.
+    /// The label is not reported at all.
     func testElementIdIdentifierWinsOverLabel() {
         let button = testViewController.bothButton
 
@@ -133,25 +133,31 @@ class AutocaptureUIKitInstrumentedTests: MixpanelBaseTests {
 
         if let props = event?.properties {
             XCTAssertEqual(props["$el_id"] as? String, "both_id")
-            XCTAssertEqual(props["$attr-aria-label"] as? String, "Both Label")
+            XCTAssertNil(
+                props["$attr-aria-label"],
+                "Accessibility labels are localized and can carry user data — never reported")
         }
     }
 
     // MARK: - Test 2: Element ID Resolution Rule 2 (accessibilityLabel fallback)
 
-    func testElementIdResolutionRule2() {
+    func testElementIdResolutionRule2_LabelIsNotUsed() {
         // Given: A button with only accessibilityLabel (no accessibilityIdentifier)
         let button = testViewController.rule2Button
 
         // When: Simulate tap
         simulateTap(on: button)
 
-        // Then: Element ID should use accessibilityLabel
+        // Then: the label is neither the element id nor reported — identity falls back to the
+        // structural hash, because a localized label cannot be a stable identifier.
         let event = waitForEvent(named: "$mp_click", timeout: 5)
         XCTAssertNotNil(event, "Should capture $mp_click event")
 
         if let props = event?.properties {
-            XCTAssertEqual(props["$el_id"] as? String, "Rule Two Label")
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertTrue(elId.hasPrefix("UIButton_"), "Expected the hash fallback, got: \(elId)")
+            XCTAssertNil(props["$attr-aria-label"])
+            XCTAssertFalse(elId.contains("Rule Two"), "Label must not leak into $el_id")
         }
     }
 
@@ -336,9 +342,11 @@ class AutocaptureUIKitInstrumentedTests: MixpanelBaseTests {
         }
     }
 
-    /// Positive case: View IS accessible AND HAS explicit accessibilityLabel.
-    /// The label SHOULD be captured in $el_id and $attr-aria-label.
-    func testAccessibleWithLabel_LabelIsCaptured() {
+    /// A view that is an accessibility element with an explicit, intentional accessibilityLabel
+    /// still must not have that text reported. Labels are localized — the same element would report
+    /// a different $el_id per language — and they can carry user data, so identity falls back to the
+    /// structural hash and no aria-label is emitted.
+    func testAccessibleWithLabel_LabelIsNeverCaptured() {
         let view = testViewController.accessibleWithLabelView
 
         simulateTap(on: view)
@@ -347,13 +355,13 @@ class AutocaptureUIKitInstrumentedTests: MixpanelBaseTests {
         XCTAssertNotNil(event, "Click event should be captured")
 
         if let props = event?.properties {
-            XCTAssertEqual(
-                props["$el_id"] as? String, "Intended Label",
-                "$el_id should use the explicit accessibilityLabel")
-
-            XCTAssertEqual(
-                props["$attr-aria-label"] as? String, "Intended Label",
-                "$attr-aria-label should be present with explicit label")
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertFalse(
+                elId.contains("Intended Label"),
+                "An intentional label must still not become $el_id, got: \(elId)")
+            XCTAssertNil(
+                props["$attr-aria-label"],
+                "$attr-aria-label must never be present")
         }
     }
 

--- a/Sources/Autocapture/ElementIdExtractor.swift
+++ b/Sources/Autocapture/ElementIdExtractor.swift
@@ -18,8 +18,9 @@ import UIKit
 /// this method returns.
 ///
 /// When no extractor is provided, the SDK falls back to an internal default implementation that
-/// resolves the identifier from the React Native `nativeID`, then `accessibilityIdentifier`, then
-/// `accessibilityLabel`.
+/// resolves the identifier from the React Native `nativeID`, then `accessibilityIdentifier`, then a
+/// structural fallback. `accessibilityLabel` is deliberately not a source: it is localized, so the
+/// same element would report a different identifier per language, and it can carry user data.
 ///
 /// **Example:**
 /// ```swift
@@ -58,15 +59,15 @@ public protocol ElementIdExtractor {
 ///    through UIKit, never SwiftUI, so the probe could only ever be wasted work there.
 /// 2. **`accessibilityIdentifier`** — stable, developer-assigned, and not user-visible. Internal
 ///    framework identifiers (e.g. `_UIKit…`, `AXID-…`) are skipped.
-/// 3. **`accessibilityLabel`** — only when the label was intentionally set (see
-///    `intentionalAccessibilityLabel(for:)`), so framework-derived text that may contain user data
-///    is not reported.
-/// 4. **Anonymous fallback** — `<ClassName>_<hash>` derived from the view's class and hash.
+/// 3. **Anonymous fallback** — `<ClassName>_<hash>`, where the hash describes the view's position in
+///    the hierarchy (see `structuralPath(for:)`) rather than its identity.
 ///
-/// For SwiftUI, steps 1–3 collapse to `accessibilityIdentifier` > `accessibilityLabel` > hash. Both
-/// of those properties live in SwiftUI's accessibility element tree rather than on the backing
-/// `UIView`, so `SemanticExtractor` resolves them from that tree and passes them in as the
-/// `accessibilityIdentifierFallback` / `accessibilityLabelFallback` arguments below.
+/// `accessibilityLabel` is deliberately absent. It is user-facing text: localized, so the same
+/// element would report a different identifier per language, and capable of carrying personal data.
+///
+/// For SwiftUI, step 1 is skipped and the identifier lives in SwiftUI's accessibility element tree
+/// rather than on the backing `UIView`, so `SemanticExtractor` resolves it from that tree and passes
+/// it in as the `accessibilityIdentifierFallback` argument below.
 final class DefaultElementIdExtractor: ElementIdExtractor {
 
     static let shared = DefaultElementIdExtractor()
@@ -80,21 +81,18 @@ final class DefaultElementIdExtractor: ElementIdExtractor {
     ]
 
     func extractElementId(from view: UIView) -> String? {
-        return elementId(
-            for: view, accessibilityIdentifierFallback: nil, accessibilityLabelFallback: nil)
+        return elementId(for: view, accessibilityIdentifierFallback: nil)
     }
 
-    /// Resolution with optional precomputed values used at priority steps 2 and 3.
+    /// Resolution with an optional precomputed identifier used at priority step 2.
     ///
-    /// SwiftUI renders its views as internal UIKit views that carry neither
-    /// `accessibilityIdentifier` nor `accessibilityLabel` on the UIKit view itself; the caller
-    /// resolves those from SwiftUI's accessibility element tree and passes them here so SwiftUI
-    /// elements still get a meaningful `$el_id`. Each fallback is consulted only after the view's
-    /// own property for that step, so an identifier always outranks any label.
+    /// SwiftUI renders its views as internal UIKit views that do not carry
+    /// `accessibilityIdentifier` on the UIKit view itself; the caller resolves it from SwiftUI's
+    /// accessibility element tree and passes it here so SwiftUI elements still get a meaningful
+    /// `$el_id`. The fallback is consulted only after the view's own identifier.
     func elementId(
         for view: UIView,
-        accessibilityIdentifierFallback: String?,
-        accessibilityLabelFallback: String?
+        accessibilityIdentifierFallback: String?
     ) -> String {
         // 1. React Native nativeID (UIKit-backed views only)
         if let nativeId = reactNativeId(for: view) {
@@ -115,15 +113,7 @@ final class DefaultElementIdExtractor: ElementIdExtractor {
             return fallbackIdentifier
         }
 
-        // 3. accessibilityLabel (only when intentionally set)
-        if let label = intentionalAccessibilityLabel(for: view) {
-            return label
-        }
-        if let fallbackLabel = accessibilityLabelFallback, !fallbackLabel.isEmpty {
-            return fallbackLabel
-        }
-
-        // 4. Anonymous fallback
+        // 3. Anonymous fallback
         return DefaultElementIdExtractor.anonymousId(for: view)
     }
 
@@ -147,32 +137,6 @@ final class DefaultElementIdExtractor: ElementIdExtractor {
         return nativeId
     }
 
-    // MARK: - Accessibility
-
-    /// Returns the view's `accessibilityLabel` only when it was intentionally set.
-    ///
-    /// UIKit auto-derives `accessibilityLabel` from child text for container views whose
-    /// `isAccessibilityElement` is false, and that derived text may contain sensitive information
-    /// (account numbers, personal details). Known UIKit controls and SwiftUI views always carry an
-    /// intentional (title-derived or explicitly set) label, so they are trusted; generic containers
-    /// — e.g. React Native's `RCTView` — are trusted only when `isAccessibilityElement` is true,
-    /// which in React Native maps to `accessible={true}`.
-    private func intentionalAccessibilityLabel(for view: UIView) -> String? {
-        let isKnownControl =
-            view is UIButton || view is UILabel || view is UISwitch
-            || view is UISlider || view is UITextField || view is UITextView
-            || view is UISegmentedControl || view is UIStepper || view is UIImageView
-        if !isKnownControl && !view.isAccessibilityElement
-            && !AutocaptureDefaults.isSwiftUIView(view)
-        {
-            return nil
-        }
-        if let label = view.accessibilityLabel, !label.isEmpty {
-            return label
-        }
-        return nil
-    }
-
     private static func isInternalIdentifier(_ identifier: String) -> Bool {
         for prefix in internalIdentifierPrefixes where identifier.hasPrefix(prefix) {
             return true
@@ -184,11 +148,51 @@ final class DefaultElementIdExtractor: ElementIdExtractor {
 
     /// The anonymous, PII-free identifier used when nothing else resolves:
     /// `<ClassName>_<hash>` (e.g. `UIButton_3f2a1b`).
+    ///
+    /// The hash describes the view's **position in the hierarchy**, not its identity. `view.hash` is
+    /// per-instance and, because Swift seeds hashing per process, differs on every launch — an
+    /// element with no identifier would get a new `$el_id` every session and could never be grouped.
+    ///
+    /// It identifies a *position* rather than a specific element: reordering siblings changes the id,
+    /// and two rows of the same list differ by index, not by content.
     static func anonymousId(for view: UIView) -> String {
         let className = String(describing: type(of: view))
-        // abs(Int.min) traps, so map it to Int.max.
-        let safeHash = view.hash == Int.min ? Int.max : abs(view.hash)
-        return "\(className)_\(String(safeHash, radix: 16))"
+        return "\(className)_\(stableHash(structuralPath(for: view)))"
+    }
+
+    /// Class names and sibling indices only — never text — so the path cannot carry user data:
+    /// `UIButton@UIStackView[2]/UIScrollView[0]/UIView[1]`.
+    static func structuralPath(for view: UIView) -> String {
+        var path = String(describing: type(of: view)) + "@"
+        var current: UIView = view
+        var depth = 0
+
+        while let parent = current.superview, depth < AutocaptureDefaults.maxHierarchyDepth {
+            if depth > 0 {
+                path += "/"
+            }
+            let index = parent.subviews.firstIndex(of: current) ?? -1
+            path += "\(String(describing: type(of: parent)))[\(index)]"
+            current = parent
+            depth += 1
+        }
+
+        if depth == 0 {
+            path += "detached"
+        }
+        return path
+    }
+
+    /// FNV-1a over the path's UTF-8 bytes.
+    ///
+    /// Swift's `hashValue` is seeded per process, so it cannot be used here: the whole point of the
+    /// structural id is that it is identical across launches.
+    private static func stableHash(_ value: String) -> String {
+        var hash: UInt32 = 2_166_136_261
+        for byte in value.utf8 {
+            hash = (hash ^ UInt32(byte)) &* 16_777_619
+        }
+        return String(hash, radix: 16)
     }
 }
 #endif

--- a/Sources/Autocapture/Model/ClickEvent.swift
+++ b/Sources/Autocapture/Model/ClickEvent.swift
@@ -41,8 +41,10 @@ public struct ClickEvent: Sendable {
     /// - React Native `nativeID` — the JS-side prop, read through the Objective-C runtime
     ///   (skipped for SwiftUI views, which React Native never renders)
     /// - `accessibilityIdentifier` — stable and not user-visible
-    /// - `accessibilityLabel` — human-readable, and only when intentionally set
-    /// - `<ClassName>_<hash>` as a last resort
+    /// - `<ClassName>_<hash>` as a last resort, hashed from the element's position in the hierarchy
+    ///
+    /// `accessibilityLabel` is deliberately not a source: it is localized, so the same element would
+    /// report a different identifier per language, and it can carry personal data.
     ///
     /// Supply an `ElementIdExtractor` through `AutocaptureOptions` to override this entirely — for
     /// example a custom string like `"buy_button"` or `"settings_cell_notifications"`.
@@ -56,13 +58,6 @@ public struct ClickEvent: Sendable {
     /// Use `String(describing: type(of: view))` to get the class name.
     /// Set to `nil` if not available.
     public let tagName: String?
-
-    /// The human-readable accessibility label of the element.
-    ///
-    /// This is the text read aloud by VoiceOver — typically the view's `accessibilityLabel`.
-    /// Examples: `"Add to cart"`, `"Play video"`, `"Close"`.
-    /// Set to `nil` if the element has no accessibility label.
-    public let accessibleLabel: String?
 
     /// The semantic role describing what the element does.
     ///
@@ -100,7 +95,6 @@ public struct ClickEvent: Sendable {
     ///     y: touch.location(in: view.window).y,
     ///     elementId: button.accessibilityIdentifier ?? "buy_button",
     ///     tagName: String(describing: type(of: button)),
-    ///     accessibleLabel: button.accessibilityLabel,
     ///     role: "button",
     ///     elements: "UIButton > UIStackView > UIView"
     /// )
@@ -112,13 +106,12 @@ public struct ClickEvent: Sendable {
     ///   - y: Touch Y coordinate in window points
     ///   - elementId: Stable identifier for the tapped element
     ///   - tagName: Class name of the tapped element (defaults to nil)
-    ///   - accessibleLabel: The element's accessibility label (defaults to nil)
     ///   - role: Semantic role like `"button"`, `"switch"`, `"link"` (defaults to nil)
     ///   - elements: View hierarchy path, `">"` separated (defaults to nil)
     ///   - isInteractive: Whether the element is interactive (defaults to true)
     public init(
         x: CGFloat, y: CGFloat, elementId: String,
-        tagName: String? = nil, accessibleLabel: String? = nil,
+        tagName: String? = nil,
         role: String? = nil, elements: String? = nil,
         isInteractive: Bool = true
     ) {
@@ -126,7 +119,6 @@ public struct ClickEvent: Sendable {
         self.y = y
         self.elementId = elementId
         self.tagName = tagName
-        self.accessibleLabel = accessibleLabel
         self.role = role
         self.elements = elements
         self.isInteractive = isInteractive
@@ -148,10 +140,6 @@ public struct ClickEvent: Sendable {
 
         if let elements = elements {
             props["$elements"] = elements
-        }
-
-        if let accessibleLabel = accessibleLabel {
-            props["$attr-aria-label"] = accessibleLabel
         }
 
         if let role = role {

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -56,14 +56,6 @@ final class SemanticExtractor {
         }
 
         let className = String(describing: type(of: targetView))
-        var accessibleLabel = findAccessibilityLabel(in: targetView)
-
-        // SwiftUI views render as internal UIKit views (e.g., PlatformGroupContainer) that
-        // don't carry the SwiftUI accessibilityLabel on the UIKit view. Query the SwiftUI
-        // accessibility element tree at the touch point to retrieve the label.
-        if accessibleLabel == nil, AutocaptureDefaults.isSwiftUIView(targetView) {
-            accessibleLabel = findSwiftUIAccessibilityLabel(at: point, view: targetView)
-        }
 
         // SwiftUI's .accessibilityIdentifier("…") never reaches the backing UIKit view either —
         // it lives in the same accessibility element tree as the label. Query it only for SwiftUI
@@ -75,8 +67,7 @@ final class SemanticExtractor {
             derivedIdentifier = findSwiftUIAccessibilityIdentifier(at: point, view: targetView)
         }
 
-        let elementId = resolveElementId(
-            for: targetView, derivedIdentifier: derivedIdentifier, derivedLabel: accessibleLabel)
+        let elementId = resolveElementId(for: targetView, derivedIdentifier: derivedIdentifier)
         let role = determineRole(for: targetView)
         let tagName = resolveTagName(className: className, role: role, view: targetView)
         let elements = buildViewHierarchy(from: targetView)
@@ -86,7 +77,6 @@ final class SemanticExtractor {
             y: point.y,
             elementId: elementId,
             tagName: tagName,
-            accessibleLabel: accessibleLabel,
             role: role,
             elements: elements,
             isInteractive: viewIsInteractive
@@ -103,18 +93,13 @@ final class SemanticExtractor {
     /// chose not to expose.
     ///
     /// Otherwise `DefaultElementIdExtractor` resolves it (React Native `nativeID` >
-    /// `accessibilityIdentifier` > `accessibilityLabel` > `<ClassName>_<hash>`; for SwiftUI the
-    /// `nativeID` step is skipped).
+    /// `accessibilityIdentifier` > `<ClassName>_<hash>`; for SwiftUI the `nativeID` step is skipped).
+    /// Accessibility labels are never used: they are localized and can carry user data.
     ///
     /// - Parameters:
     ///   - derivedIdentifier: Identifier read from SwiftUI's accessibility element tree, used at the
     ///     `accessibilityIdentifier` priority step when the view carries none itself.
-    ///   - derivedLabel: The accessibility label already resolved by `extractSemantics`, including
-    ///     labels read from SwiftUI's accessibility element tree. Used at the `accessibilityLabel`
-    ///     priority step.
-    private func resolveElementId(
-        for view: UIView, derivedIdentifier: String?, derivedLabel: String?
-    ) -> String {
+    private func resolveElementId(for view: UIView, derivedIdentifier: String?) -> String {
         if let custom = autocaptureOptions.elementIdExtractor {
             if let customId = custom.extractElementId(from: view), !customId.isEmpty {
                 return customId
@@ -122,39 +107,10 @@ final class SemanticExtractor {
             return DefaultElementIdExtractor.anonymousId(for: view)
         }
         return DefaultElementIdExtractor.shared.elementId(
-            for: view,
-            accessibilityIdentifierFallback: derivedIdentifier,
-            accessibilityLabelFallback: derivedLabel)
+            for: view, accessibilityIdentifierFallback: derivedIdentifier)
     }
 
     // MARK: - Accessibility Property Discovery
-
-    /// Returns the view's accessibilityLabel only if it was explicitly set by the developer.
-    ///
-    /// UIKit auto-derives accessibilityLabel from child text content for container
-    /// views where isAccessibilityElement is false. That derived text may contain
-    /// sensitive information (e.g., account numbers, personal details).
-    ///
-    /// For known UIKit controls (UIButton, UILabel, etc.) and SwiftUI views, the
-    /// label is always intentional (title-derived or explicitly set), so we capture it.
-    /// For generic container views (e.g., React Native's RCTView), we only capture
-    /// the label when isAccessibilityElement is true — in React Native, this maps
-    /// to `accessible={true}`, signaling an explicitly set label.
-    private func findAccessibilityLabel(in view: UIView) -> String? {
-        let isKnownControl =
-            view is UIButton || view is UILabel || view is UISwitch
-            || view is UISlider || view is UITextField || view is UITextView
-            || view is UISegmentedControl || view is UIStepper || view is UIImageView
-        if !isKnownControl && !view.isAccessibilityElement
-            && !AutocaptureDefaults.isSwiftUIView(view)
-        {
-            return nil
-        }
-        if let label = view.accessibilityLabel, !label.isEmpty {
-            return label
-        }
-        return nil
-    }
 
     // MARK: - Role Detection
 
@@ -272,40 +228,6 @@ final class SemanticExtractor {
             current = v.superview
             depth += 1
         }
-        return nil
-    }
-
-    /// Query the SwiftUI accessibility element tree at the touch point to retrieve the label.
-    ///
-    /// SwiftUI views render as internal UIKit views (e.g., PlatformGroupContainer) that don't
-    /// expose `accessibilityLabel` on the UIKit view. The label lives in SwiftUI's accessibility
-    /// element tree, which we can query via `accessibilityHitTest`.
-    ///
-    /// We walk up to find the UIHostingController's view (class name contains "Hosting"),
-    /// which owns the full SwiftUI accessibility tree. Calling `accessibilityHitTest` on
-    /// a leaf PlatformGroupContainer won't traverse the tree properly.
-    private func findSwiftUIAccessibilityLabel(at windowPoint: CGPoint, view: UIView) -> String? {
-        guard #available(iOS 18.0, *) else { return nil }
-        guard let window = view.window else { return nil }
-
-        // Walk up to find the UIHostingController's view which owns the accessibility tree
-        var current: UIView? = view
-        var depth = 0
-        while let v = current, depth < AutocaptureDefaults.maxAncestorSearchDepth {
-            let className = String(describing: type(of: v))
-            if className.contains("Hosting") {
-                let screenPoint = window.convert(windowPoint, to: window.screen.coordinateSpace)
-                if let element = v.accessibilityHitTest(screenPoint, event: nil) as? NSObject,
-                    let label = element.accessibilityLabel, !label.isEmpty
-                {
-                    return label
-                }
-                break
-            }
-            current = v.superview
-            depth += 1
-        }
-
         return nil
     }
 


### PR DESCRIPTION
## Why

`accessibilityLabel` is user-facing text. Two problems with treating it as identity:

- **It is localized.** The same button reports `Checkout` in English and `Pagar` in Spanish, so a single element splits into one `$el_id` per language and cannot be grouped.
- **It can carry personal data.**

The same reasoning applies to reporting it at all, so `$attr-aria-label` is removed from the payload.

Stacked on #766 — merges into `fix/review-comments`. Companion Android PR: mixpanel/mixpanel-android#997.

## What changed

Resolution is now **nativeID → accessibilityIdentifier → `<ClassName>_<hash>`**. The nativeID step is still skipped for SwiftUI, and the identifier is still resolved from SwiftUI's accessibility element tree when the backing `UIView` has none.

Removed: the `accessibilityLabel` step and `intentionalAccessibilityLabel` from `DefaultElementIdExtractor`, the `accessibilityLabelFallback` parameter, `SemanticExtractor.findAccessibilityLabel` and `findSwiftUIAccessibilityLabel`, and `ClickEvent.accessibleLabel` with its `$attr-aria-label` output. The `ClickEvent` change is a public API break, acceptable because autocapture is unreleased.

## The hash had to change too

With the label gone, an element with no identifier falls to `<ClassName>_<hash>` — and that hash was `view.hash`. Swift seeds hashing per process, so the id differed on **every launch**: un-instrumented screens would have produced a fresh `$el_id` each session and never grouped.

The hash now describes **where the element sits**:

```
UIButton@UIStackView[2]/UIScrollView[0]/UIView[1]
```

Class names and sibling indices only — no user text. It is hashed with **FNV-1a over the UTF-8 bytes**, not `hashValue`, precisely because `hashValue` is per-process seeded and would reintroduce the instability this change removes. The payload shape is unchanged: `<ClassName>_<hash>`.

Worth knowing: this identifies a **position, not a row** — reordering siblings changes the id, and two rows of one list differ by index rather than content.

## Tests — 76/76 pass on an iPhone 17 simulator

- The label-priority cases in `DefaultElementIdExtractorTests` are replaced by a test that no view shape — `UILabel`, `UIButton`, plain `UIView` — ever resolves to its label, whatever its `isAccessibilityElement` state.
- The "label is captured" tests in the UIKit and SwiftUI suites became leak-regression tests: an intentional label must appear in **no** property.
- New coverage for the structural hash: identical for the same layout built twice, different for siblings at different positions.
- `swift build` still passes for the non-iOS platforms.

## Before merging

Anything downstream consuming `$attr-aria-label` — dashboards, session-replay correlation — loses that property. Worth a check. Android keeps the same shape, so the two SDKs stay aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)