### PR TITLE
chore: remove the unused signalUIChange() API

### DIFF
--- a/Sources/Autocapture/AutocaptureManager.swift
+++ b/Sources/Autocapture/AutocaptureManager.swift
@@ -133,17 +133,6 @@ final class AutocaptureManager {
         MixpanelLogger.info(message: "AutocaptureManager: stopped")
     }
 
-    /// Signals that a UI change occurred.
-    ///
-    /// Call this when a UI change happens that the dead click detector cannot observe,
-    /// such as navigation in React Native or other framework-driven UI changes.
-    /// This cancels any pending dead click detection to prevent false positives.
-    func signalUIChange() {
-        deadClickDetector?.cancelPendingCheck()
-        rageClickTracker?.reset()
-        MixpanelLogger.debug(message: "AutocaptureManager: UI change signaled, cancelled pending detections")
-    }
-
     // MARK: - Touch Handling
 
     /// Handle a touch event from the interceptor.

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -1378,26 +1378,6 @@ extension MixpanelInstance {
         }
     }
 
-    // MARK: - Autocapture
-
-    #if os(iOS)
-    /**
-      Signals to the SDK that a UI change occurred.
-
-      Call this when a UI change happens that the dead click detector cannot observe,
-      such as navigation in React Native or other framework-driven UI changes.
-      This cancels any pending dead click detection to prevent false positives.
-
-      This method is safe to call even if autocapture is not enabled; it will simply do nothing.
-      On Mac Catalyst, where autocapture is unsupported, it is always a no-op.
-     */
-    public func signalUIChange() {
-        #if !targetEnvironment(macCatalyst)
-        autocaptureManager?.signalUIChange()
-        #endif
-    }
-    #endif
-
 }
 
 extension MixpanelInstance {


### PR DESCRIPTION
Stacked on #772 (which is stacked on #771).

`signalUIChange()` was an escape hatch for JS-driven navigation the dead click detector cannot observe: calling it cancelled any pending dead click check so a React Navigation transition wouldn't produce a false `$mp_dead_click`. It ships as public API but **nothing calls it**.

## The concern it addressed doesn't reproduce

The API was designed before the behavior was measured. React Native testing shows the native detector *does* see JS-driven navigation: React Navigation renders through the native view hierarchy, so the screen change mutates the native view tree inside the 500 ms detection window and cancels the pending check like any other UI response. Dead clicks are tracked correctly on React Native with no host-app cooperation.

So the method isn't just uncalled — the case it existed for is already handled by the ordinary detection path.

## Confirmed unused

Searched the whole workspace before removing:

| Consumer | Result |
|---|---|
| `mixpanel-swift` Sources | only the public method → the manager method; no other caller |
| `MixpanelDemo` app + tests | no references |
| `mixpanel-react-native` | none, on any local or remote branch |
| `mixpanel-flutter` | none, on any local or remote branch |
| `mixpanel-android` | no equivalent API exists in `analytics/src` on any branch |

Android never had the API, so a React Native bridge — the only thing that would have consumed it — was never buildable symmetrically anyway.

## Changes

- `MixpanelInstance.signalUIChange()` — removed, along with the now-empty `// MARK: - Autocapture` block.
- `AutocaptureManager.signalUIChange()` — removed. Its body only called `deadClickDetector?.cancelPendingCheck()` and `rageClickTracker?.reset()`; both are still called from `stop()`, so no behavior is orphaned.

No other autocapture behavior changes.

## Verification

- `xcodebuild build` clean for iOS Simulator and Mac Catalyst
- `swift-format` clean on both changed files
- 55 tests pass: `AutocaptureOptionsTests`, `DefaultElementIdExtractorTests`, `SemanticExtractorElementIdTests`, `ElementIdExtractorEndToEndTests`, `AutocaptureUIKitInstrumentedTests`, `RageClickTrackerTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)