### PR TITLE
chore: correct autocapture doc for $el_id and platform support

### DIFF
--- a/context/AUTOCAPTURE.md
+++ b/context/AUTOCAPTURE.md
@@ -85,54 +85,67 @@ All autocapture events include these properties:
 | `$y` | Touch Y coordinate (screen points) |
 | `$el_id` | Element identifier (see resolution rules below) |
 | `$el_tag_name` | Class name of the view (e.g., `UIButton`) |
-| `$attr-aria-label` | Accessibility label |
 | `$attr-role` | Element role (Button, Switch, etc.) |
 | `$elements` | View hierarchy string (max 5 levels) |
 
+There is no `$attr-aria-label` property. Accessibility labels are not reported at all.
+
 ## Element Identification (`$el_id`)
+
+`$el_id` resolution is internal to the SDK and not configurable by the host app.
 
 ### Walk-Up to Clickable Parent
 
 When a non-interactive leaf view (e.g., `UILabel` inside a `UIButton`) is tapped, the SDK walks up the view hierarchy to the nearest interactive ancestor and uses its identity for `$el_id`. This is always-on behavior — not configurable.
 
-- The walk-up always takes the interactive parent's identity, even if the leaf has its own `accessibilityLabel`.
+- The walk-up always takes the interactive parent's identity, even if the leaf has its own identifier.
 - Stops at the first interactive ancestor (nested clickables: inner wins).
 - Max ancestor search depth: **10 levels**.
 - If no interactive ancestor is found within 10 levels, the leaf's own identity (or hash fallback) is used.
 
-The `$el_id` property uses different resolution rules for UIKit and SwiftUI:
+`accessibilityLabel` is **never** a source, on either path: it is user-facing text, so it is
+localized — the same element would report a different identifier per language — and it can carry
+personal data.
 
 ### UIKit Resolution Order
 
-1. `accessibilityIdentifier` (if non-empty)
-2. `accessibilityLabel` (if non-empty)
-3. `ClassName_<hash>` (fallback)
+1. React Native `nativeID` — the JS-side prop, read through the Objective-C runtime so the SDK
+   carries no compile-time dependency on React Native
+2. `accessibilityIdentifier` (if non-empty, and not a framework-internal identifier such as
+   `_private` or `AXID-1`)
+3. `<ClassName>_<hash>` (fallback)
 
 ```swift
-// Recommended: Set accessibilityIdentifier for reliable tracking
+// Give the interactive element an accessibilityIdentifier
 button.accessibilityIdentifier = "checkout_button"
 
-// Alternative: accessibilityLabel (also used for VoiceOver)
+// accessibilityLabel is for VoiceOver only — it never becomes $el_id
 button.accessibilityLabel = "Checkout"
 ```
 
 ### SwiftUI Resolution Order
 
-1. `accessibilityLabel` (primary - always available)
-2. `accessibilityIdentifier` (only available when VoiceOver is active)
-3. `ClassName_<hash>` (fallback)
+1. `accessibilityIdentifier`, read from SwiftUI's accessibility element tree
+2. `<ClassName>_<hash>` (fallback)
+
+There is no `nativeID` step: React Native renders through UIKit, never SwiftUI.
 
 ```swift
-// Recommended: Use accessibilityLabel (always works)
 Button("Checkout") { /* ... */ }
-    .accessibilityLabel("checkout_button")
-
-// Note: accessibilityIdentifier only works when VoiceOver is active
-Button("Checkout") { /* ... */ }
-    .accessibilityIdentifier("checkout_button")  // May not be captured
+    .accessibilityIdentifier("checkout_button")
 ```
 
-**Why the difference?** SwiftUI's accessibility tree is lazily materialized only when VoiceOver or Accessibility Inspector is running. Without these tools, `accessibilityIdentifier` returns nil.
+**Caveat:** SwiftUI never puts the identifier on the backing UIKit view — it lives in the
+accessibility element tree, which the SDK queries via `accessibilityHitTest`. That query requires
+**iOS 18+**, and returns nil when no accessibility client is active. On iOS 15–17, or with the tree
+unmaterialized, SwiftUI elements fall through to `<ClassName>_<hash>`.
+
+### The hash fallback
+
+`<ClassName>_<hash>` is derived from the element's **position** in the hierarchy, not its instance,
+so it is stable across app launches. It identifies a position rather than a specific element:
+reordering siblings changes it, and two rows of the same list differ by index rather than by
+content. Instrument the elements you care about.
 
 ## Dead Click Detection
 
@@ -178,7 +191,7 @@ These controls are excluded from dead click detection because they always produc
 |----------|---------|-------|
 | iOS | Full | Primary target |
 | iPadOS | Full | Same as iOS |
