### PR TITLE
feat: mark autocapture as experimental (beta)

### DIFF
--- a/Sources/Autocapture.swift
+++ b/Sources/Autocapture.swift
@@ -11,6 +11,9 @@ import Foundation
 
 /// Access to autocapture tracking methods, available as an accessible variable from
 /// the main Mixpanel instance.
+///
+/// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the
+///   properties it captures may change in a future release before general availability.
 open class Autocapture {
 
     weak var mixpanelInstance: MixpanelInstance?

--- a/Sources/Autocapture/AutocaptureManager.swift
+++ b/Sources/Autocapture/AutocaptureManager.swift
@@ -89,6 +89,13 @@ final class AutocaptureManager {
     // MARK: - Lifecycle
 
     /// Start autocapture by installing the touch interceptor.
+    /// Logged at warning level, once per start, so developers who never read the documentation
+    /// still learn that autocapture is not yet GA.
+    private static let experimentalWarning =
+        "Autocapture is experimental (beta): it may contain issues, and its API and captured "
+        + "properties may change before general availability. Pin your SDK version if you build "
+        + "reports on autocaptured events."
+
     func start() {
         lock.lock()
         defer { lock.unlock() }
@@ -104,6 +111,7 @@ final class AutocaptureManager {
         touchInterceptor.install(manager: self)
 
         MixpanelLogger.info(message: "AutocaptureManager: started")
+        MixpanelLogger.warn(message: AutocaptureManager.experimentalWarning)
     }
 
     /// Stop autocapture and clean up.

--- a/Sources/Autocapture/AutocaptureOptions.swift
+++ b/Sources/Autocapture/AutocaptureOptions.swift
@@ -101,8 +101,13 @@ enum AutocaptureDefaults {
 /// Configuration options for click event capture.
 ///
 /// When enabled, a `$mp_click` event is tracked for every tap on any element.
-/// Each event includes the touch coordinates, element identifier, class name,
-/// accessibility label, semantic role, and view hierarchy path.
+/// Each event includes the touch coordinates, element identifier, class name, semantic role, and
+/// view hierarchy path. Accessibility labels are never captured: they are localized and can carry
+/// user data.
+///
+/// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the properties
+///   it captures may change in a future release before general availability. Pin your SDK version if
+///   you build reports on autocaptured events.
 public struct ClickOptions {
     /// Whether click capture is enabled. Defaults to `true` when autocapture is enabled.
     public let enabled: Bool
@@ -118,6 +123,10 @@ public struct ClickOptions {
 ///
 /// Rage clicks are detected when a user taps rapidly multiple times in the same area,
 /// indicating frustration with an unresponsive element.
+///
+/// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the properties
+///   it captures may change in a future release before general availability. Pin your SDK version if
+///   you build reports on autocaptured events.
 public struct RageClickOptions {
     /// Whether rage click detection is enabled. Defaults to `true`.
     public let enabled: Bool
@@ -155,6 +164,10 @@ public struct RageClickOptions {
 ///
 /// Dead clicks are detected when a user taps on an interactive element
 /// but no visible UI change occurs, indicating a broken or unresponsive element.
+///
+/// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the properties
+///   it captures may change in a future release before general availability. Pin your SDK version if
+///   you build reports on autocaptured events.
 public struct DeadClickOptions {
     /// Whether dead click detection is enabled. Defaults to `true`.
     public let enabled: Bool
@@ -207,6 +220,10 @@ public struct DeadClickOptions {
 ///     autocaptureOptions: autocaptureOpts
 /// )
 /// ```
+///
+/// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the properties
+///   it captures may change in a future release before general availability. Pin your SDK version if
+///   you build reports on autocaptured events.
 public struct AutocaptureOptions {
     /// Configuration for basic click capture.
     public let clickOptions: ClickOptions

--- a/Sources/Autocapture/ElementIdExtractor.swift
+++ b/Sources/Autocapture/ElementIdExtractor.swift
@@ -40,6 +40,10 @@ import UIKit
 ///
 /// **Threading:** `extractElementId(from:)` is called on the main thread immediately after the hit
 /// test that resolved the tapped view. Keep the implementation fast and side-effect free.
+///
+/// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the properties
+///   it captures may change in a future release before general availability. Pin your SDK version if
+///   you build reports on autocaptured events.
 public protocol ElementIdExtractor {
     /// Returns the `$el_id` to report for the given view.
     ///

--- a/Sources/Autocapture/Model/ClickEvent.swift
+++ b/Sources/Autocapture/Model/ClickEvent.swift
@@ -17,6 +17,10 @@ import UIKit
 /// All stored properties are value types (`CGFloat`, `String`, `Bool`), so the event can safely
 /// cross threads — it is handed from the main thread, where it is extracted, to the queue that
 /// emits it.
+///
+/// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the properties
+///   it captures may change in a future release before general availability. Pin your SDK version if
+///   you build reports on autocaptured events.
 public struct ClickEvent: Sendable {
     // MARK: - Position
 

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -104,6 +104,9 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
     open var people: People!
 
     /// Accessor to the Mixpanel Autocapture API object.
+    ///
+    /// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the
+    ///   properties it captures may change in a future release before general availability.
     open var autocapture: Autocapture!
 
     #if os(iOS)

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -267,6 +267,9 @@ public class MixpanelOptions {
     /// ```
     ///
     /// **Note:** Autocapture is only available on iOS.
+    ///
+    /// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the
+    ///   properties it captures may change in a future release before general availability.
     public let autocaptureOptions: AutocaptureOptions?
 
     public init(


### PR DESCRIPTION
## Why

Autocapture works and is safe to try, but it is not at GA: element identification depends on how a screen is built, the API can still change, and captured property shapes can be refined.

Stacked on #767 — merges into `fix/el-id-drop-accessibility-labels`. Companion Android PR: mixpanel/mixpanel-android#999.

## Approach — identical on both platforms

Per team decision, Android and iOS signal beta status the same way:

1. **An "Experimental (beta)" note in the documentation** of every public autocapture symbol, shown in Xcode Quick Help and generated docs.
2. **One warn-level log line when autocapture starts**, for developers who never open the docs:

```
Autocapture is experimental (beta): it may contain issues, and its API and captured properties
may change before general availability. Pin your SDK version if you build reports on
autocaptured events.
```

No compile-time gate on either platform. For the record, the two Swift mechanisms that would warn at the call site were both rejected: `@available(*, deprecated, message:)` tells developers a brand-new feature is *being removed*, and would warn throughout `MixpanelDemo` and both React Native samples; `@_spi(Experimental)` would force `MixpanelOptions`' single shared initializer to become SPI — so every developer, autocapture or not, would need `@_spi(Experimental) import Mixpanel` — besides being invisible to Objective-C and an unsupported underscored attribute.

## Documented surface

`AutocaptureOptions`, `ClickOptions`, `RageClickOptions`, `DeadClickOptions`, `ClickEvent`, the `ElementIdExtractor` protocol, `MixpanelOptions.autocaptureOptions`, `MixpanelInstance.autocapture`, and the `Autocapture` facade.

Drive-by fix: `ClickOptions`' documentation still listed the accessibility label among captured properties — untrue since labels were dropped from capture in #767.

## Removal at GA

Delete the callouts and one log statement. They are comments, so nothing a consumer wrote can break.

## Testing

43 autocapture tests pass on an iPhone 17 simulator; `swift build` is clean for the non-iOS platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)