### PR TITLE
fix: do not start autocapture on Mac Catalyst

### DIFF
--- a/Sources/Autocapture/AutocaptureOptions.swift
+++ b/Sources/Autocapture/AutocaptureOptions.swift
@@ -221,6 +221,9 @@ public struct DeadClickOptions {
 /// )
 /// ```
 ///
+/// **Platform support:** iOS only. Mac Catalyst builds accept these options so shared iOS sources
+/// keep compiling, but automatic capture never starts there.
+///
 /// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the properties
 ///   it captures may change in a future release before general availability. Pin your SDK version if
 ///   you build reports on autocaptured events.

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -109,8 +109,9 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
     ///   properties it captures may change in a future release before general availability.
     open var autocapture: Autocapture!
 
-    #if os(iOS)
+    #if os(iOS) && !targetEnvironment(macCatalyst)
     /// Autocapture manager for click, rage click, and dead click detection.
+    /// Not available on Mac Catalyst, where automatic capture is unsupported.
     var autocaptureManager: AutocaptureManager?
     #endif
 
@@ -558,11 +559,11 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
             optOutTracking()
         }
 
-        // Initialize autocapture if enabled (iOS only)
+        // Initialize autocapture if enabled (iOS only, excluding Mac Catalyst)
         // Done after opt-out check so autocapture is not started when tracking is opted out.
         // Note: optOutTracking() runs async on trackingQueue, so hasOptedOutTracking() may
         // not reflect the default yet. Check optOutTrackingByDefault directly as well.
-        #if os(iOS)
+        #if os(iOS) && !targetEnvironment(macCatalyst)
         if let autocaptureOpts = self.options.autocaptureOptions, autocaptureOpts.isEnabled {
             if optOutTrackingByDefault || hasOptedOutTracking() {
                 MixpanelLogger.info(message: "Autocapture disabled: tracking is opted out")
@@ -576,6 +577,10 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
                 autocaptureManager?.start()
                 MixpanelLogger.info(message: "AutocaptureManager started")
             }
+        }
+        #elseif os(iOS) && targetEnvironment(macCatalyst)
+        if let autocaptureOpts = self.options.autocaptureOptions, autocaptureOpts.isEnabled {
+            MixpanelLogger.info(message: "Autocapture is not supported on Mac Catalyst")
         }
         #endif
 
@@ -679,7 +684,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
 
     deinit {
         NotificationCenter.default.removeObserver(self)
-        #if os(iOS)
+        #if os(iOS) && !targetEnvironment(macCatalyst)
         autocaptureManager?.stop()
         #endif
         #if os(iOS) && !os(watchOS) && !targetEnvironment(macCatalyst)
@@ -1384,9 +1389,12 @@ extension MixpanelInstance {
       This cancels any pending dead click detection to prevent false positives.
 
       This method is safe to call even if autocapture is not enabled; it will simply do nothing.
+      On Mac Catalyst, where autocapture is unsupported, it is always a no-op.
      */
     public func signalUIChange() {
+        #if !targetEnvironment(macCatalyst)
         autocaptureManager?.signalUIChange()
+        #endif
     }
     #endif
 
@@ -1900,7 +1908,7 @@ extension MixpanelInstance {
                 flagManager.reset()
             }
 
-            #if os(iOS)
+            #if os(iOS) && !targetEnvironment(macCatalyst)
             self.autocaptureManager?.stop()
             #endif
         }
@@ -1932,7 +1940,7 @@ extension MixpanelInstance {
             }
             self.track(event: "$opt_in", properties: properties)
 
-            #if os(iOS)
+            #if os(iOS) && !targetEnvironment(macCatalyst)
             // Restart autocapture if it was configured but stopped due to opt-out
             if self.autocaptureManager == nil,
                 let autocaptureOpts = self.options.autocaptureOptions,

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -266,7 +266,9 @@ public class MixpanelOptions {
     /// )
     /// ```
     ///
-    /// **Note:** Autocapture is only available on iOS.
+    /// **Note:** Autocapture is only available on iOS. It is not supported when the app runs as a
+    /// Mac Catalyst build; the options are accepted so shared iOS sources still compile, but no
+    /// automatic capture takes place there.
     ///
     /// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the
     ///   properties it captures may change in a future release before general availability.


### PR DESCRIPTION
Addresses [@ketanmixpanel's review comment](https://github.com/mixpanel/mixpanel-swift/pull/746#discussion_r3829538274) on #746.

## Problem

Mac Catalyst builds compile under `#if os(iOS)`, so the autocapture manager was being started when an iPhone/iPad app runs on the Mac — a platform where the touch interception it relies on isn't a supported configuration.

## Change

Every autocapture **activation** site is now guarded with `#if os(iOS) && !targetEnvironment(macCatalyst)`:

- `autocaptureManager` property declaration
- manager construction/start in `init`
- `stop()` in `deinit`
- `signalUIChange()` body (the method stays public on Catalyst and no-ops)
- `stop()` in `optOutTracking()` and the restart path in `optInTracking()`

## Note on the public API

The public surface — `AutocaptureOptions`, `MixpanelOptions.autocaptureOptions`, `Autocapture.trackClick(_:)` — deliberately still compiles under Mac Catalyst. A Catalyst build is the same iOS source, so `#if`-ing the types out would be source-breaking for any app that configures autocapture and also ships a Catalyst target. Instead, passing enabled options on Catalyst logs:

```
Autocapture is not supported on Mac Catalyst
```

so it isn't a silent no-op. Doc comments on `MixpanelOptions.autocaptureOptions` and `AutocaptureOptions` note the platform limitation. Happy to compile the API out entirely instead if we'd rather it be a hard error at build time.

## Verification

`xcodebuild build` succeeds with no new warnings for:

- Mac Catalyst (`platform=macOS,variant=Mac Catalyst`)
- iOS Simulator (iPhone 16)
- macOS (`Mixpanel_macOS`)

`swift-format` clean on all changed files.

## Unrelated pre-existing issue

The iOS/Catalyst build on the base branch emits `Skipping duplicate build file in Compile Sources` for all 8 `Sources/Autocapture/*.swift` files — af30758 looks to have added them to the `Mixpanel` target a second time. Not touched here; worth a separate pbxproj cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)