### PR TITLE
chore: remove custom ElementIdExtractor from autocapture options

### DIFF
--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
@@ -74,18 +74,6 @@ class AutocaptureOptionsTests: XCTestCase {
         XCTAssertTrue(options.deadClickOptions.enabled)
     }
 
-    func testAutocaptureOptionsDefaultToNoElementIdExtractor() {
-        XCTAssertNil(AutocaptureOptions().elementIdExtractor)
-    }
-
-    func testAutocaptureOptionsRetainTheElementIdExtractor() {
-        let extractor = ConstantElementIdExtractor("custom_el_id")
-        let options = AutocaptureOptions(elementIdExtractor: extractor)
-
-        XCTAssertNotNil(options.elementIdExtractor)
-        XCTAssertEqual(options.elementIdExtractor?.extractElementId(from: UIView()), "custom_el_id")
-    }
-
     func testAutocaptureOptionsIsEnabledWhenAnyFeatureEnabled() {
         // Only click enabled
         let clickOnly = AutocaptureOptions(
@@ -330,19 +318,6 @@ private final class FakeReactNativeView: UIView {
     @objc var nativeID: String?
 }
 
-/// Returns a fixed identifier for every view.
-private final class ConstantElementIdExtractor: ElementIdExtractor {
-    let identifier: String?
-
-    init(_ identifier: String?) {
-        self.identifier = identifier
-    }
-
-    func extractElementId(from view: UIView) -> String? {
-        return identifier
-    }
-}
-
 /// Tests the `$el_id` resolution order implemented by `DefaultElementIdExtractor`:
 /// React Native `nativeID` > `accessibilityIdentifier` > `<ClassName>_<hash>`. Accessibility labels
 /// are never a source: they are localized and can carry user data.
@@ -352,6 +327,12 @@ class DefaultElementIdExtractorTests: XCTestCase {
     private let hashIdPattern = "^[A-Za-z0-9_]+_[0-9a-f]+$"
 
     private let extractor = DefaultElementIdExtractor.shared
+
+    /// The resolver takes a SwiftUI accessibility-tree fallback identifier; the cases below exercise
+    /// the UIKit path, where there is none. The SwiftUI cases pass one explicitly.
+    private func elementId(for view: UIView) -> String {
+        return extractor.elementId(for: view, accessibilityIdentifierFallback: nil)
+    }
 
     private func assertMatchesHashFallback(_ elementId: String, _ message: String = "") {
         XCTAssertNotNil(
@@ -368,7 +349,7 @@ class DefaultElementIdExtractorTests: XCTestCase {
         view.isAccessibilityElement = true
         view.accessibilityLabel = "Checkout"
 
-        XCTAssertEqual(extractor.extractElementId(from: view), "rn_checkout_button")
+        XCTAssertEqual(elementId(for: view), "rn_checkout_button")
     }
 
     func testEmptyNativeIdFallsThroughToIdentifier() {
@@ -376,7 +357,7 @@ class DefaultElementIdExtractorTests: XCTestCase {
         view.nativeID = ""
         view.accessibilityIdentifier = "checkout_identifier"
 
-        XCTAssertEqual(extractor.extractElementId(from: view), "checkout_identifier")
+        XCTAssertEqual(elementId(for: view), "checkout_identifier")
     }
 
     func testViewWithoutNativeIdPropertyIsHandled() {
@@ -384,7 +365,7 @@ class DefaultElementIdExtractorTests: XCTestCase {
         let view = UIView()
         view.accessibilityIdentifier = "plain_view"
 
-        XCTAssertEqual(extractor.extractElementId(from: view), "plain_view")
+        XCTAssertEqual(elementId(for: view), "plain_view")
     }
 
     // MARK: - Priority 2: accessibilityIdentifier
@@ -395,7 +376,7 @@ class DefaultElementIdExtractorTests: XCTestCase {
         button.accessibilityIdentifier = "checkout_identifier"
         button.accessibilityLabel = "Checkout"
 
-        XCTAssertEqual(extractor.extractElementId(from: button), "checkout_identifier")
+        XCTAssertEqual(elementId(for: button), "checkout_identifier")
     }
 
     func testEmptyIdentifierFallsThroughToTheStructuralHash() {
@@ -403,7 +384,7 @@ class DefaultElementIdExtractorTests: XCTestCase {
         button.accessibilityIdentifier = ""
         button.accessibilityLabel = "Checkout"
 
-        let elementId = extractor.extractElementId(from: button) ?? ""
+        let elementId = elementId(for: button)
         assertMatchesHashFallback(elementId)
         XCTAssertFalse(elementId.contains("Checkout"), "Labels are never used as identity")
     }
@@ -414,7 +395,7 @@ class DefaultElementIdExtractorTests: XCTestCase {
             button.accessibilityIdentifier = internalIdentifier
 
             assertMatchesHashFallback(
-                extractor.extractElementId(from: button) ?? "",
+                elementId(for: button),
                 "Framework-internal identifier \(internalIdentifier) should be skipped")
         }
     }
@@ -428,7 +409,7 @@ class DefaultElementIdExtractorTests: XCTestCase {
             view.isAccessibilityElement = true
             view.accessibilityLabel = "Account ending 4321"
 
-            let elementId = extractor.extractElementId(from: view) ?? ""
+            let elementId = elementId(for: view)
             assertMatchesHashFallback(elementId)
             XCTAssertFalse(
                 elementId.contains("4321"),
@@ -439,7 +420,7 @@ class DefaultElementIdExtractorTests: XCTestCase {
     // MARK: - Priority 4: hash fallback
 
     func testHashFallbackUsesClassName() {
-        let elementId = extractor.extractElementId(from: UIButton()) ?? ""
+        let elementId = elementId(for: UIButton())
 
         XCTAssertNotNil(
             elementId.range(of: "^UIButton_[0-9a-f]+$", options: .regularExpression),
@@ -459,8 +440,8 @@ class DefaultElementIdExtractorTests: XCTestCase {
         }
 
         XCTAssertEqual(
-            extractor.extractElementId(from: buildLeaf()),
-            extractor.extractElementId(from: buildLeaf()),
+            elementId(for: buildLeaf()),
+            elementId(for: buildLeaf()),
             "The same structure must resolve to the same id")
     }
 
@@ -472,17 +453,17 @@ class DefaultElementIdExtractorTests: XCTestCase {
         root.addSubview(second)
 
         XCTAssertNotEqual(
-            extractor.extractElementId(from: first), extractor.extractElementId(from: second),
+            elementId(for: first), elementId(for: second),
             "Siblings at different positions must resolve to different ids")
     }
 
     func testAnonymousIdMatchesTheDefaultChainFallback() {
-        // resolveElementId() hands a nil-returning custom extractor over to anonymousId(); both
-        // paths must produce the same shape.
+        // The end of the resolution chain and anonymousId() must produce the same identifier — the
+        // hash fallback has no second implementation.
         let view = UIButton()
 
         XCTAssertEqual(
-            extractor.extractElementId(from: view),
+            elementId(for: view),
             DefaultElementIdExtractor.anonymousId(for: view))
     }
 
@@ -531,61 +512,34 @@ class DefaultElementIdExtractorTests: XCTestCase {
     }
 }
 
-/// Verifies that `AutocaptureOptions.elementIdExtractor` actually governs the `$el_id` that reaches
-/// the `ClickEvent` — the integration point between the option and the hit-test path.
+/// Verifies the `$el_id` that reaches the `ClickEvent` — the integration point between
+/// `DefaultElementIdExtractor` and the hit-test path.
 class SemanticExtractorElementIdTests: XCTestCase {
 
     private let point = CGPoint(x: 10, y: 20)
 
-    private func elementId(for view: UIView, options: AutocaptureOptions) -> String {
-        return SemanticExtractor(autocaptureOptions: options)
+    private func elementId(for view: UIView) -> String {
+        return SemanticExtractor()
             .extractSemantics(from: view, at: point)
             .elementId
     }
 
-    func testDefaultResolutionUsedWhenNoExtractorProvided() {
+    func testAccessibilityIdentifierResolvesElementId() {
         let button = UIButton()
         button.accessibilityIdentifier = "checkout_identifier"
         button.accessibilityLabel = "Checkout"
 
-        XCTAssertEqual(
-            elementId(for: button, options: AutocaptureOptions()), "checkout_identifier")
+        XCTAssertEqual(elementId(for: button), "checkout_identifier")
     }
 
-    func testCustomExtractorReplacesDefaultResolution() {
+    func testViewWithoutIdentifierFallsBackToAnonymousId() {
         let button = UIButton()
-        button.accessibilityIdentifier = "checkout_identifier"
-
-        let options = AutocaptureOptions(
-            elementIdExtractor: ConstantElementIdExtractor("custom_el_id"))
-
-        XCTAssertEqual(elementId(for: button, options: options), "custom_el_id")
-    }
-
-    func testCustomExtractorReturningNilFallsBackToAnonymousId() {
-        // Returning nil means "report nothing identifying" — the SDK must not quietly fall back to
-        // metadata the developer declined to expose.
-        let button = UIButton()
-        button.accessibilityIdentifier = "checkout_identifier"
         button.accessibilityLabel = "Checkout"
 
-        let options = AutocaptureOptions(elementIdExtractor: ConstantElementIdExtractor(nil))
-        let resolved = elementId(for: button, options: options)
+        let resolved = elementId(for: button)
 
         XCTAssertEqual(resolved, DefaultElementIdExtractor.anonymousId(for: button))
-        XCTAssertFalse(resolved.contains("checkout_identifier"))
         XCTAssertFalse(resolved.contains("Checkout"))
-    }
-
-    func testCustomExtractorReturningEmptyStringFallsBackToAnonymousId() {
-        let button = UIButton()
-        button.accessibilityIdentifier = "checkout_identifier"
-
-        let options = AutocaptureOptions(elementIdExtractor: ConstantElementIdExtractor(""))
-
-        XCTAssertEqual(
-            elementId(for: button, options: options),
-            DefaultElementIdExtractor.anonymousId(for: button))
     }
 
     func testAccessibilityLabelIsNeverReported() {
@@ -594,7 +548,7 @@ class SemanticExtractorElementIdTests: XCTestCase {
         button.accessibilityIdentifier = "checkout_identifier"
         button.accessibilityLabel = "Checkout"
 
-        let event = SemanticExtractor(autocaptureOptions: AutocaptureOptions())
+        let event = SemanticExtractor()
             .extractSemantics(from: button, at: point)
 
         XCTAssertEqual(event.elementId, "checkout_identifier")
@@ -604,8 +558,8 @@ class SemanticExtractorElementIdTests: XCTestCase {
     }
 }
 
-/// End-to-end coverage for the extractor: an implementation handed to `MixpanelOptions` must survive
-/// SDK initialization and govern the `$el_id` of a `$mp_click` produced by a real touch.
+/// End-to-end coverage for `$el_id`: the identifier the SDK resolves must survive SDK
+/// initialization and govern the `$el_id` of a `$mp_click` produced by a real touch.
 class ElementIdExtractorEndToEndTests: MixpanelBaseTests {
 
     private var testWindow: UIWindow!
@@ -660,34 +614,8 @@ class ElementIdExtractorEndToEndTests: MixpanelBaseTests {
 
     @objc private func buttonTapped() {}
 
-    func testCustomExtractorGovernsElementIdEndToEnd() {
-        startMixpanel(extractor: ConstantElementIdExtractor("custom_el_id"))
-
-        simulateTap()
-
-        let properties = waitForClickProperties()
-        XCTAssertNotNil(properties, "Should capture $mp_click event")
-        XCTAssertEqual(properties?["$el_id"] as? String, "custom_el_id")
-    }
-
-    func testExtractorReturningNilYieldsAnonymousIdEndToEnd() {
-        startMixpanel(extractor: ConstantElementIdExtractor(nil))
-
-        simulateTap()
-
-        let properties = waitForClickProperties()
-        XCTAssertNotNil(properties, "Should capture $mp_click event")
-        let elementId = properties?["$el_id"] as? String ?? ""
-        XCTAssertNotNil(
-            elementId.range(of: "^UIButton_[0-9a-f]+$", options: .regularExpression),
-            "Expected the anonymous id, got: \(elementId)")
-        XCTAssertFalse(
-            elementId.contains("checkout_identifier"),
-            "Suppressed identifier must not leak into $el_id")
-    }
-
-    func testDefaultResolutionEndToEndWithoutExtractor() {
-        startMixpanel(extractor: nil)
+    func testDefaultResolutionEndToEnd() {
+        startMixpanel()
 
         simulateTap()
 
@@ -699,7 +627,7 @@ class ElementIdExtractorEndToEndTests: MixpanelBaseTests {
     /// A React Native view exposes the JS-side `nativeID` prop as an `@objc` property; it must win
     /// $el_id over the accessibility metadata React Native also sets.
     func testReactNativeNativeIdWinsEndToEnd() {
-        startMixpanel(extractor: nil)
+        startMixpanel()
 
         let setupExpectation = expectation(description: "RN view added")
         let rnView = FakeReactNativeView()
@@ -739,7 +667,7 @@ class ElementIdExtractorEndToEndTests: MixpanelBaseTests {
 
     // MARK: - Helpers
 
-    private func startMixpanel(extractor: ElementIdExtractor?) {
+    private func startMixpanel() {
         let token = randomId()
         let options = MixpanelOptions(
             token: token,
@@ -751,8 +679,7 @@ class ElementIdExtractorEndToEndTests: MixpanelBaseTests {
             autocaptureOptions: AutocaptureOptions(
                 clickOptions: ClickOptions(enabled: true),
                 rageClickOptions: RageClickOptions(enabled: false),
-                deadClickOptions: DeadClickOptions(enabled: false),
-                elementIdExtractor: extractor
+                deadClickOptions: DeadClickOptions(enabled: false)
             )
         )
 

--- a/Sources/Autocapture/AutocaptureManager.swift
+++ b/Sources/Autocapture/AutocaptureManager.swift
@@ -59,7 +59,7 @@ final class AutocaptureManager {
         self.autocapture = autocapture
 
         // Initialize components
-        self.semanticExtractor = SemanticExtractor(autocaptureOptions: options)
+        self.semanticExtractor = SemanticExtractor()
 
         // Initialize rage click tracker if enabled
         if options.rageClickOptions.enabled {

--- a/Sources/Autocapture/AutocaptureOptions.swift
+++ b/Sources/Autocapture/AutocaptureOptions.swift
@@ -237,36 +237,11 @@ public struct AutocaptureOptions {
     /// Configuration for dead click detection.
     public let deadClickOptions: DeadClickOptions
 
-    #if os(iOS)
-    /// Optional custom resolver for the `$el_id` reported on autocaptured interactions.
-    ///
-    /// When `nil` (the default), the SDK resolves `$el_id` internally: React Native `nativeID`,
-    /// then `accessibilityIdentifier`, then `accessibilityLabel`, then an anonymous `<ClassName>_<hash>`
-    /// identifier. Supply an implementation to control exactly which identifier is reported and to
-    /// keep personally identifiable information out of the payload.
-    ///
-    /// - SeeAlso: ``ElementIdExtractor``
-    public let elementIdExtractor: ElementIdExtractor?
-    #endif
-
     /// Returns `true` if any autocapture feature is enabled.
     public var isEnabled: Bool {
         return clickOptions.enabled || rageClickOptions.enabled || deadClickOptions.enabled
     }
 
-    #if os(iOS)
-    public init(
-        clickOptions: ClickOptions = ClickOptions(),
-        rageClickOptions: RageClickOptions = RageClickOptions(),
-        deadClickOptions: DeadClickOptions = DeadClickOptions(),
-        elementIdExtractor: ElementIdExtractor? = nil
-    ) {
-        self.clickOptions = clickOptions
-        self.rageClickOptions = rageClickOptions
-        self.deadClickOptions = deadClickOptions
-        self.elementIdExtractor = elementIdExtractor
-    }
-    #else
     public init(
         clickOptions: ClickOptions = ClickOptions(),
         rageClickOptions: RageClickOptions = RageClickOptions(),
@@ -276,5 +251,4 @@ public struct AutocaptureOptions {
         self.rageClickOptions = rageClickOptions
         self.deadClickOptions = deadClickOptions
     }
-    #endif
 }

--- a/Sources/Autocapture/ElementIdExtractor.swift
+++ b/Sources/Autocapture/ElementIdExtractor.swift
@@ -8,54 +8,11 @@
 #if os(iOS)
 import UIKit
 
-// MARK: - ElementIdExtractor
+// MARK: - DefaultElementIdExtractor
 
 /// Resolves the `$el_id` property reported for an autocaptured interaction.
 ///
-/// Provide an implementation via `AutocaptureOptions(elementIdExtractor:)` to take full control
-/// over which identifier the SDK reports for a tapped view. This is the recommended way to keep
-/// personally identifiable information out of autocapture events: the SDK only ever reports what
-/// this method returns.
-///
-/// When no extractor is provided, the SDK falls back to an internal default implementation that
-/// resolves the identifier from the React Native `nativeID`, then `accessibilityIdentifier`, then a
-/// structural fallback. `accessibilityLabel` is deliberately not a source: it is localized, so the
-/// same element would report a different identifier per language, and it can carry user data.
-///
-/// **Example:**
-/// ```swift
-/// final class TrackingIdExtractor: ElementIdExtractor {
-///     func extractElementId(from view: UIView) -> String? {
-///         // Only report identifiers the team explicitly opted into.
-///         guard let id = view.accessibilityIdentifier, id.hasPrefix("track_") else { return nil }
-///         return id
-///     }
-/// }
-///
-/// let options = MixpanelOptions(
-///     token: "YOUR_TOKEN",
-///     autocaptureOptions: AutocaptureOptions(elementIdExtractor: TrackingIdExtractor())
-/// )
-/// ```
-///
-/// **Threading:** `extractElementId(from:)` is called on the main thread immediately after the hit
-/// test that resolved the tapped view. Keep the implementation fast and side-effect free.
-///
-/// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the properties
-///   it captures may change in a future release before general availability. Pin your SDK version if
-///   you build reports on autocaptured events.
-public protocol ElementIdExtractor {
-    /// Returns the `$el_id` to report for the given view.
-    ///
-    /// - Parameter view: The view resolved by the autocapture hit test.
-    /// - Returns: The identifier to report, or `nil` to let the SDK report an anonymous
-    ///   `<ClassName>_<hash>` identifier instead. Empty strings are treated as `nil`.
-    func extractElementId(from view: UIView) -> String?
-}
-
-// MARK: - DefaultElementIdExtractor
-
-/// Default `ElementIdExtractor` used when the host app does not supply its own.
+/// This is the SDK's only `$el_id` resolver; there is no way for a host app to substitute its own.
 ///
 /// Resolution priority:
 /// 1. **React Native `nativeID`** — read through the Objective-C runtime so the SDK carries no
@@ -72,7 +29,7 @@ public protocol ElementIdExtractor {
 /// For SwiftUI, step 1 is skipped and the identifier lives in SwiftUI's accessibility element tree
 /// rather than on the backing `UIView`, so `SemanticExtractor` resolves it from that tree and passes
 /// it in as the `accessibilityIdentifierFallback` argument below.
-final class DefaultElementIdExtractor: ElementIdExtractor {
+final class DefaultElementIdExtractor {
 
     static let shared = DefaultElementIdExtractor()
 
@@ -83,10 +40,6 @@ final class DefaultElementIdExtractor: ElementIdExtractor {
         "UITransitionView",
         "UILayoutContainerView",
     ]
-
-    func extractElementId(from view: UIView) -> String? {
-        return elementId(for: view, accessibilityIdentifierFallback: nil)
-    }
 
     /// Resolution with an optional precomputed identifier used at priority step 2.
     ///

--- a/Sources/Autocapture/Model/ClickEvent.swift
+++ b/Sources/Autocapture/Model/ClickEvent.swift
@@ -50,8 +50,8 @@ public struct ClickEvent: Sendable {
     /// `accessibilityLabel` is deliberately not a source: it is localized, so the same element would
     /// report a different identifier per language, and it can carry personal data.
     ///
-    /// Supply an `ElementIdExtractor` through `AutocaptureOptions` to override this entirely — for
-    /// example a custom string like `"buy_button"` or `"settings_cell_notifications"`.
+    /// When constructing a `ClickEvent` yourself, prefer a stable, human-readable string such as
+    /// `"buy_button"` or `"settings_cell_notifications"`.
     ///
     /// Avoid dynamic values (e.g., cell index, timestamp) — they prevent meaningful grouping.
     public let elementId: String

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -13,14 +13,6 @@ import UIKit
 ///
 /// Handles element identification and role detection.
 final class SemanticExtractor {
-    // MARK: - Configuration
-
-    private let autocaptureOptions: AutocaptureOptions
-
-    init(autocaptureOptions: AutocaptureOptions = AutocaptureOptions()) {
-        self.autocaptureOptions = autocaptureOptions
-    }
-
     // MARK: - Constants
 
     private static let maxHierarchyDepth = AutocaptureDefaults.maxHierarchyDepth
@@ -87,25 +79,14 @@ final class SemanticExtractor {
 
     /// Resolve the `$el_id` for the target view.
     ///
-    /// When the host app supplied an ``ElementIdExtractor`` through `AutocaptureOptions`, that
-    /// extractor is the only source of the identifier: a `nil`/empty return yields the anonymous
-    /// `<ClassName>_<hash>` identifier rather than silently falling back to view metadata the developer
-    /// chose not to expose.
-    ///
-    /// Otherwise `DefaultElementIdExtractor` resolves it (React Native `nativeID` >
-    /// `accessibilityIdentifier` > `<ClassName>_<hash>`; for SwiftUI the `nativeID` step is skipped).
-    /// Accessibility labels are never used: they are localized and can carry user data.
+    /// `DefaultElementIdExtractor` resolves it (React Native `nativeID` > `accessibilityIdentifier` >
+    /// `<ClassName>_<hash>`; for SwiftUI the `nativeID` step is skipped). Accessibility labels are
+    /// never used: they are localized and can carry user data.
     ///
     /// - Parameters:
     ///   - derivedIdentifier: Identifier read from SwiftUI's accessibility element tree, used at the
     ///     `accessibilityIdentifier` priority step when the view carries none itself.
     private func resolveElementId(for view: UIView, derivedIdentifier: String?) -> String {
-        if let custom = autocaptureOptions.elementIdExtractor {
-            if let customId = custom.extractElementId(from: view), !customId.isEmpty {
-                return customId
-            }
-            return DefaultElementIdExtractor.anonymousId(for: view)
-        }
         return DefaultElementIdExtractor.shared.elementId(
             for: view, accessibilityIdentifierFallback: derivedIdentifier)
     }


### PR DESCRIPTION
Stacked on #771. This release ships only the SDK's internal `$el_id` resolution, so the public seam that let a host app substitute its own resolver is removed.

## Changes

- **`AutocaptureOptions`** — dropped the `elementIdExtractor` property and init parameter. It was the only iOS-specific member, so the `#if os(iOS)` / `#else` init split collapses into a single cross-platform initializer.
- **`SemanticExtractor`** — `resolveElementId()` always goes through `DefaultElementIdExtractor`. `AutocaptureOptions` was only ever consulted for the extractor, so the stored property and the `init(autocaptureOptions:)` parameter are gone too.
- **`ElementIdExtractor.swift`** — deleted the `public protocol ElementIdExtractor` and `DefaultElementIdExtractor`'s conformance, including the now-dead `extractElementId(from:)` shim. `DefaultElementIdExtractor` is a plain `final class`; the file keeps its name.
- Doc comments in `MixpanelOptions` and `ClickEvent` no longer point at the removed option.

`$el_id` resolution itself is unchanged: React Native `nativeID` → `accessibilityIdentifier` → `<ClassName>_<hash>`, with `accessibilityLabel` still deliberately excluded.

## Tests

Removed the 7 tests that asserted custom-extractor behavior (plus the `ConstantElementIdExtractor` fixture). Kept all default-resolution coverage — `DefaultElementIdExtractorTests`, the SwiftUI fallback cases, the React Native `nativeID` end-to-end test — and rewired it to the resolver's real entry point, `elementId(for:accessibilityIdentifierFallback:)`, via a small test-local helper rather than keeping a test-only method in production code.

## Verification

- `xcodebuild build` clean for iOS Simulator, Mac Catalyst, and macOS
- `swift-format` clean on all changed files
- **30 tests pass**: `AutocaptureOptionsTests`, `DefaultElementIdExtractorTests`, `SemanticExtractorElementIdTests`, `ElementIdExtractorEndToEndTests`
- **77/78 pass** across the wider autocapture suites (`RageClickTrackerTests`, `ClickEventTests`, `AutocaptureWalkUpUIKitTests`, `AutocaptureUIKitInstrumentedTests`, `AutocaptureSwiftUIInstrumentedTests`, both label-derivation suites)

## Pre-existing failure, not caused by this PR

`AutocaptureWalkUpUIKitTests.testNoWalkUp_NonInteractiveLeafWithLabelNoInteractiveAncestor_GetsOwnLabel` (`AutocaptureWalkUpInstrumentedTests.swift:520`) fails identically on the base branch — verified by stashing this diff and re-running. It expects `$el_id == "orphan_label"` from an `accessibilityLabel`, which 61a6451 deliberately stopped doing; the test was left stale. Happy to fix it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)