### PR TITLE
fix: Added scene delegate functionality to sample app

### DIFF
--- a/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
+++ b/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1668B43D2FF79B9C00AF2B30 /* JSONHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1668B43B2FF79B9C00AF2B30 /* JSONHandlerTests.swift */; };
 		1668B43E2FF79B9C00AF2B30 /* MixpanelBackupHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1668B43C2FF79B9C00AF2B30 /* MixpanelBackupHostTests.swift */; };
+		169483E23037612D0080D934 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169483E13037612D0080D934 /* SceneDelegate.swift */; };
 		171E4C1C2DB055BC00B7CB11 /* MixpanelFeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171E4C1B2DB055A900B7CB11 /* MixpanelFeatureFlagTests.swift */; };
 		174205522F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174205512F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift */; };
 		174563BA2DD74E9ABE905B9A /* MixpanelScreenTrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3018131FE6FE484786E6788E /* MixpanelScreenTrackingTests.swift */; };
@@ -267,6 +268,7 @@
 /* Begin PBXFileReference section */
 		1668B43B2FF79B9C00AF2B30 /* JSONHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONHandlerTests.swift; sourceTree = "<group>"; };
 		1668B43C2FF79B9C00AF2B30 /* MixpanelBackupHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelBackupHostTests.swift; sourceTree = "<group>"; };
+		169483E13037612D0080D934 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		171E4C1B2DB055A900B7CB11 /* MixpanelFeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelFeatureFlagTests.swift; sourceTree = "<group>"; };
 		174205512F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelDeviceIdProviderTests.swift; sourceTree = "<group>"; };
 		1A1B2C3D4E5F60718293A4B1 /* MixpanelFeatureFlagPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelFeatureFlagPersistenceTests.swift; sourceTree = "<group>"; };
@@ -606,6 +608,7 @@
 		E15FF7D51D0461130076CDE3 /* MixpanelDemo */ = {
 			isa = PBXGroup;
 			children = (
+				169483E13037612D0080D934 /* SceneDelegate.swift */,
 				E16BAEB41D3DB4FC00C442CE /* MixpanelDemo.entitlements */,
 				E15FF7DA1D0461130076CDE3 /* Main.storyboard */,
 				E15FF7D61D0461130076CDE3 /* AppDelegate.swift */,
@@ -1143,6 +1146,7 @@
 			files = (
 				60CB587123D77F9200F1632B /* LoginViewController.swift in Sources */,
 				E146F1941D398D0A00D75B49 /* TrackingViewController.swift in Sources */,
+				169483E23037612D0080D934 /* SceneDelegate.swift in Sources */,
 				E146F1961D398D1600D75B49 /* PeopleViewController.swift in Sources */,
 				E146F19A1D399AF300D75B49 /* UtilityViewController.swift in Sources */,
 				E15FF7D71D0461130076CDE3 /* AppDelegate.swift in Sources */,
@@ -1826,7 +1830,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -1880,7 +1884,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
@@ -1903,7 +1907,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = MixpanelDemo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1933,7 +1937,7 @@
 				CURRENT_PROJECT_VERSION = 6;
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = MixpanelDemo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/MixpanelDemo/MixpanelDemo.xcodeproj/xcshareddata/xcschemes/MixpanelDemo.xcscheme
+++ b/MixpanelDemo/MixpanelDemo.xcodeproj/xcshareddata/xcschemes/MixpanelDemo.xcscheme
@@ -92,6 +92,9 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
+      <MetalAPIValidationSettings
+         isEnabled = "No">
+      </MetalAPIValidationSettings>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/MixpanelDemo/MixpanelDemo/AppDelegate.swift
+++ b/MixpanelDemo/MixpanelDemo/AppDelegate.swift
@@ -154,4 +154,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         return true
     }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        return UISceneConfiguration(
+            name: "Default Configuration",
+            sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+    }
 }

--- a/MixpanelDemo/MixpanelDemo/Info.plist
+++ b/MixpanelDemo/MixpanelDemo/Info.plist
@@ -27,12 +27,29 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/MixpanelDemo/MixpanelDemo/SceneDelegate.swift
+++ b/MixpanelDemo/MixpanelDemo/SceneDelegate.swift
@@ -1,0 +1,33 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+
+        window = UIWindow(windowScene: windowScene)
+
+        // The window will be set up from the Main storyboard automatically
+        // This ensures the storyboard-based UI is properly loaded
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+    }
+}

