### PR TITLE
chore: add verified AGENTS.md agent context; fix stale copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,11 +13,13 @@ the surfaces that only read copilot-instructions.md, and repeats just the essent
 - **Tests live in `MixpanelDemo/` (Xcode project), not SPM.** Primary command (from `MixpanelDemo/`):
 
   ```bash
-  xcodebuild -scheme MixpanelDemo -derivedDataPath Build/ \
+  set -o pipefail && xcodebuild -scheme MixpanelDemo -derivedDataPath Build/ \
     -destination 'name=iPhone 17 Pro,OS=latest' -configuration Debug \
     ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES -enableCodeCoverage YES \
     clean build test | xcpretty -c
   ```
+
+  (`set -o pipefail` is required — otherwise xcpretty's exit code hides xcodebuild failures.)
 
   macOS: `-scheme MixpanelDemoMac -destination 'platform=macOS,arch=arm64'`;
   tvOS: `-scheme MixpanelDemoTV -destination 'platform=tvOS Simulator,name=Apple TV'`.
@@ -26,12 +28,13 @@ the surfaces that only read copilot-instructions.md, and repeats just the essent
 - **PR titles must match `^(feat|fix|chore|release): .+$`** — a blocking CI check.
 - Error philosophy: never crash the host app — fail soft, log via `MixpanelLogger`.
   Debug-only assertions (`MPAssert`) are fine; no traps in release paths.
-- Adding a source file? Also add it to the podspec `base_source_files` list (tvOS/macOS/watchOS
-  subspecs enumerate files explicitly).
-- Version (currently 6.5.1) is synced across the podspec, `Info.plist`,
-  `Sources/AutomaticProperties.swift` `libVersion()`, and `scripts/generate_docs.sh` — but
-  version bumps are done by the `prepare-release.yml` workflow, not by hand, and
-  `scripts/release.py` is dead code.
+- Adding a source file? Also add it to BOTH the podspec `base_source_files` list
+  (tvOS/macOS/watchOS subspecs enumerate files explicitly) AND the `Mixpanel.xcodeproj`
+  source build phases (Carthage builds the xcodeproj and would otherwise omit the file).
+- The SDK version is synced across the podspec, `Info.plist`,
+  `Sources/AutomaticProperties.swift` `libVersion()` (the authoritative copy), and
+  `scripts/generate_docs.sh` — version bumps are done by the `prepare-release.yml` workflow,
+  not by hand, and `scripts/release.py` is dead code.
 
 For architecture (two network paths, SQLite persistence, queue/lock model), testing patterns
 (`MixpanelBaseTests` helpers), platform gates (no automatic events on watchOS), and the

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,149 +1,38 @@
 # Copilot Instructions for mixpanel-swift
 
-## Repository Summary
+The canonical, verified agent instructions live in the repo root **`AGENTS.md`** — read that
+file first. Copilot surfaces that support AGENTS.md load it automatically; this file exists for
+the surfaces that only read copilot-instructions.md, and repeats just the essentials.
 
-This repository contains the **Mixpanel Swift SDK** - an analytics tracking library for Apple platforms. It enables iOS, tvOS, macOS, and watchOS applications to send event and user data to Mixpanel. The SDK supports Swift Package Manager, CocoaPods, and Carthage for installation.
+## Essentials
 
-**Languages/Frameworks:** Swift 5.0+  
-**Platforms:** iOS 12+, tvOS 11+, macOS 10.13+, watchOS 4+  
-**Project Size:** ~6,000 lines of Swift code across ~25 source files
+- **Mixpanel Swift SDK** for iOS 12+, tvOS 12+, macOS 10.13+, watchOS 4+.
+  `swift-tools-version: 5.3`; keep code valid for Swift < 6.1 (no trailing commas in calls).
+- ~8,000 lines across 25 Swift files, flat in `Sources/`. Two dependencies only
+  (`mixpanel-swift-common`, `json-logic-swift`) — do not add more.
+- **Tests live in `MixpanelDemo/` (Xcode project), not SPM.** Primary command (from `MixpanelDemo/`):
 
-## Building and Testing
+  ```bash
+  xcodebuild -scheme MixpanelDemo -derivedDataPath Build/ \
+    -destination 'name=iPhone 17 Pro,OS=latest' -configuration Debug \
+    ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES -enableCodeCoverage YES \
+    clean build test | xcpretty -c
+  ```
 
-### Prerequisites
-- **macOS with Xcode** is required (Apple platform SDK dependencies: UIKit, Foundation, CoreTelephony)
-- **SwiftLint** is used for linting (installed via Homebrew: `brew install swiftlint`)
-- **CocoaPods** is required for pod linting: `gem install cocoapods`
+  macOS: `-scheme MixpanelDemoMac -destination 'platform=macOS,arch=arm64'`;
+  tvOS: `-scheme MixpanelDemoTV -destination 'platform=tvOS Simulator,name=Apple TV'`.
+- **Formatting is Apple swift-format** (`.swift-format`: lineLength 120, 4-space indent) via
+  `sh ./scripts/format-swift.sh`. There is **no SwiftLint** in this repo.
+- **PR titles must match `^(feat|fix|chore|release): .+$`** — a blocking CI check.
+- Error philosophy: never crash the host app — fail soft, log via `MixpanelLogger`.
+  Debug-only assertions (`MPAssert`) are fine; no traps in release paths.
+- Adding a source file? Also add it to the podspec `base_source_files` list (tvOS/macOS/watchOS
+  subspecs enumerate files explicitly).
+- Version (currently 6.5.1) is synced across the podspec, `Info.plist`,
+  `Sources/AutomaticProperties.swift` `libVersion()`, and `scripts/generate_docs.sh` — but
+  version bumps are done by the `prepare-release.yml` workflow, not by hand, and
+  `scripts/release.py` is dead code.
 
-### Build Commands
-
-**Swift Package Manager (does not work without Apple SDK):**
-```bash
-swift build  # Requires macOS with Xcode - will fail on Linux
-```
-
-**Xcode Build & Test (iOS) - PRIMARY METHOD:**
-```bash
-cd MixpanelDemo
-# Use available simulator - check with: xcrun simctl list devices
-xcodebuild \
-  -scheme MixpanelDemo \
-  -derivedDataPath Build/ \
-  -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' \
-  -configuration Debug \
-  ONLY_ACTIVE_ARCH=NO \
-  ENABLE_TESTABILITY=YES \
-  -enableCodeCoverage YES \
-  clean build test | xcpretty -c
-```
-
-**Xcode Build & Test (macOS):**
-```bash
-cd MixpanelDemo
-xcodebuild \
-  -scheme MixpanelDemoMac \
-  -derivedDataPath Build/ \
-  -configuration Debug \
-  ONLY_ACTIVE_ARCH=NO \
-  ENABLE_TESTABILITY=YES \
-  -enableCodeCoverage YES \
-  clean build test | xcpretty -c
-```
-
-**Pod Lint (validates CocoaPods spec):**
-```bash
-pod lib lint --allow-warnings
-```
-
-**SwiftLint:**
-```bash
-swiftlint lint --config .swiftlint.yml
-```
-
-### Important Notes
-- Building requires macOS with Xcode - the SDK uses Apple platform frameworks (UIKit, CoreTelephony)
-- Tests run from `MixpanelDemo/` directory using Xcode schemes
-- CI uses `xcpretty` for cleaner output - install via `gem install xcpretty`
-- Available Xcode schemes: `MixpanelDemo` (iOS), `MixpanelDemoMac`, `MixpanelDemoTV`, `MixpanelDemoWatch`
-
-## Project Layout
-
-### Source Files
-- **`Sources/`** - Main SDK source files
-  - `Mixpanel.swift` - Primary entry point, initialization methods
-  - `MixpanelInstance.swift` - Core instance management (~1000 lines)
-  - `Track.swift` - Event tracking logic
-  - `People.swift` - User profile management
-  - `Group.swift` - Group analytics
-  - `Flush.swift`, `FlushRequest.swift` - Network flush logic
-  - `MPDB.swift`, `MixpanelPersistence.swift` - SQLite persistence
-  - `FeatureFlags.swift` - Feature flags support
-  - `AutomaticEvents.swift`, `AutomaticProperties.swift` - Auto-tracking
-  - `MixpanelOptions.swift` - Configuration options
-- **`Sources/Mixpanel/PrivacyInfo.xcprivacy`** - Apple privacy manifest
-
-### Demo App and Tests
-- **`MixpanelDemo/`** - Demo application and test suite
-  - `MixpanelDemo.xcodeproj/` - Xcode project (use this for building)
-  - `MixpanelDemoTests/` - iOS unit tests
-  - `MixpanelDemoMacTests/` - macOS unit tests
-  - `MixpanelDemoTVTests/` - tvOS tests
-  - Test files: `MixpanelBaseTests.swift` (base class), `MixpanelDemoTests.swift` (main tests)
-
-### Configuration Files
-- **`Package.swift`** - Swift Package Manager manifest
-- **`Mixpanel-swift.podspec`** - CocoaPods specification (version: 5.1.3)
-- **`.swiftlint.yml`** - SwiftLint rules (line_length: 140, excludes `MixpanelDemo/`)
-- **`Info.plist`** - Framework bundle info
-- **`Mixpanel.xcodeproj/`** - Framework Xcode project (schemes: Mixpanel, Mixpanel_macOS, Mixpanel_tvOS, Mixpanel_watchOS)
-
-### CI/CD Workflows (`.github/workflows/`)
-- **`iOS.yml`** - iOS tests on pull requests/pushes to master
-- **`macOS.yml`** - macOS tests on pull requests/pushes to master  
-- **`release.yml`** - Automated release on version tags (v*)
-
-### Scripts (`scripts/`)
-- `generate_docs.sh` - Generates API documentation with Jazzy
-- `carthage.sh` - Builds Carthage framework
-- `release.py` - Version bumping script (updates podspec, Info.plist, AutomaticProperties.swift)
-
-## Making Changes
-
-### Version Updates
-When updating the SDK version, these files must be modified:
-1. `Mixpanel-swift.podspec` - `s.version` field
-2. `Info.plist` - `CFBundleShortVersionString` key
-3. `Sources/AutomaticProperties.swift` - `libVersion()` function return value (line ~151)
-4. `scripts/generate_docs.sh` - `--module-version` parameter
-
-### Test Patterns
-Tests use `MixpanelBaseTests` as base class. Key patterns:
-- Use `randomId()` for test tokens
-- Use `waitForTrackingQueue()` after async operations
-- Use `flushAndWaitForTrackingQueue()` for network operations
-- Call `removeDBfile(token)` in teardown to clean SQLite files
-
-### Platform-Specific Code
-Use conditional compilation:
-```swift
-#if !os(OSX)
-  import UIKit
-#else
-  import Cocoa
-#endif
-
-#if os(iOS)
-  // iOS-specific code
-#endif
-```
-
-### SwiftLint Exclusions
-Files excluded from linting are listed in `.swiftlint.yml` - includes legacy/deprecated code. When adding new files, ensure they follow the configured rules (line_length: 140).
-
-## Validation Checklist
-1. Run SwiftLint: `swiftlint lint --config .swiftlint.yml`
-2. Build and test iOS: Use `xcodebuild` with `MixpanelDemo` scheme
-3. Validate pod spec: `pod lib lint --allow-warnings`
-4. Ensure no breaking changes to public API (check `open class` and `public` declarations)
-
-Trust these instructions. Only search the codebase if information here is incomplete or incorrect.
+For architecture (two network paths, SQLite persistence, queue/lock model), testing patterns
+(`MixpanelBaseTests` helpers), platform gates (no automatic events on watchOS), and the
+three-step release process, see `AGENTS.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,6 @@ Carthage/Build/
 
 MixpanelDemo/build/
 
-# Claude.ai instructions
-CLAUDE.md
+# Claude Code personal settings stay ignored; CLAUDE.md is tracked —
+# it is a one-line bridge importing AGENTS.md (see AGENTS.md)
 .claude/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,28 +12,40 @@ Prioritizes: never crash the host app, thread safety, backward compatibility.
 
 - Platforms: **iOS 12+, tvOS 12+, macOS 10.13+, watchOS 4+** (`Package.swift`, podspec agree)
 - `swift-tools-version: 5.3`; podspec `swift_version = '5.0'`; code must stay valid for
-  **Swift < 6.1** (CI rejects trailing commas in call sites)
+  **Swift < 6.1** — no trailing commas in call sites (enforced by the local pre-commit hook;
+  the CI check for it is informational only)
 - Dependencies (only two, `Package.swift`): `mixpanel-swift-common` (event bridge),
   `json-logic-swift`. **Do not add dependencies.**
-- Version `6.5.1` lives in **four synced places**: `Mixpanel-swift.podspec` (`s.version`),
-  `Info.plist` (`CFBundleShortVersionString`), `Sources/AutomaticProperties.swift`
-  (`libVersion()`), `scripts/generate_docs.sh` (`--module-version`). `Package.swift` carries
-  no version. Release tags have **no `v` prefix** (since 6.4.0).
+- The SDK version lives in **four synced places** (bumped together by `prepare-release.yml` —
+  do not restate the value elsewhere): `Mixpanel-swift.podspec` (`s.version`), `Info.plist`
+  (`CFBundleShortVersionString`), `Sources/AutomaticProperties.swift` (`libVersion()` — the
+  current-version oracle the release workflow greps), `scripts/generate_docs.sh`
+  (`--module-version`). `Package.swift` carries no version. Release tags have **no `v`
+  prefix** (since 6.4.0).
 
 ## Build, test, lint
 
 Tests live in the **demo app project**, not SPM — there is no `.testTarget` in `Package.swift`.
 
 ```bash
-# iOS build + test (primary; what CI runs, from MixpanelDemo/)
-cd MixpanelDemo && xcodebuild -scheme MixpanelDemo -derivedDataPath Build/ \
+# iOS build + test (primary; what CI runs, from MixpanelDemo/).
+# set -o pipefail is essential — without it xcpretty's exit code masks xcodebuild failures.
+cd MixpanelDemo && set -o pipefail && xcodebuild -scheme MixpanelDemo -derivedDataPath Build/ \
   -destination 'name=iPhone 17 Pro,OS=latest' -configuration Debug \
   ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES -enableCodeCoverage YES \
   clean build test | xcpretty -c
 
-# macOS / tvOS variants (CI: macOS.yml, tvOS.yml)
-cd MixpanelDemo && xcodebuild -scheme MixpanelDemoMac -destination 'platform=macOS,arch=arm64' ... clean build test | xcpretty -c
-cd MixpanelDemo && xcodebuild -scheme MixpanelDemoTV -destination 'platform=tvOS Simulator,name=Apple TV' ... clean build test | xcpretty -c
+# macOS (CI: macOS.yml)
+cd MixpanelDemo && set -o pipefail && xcodebuild -scheme MixpanelDemoMac -derivedDataPath Build/ \
+  -destination 'platform=macOS,arch=arm64' -configuration Debug \
+  ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES -enableCodeCoverage YES \
+  clean build test | xcpretty -c
+
+# tvOS (CI: tvOS.yml)
+cd MixpanelDemo && set -o pipefail && xcodebuild -scheme MixpanelDemoTV -derivedDataPath Build/ \
+  -destination 'platform=tvOS Simulator,name=Apple TV' -configuration Debug \
+  ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES -enableCodeCoverage YES \
+  clean build test | xcpretty -c
 
 # SPM compile check (works locally; not used in CI)
 swift build
@@ -44,15 +56,16 @@ sh ./scripts/format-swift.sh <files...>   # or no args to format the whole repo
 
 - Config: `.swift-format` (lineLength **120**, 4-space indent, `trailingCommas: neverUsed`,
   `indentSwitchCaseLabels: true`). A `.githooks/pre-commit` hook checks staged files.
-- CI (`pr-checks.yml`): **PR titles must match `^(feat|fix|chore|release): .+$`** (blocking);
-  swift-format check is informational; a blocking-adjacent awk step rejects trailing commas.
+- CI (`pr-checks.yml`): **PR titles must match `^(feat|fix|chore|release): .+$`** (blocking).
+  The entire `format-check` job — swift-format diff AND the trailing-comma scan — is
+  `continue-on-error: true`, i.e. informational only; the pre-commit hook is the real gate.
 - Scheme gotcha: only `MixpanelDemo` and the watch schemes are **shared**;
   `MixpanelDemoMac`/`MixpanelDemoTV` are targets relying on Xcode's implicit scheme creation.
 - No watchOS test target or CI exists.
 
 ### Testing conventions
 
-- iOS suite `MixpanelDemo/MixpanelDemoTests/` (15 files) is the superset; Mac mirrors part of
+- iOS suite `MixpanelDemo/MixpanelDemoTests/` (16 files) is the superset; Mac mirrors part of
   it (9 files, separate copy of the base class); TV has 3 files that do **not** use the base class.
 - Base class `MixpanelBaseTests` helpers take the instance as an argument:
   `waitForTrackingQueue(_ mixpanel:)`, `flushAndWaitForTrackingQueue(_ mixpanel:)`,
@@ -77,8 +90,9 @@ Mixpanel (static facade) → MixpanelManager registry → MixpanelInstance (per 
   Auth is `Basic base64("<token>:")`. Second endpoint: POST `/flags/<id>/first-time-events`.
   ⚠️ `serverURL.didSet` on the instance updates only the flush path; `FeatureFlagManager`
   snapshots `serverURL` at init.
-- **Persistence**: `MPDB` — one SQLite file `<sanitizedName>_MPDB.sqlite` (Library dir on iOS,
-  Caches elsewhere), WAL mode, tables `mixpanel_<token>_{events,people,groups}` with schema
+- **Persistence**: `MPDB` — one SQLite file `<sanitizedInstanceName>_MPDB.sqlite` (Library dir
+  on iOS, Caches elsewhere), WAL mode, tables `mixpanel_<sanitizedInstanceName>_{events,people,groups}`
+  (keyed by **instanceName**, which defaults to the token but can differ) with schema
   `(id, data blob, time real, flag integer)`; `flag` marks un-identified People rows, flipped by
   `identifyPeople`. `MixpanelPersistence` also owns UserDefaults (suite `"Mixpanel"`, keys
   prefixed `mixpanel-<instanceName>-`) for identity, super properties, timed events, opt-out,
@@ -90,13 +104,17 @@ Mixpanel (static facade) → MixpanelManager registry → MixpanelInstance (per 
   `flushBatchSize` clamps to 50 (`APIConstants.maxBatchSize`). No OperationQueue anywhere.
 - **Lifecycle**: didBecomeActive starts the timer; willResignActive stops it; iOS/tvOS
   didEnterBackground takes a background task + full flush (`flushOnBackground` default true).
-  No lifecycle listeners on watchOS or in app extensions (extensions flush on every track).
+  No lifecycle listeners on watchOS. On iOS/tvOS the listener setup skips app extensions
+  (which instead flush on every track), but the macOS branch registers its `NSApplication`
+  observers unconditionally.
 
 ## Public API & conventions
 
 - **Singleton per `instanceName`** (defaults to the token), registry in `MixpanelManager`;
-  most recently initialized becomes `mainInstance()`. `mainInstance()` **asserts in debug** if
-  uninitialized — `safeMainInstance()` is the non-asserting variant.
+  most recently initialized becomes `mainInstance()`. `mainInstance()` **asserts in debug on
+  device builds** if uninitialized (the assert is `#if !targetEnvironment(simulator)`, so
+  simulator runs — including the test suite — skip it) — `safeMainInstance()` is the
+  non-asserting variant.
 - `MixpanelOptions` is a plain `public init` with ~15 defaulted params — **not a builder**.
   ⚠️ Default divergence: `useGzipCompression` defaults **true** via `MixpanelOptions` but
   **false** via the legacy `initialize(token:...)` overloads.
@@ -108,16 +126,21 @@ Mixpanel (static facade) → MixpanelManager registry → MixpanelInstance (per 
 - Visibility: `open` for customer-overridable surface (`Mixpanel`, `MixpanelInstance`, `People`,
   `Group`, `Autocapture`); `public` for protocols/structs; `internal` for machinery
   (`Track`, `Flush`, `Network`, `MPDB`, `MixpanelPersistence`, `FeatureFlagManager`).
-  Delegates are `AnyObject`-constrained and held `weak`.
+  Delegates are `AnyObject`-constrained and held `weak` — with one exception:
+  `ProxyServerConfig` is a struct whose `delegate` is a strong `let` (and `MixpanelOptions`
+  retains the config), so a proxy delegate's lifetime is tied to the options object even
+  though `MixpanelInstance.proxyServerDelegate` itself is weak.
 - Locked state uses backing `_foo` + computed `foo` under `ReadWriteLock`
   (snapshot under lock → mutate copy → write back).
 - Platform gates to respect: automatic events, `minimumSessionDuration`/`maximumSessionDuration`
   do **not exist on watchOS**; reachability/`$wifi`/CoreTelephony are iOS-only
   (`!targetEnvironment(macCatalyst)`); `Autocapture` is manual screen-tracking API only
   (no UIKit hooking, no platform gate).
-- **CocoaPods gotcha**: the podspec ships `Sources/*.swift` on iOS but an explicit
-  `base_source_files` list on tvOS/macOS/watchOS — **adding a source file requires updating
-  the podspec list** or non-iOS pods silently miss it.
+- **New-source-file gotcha (two manifests)**: adding a file to `Sources/` is not enough.
+  (1) The podspec ships `Sources/*.swift` on iOS but an explicit `base_source_files` list on
+  tvOS/macOS/watchOS — update it or non-iOS pods silently miss the file. (2) `Mixpanel.xcodeproj`
+  enumerates every source in its build phases and is what Carthage builds
+  (`carthage build --no-skip-current`) — add the file there too or Carthage frameworks omit it.
 
 ## Release process
 
@@ -141,5 +164,6 @@ the real process).
 2. `sh ./scripts/format-swift.sh` on changed files (or rely on the pre-commit hook).
 3. PR title matches `^(feat|fix|chore|release): .+$`.
 4. No new dependencies; no breaking changes to `open`/`public` API.
-5. New source file? Update the podspec `base_source_files` list.
+5. New source file? Update BOTH the podspec `base_source_files` list AND the
+   `Mixpanel.xcodeproj` source build phases (Carthage builds the xcodeproj).
 6. New tests where behavior changed (iOS suite first; mirror to Mac when applicable).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,145 @@
+# AGENTS.md — Mixpanel Swift SDK
+
+Canonical instructions for AI coding agents (Claude Code, Cursor, Copilot, Codex, etc.).
+`CLAUDE.md` imports this file via `@AGENTS.md` — edit **this** file. Every fact below was
+verified against the code at v6.5.1; when code and doc disagree, trust the code and fix this file.
+
+**Mixpanel Swift SDK** — analytics library for Apple platforms (iOS, tvOS, macOS, watchOS).
+Ships via SPM, CocoaPods, and Carthage. ~8,000 lines across 25 Swift files, flat in `Sources/`.
+Prioritizes: never crash the host app, thread safety, backward compatibility.
+
+## Project configuration
+
+- Platforms: **iOS 12+, tvOS 12+, macOS 10.13+, watchOS 4+** (`Package.swift`, podspec agree)
+- `swift-tools-version: 5.3`; podspec `swift_version = '5.0'`; code must stay valid for
+  **Swift < 6.1** (CI rejects trailing commas in call sites)
+- Dependencies (only two, `Package.swift`): `mixpanel-swift-common` (event bridge),
+  `json-logic-swift`. **Do not add dependencies.**
+- Version `6.5.1` lives in **four synced places**: `Mixpanel-swift.podspec` (`s.version`),
+  `Info.plist` (`CFBundleShortVersionString`), `Sources/AutomaticProperties.swift`
+  (`libVersion()`), `scripts/generate_docs.sh` (`--module-version`). `Package.swift` carries
+  no version. Release tags have **no `v` prefix** (since 6.4.0).
+
+## Build, test, lint
+
+Tests live in the **demo app project**, not SPM — there is no `.testTarget` in `Package.swift`.
+
+```bash
+# iOS build + test (primary; what CI runs, from MixpanelDemo/)
+cd MixpanelDemo && xcodebuild -scheme MixpanelDemo -derivedDataPath Build/ \
+  -destination 'name=iPhone 17 Pro,OS=latest' -configuration Debug \
+  ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES -enableCodeCoverage YES \
+  clean build test | xcpretty -c
+
+# macOS / tvOS variants (CI: macOS.yml, tvOS.yml)
+cd MixpanelDemo && xcodebuild -scheme MixpanelDemoMac -destination 'platform=macOS,arch=arm64' ... clean build test | xcpretty -c
+cd MixpanelDemo && xcodebuild -scheme MixpanelDemoTV -destination 'platform=tvOS Simulator,name=Apple TV' ... clean build test | xcpretty -c
+
+# SPM compile check (works locally; not used in CI)
+swift build
+
+# Formatting — Apple swift-format, NOT SwiftLint (there is no .swiftlint.yml)
+sh ./scripts/format-swift.sh <files...>   # or no args to format the whole repo
+```
+
+- Config: `.swift-format` (lineLength **120**, 4-space indent, `trailingCommas: neverUsed`,
+  `indentSwitchCaseLabels: true`). A `.githooks/pre-commit` hook checks staged files.
+- CI (`pr-checks.yml`): **PR titles must match `^(feat|fix|chore|release): .+$`** (blocking);
+  swift-format check is informational; a blocking-adjacent awk step rejects trailing commas.
+- Scheme gotcha: only `MixpanelDemo` and the watch schemes are **shared**;
+  `MixpanelDemoMac`/`MixpanelDemoTV` are targets relying on Xcode's implicit scheme creation.
+- No watchOS test target or CI exists.
+
+### Testing conventions
+
+- iOS suite `MixpanelDemo/MixpanelDemoTests/` (15 files) is the superset; Mac mirrors part of
+  it (9 files, separate copy of the base class); TV has 3 files that do **not** use the base class.
+- Base class `MixpanelBaseTests` helpers take the instance as an argument:
+  `waitForTrackingQueue(_ mixpanel:)`, `flushAndWaitForTrackingQueue(_ mixpanel:)`,
+  plus `randomId()`, `removeDBfile(_ token:)` (call in teardown to delete SQLite files),
+  `waitForAsyncTasks()`, and queue readers (`eventQueue(token:)`, `peopleQueue(token:)`, …).
+
+## Architecture
+
+Producer-consumer over SQLite; **two network paths** sharing the `Network` base class:
+
+```
+Mixpanel (static facade) → MixpanelManager registry → MixpanelInstance (per instanceName)
+  ├─ track ─→ trackingQueue ─→ Track (builds envelope) ─→ MixpanelPersistence ─→ MPDB (SQLite)
+  ├─ flush ─→ trackingQueue (load batches) ─→ networkQueue ─→ Flush ─→ FlushRequest ─→ URLSession
+  └─ flags ─→ FeatureFlagManager ─→ Network directly (async GET /flags/, Basic auth)
+```
+
+- **Flush path** (`Flush`/`FlushRequest`): batches of ≤50, gzip (configurable), primary→backup-host
+  failover, retry backoff with `Retry-After`, **synchronous** send (semaphore, 120 s timeout).
+  On success, rows are deleted by id back on `trackingQueue`.
+- **Flags path** (`FeatureFlags.swift`): does NOT go through `Flush` — no gzip/backoff/backup-host.
+  Auth is `Basic base64("<token>:")`. Second endpoint: POST `/flags/<id>/first-time-events`.
+  ⚠️ `serverURL.didSet` on the instance updates only the flush path; `FeatureFlagManager`
+  snapshots `serverURL` at init.
+- **Persistence**: `MPDB` — one SQLite file `<sanitizedName>_MPDB.sqlite` (Library dir on iOS,
+  Caches elsewhere), WAL mode, tables `mixpanel_<token>_{events,people,groups}` with schema
+  `(id, data blob, time real, flag integer)`; `flag` marks un-identified People rows, flipped by
+  `identifyPeople`. `MixpanelPersistence` also owns UserDefaults (suite `"Mixpanel"`, keys
+  prefixed `mixpanel-<instanceName>-`) for identity, super properties, timed events, opt-out,
+  and the flags blob. Legacy NSKeyedArchiver→SQLite migration runs at init.
+- **Concurrency**: per-instance **serial** `trackingQueue` and `networkQueue` (labels
+  `com.mixpanel.<token>.tracking)`/`.network)` — the stray `)` is in the code);
+  `ReadWriteLock` = concurrent DispatchQueue with barrier writes; flush `Timer` on the main
+  queue, default interval **60 s** (0 disables; setting it also flushes immediately);
+  `flushBatchSize` clamps to 50 (`APIConstants.maxBatchSize`). No OperationQueue anywhere.
+- **Lifecycle**: didBecomeActive starts the timer; willResignActive stops it; iOS/tvOS
+  didEnterBackground takes a background task + full flush (`flushOnBackground` default true).
+  No lifecycle listeners on watchOS or in app extensions (extensions flush on every track).
+
+## Public API & conventions
+
+- **Singleton per `instanceName`** (defaults to the token), registry in `MixpanelManager`;
+  most recently initialized becomes `mainInstance()`. `mainInstance()` **asserts in debug** if
+  uninitialized — `safeMainInstance()` is the non-asserting variant.
+- `MixpanelOptions` is a plain `public init` with ~15 defaulted params — **not a builder**.
+  ⚠️ Default divergence: `useGzipCompression` defaults **true** via `MixpanelOptions` but
+  **false** via the legacy `initialize(token:...)` overloads.
+- Platform-split init: on iOS/tvOS/visionOS `trackAutomaticEvents:` is required (no default);
+  on macOS/watchOS it defaults to `false`.
+- **Error philosophy — fail soft + log**: catch, `MixpanelLogger.warn/error`, return nil/false;
+  never crash release builds. `MPAssert`/`assertPropertyTypes` trap **only in debug**.
+  Logging is off by default (`loggingEnabled = true` to enable).
+- Visibility: `open` for customer-overridable surface (`Mixpanel`, `MixpanelInstance`, `People`,
+  `Group`, `Autocapture`); `public` for protocols/structs; `internal` for machinery
+  (`Track`, `Flush`, `Network`, `MPDB`, `MixpanelPersistence`, `FeatureFlagManager`).
+  Delegates are `AnyObject`-constrained and held `weak`.
+- Locked state uses backing `_foo` + computed `foo` under `ReadWriteLock`
+  (snapshot under lock → mutate copy → write back).
+- Platform gates to respect: automatic events, `minimumSessionDuration`/`maximumSessionDuration`
+  do **not exist on watchOS**; reachability/`$wifi`/CoreTelephony are iOS-only
+  (`!targetEnvironment(macCatalyst)`); `Autocapture` is manual screen-tracking API only
+  (no UIKit hooking, no platform gate).
+- **CocoaPods gotcha**: the podspec ships `Sources/*.swift` on iOS but an explicit
+  `base_source_files` list on tvOS/macOS/watchOS — **adding a source file requires updating
+  the podspec list** or non-iOS pods silently miss it.
+
+## Release process
+
+Three manual `workflow_dispatch` workflows, driven by `.github/modules.json`
+(module `analytics`: podspec path, `version_files`, empty `tag_prefix`).
+**`scripts/release.py` is dead code — do not use it** (it tags with a `v` prefix, contradicting
+the real process).
+
+1. **`prepare-release.yml`** — bumps the four version locations, regenerates Jazzy `docs/`,
+   prepends the changelog, opens a `release/<version>` PR (idempotent; title matches the PR gate).
+2. **`release-spm.yml`** (master only, `release` environment) — validates versions everywhere,
+   `pod lib lint`, Carthage smoke build, creates the annotated tag (immutable — never re-tag),
+   drafts the GitHub Release from the changelog.
+3. **`release-cocoapod.yml`** (`release-cocoapods` environment, manual approval;
+   secret `COCOAPODS_TRUNK_TOKEN`) — re-validates inside the tag, `pod trunk push`.
+   Finish by publishing the draft GitHub Release.
+
+## Validation before a PR
+
+1. Build + test iOS (and macOS/tvOS when the change is platform-relevant).
+2. `sh ./scripts/format-swift.sh` on changed files (or rely on the pre-commit hook).
+3. PR title matches `^(feat|fix|chore|release): .+$`.
+4. No new dependencies; no breaking changes to `open`/`public` API.
+5. New source file? Update the podspec `base_source_files` list.
+6. New tests where behavior changed (iOS suite first; mirror to Mac when applicable).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

Gives AI coding agents accurate, token-efficient context at session start — mirroring mixpanel/mixpanel-android#1005. Unlike the Android repo, this repo had almost no agent scaffolding (only a stale `copilot-instructions.md`), so this is creation from **audited facts**: two parallel code audits gathered `file:line` evidence for every claim before anything was written.

### Added
- **`AGENTS.md`** (root) — the cross-tool standard file (Codex, Cursor, Copilot, etc. read it natively). Router-style, verified content: exact CI build/test commands, the two-network-path architecture (flush pipeline vs feature flags), SQLite/UserDefaults persistence model, queue/lock concurrency model, platform gates (e.g. no automatic events on watchOS), API conventions and gotchas (podspec `base_source_files` must be updated when adding files; `useGzipCompression` default divergence; scheme-sharing trap), and the real 3-step `workflow_dispatch` release chain driven by `.github/modules.json`.
- **`CLAUDE.md`** — one-line `@AGENTS.md` import (Claude Code's documented bridge; it does not read AGENTS.md natively).

### Fixed — `.github/copilot-instructions.md` had drifted badly
| Stale claim | Reality |
|---|---|
| podspec version 5.1.3 | 6.5.1 (4 minor releases behind) |
| SwiftLint + `.swiftlint.yml` (incl. validation checklist step) | No SwiftLint anywhere; repo uses **Apple swift-format** (`.swift-format`, lineLength 120) + pre-commit hook + CI check |
| `release.yml` triggered on `v*` tags | Doesn't exist. Actual: `prepare-release.yml` → `release-spm.yml` → `release-cocoapod.yml`, all manual `workflow_dispatch`; tags have **no** `v` prefix since 6.4.0 |
| `scripts/release.py` as the version-bump process | Dead code — nothing references it, and it tags with a `v` prefix contradicting `modules.json` |
| tvOS 11+ | tvOS 12+ (`Package.swift`, podspec) |
| CI destination iPhone 15 | iPhone 17 Pro |
| "~6,000 lines" / `MixpanelInstance` "~1000 lines" | 7,988 lines / 1,906 lines |
| Test helper signatures | `waitForTrackingQueue(_:)`/`flushAndWaitForTrackingQueue(_:)` take a `MixpanelInstance` argument |

It's now a lean pointer to `AGENTS.md` plus essentials, for Copilot surfaces that only read this file.

### ⚠️ Reviewer decision: `.gitignore` change
`CLAUDE.md` was deliberately gitignored in May 2025 (#670, "Claude.ai instructions") — presumably when it held personal scratch notes. This PR **unignores it** so the committed one-line `@AGENTS.md` bridge reaches all clones; `.claude/*` (personal settings) stays ignored. If keeping it ignored is preferred, drop the second commit and Claude Code users can create the bridge locally.

## Validation
- All load-bearing claims spot-checked against source after the audits (podspec version, `.swift-format` config, no tracked swiftlint file, CI destinations, PR-title regex, `modules.json` tag prefix, tvOS min, `libVersion()`, source file/line counts).
- Docs-only change; no source or CI behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)