-| macOS (Catalyst) | Limited | May need testing |
+| macOS (Catalyst) | Not supported | Options are accepted so shared iOS sources compile, but capture never starts |
 | tvOS | Not supported | Different interaction model |
 | watchOS | Not supported | Different SDK |
 | visionOS | Not supported | Different interaction model |
@@ -218,8 +231,14 @@ AutocaptureManager: emitted $mp_dead_click for broken_link
 - Ensure the app is not in an app extension (autocapture is disabled in extensions)
 
 **SwiftUI elements showing hash IDs:**
-- Set `accessibilityLabel` on interactive elements
-- `accessibilityIdentifier` only works when VoiceOver is active
+- Set `.accessibilityIdentifier("...")` on the interactive element — it is the only `$el_id` source
+- Reading it requires iOS 18+ and a materialized accessibility tree; on iOS 15–17 the element falls
+  back to the hash regardless of what you set
+- An `accessibilityLabel` will not help; it is never used as an identifier
+
+**UIKit or React Native elements showing hash IDs:**
+- Set `accessibilityIdentifier` on the element that handles the tap, or a `nativeID` prop in React
+  Native — an identifier on a non-interactive ancestor is not used
 
 **False positive dead clicks:**
 - Element may have a handler that doesn't produce visible UI change
@@ -230,13 +249,18 @@ AutocaptureManager: emitted $mp_dead_click for broken_link
 
 - Touch coordinates
 - View class names and hierarchy
-- Accessibility labels and identifiers
+- `accessibilityIdentifier`s and React Native `nativeID`s
+- Element roles
 
 ### What is NOT Captured
 
 - Visible text content (see note below)
+- Accessibility labels
 
-Autocapture does not capture visible text content (`$el_text`) from tapped elements. Tracking text can be invasive and raise privacy concerns. Additionally, the complexity of nested view hierarchies can cause text extraction to capture content from unintended views — for example, tapping a container view might extract text from a deeply nested label that isn't semantically related to the tap. The remaining captured properties (`$el_id`, `$el_tag_name`, `$attr-aria-label`, `$attr-role`, `$elements`) are purely structural UI metadata.
+Autocapture does not capture visible text content (`$el_text`) from tapped elements. Tracking text can be invasive and raise privacy concerns. Additionally, the complexity of nested view hierarchies can cause text extraction to capture content from unintended views — for example, tapping a container view might extract text from a deeply nested label that isn't semantically related to the tap. The remaining captured properties (`$el_id`, `$el_tag_name`, `$attr-role`, `$elements`) are purely structural UI metadata.
+
+`accessibilityLabel` is not captured either. It is user-facing text that can carry personal data, and
+it is localized, so it never becomes an identifier and is not reported as a property.
 
 ### AppTrackingTransparency
 


### PR DESCRIPTION
Stacked on #773 (→ #772 → #771). Docs only — no code changes.

`context/AUTOCAPTURE.md` still taught `accessibilityLabel` as the way to control `$el_id`. That stopped being true when labels were dropped as an identity source (`61a6451`), and the doc was wrong in five places. Fixing it surfaced three neighbouring claims that were wrong for related reasons.

## The `accessibilityLabel` claims

| Where | Said | Now |
|---|---|---|
| Event properties | `$attr-aria-label` is captured | property removed; explicit note that labels are not reported |
| UIKit order | identifier → **label** → hash | `nativeID` → identifier → hash |
| SwiftUI order | **label (primary)** → identifier → hash | identifier → hash |
| Troubleshooting | "Set `accessibilityLabel` on interactive elements" | set `.accessibilityIdentifier(...)`; a label will not help |
| Privacy | labels listed under *What is Captured* | moved to *What is NOT Captured*, with the localization/PII reasoning |

## Neighbouring corrections

- **The SwiftUI caveat was wrong about the constraint.** It said `accessibilityIdentifier` "only works when VoiceOver is active". The actual gate in `SemanticExtractor.findSwiftUIAccessibilityIdentifier` is `guard #available(iOS 18.0, *)` plus a materialized accessibility tree — so on iOS 15–17 a SwiftUI element falls back to the hash no matter what you set. Reworded, and the troubleshooting entry now says the same.
- **Added a "hash fallback" section.** `<ClassName>_<hash>` is derived from the element's position in the hierarchy, not its instance, so it is stable across launches — but reordering siblings changes it, and list rows differ by index rather than content. Worth stating, since it is what un-instrumented elements get.
- **UIKit order gained the two steps it was missing:** the React Native `nativeID` probe, and the skipping of framework-internal identifiers (`_private`, `AXID-…`).
- **Platform table:** Mac Catalyst was "Limited | May need testing"; it is now "Not supported", matching the guards added in #771. A new troubleshooting entry covers UIKit / React Native elements resolving to a hash, which had no counterpart to the SwiftUI one.

Every statement here was checked against the code on this branch rather than carried over from the old text.