--- a/MixpanelDemo/MixpanelDemo/SceneDelegate.swift
+++ b/MixpanelDemo/MixpanelDemo/SceneDelegate.swift
@@ -8,12 +8,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         willConnectTo session: UISceneSession,
         options connectionOptions: UIScene.ConnectionOptions
     ) {
-        guard let windowScene = (scene as? UIWindowScene) else { return }
-
-        window = UIWindow(windowScene: windowScene)
-
-        // The window will be set up from the Main storyboard automatically
-        // This ensures the storyboard-based UI is properly loaded
+        // When using storyboards, the window and root view controller are created automatically
+        // from the storyboard specified in Info.plist's UISceneStoryboardFile
+        guard let _ = (scene as? UIWindowScene) else { return }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/MixpanelDemo/MixpanelDemo/SceneDelegate.swift
+++ b/MixpanelDemo/MixpanelDemo/SceneDelegate.swift
@@ -10,7 +10,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         // When using storyboards, the window and root view controller are created automatically
         // from the storyboard specified in Info.plist's UISceneStoryboardFile
-        guard let _ = (scene as? UIWindowScene) else { return }
+        guard (scene as? UIWindowScene) != nil else { return }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
This pull request updates the MixpanelDemo iOS project to support the modern iOS multi-window scene lifecycle introduced in iOS 13. The main changes include adding a `SceneDelegate`, updating the deployment target, and modifying the project configuration and `Info.plist` to enable scene support.

**Scene lifecycle and project configuration updates:**

* Added a new `SceneDelegate.swift` file and registered it in the project to manage the app's UI lifecycle with scenes. (`MixpanelDemo/SceneDelegate.swift`, `project.pbxproj`, [[1]](diffhunk://#diff-27839b9d6ce138067eebe7e8d3c8e0f42000f1406515f3623fdb43e75209a229R1-R33) [[2]](diffhunk://#diff-118db5f9f9e95f2fe22afb05294f6ae087a8630369ed6fb4088700ff327d80c9R12) [[3]](diffhunk://#diff-118db5f9f9e95f2fe22afb05294f6ae087a8630369ed6fb4088700ff327d80c9R271) [[4]](diffhunk://#diff-118db5f9f9e95f2fe22afb05294f6ae087a8630369ed6fb4088700ff327d80c9R611) [[5]](diffhunk://#diff-118db5f9f9e95f2fe22afb05294f6ae087a8630369ed6fb4088700ff327d80c9R1149)
* Updated `Info.plist` to include the `UIApplicationSceneManifest` key, configuring the app to use the scene-based lifecycle and referencing the new `SceneDelegate`. The previous `UIMainStoryboardFile` key was removed as this is now handled by the scene manifest.
* Modified `AppDelegate.swift` to implement the required scene session lifecycle methods, delegating UI management to the `SceneDelegate`.

**Deployment target and build settings:**

* Raised the iOS deployment target from 12.0 to 13.0 in all relevant build configurations to enable scene support. (`project.pbxproj`, [[1]](diffhunk://#diff-118db5f9f9e95f2fe22afb05294f6ae087a8630369ed6fb4088700ff327d80c9L1829-R1833) [[2]](diffhunk://#diff-118db5f9f9e95f2fe22afb05294f6ae087a8630369ed6fb4088700ff327d80c9L1883-R1887) [[3]](diffhunk://#diff-118db5f9f9e95f2fe22afb05294f6ae087a8630369ed6fb4088700ff327d80c9L1906-R1910) [[4]](diffhunk://#diff-118db5f9f9e95f2fe22afb05294f6ae087a8630369ed6fb4088700ff327d80c9L1936-R1940)
* Disabled Metal API validation in the Xcode scheme for launch actions. (`MixpanelDemo.xcscheme`, [MixpanelDemo/MixpanelDemo.xcodeproj/xcshareddata/xcschemes/MixpanelDemo.xcschemeR95-R97](diffhunk://#diff-5b5e58d39ff4d633937f121f091f27e1fc277d870da3a8b59245b414ee61f772R95-R97))

These updates modernize the app's lifecycle management and ensure compatibility with current iOS standards.