### PR TITLE
feat: autocapture (beta) — clicks, rage clicks and dead clicks

### DIFF
--- a/Mixpanel-swift.podspec
+++ b/Mixpanel-swift.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
   }
 
   s.subspec 'Complete' do |ss|
-    ss.ios.source_files = ['Sources/*.swift']
+    ss.ios.source_files = ['Sources/**/*.swift']
     ss.tvos.source_files = base_source_files
     ss.osx.source_files = base_source_files
     ss.watchos.source_files = base_source_files

--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		0AA1DE0DA9BEA10750F15ECD /* TouchInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04558C747B60EA2884344AC4 /* TouchInterceptor.swift */; };
+		1609F42C30385B9900C152B9 /* AutocaptureOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B29F5E5066FADE60A88040 /* AutocaptureOptions.swift */; };
+		1609F42D30385BA200C152B9 /* AutocaptureOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B29F5E5066FADE60A88040 /* AutocaptureOptions.swift */; };
+		1609F42E30385BAA00C152B9 /* AutocaptureOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B29F5E5066FADE60A88040 /* AutocaptureOptions.swift */; };
 		16178FD12F687EE200E022F2 /* jsonlogic in Frameworks */ = {isa = PBXBuildFile; productRef = 17JSONLOGIC00000002 /* jsonlogic */; };
 		16178FD22F687EE200E022F2 /* jsonlogic in Frameworks */ = {isa = PBXBuildFile; productRef = 17JSONLOGIC00000003 /* jsonlogic */; };
 		16178FD32F687EE200E022F2 /* jsonlogic in Frameworks */ = {isa = PBXBuildFile; productRef = 17JSONLOGIC00000004 /* jsonlogic */; };
@@ -29,6 +32,8 @@
 		17C6547B2BB1F16000C8A126 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1728208D2BA8BDE4002CD973 /* PrivacyInfo.xcprivacy */; };
 		17C6547C2BB1F16400C8A126 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1728208D2BA8BDE4002CD973 /* PrivacyInfo.xcprivacy */; };
 		17C6547D2BB1F16800C8A126 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1728208D2BA8BDE4002CD973 /* PrivacyInfo.xcprivacy */; };
+		1A2B3C4D5E6F70819AB0C001 /* ElementIdExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70819AB0C004 /* ElementIdExtractor.swift */; };
+		1A2B3C4D5E6F70819AB0C002 /* ElementIdExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70819AB0C003 /* ElementIdExtractor.swift */; };
 		2A5D30DD0C468327425DC577 /* AutocaptureOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B29F5E5066FADE60A88040 /* AutocaptureOptions.swift */; };
 		2DAF6E6DB83491224C2FAD66 /* TouchInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F39A9A035CD63B87C7C4C8E7 /* TouchInterceptor.swift */; };
 		48D1B82CD01A008022E3D759 /* AutocaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AFC14475BD4DC3722712CA /* AutocaptureManager.swift */; };
@@ -62,7 +67,6 @@
 		86F86EC222443A1300B69832 /* Track.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11594A01D01C597007F8B4F /* Track.swift */; };
 		86F86EC422443A2300B69832 /* ReadWriteLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9614161F3BB87700C3EF3E /* ReadWriteLock.swift */; };
 		86F86EC522443A2C00B69832 /* People.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15FF7C71D0435670076CDE3 /* People.swift */; };
-		AC10CA0002000001 /* Autocapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC10CA0001000001 /* Autocapture.swift */; };
 		86F86EC622443A3100B69832 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1982BFE1D0AC2E2006B7330 /* Error.swift */; };
 		86F86EC722443A3C00B69832 /* FileLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD56811D306B7B0045D3DB /* FileLogging.swift */; };
 		86F86EC922443A4700B69832 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D335CD1D30578E00E68E12 /* Constants.swift */; };
@@ -77,8 +81,10 @@
 		A18176D6C7255FA1611B3BF1 /* SemanticExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06325D1AC34056FFA59B35DF /* SemanticExtractor.swift */; };
 		A5507733A1B4945D84E53B33 /* SemanticExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DC0B63B575B53F8DE3BF79 /* SemanticExtractor.swift */; };
 		A9364BC8EBB564C53ADC5156 /* AutocaptureOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60F434067003D809DE25DFE /* AutocaptureOptions.swift */; };
-		1A2B3C4D5E6F70819AB0C001 /* ElementIdExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70819AB0C004 /* ElementIdExtractor.swift */; };
-		1A2B3C4D5E6F70819AB0C002 /* ElementIdExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70819AB0C003 /* ElementIdExtractor.swift */; };
+		AC10CA0002000001 /* Autocapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC10CA0001000001 /* Autocapture.swift */; };
+		AC10CA0002000002 /* Autocapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC10CA0001000001 /* Autocapture.swift */; };
+		AC10CA0002000003 /* Autocapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC10CA0001000001 /* Autocapture.swift */; };
+		AC10CA0002000004 /* Autocapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC10CA0001000001 /* Autocapture.swift */; };
 		BB9614171F3BB87700C3EF3E /* ReadWriteLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9614161F3BB87700C3EF3E /* ReadWriteLock.swift */; };
 		C694CF0F56D88BC591A0054A /* DeadClickDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99155E36042EDC3C22F18B45 /* DeadClickDetector.swift */; };
 		E10D118D1EC0F30900195CCD /* AutomaticEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E151FA371E70DFB5002EF53D /* AutomaticEvents.swift */; };
@@ -99,14 +105,12 @@
 		E12782C41D4AB5CB0025FB05 /* FlushRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D335CB1D303A0D00E68E12 /* FlushRequest.swift */; };
 		E12782C51D4AB5CB0025FB05 /* Track.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11594A01D01C597007F8B4F /* Track.swift */; };
 		E12782C61D4AB5CB0025FB05 /* People.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15FF7C71D0435670076CDE3 /* People.swift */; };
-		AC10CA0002000003 /* Autocapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC10CA0001000001 /* Autocapture.swift */; };
 		E12782C71D4AB5CB0025FB05 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1982BFE1D0AC2E2006B7330 /* Error.swift */; };
 		E12782C81D4AB5CB0025FB05 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D335CD1D30578E00E68E12 /* Constants.swift */; };
 		E12782C91D4AB5CB0025FB05 /* AutomaticProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D335CF1D3059A800E68E12 /* AutomaticProperties.swift */; };
 		E151FA381E70DFB5002EF53D /* AutomaticEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E151FA371E70DFB5002EF53D /* AutomaticEvents.swift */; };
 		E15FF7C61D02C9E10076CDE3 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E15FF7C51D02C9E10076CDE3 /* CoreTelephony.framework */; };
 		E15FF7C81D0435670076CDE3 /* People.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15FF7C71D0435670076CDE3 /* People.swift */; };
-		AC10CA0002000002 /* Autocapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC10CA0001000001 /* Autocapture.swift */; };
 		E165228F1D6781DF000D5949 /* MixpanelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E165228E1D6781DF000D5949 /* MixpanelType.swift */; };
 		E16522901D67D421000D5949 /* MixpanelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E165228E1D6781DF000D5949 /* MixpanelType.swift */; };
 		E19052001F9548F000900E5D /* ReadWriteLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9614161F3BB87700C3EF3E /* ReadWriteLock.swift */; };
@@ -133,7 +137,6 @@
 		E1F15FE21E64B60D00391AE3 /* Flush.swift in Sources */ = {isa = PBXBuildFile; fileRef = E115949E1D01BE14007F8B4F /* Flush.swift */; };
 		E1F15FE31E64B60D00391AE3 /* Track.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11594A01D01C597007F8B4F /* Track.swift */; };
 		E1F15FE41E64B60D00391AE3 /* People.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15FF7C71D0435670076CDE3 /* People.swift */; };
-		AC10CA0002000004 /* Autocapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC10CA0001000001 /* Autocapture.swift */; };
 		E2281F33D7C441677B124788 /* RageClickTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53AF035597E8943FA5E9E2F0 /* RageClickTracker.swift */; };
 		EA0C3E40CD32AC89419401FF /* ClickEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A88BBA466C3B88E18FCA33 /* ClickEvent.swift */; };
 /* End PBXBuildFile section */
@@ -144,9 +147,10 @@
 		171E4C112DAF108400B7CB11 /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
 		171E4C162DAF2B3100B7CB11 /* MixpanelOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelOptions.swift; sourceTree = "<group>"; };
 		1728208D2BA8BDE4002CD973 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Sources/Mixpanel/PrivacyInfo.xcprivacy; sourceTree = SOURCE_ROOT; };
+		1A2B3C4D5E6F70819AB0C003 /* ElementIdExtractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ElementIdExtractor.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F70819AB0C004 /* ElementIdExtractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElementIdExtractor.swift; path = Sources/Autocapture/ElementIdExtractor.swift; sourceTree = "<group>"; };
 		1CD6F1660CF2314121E328BE /* DeadClickDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DeadClickDetector.swift; path = Sources/Autocapture/DeadClickDetector.swift; sourceTree = "<group>"; };
 		38B29F5E5066FADE60A88040 /* AutocaptureOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AutocaptureOptions.swift; sourceTree = "<group>"; };
-		1A2B3C4D5E6F70819AB0C003 /* ElementIdExtractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ElementIdExtractor.swift; sourceTree = "<group>"; };
 		51DD56791D306B740045D3DB /* MixpanelLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MixpanelLogger.swift; sourceTree = "<group>"; };
 		51DD56801D306B7B0045D3DB /* PrintLogging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrintLogging.swift; sourceTree = "<group>"; };
 		51DD56811D306B7B0045D3DB /* FileLogging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileLogging.swift; sourceTree = "<group>"; };
@@ -163,9 +167,9 @@
 		99155E36042EDC3C22F18B45 /* DeadClickDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeadClickDetector.swift; sourceTree = "<group>"; };
 		99F9956D2BF2A5F6398C0A59 /* AutocaptureManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AutocaptureManager.swift; sourceTree = "<group>"; };
 		A6AFC14475BD4DC3722712CA /* AutocaptureManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AutocaptureManager.swift; path = Sources/Autocapture/AutocaptureManager.swift; sourceTree = "<group>"; };
+		AC10CA0001000001 /* Autocapture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Autocapture.swift; sourceTree = "<group>"; };
 		BB9614161F3BB87700C3EF3E /* ReadWriteLock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadWriteLock.swift; sourceTree = "<group>"; };
 		D60F434067003D809DE25DFE /* AutocaptureOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AutocaptureOptions.swift; path = Sources/Autocapture/AutocaptureOptions.swift; sourceTree = "<group>"; };
-		1A2B3C4D5E6F70819AB0C004 /* ElementIdExtractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElementIdExtractor.swift; path = Sources/Autocapture/ElementIdExtractor.swift; sourceTree = "<group>"; };
 		E115947D1CFF1491007F8B4F /* Mixpanel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mixpanel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E11594821CFF1491007F8B4F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Info.plist; sourceTree = "<group>"; };
 		E115948A1CFF1538007F8B4F /* Mixpanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mixpanel.swift; sourceTree = "<group>"; };
@@ -178,7 +182,6 @@
 		E151FA371E70DFB5002EF53D /* AutomaticEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutomaticEvents.swift; sourceTree = "<group>"; };
 		E15FF7C51D02C9E10076CDE3 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
 		E15FF7C71D0435670076CDE3 /* People.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = People.swift; sourceTree = "<group>"; };
-		AC10CA0001000001 /* Autocapture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Autocapture.swift; sourceTree = "<group>"; };
 		E165228E1D6781DF000D5949 /* MixpanelType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MixpanelType.swift; sourceTree = "<group>"; };
 		E190522C1F9FC1BC00900E5D /* SessionMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMetadata.swift; sourceTree = "<group>"; };
 		E1982BFE1D0AC2E2006B7330 /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
@@ -230,6 +233,21 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1609F42B30385B7F00C152B9 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				A6AFC14475BD4DC3722712CA /* AutocaptureManager.swift */,
+				D60F434067003D809DE25DFE /* AutocaptureOptions.swift */,
+				1A2B3C4D5E6F70819AB0C004 /* ElementIdExtractor.swift */,
+				1CD6F1660CF2314121E328BE /* DeadClickDetector.swift */,
+				8BC47FE0246899E1C4E424FA /* RageClickTracker.swift */,
+				74DC0B63B575B53F8DE3BF79 /* SemanticExtractor.swift */,
+				F39A9A035CD63B87C7C4C8E7 /* TouchInterceptor.swift */,
+				87A88BBA466C3B88E18FCA33 /* ClickEvent.swift */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
 		1651FD832F83B6F10065BB7E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -257,7 +275,6 @@
 				06325D1AC34056FFA59B35DF /* SemanticExtractor.swift */,
 				04558C747B60EA2884344AC4 /* TouchInterceptor.swift */,
 			);
-			name = Autocapture;
 			path = Autocapture;
 			sourceTree = "<group>";
 		};
@@ -284,7 +301,6 @@
 			children = (
 				7F6AD00C3E5DEC0700973C08 /* ClickEvent.swift */,
 			);
-			name = Model;
 			path = Model;
 			sourceTree = "<group>";
 		};
@@ -294,6 +310,7 @@
 				E115947F1CFF1491007F8B4F /* Mixpanel */,
 				1651FD832F83B6F10065BB7E /* Frameworks */,
 				E115947E1CFF1491007F8B4F /* Products */,
+				1609F42B30385B7F00C152B9 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -602,6 +619,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1609F42E30385BAA00C152B9 /* AutocaptureOptions.swift in Sources */,
 				86F86EF7224554B900B69832 /* Group.swift in Sources */,
 				86F86ECA22443A4C00B69832 /* SessionMetadata.swift in Sources */,
 				86F86EC922443A4700B69832 /* Constants.swift in Sources */,
@@ -682,6 +700,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1609F42C30385B9900C152B9 /* AutocaptureOptions.swift in Sources */,
 				67FF65E521878416005161FA /* Group.swift in Sources */,
 				E12782BB1D4AB5CB0025FB05 /* PrintLogging.swift in Sources */,
 				E12782BC1D4AB5CB0025FB05 /* FileLogging.swift in Sources */,
@@ -714,6 +733,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1609F42D30385BA200C152B9 /* AutocaptureOptions.swift in Sources */,
 				67FF65E421878414005161FA /* Group.swift in Sources */,
 				E1F15FE01E64B60D00391AE3 /* MixpanelInstance.swift in Sources */,
 				E1F15FDF1E64B60D00391AE3 /* Mixpanel.swift in Sources */,

--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -32,17 +32,12 @@
 		17C6547B2BB1F16000C8A126 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1728208D2BA8BDE4002CD973 /* PrivacyInfo.xcprivacy */; };
 		17C6547C2BB1F16400C8A126 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1728208D2BA8BDE4002CD973 /* PrivacyInfo.xcprivacy */; };
 		17C6547D2BB1F16800C8A126 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1728208D2BA8BDE4002CD973 /* PrivacyInfo.xcprivacy */; };
-		1A2B3C4D5E6F70819AB0C001 /* ElementIdExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70819AB0C004 /* ElementIdExtractor.swift */; };
 		1A2B3C4D5E6F70819AB0C002 /* ElementIdExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70819AB0C003 /* ElementIdExtractor.swift */; };
 		2A5D30DD0C468327425DC577 /* AutocaptureOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B29F5E5066FADE60A88040 /* AutocaptureOptions.swift */; };
-		2DAF6E6DB83491224C2FAD66 /* TouchInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F39A9A035CD63B87C7C4C8E7 /* TouchInterceptor.swift */; };
-		48D1B82CD01A008022E3D759 /* AutocaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AFC14475BD4DC3722712CA /* AutocaptureManager.swift */; };
 		4FB79FD4199BD2C1AEA83B1C /* AutocaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99F9956D2BF2A5F6398C0A59 /* AutocaptureManager.swift */; };
 		51DD567C1D306B740045D3DB /* MixpanelLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD56791D306B740045D3DB /* MixpanelLogger.swift */; };
 		51DD56831D306B7B0045D3DB /* PrintLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD56801D306B7B0045D3DB /* PrintLogging.swift */; };
 		51DD56841D306B7B0045D3DB /* FileLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD56811D306B7B0045D3DB /* FileLogging.swift */; };
-		5C6E56DD87033A7A76E027E7 /* RageClickTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC47FE0246899E1C4E424FA /* RageClickTracker.swift */; };
-		662C13B6649508B946312234 /* DeadClickDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CD6F1660CF2314121E328BE /* DeadClickDetector.swift */; };
 		673ABE3A21360CBE00B1784B /* Group.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673ABE3921360CBE00B1784B /* Group.swift */; };
 		67FF65E421878414005161FA /* Group.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673ABE3921360CBE00B1784B /* Group.swift */; };
 		67FF65E521878416005161FA /* Group.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673ABE3921360CBE00B1784B /* Group.swift */; };
@@ -79,8 +74,6 @@
 		95ECF06A2C9B851B006364D2 /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95ECF0662C9B83D8006364D2 /* Data+Compression.swift */; };
 		95ECF06B2C9B851C006364D2 /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95ECF0662C9B83D8006364D2 /* Data+Compression.swift */; };
 		A18176D6C7255FA1611B3BF1 /* SemanticExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06325D1AC34056FFA59B35DF /* SemanticExtractor.swift */; };
-		A5507733A1B4945D84E53B33 /* SemanticExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DC0B63B575B53F8DE3BF79 /* SemanticExtractor.swift */; };
-		A9364BC8EBB564C53ADC5156 /* AutocaptureOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60F434067003D809DE25DFE /* AutocaptureOptions.swift */; };
 		AC10CA0002000001 /* Autocapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC10CA0001000001 /* Autocapture.swift */; };
 		AC10CA0002000002 /* Autocapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC10CA0001000001 /* Autocapture.swift */; };
 		AC10CA0002000003 /* Autocapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC10CA0001000001 /* Autocapture.swift */; };
@@ -138,7 +131,6 @@
 		E1F15FE31E64B60D00391AE3 /* Track.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11594A01D01C597007F8B4F /* Track.swift */; };
 		E1F15FE41E64B60D00391AE3 /* People.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15FF7C71D0435670076CDE3 /* People.swift */; };
 		E2281F33D7C441677B124788 /* RageClickTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53AF035597E8943FA5E9E2F0 /* RageClickTracker.swift */; };
-		EA0C3E40CD32AC89419401FF /* ClickEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A88BBA466C3B88E18FCA33 /* ClickEvent.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -148,28 +140,21 @@
 		171E4C162DAF2B3100B7CB11 /* MixpanelOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelOptions.swift; sourceTree = "<group>"; };
 		1728208D2BA8BDE4002CD973 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Sources/Mixpanel/PrivacyInfo.xcprivacy; sourceTree = SOURCE_ROOT; };
 		1A2B3C4D5E6F70819AB0C003 /* ElementIdExtractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ElementIdExtractor.swift; sourceTree = "<group>"; };
-		1A2B3C4D5E6F70819AB0C004 /* ElementIdExtractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElementIdExtractor.swift; path = Sources/Autocapture/ElementIdExtractor.swift; sourceTree = "<group>"; };
-		1CD6F1660CF2314121E328BE /* DeadClickDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DeadClickDetector.swift; path = Sources/Autocapture/DeadClickDetector.swift; sourceTree = "<group>"; };
 		38B29F5E5066FADE60A88040 /* AutocaptureOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AutocaptureOptions.swift; sourceTree = "<group>"; };
 		51DD56791D306B740045D3DB /* MixpanelLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MixpanelLogger.swift; sourceTree = "<group>"; };
 		51DD56801D306B7B0045D3DB /* PrintLogging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrintLogging.swift; sourceTree = "<group>"; };
 		51DD56811D306B7B0045D3DB /* FileLogging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileLogging.swift; sourceTree = "<group>"; };
 		53AF035597E8943FA5E9E2F0 /* RageClickTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RageClickTracker.swift; sourceTree = "<group>"; };
 		673ABE3921360CBE00B1784B /* Group.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Group.swift; sourceTree = "<group>"; };
-		74DC0B63B575B53F8DE3BF79 /* SemanticExtractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SemanticExtractor.swift; path = Sources/Autocapture/SemanticExtractor.swift; sourceTree = "<group>"; };
 		7F6AD00C3E5DEC0700973C08 /* ClickEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClickEvent.swift; sourceTree = "<group>"; };
 		8625BEBA26D045CE0009BAA9 /* MPDB.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPDB.swift; sourceTree = "<group>"; };
 		868550AB2699096F001FCDDC /* MixpanelPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelPersistence.swift; sourceTree = "<group>"; };
 		86F86E81224404BD00B69832 /* Mixpanel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mixpanel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		87A88BBA466C3B88E18FCA33 /* ClickEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ClickEvent.swift; path = Sources/Autocapture/Model/ClickEvent.swift; sourceTree = "<group>"; };
-		8BC47FE0246899E1C4E424FA /* RageClickTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RageClickTracker.swift; path = Sources/Autocapture/RageClickTracker.swift; sourceTree = "<group>"; };
 		95ECF0662C9B83D8006364D2 /* Data+Compression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Compression.swift"; sourceTree = "<group>"; };
 		99155E36042EDC3C22F18B45 /* DeadClickDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeadClickDetector.swift; sourceTree = "<group>"; };
 		99F9956D2BF2A5F6398C0A59 /* AutocaptureManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AutocaptureManager.swift; sourceTree = "<group>"; };
-		A6AFC14475BD4DC3722712CA /* AutocaptureManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AutocaptureManager.swift; path = Sources/Autocapture/AutocaptureManager.swift; sourceTree = "<group>"; };
 		AC10CA0001000001 /* Autocapture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Autocapture.swift; sourceTree = "<group>"; };
 		BB9614161F3BB87700C3EF3E /* ReadWriteLock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadWriteLock.swift; sourceTree = "<group>"; };
-		D60F434067003D809DE25DFE /* AutocaptureOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AutocaptureOptions.swift; path = Sources/Autocapture/AutocaptureOptions.swift; sourceTree = "<group>"; };
 		E115947D1CFF1491007F8B4F /* Mixpanel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mixpanel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E11594821CFF1491007F8B4F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Info.plist; sourceTree = "<group>"; };
 		E115948A1CFF1538007F8B4F /* Mixpanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mixpanel.swift; sourceTree = "<group>"; };
@@ -189,7 +174,6 @@
 		E1D335CD1D30578E00E68E12 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		E1D335CF1D3059A800E68E12 /* AutomaticProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutomaticProperties.swift; sourceTree = "<group>"; };
 		E1F15FC91E64A10700391AE3 /* Mixpanel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mixpanel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F39A9A035CD63B87C7C4C8E7 /* TouchInterceptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TouchInterceptor.swift; path = Sources/Autocapture/TouchInterceptor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -233,21 +217,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		1609F42B30385B7F00C152B9 /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-				A6AFC14475BD4DC3722712CA /* AutocaptureManager.swift */,
-				D60F434067003D809DE25DFE /* AutocaptureOptions.swift */,
-				1A2B3C4D5E6F70819AB0C004 /* ElementIdExtractor.swift */,
-				1CD6F1660CF2314121E328BE /* DeadClickDetector.swift */,
-				8BC47FE0246899E1C4E424FA /* RageClickTracker.swift */,
-				74DC0B63B575B53F8DE3BF79 /* SemanticExtractor.swift */,
-				F39A9A035CD63B87C7C4C8E7 /* TouchInterceptor.swift */,
-				87A88BBA466C3B88E18FCA33 /* ClickEvent.swift */,
-			);
-			name = "Recovered References";
-			sourceTree = "<group>";
-		};
 		1651FD832F83B6F10065BB7E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -310,7 +279,6 @@
 				E115947F1CFF1491007F8B4F /* Mixpanel */,
 				1651FD832F83B6F10065BB7E /* Frameworks */,
 				E115947E1CFF1491007F8B4F /* Products */,
-				1609F42B30385B7F00C152B9 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -677,14 +645,6 @@
 				51DD56841D306B7B0045D3DB /* FileLogging.swift in Sources */,
 				E1D335CC1D303A0D00E68E12 /* FlushRequest.swift in Sources */,
 				E115948B1CFF1538007F8B4F /* Mixpanel.swift in Sources */,
-				48D1B82CD01A008022E3D759 /* AutocaptureManager.swift in Sources */,
-				A9364BC8EBB564C53ADC5156 /* AutocaptureOptions.swift in Sources */,
-				1A2B3C4D5E6F70819AB0C001 /* ElementIdExtractor.swift in Sources */,
-				662C13B6649508B946312234 /* DeadClickDetector.swift in Sources */,
-				5C6E56DD87033A7A76E027E7 /* RageClickTracker.swift in Sources */,
-				A5507733A1B4945D84E53B33 /* SemanticExtractor.swift in Sources */,
-				2DAF6E6DB83491224C2FAD66 /* TouchInterceptor.swift in Sources */,
-				EA0C3E40CD32AC89419401FF /* ClickEvent.swift in Sources */,
 				4FB79FD4199BD2C1AEA83B1C /* AutocaptureManager.swift in Sources */,
 				2A5D30DD0C468327425DC577 /* AutocaptureOptions.swift in Sources */,
 				1A2B3C4D5E6F70819AB0C002 /* ElementIdExtractor.swift in Sources */,

--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0AA1DE0DA9BEA10750F15ECD /* TouchInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04558C747B60EA2884344AC4 /* TouchInterceptor.swift */; };
 		16178FD12F687EE200E022F2 /* jsonlogic in Frameworks */ = {isa = PBXBuildFile; productRef = 17JSONLOGIC00000002 /* jsonlogic */; };
 		16178FD22F687EE200E022F2 /* jsonlogic in Frameworks */ = {isa = PBXBuildFile; productRef = 17JSONLOGIC00000003 /* jsonlogic */; };
 		16178FD32F687EE200E022F2 /* jsonlogic in Frameworks */ = {isa = PBXBuildFile; productRef = 17JSONLOGIC00000004 /* jsonlogic */; };
@@ -23,13 +24,20 @@
 		171E4C182DAF2B3100B7CB11 /* MixpanelOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171E4C162DAF2B3100B7CB11 /* MixpanelOptions.swift */; };
 		171E4C192DAF2B3100B7CB11 /* MixpanelOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171E4C162DAF2B3100B7CB11 /* MixpanelOptions.swift */; };
 		171E4C1A2DAF2B3100B7CB11 /* MixpanelOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171E4C162DAF2B3100B7CB11 /* MixpanelOptions.swift */; };
+		1791E3CAF5CEAABAE27B3420 /* ClickEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F6AD00C3E5DEC0700973C08 /* ClickEvent.swift */; };
 		17C6547A2BB1F15C00C8A126 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1728208D2BA8BDE4002CD973 /* PrivacyInfo.xcprivacy */; };
 		17C6547B2BB1F16000C8A126 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1728208D2BA8BDE4002CD973 /* PrivacyInfo.xcprivacy */; };
 		17C6547C2BB1F16400C8A126 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1728208D2BA8BDE4002CD973 /* PrivacyInfo.xcprivacy */; };
 		17C6547D2BB1F16800C8A126 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1728208D2BA8BDE4002CD973 /* PrivacyInfo.xcprivacy */; };
+		2A5D30DD0C468327425DC577 /* AutocaptureOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B29F5E5066FADE60A88040 /* AutocaptureOptions.swift */; };
+		2DAF6E6DB83491224C2FAD66 /* TouchInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F39A9A035CD63B87C7C4C8E7 /* TouchInterceptor.swift */; };
+		48D1B82CD01A008022E3D759 /* AutocaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AFC14475BD4DC3722712CA /* AutocaptureManager.swift */; };
+		4FB79FD4199BD2C1AEA83B1C /* AutocaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99F9956D2BF2A5F6398C0A59 /* AutocaptureManager.swift */; };
 		51DD567C1D306B740045D3DB /* MixpanelLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD56791D306B740045D3DB /* MixpanelLogger.swift */; };
 		51DD56831D306B7B0045D3DB /* PrintLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD56801D306B7B0045D3DB /* PrintLogging.swift */; };
 		51DD56841D306B7B0045D3DB /* FileLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DD56811D306B7B0045D3DB /* FileLogging.swift */; };
+		5C6E56DD87033A7A76E027E7 /* RageClickTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC47FE0246899E1C4E424FA /* RageClickTracker.swift */; };
+		662C13B6649508B946312234 /* DeadClickDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CD6F1660CF2314121E328BE /* DeadClickDetector.swift */; };
 		673ABE3A21360CBE00B1784B /* Group.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673ABE3921360CBE00B1784B /* Group.swift */; };
 		67FF65E421878414005161FA /* Group.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673ABE3921360CBE00B1784B /* Group.swift */; };
 		67FF65E521878416005161FA /* Group.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673ABE3921360CBE00B1784B /* Group.swift */; };
@@ -66,7 +74,11 @@
 		95ECF0692C9B851B006364D2 /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95ECF0662C9B83D8006364D2 /* Data+Compression.swift */; };
 		95ECF06A2C9B851B006364D2 /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95ECF0662C9B83D8006364D2 /* Data+Compression.swift */; };
 		95ECF06B2C9B851C006364D2 /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95ECF0662C9B83D8006364D2 /* Data+Compression.swift */; };
+		A18176D6C7255FA1611B3BF1 /* SemanticExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06325D1AC34056FFA59B35DF /* SemanticExtractor.swift */; };
+		A5507733A1B4945D84E53B33 /* SemanticExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DC0B63B575B53F8DE3BF79 /* SemanticExtractor.swift */; };
+		A9364BC8EBB564C53ADC5156 /* AutocaptureOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60F434067003D809DE25DFE /* AutocaptureOptions.swift */; };
 		BB9614171F3BB87700C3EF3E /* ReadWriteLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9614161F3BB87700C3EF3E /* ReadWriteLock.swift */; };
+		C694CF0F56D88BC591A0054A /* DeadClickDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99155E36042EDC3C22F18B45 /* DeadClickDetector.swift */; };
 		E10D118D1EC0F30900195CCD /* AutomaticEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E151FA371E70DFB5002EF53D /* AutomaticEvents.swift */; };
 		E115948B1CFF1538007F8B4F /* Mixpanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E115948A1CFF1538007F8B4F /* Mixpanel.swift */; };
 		E115948E1D000709007F8B4F /* MixpanelInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = E115948D1D000709007F8B4F /* MixpanelInstance.swift */; };
@@ -120,21 +132,36 @@
 		E1F15FE31E64B60D00391AE3 /* Track.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11594A01D01C597007F8B4F /* Track.swift */; };
 		E1F15FE41E64B60D00391AE3 /* People.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15FF7C71D0435670076CDE3 /* People.swift */; };
 		AC10CA0002000004 /* Autocapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC10CA0001000001 /* Autocapture.swift */; };
+		E2281F33D7C441677B124788 /* RageClickTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53AF035597E8943FA5E9E2F0 /* RageClickTracker.swift */; };
+		EA0C3E40CD32AC89419401FF /* ClickEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A88BBA466C3B88E18FCA33 /* ClickEvent.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		04558C747B60EA2884344AC4 /* TouchInterceptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TouchInterceptor.swift; sourceTree = "<group>"; };
+		06325D1AC34056FFA59B35DF /* SemanticExtractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SemanticExtractor.swift; sourceTree = "<group>"; };
 		171E4C112DAF108400B7CB11 /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
 		171E4C162DAF2B3100B7CB11 /* MixpanelOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelOptions.swift; sourceTree = "<group>"; };
 		1728208D2BA8BDE4002CD973 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Sources/Mixpanel/PrivacyInfo.xcprivacy; sourceTree = SOURCE_ROOT; };
+		1CD6F1660CF2314121E328BE /* DeadClickDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DeadClickDetector.swift; path = Sources/Autocapture/DeadClickDetector.swift; sourceTree = "<group>"; };
+		38B29F5E5066FADE60A88040 /* AutocaptureOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AutocaptureOptions.swift; sourceTree = "<group>"; };
 		51DD56791D306B740045D3DB /* MixpanelLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MixpanelLogger.swift; sourceTree = "<group>"; };
 		51DD56801D306B7B0045D3DB /* PrintLogging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrintLogging.swift; sourceTree = "<group>"; };
 		51DD56811D306B7B0045D3DB /* FileLogging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileLogging.swift; sourceTree = "<group>"; };
+		53AF035597E8943FA5E9E2F0 /* RageClickTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RageClickTracker.swift; sourceTree = "<group>"; };
 		673ABE3921360CBE00B1784B /* Group.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Group.swift; sourceTree = "<group>"; };
+		74DC0B63B575B53F8DE3BF79 /* SemanticExtractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SemanticExtractor.swift; path = Sources/Autocapture/SemanticExtractor.swift; sourceTree = "<group>"; };
+		7F6AD00C3E5DEC0700973C08 /* ClickEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClickEvent.swift; sourceTree = "<group>"; };
 		8625BEBA26D045CE0009BAA9 /* MPDB.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPDB.swift; sourceTree = "<group>"; };
 		868550AB2699096F001FCDDC /* MixpanelPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelPersistence.swift; sourceTree = "<group>"; };
 		86F86E81224404BD00B69832 /* Mixpanel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mixpanel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		87A88BBA466C3B88E18FCA33 /* ClickEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ClickEvent.swift; path = Sources/Autocapture/Model/ClickEvent.swift; sourceTree = "<group>"; };
+		8BC47FE0246899E1C4E424FA /* RageClickTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RageClickTracker.swift; path = Sources/Autocapture/RageClickTracker.swift; sourceTree = "<group>"; };
 		95ECF0662C9B83D8006364D2 /* Data+Compression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Compression.swift"; sourceTree = "<group>"; };
+		99155E36042EDC3C22F18B45 /* DeadClickDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeadClickDetector.swift; sourceTree = "<group>"; };
+		99F9956D2BF2A5F6398C0A59 /* AutocaptureManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AutocaptureManager.swift; sourceTree = "<group>"; };
+		A6AFC14475BD4DC3722712CA /* AutocaptureManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AutocaptureManager.swift; path = Sources/Autocapture/AutocaptureManager.swift; sourceTree = "<group>"; };
 		BB9614161F3BB87700C3EF3E /* ReadWriteLock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadWriteLock.swift; sourceTree = "<group>"; };
+		D60F434067003D809DE25DFE /* AutocaptureOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AutocaptureOptions.swift; path = Sources/Autocapture/AutocaptureOptions.swift; sourceTree = "<group>"; };
 		E115947D1CFF1491007F8B4F /* Mixpanel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mixpanel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E11594821CFF1491007F8B4F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Info.plist; sourceTree = "<group>"; };
 		E115948A1CFF1538007F8B4F /* Mixpanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mixpanel.swift; sourceTree = "<group>"; };
@@ -155,6 +182,7 @@
 		E1D335CD1D30578E00E68E12 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		E1D335CF1D3059A800E68E12 /* AutomaticProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutomaticProperties.swift; sourceTree = "<group>"; };
 		E1F15FC91E64A10700391AE3 /* Mixpanel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mixpanel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F39A9A035CD63B87C7C4C8E7 /* TouchInterceptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TouchInterceptor.swift; path = Sources/Autocapture/TouchInterceptor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -213,6 +241,21 @@
 			path = Mixpanel;
 			sourceTree = "<group>";
 		};
+		44C8A3159D6ED585B638A598 /* Autocapture */ = {
+			isa = PBXGroup;
+			children = (
+				CC6DD07E38E5B14C184263E3 /* Model */,
+				99F9956D2BF2A5F6398C0A59 /* AutocaptureManager.swift */,
+				38B29F5E5066FADE60A88040 /* AutocaptureOptions.swift */,
+				99155E36042EDC3C22F18B45 /* DeadClickDetector.swift */,
+				53AF035597E8943FA5E9E2F0 /* RageClickTracker.swift */,
+				06325D1AC34056FFA59B35DF /* SemanticExtractor.swift */,
+				04558C747B60EA2884344AC4 /* TouchInterceptor.swift */,
+			);
+			name = Autocapture;
+			path = Autocapture;
+			sourceTree = "<group>";
+		};
 		51DD56771D306B620045D3DB /* Log */ = {
 			isa = PBXGroup;
 			children = (
@@ -229,6 +272,15 @@
 				51DD56811D306B7B0045D3DB /* FileLogging.swift */,
 			);
 			name = Logging;
+			sourceTree = "<group>";
+		};
+		CC6DD07E38E5B14C184263E3 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				7F6AD00C3E5DEC0700973C08 /* ClickEvent.swift */,
+			);
+			name = Model;
+			path = Model;
 			sourceTree = "<group>";
 		};
 		E11594731CFF1491007F8B4F = {
@@ -270,6 +322,7 @@
 				E189D8FB1D5A6943007F3F29 /* Networking */,
 				51DD56771D306B620045D3DB /* Log */,
 				E189D8FA1D5A692A007F3F29 /* Utilities */,
+				44C8A3159D6ED585B638A598 /* Autocapture */,
 				E115948A1CFF1538007F8B4F /* Mixpanel.swift */,
 				E115948D1D000709007F8B4F /* MixpanelInstance.swift */,
 				171E4C112DAF108400B7CB11 /* FeatureFlags.swift */,
@@ -601,6 +654,20 @@
 				51DD56841D306B7B0045D3DB /* FileLogging.swift in Sources */,
 				E1D335CC1D303A0D00E68E12 /* FlushRequest.swift in Sources */,
 				E115948B1CFF1538007F8B4F /* Mixpanel.swift in Sources */,
+				48D1B82CD01A008022E3D759 /* AutocaptureManager.swift in Sources */,
+				A9364BC8EBB564C53ADC5156 /* AutocaptureOptions.swift in Sources */,
+				662C13B6649508B946312234 /* DeadClickDetector.swift in Sources */,
+				5C6E56DD87033A7A76E027E7 /* RageClickTracker.swift in Sources */,
+				A5507733A1B4945D84E53B33 /* SemanticExtractor.swift in Sources */,
+				2DAF6E6DB83491224C2FAD66 /* TouchInterceptor.swift in Sources */,
+				EA0C3E40CD32AC89419401FF /* ClickEvent.swift in Sources */,
+				4FB79FD4199BD2C1AEA83B1C /* AutocaptureManager.swift in Sources */,
+				2A5D30DD0C468327425DC577 /* AutocaptureOptions.swift in Sources */,
+				C694CF0F56D88BC591A0054A /* DeadClickDetector.swift in Sources */,
+				E2281F33D7C441677B124788 /* RageClickTracker.swift in Sources */,
+				A18176D6C7255FA1611B3BF1 /* SemanticExtractor.swift in Sources */,
+				0AA1DE0DA9BEA10750F15ECD /* TouchInterceptor.swift in Sources */,
+				1791E3CAF5CEAABAE27B3420 /* ClickEvent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Mixpanel.xcodeproj/project.pbxproj
+++ b/Mixpanel.xcodeproj/project.pbxproj
@@ -77,6 +77,8 @@
 		A18176D6C7255FA1611B3BF1 /* SemanticExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06325D1AC34056FFA59B35DF /* SemanticExtractor.swift */; };
 		A5507733A1B4945D84E53B33 /* SemanticExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DC0B63B575B53F8DE3BF79 /* SemanticExtractor.swift */; };
 		A9364BC8EBB564C53ADC5156 /* AutocaptureOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60F434067003D809DE25DFE /* AutocaptureOptions.swift */; };
+		1A2B3C4D5E6F70819AB0C001 /* ElementIdExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70819AB0C004 /* ElementIdExtractor.swift */; };
+		1A2B3C4D5E6F70819AB0C002 /* ElementIdExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70819AB0C003 /* ElementIdExtractor.swift */; };
 		BB9614171F3BB87700C3EF3E /* ReadWriteLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9614161F3BB87700C3EF3E /* ReadWriteLock.swift */; };
 		C694CF0F56D88BC591A0054A /* DeadClickDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99155E36042EDC3C22F18B45 /* DeadClickDetector.swift */; };
 		E10D118D1EC0F30900195CCD /* AutomaticEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E151FA371E70DFB5002EF53D /* AutomaticEvents.swift */; };
@@ -144,6 +146,7 @@
 		1728208D2BA8BDE4002CD973 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Sources/Mixpanel/PrivacyInfo.xcprivacy; sourceTree = SOURCE_ROOT; };
 		1CD6F1660CF2314121E328BE /* DeadClickDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DeadClickDetector.swift; path = Sources/Autocapture/DeadClickDetector.swift; sourceTree = "<group>"; };
 		38B29F5E5066FADE60A88040 /* AutocaptureOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AutocaptureOptions.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F70819AB0C003 /* ElementIdExtractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ElementIdExtractor.swift; sourceTree = "<group>"; };
 		51DD56791D306B740045D3DB /* MixpanelLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MixpanelLogger.swift; sourceTree = "<group>"; };
 		51DD56801D306B7B0045D3DB /* PrintLogging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrintLogging.swift; sourceTree = "<group>"; };
 		51DD56811D306B7B0045D3DB /* FileLogging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileLogging.swift; sourceTree = "<group>"; };
@@ -162,6 +165,7 @@
 		A6AFC14475BD4DC3722712CA /* AutocaptureManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AutocaptureManager.swift; path = Sources/Autocapture/AutocaptureManager.swift; sourceTree = "<group>"; };
 		BB9614161F3BB87700C3EF3E /* ReadWriteLock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadWriteLock.swift; sourceTree = "<group>"; };
 		D60F434067003D809DE25DFE /* AutocaptureOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AutocaptureOptions.swift; path = Sources/Autocapture/AutocaptureOptions.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F70819AB0C004 /* ElementIdExtractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElementIdExtractor.swift; path = Sources/Autocapture/ElementIdExtractor.swift; sourceTree = "<group>"; };
 		E115947D1CFF1491007F8B4F /* Mixpanel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mixpanel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E11594821CFF1491007F8B4F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Info.plist; sourceTree = "<group>"; };
 		E115948A1CFF1538007F8B4F /* Mixpanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mixpanel.swift; sourceTree = "<group>"; };
@@ -247,6 +251,7 @@
 				CC6DD07E38E5B14C184263E3 /* Model */,
 				99F9956D2BF2A5F6398C0A59 /* AutocaptureManager.swift */,
 				38B29F5E5066FADE60A88040 /* AutocaptureOptions.swift */,
+				1A2B3C4D5E6F70819AB0C003 /* ElementIdExtractor.swift */,
 				99155E36042EDC3C22F18B45 /* DeadClickDetector.swift */,
 				53AF035597E8943FA5E9E2F0 /* RageClickTracker.swift */,
 				06325D1AC34056FFA59B35DF /* SemanticExtractor.swift */,
@@ -656,6 +661,7 @@
 				E115948B1CFF1538007F8B4F /* Mixpanel.swift in Sources */,
 				48D1B82CD01A008022E3D759 /* AutocaptureManager.swift in Sources */,
 				A9364BC8EBB564C53ADC5156 /* AutocaptureOptions.swift in Sources */,
+				1A2B3C4D5E6F70819AB0C001 /* ElementIdExtractor.swift in Sources */,
 				662C13B6649508B946312234 /* DeadClickDetector.swift in Sources */,
 				5C6E56DD87033A7A76E027E7 /* RageClickTracker.swift in Sources */,
 				A5507733A1B4945D84E53B33 /* SemanticExtractor.swift in Sources */,
@@ -663,6 +669,7 @@
 				EA0C3E40CD32AC89419401FF /* ClickEvent.swift in Sources */,
 				4FB79FD4199BD2C1AEA83B1C /* AutocaptureManager.swift in Sources */,
 				2A5D30DD0C468327425DC577 /* AutocaptureOptions.swift in Sources */,
+				1A2B3C4D5E6F70819AB0C002 /* ElementIdExtractor.swift in Sources */,
 				C694CF0F56D88BC591A0054A /* DeadClickDetector.swift in Sources */,
 				E2281F33D7C441677B124788 /* RageClickTracker.swift in Sources */,
 				A18176D6C7255FA1611B3BF1 /* SemanticExtractor.swift in Sources */,

--- a/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
+++ b/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
@@ -25,7 +25,6 @@
 		673ABE4321405A0500B1784B /* MixpanelGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673ABE4221405A0500B1784B /* MixpanelGroupTests.swift */; };
 		7F3A4B5C6D7E8F9A0B1C2D3E /* MixpanelScreenTrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D5E6F7A8B9C0D1E2F3A4B5C /* MixpanelScreenTrackingTests.swift */; };
 		7E01564E4913076E148AE9E1 /* AutocaptureSwiftUIInstrumentedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B0A4D17C3AB8AF617801F4 /* AutocaptureSwiftUIInstrumentedTests.swift */; };
-		8A2F3B5C1D9E7A4B0C6F8D2E /* AutocaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4D6E8F2A1B3C5D7E0F9A4B /* AutocaptureTests.swift */; };
 		860BE3132072B85D00C12F18 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 860BE30F2072B83E00C12F18 /* CoreTelephony.framework */; };
 		860BE3712076FBCC00C12F18 /* GDPRViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 860BE3702076FBCC00C12F18 /* GDPRViewController.swift */; };
 		862773E3206B3B1D00CBE79E /* MixpanelOptOutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862773E2206B3B1D00CBE79E /* MixpanelOptOutTests.swift */; };
@@ -66,7 +65,6 @@
 		86F86F2E22460B4F00B69832 /* Mixpanel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E16C35E41D872045003500AC /* Mixpanel.framework */; };
 		86F86F2F22460B4F00B69832 /* Mixpanel.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E16C35E41D872045003500AC /* Mixpanel.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8A2F3B5C1D9E7A4B0C6F8D2E /* AutocaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4D6E8F2A1B3C5D7E0F9A4B /* AutocaptureTests.swift */; };
-		A4E1266DF2B6E40D2408CB44 /* AutocaptureUIKitInstrumentedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EE1ACA2C88917BC782B4D6 /* AutocaptureUIKitInstrumentedTests.swift */; };
 		A4E1266DF2B6E40D2408CB44 /* AutocaptureUIKitInstrumentedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EE1ACA2C88917BC782B4D6 /* AutocaptureUIKitInstrumentedTests.swift */; };
 		C5D8E3F2A7B1094C6E2D3F9A /* AutocaptureWalkUpInstrumentedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F7A2D19E4C06853D1F7B8A /* AutocaptureWalkUpInstrumentedTests.swift */; };
 		A88996800DA044B4B1886E99 /* MixpanelScreenTrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8D4E5F3A1B2C7D8E9F0A1B /* MixpanelScreenTrackingTests.swift */; };
@@ -851,12 +849,14 @@
 				E15FF7D01D0461130076CDE3 /* Frameworks */,
 				E15FF7D11D0461130076CDE3 /* Resources */,
 				E15FF8001D0461D70076CDE3 /* Embed Frameworks */,
+				86F86EB522440C6000B69832 /* Embed Watch Content */,
 				60DDD15223D39621004F7CBB /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				E15FF7FF1D0461D70076CDE3 /* PBXTargetDependency */,
+				86F86EA722440C6000B69832 /* PBXTargetDependency */,
 			);
 			name = MixpanelDemo;
 			productName = MixpanelDemo;

--- a/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
+++ b/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
@@ -66,10 +66,13 @@
 		86F86F2F22460B4F00B69832 /* Mixpanel.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E16C35E41D872045003500AC /* Mixpanel.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8A2F3B5C1D9E7A4B0C6F8D2E /* AutocaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4D6E8F2A1B3C5D7E0F9A4B /* AutocaptureTests.swift */; };
 		A4E1266DF2B6E40D2408CB44 /* AutocaptureUIKitInstrumentedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EE1ACA2C88917BC782B4D6 /* AutocaptureUIKitInstrumentedTests.swift */; };
-		A88996800DA044B4B1886E99 /* MixpanelScreenTrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8D4E5F3A1B2C7D8E9F0A1B /* MixpanelScreenTrackingTests.swift */; };
 		A4E1266DF2B6E40D2408CB44 /* AutocaptureUIKitInstrumentedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EE1ACA2C88917BC782B4D6 /* AutocaptureUIKitInstrumentedTests.swift */; };
+		C5D8E3F2A7B1094C6E2D3F9A /* AutocaptureWalkUpInstrumentedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F7A2D19E4C06853D1F7B8A /* AutocaptureWalkUpInstrumentedTests.swift */; };
+		A88996800DA044B4B1886E99 /* MixpanelScreenTrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8D4E5F3A1B2C7D8E9F0A1B /* MixpanelScreenTrackingTests.swift */; };
 		B1AB7B0E940444B7A9B0876A /* MixpanelEventBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DA802B4623D45938280B06A /* MixpanelEventBridgeTests.swift */; };
 		B6C3E0B03160EF7DDB69AAAB /* SwiftUIAutocaptureTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83EAF4BE599F7053770EA4B /* SwiftUIAutocaptureTestView.swift */; };
+		F1A1B1C1D1E1F101A2B2C2D2 /* SwiftUIWalkUpTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A1B1C1D1E1F101A2B2C2D3 /* SwiftUIWalkUpTestView.swift */; };
+		F2A2B2C2D2E2F202A3B3C3D3 /* UIKitWalkUpTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A2B2C2D2E2F202A3B3C3D4 /* UIKitWalkUpTestViewController.swift */; };
 		B984558A6D6A347FB5E78676 /* UIKitAutocaptureTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531CEA4F4E84AE3A52284BC0 /* UIKitAutocaptureTestViewController.swift */; };
 		B1AD8EC39EFE /* AutocaptureMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1ACFF63A6F0 /* AutocaptureMenuViewController.swift */; };
 		C1A2B3C4D5E6F708192A3B4C /* ComplexUIKitStressTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4D5E6F708192A3B4C /* ComplexUIKitStressTestViewController.swift */; };
@@ -285,6 +288,7 @@
 		2D5E6F7A8B9C0D1E2F3A4B5C /* MixpanelScreenTrackingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MixpanelScreenTrackingTests.swift; sourceTree = "<group>"; };
 		3018131FE6FE484786E6788E /* MixpanelScreenTrackingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MixpanelScreenTrackingTests.swift; sourceTree = "<group>"; };
 		41EE1ACA2C88917BC782B4D6 /* AutocaptureUIKitInstrumentedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AutocaptureUIKitInstrumentedTests.swift; sourceTree = "<group>"; };
+		B3F7A2D19E4C06853D1F7B8A /* AutocaptureWalkUpInstrumentedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AutocaptureWalkUpInstrumentedTests.swift; sourceTree = "<group>"; };
 		51DD56891D3077390045D3DB /* LoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
 		531CEA4F4E84AE3A52284BC0 /* UIKitAutocaptureTestViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIKitAutocaptureTestViewController.swift; sourceTree = "<group>"; };
 		B1ACFF63A6F0 /* AutocaptureMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocaptureMenuViewController.swift; sourceTree = "<group>"; };
@@ -347,6 +351,8 @@
 		9C4D6E8F2A1B3C5D7E0F9A4B /* AutocaptureTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AutocaptureTests.swift; sourceTree = "<group>"; };
 		9C8D4E5F3A1B2C7D8E9F0A1B /* MixpanelScreenTrackingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MixpanelScreenTrackingTests.swift; sourceTree = "<group>"; };
 		A83EAF4BE599F7053770EA4B /* SwiftUIAutocaptureTestView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwiftUIAutocaptureTestView.swift; sourceTree = "<group>"; };
+		F1A1B1C1D1E1F101A2B2C2D3 /* SwiftUIWalkUpTestView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwiftUIWalkUpTestView.swift; sourceTree = "<group>"; };
+		F2A2B2C2D2E2F202A3B3C3D4 /* UIKitWalkUpTestViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIKitWalkUpTestViewController.swift; sourceTree = "<group>"; };
 		B0454269B91B8DAD46D580E9 /* MixpanelAutomaticEventsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MixpanelAutomaticEventsTests.swift; sourceTree = "<group>"; };
 		B34EFF52AF7D4D6BACA89305 /* MixpanelEventBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelEventBridgeTests.swift; sourceTree = "<group>"; };
 		E1016E351D3D46DF00075BB7 /* ActionCompleteViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionCompleteViewController.swift; sourceTree = "<group>"; };
@@ -642,6 +648,8 @@
 				D1A2B3C4D5E6F708192A3B4C /* ComplexUIKitStressTestViewController.swift */,
 				B1ACFF63A6F0 /* AutocaptureMenuViewController.swift */,
 				D2A2B3C4D5E6F708192A3B4C /* ComplexSwiftUIStressTestView.swift */,
+				F1A1B1C1D1E1F101A2B2C2D3 /* SwiftUIWalkUpTestView.swift */,
+				F2A2B2C2D2E2F202A3B3C3D4 /* UIKitWalkUpTestViewController.swift */,
 				SC3N3D3L30A7E0001A2B3C4D /* SceneDelegate.swift */,
 			);
 			path = MixpanelDemo;
@@ -669,6 +677,7 @@
 				E12BD03A1D8A14D6008989C9 /* Supporting Files */,
 				9C4D6E8F2A1B3C5D7E0F9A4B /* AutocaptureTests.swift */,
 				41EE1ACA2C88917BC782B4D6 /* AutocaptureUIKitInstrumentedTests.swift */,
+				B3F7A2D19E4C06853D1F7B8A /* AutocaptureWalkUpInstrumentedTests.swift */,
 				73B0A4D17C3AB8AF617801F4 /* AutocaptureSwiftUIInstrumentedTests.swift */,
 			);
 			path = MixpanelDemoTests;
@@ -1181,6 +1190,8 @@
 				C1A2B3C4D5E6F708192A3B4C /* ComplexUIKitStressTestViewController.swift in Sources */,
 				B1AD8EC39EFE /* AutocaptureMenuViewController.swift in Sources */,
 				C2A2B3C4D5E6F708192A3B4C /* ComplexSwiftUIStressTestView.swift in Sources */,
+				F1A1B1C1D1E1F101A2B2C2D2 /* SwiftUIWalkUpTestView.swift in Sources */,
+				F2A2B2C2D2E2F202A3B3C3D3 /* UIKitWalkUpTestViewController.swift in Sources */,
 				SC3N3D3L30A7E0011A2B3C4D /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1207,6 +1218,7 @@
 				174563BA2DD74E9ABE905B9A /* MixpanelScreenTrackingTests.swift in Sources */,
 				8A2F3B5C1D9E7A4B0C6F8D2E /* AutocaptureTests.swift in Sources */,
 				A4E1266DF2B6E40D2408CB44 /* AutocaptureUIKitInstrumentedTests.swift in Sources */,
+				C5D8E3F2A7B1094C6E2D3F9A /* AutocaptureWalkUpInstrumentedTests.swift in Sources */,
 				7E01564E4913076E148AE9E1 /* AutocaptureSwiftUIInstrumentedTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2013,7 +2025,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
-				IPHONEOS_DEPLOYMENT_TARGET = "$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -2029,7 +2040,6 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = MixpanelDemoTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = "$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
+++ b/MixpanelDemo/MixpanelDemo.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		671EECAF21432E5F006DD9FA /* GroupsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 671EECAE21432E5F006DD9FA /* GroupsViewController.swift */; };
 		673ABE4321405A0500B1784B /* MixpanelGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673ABE4221405A0500B1784B /* MixpanelGroupTests.swift */; };
 		7F3A4B5C6D7E8F9A0B1C2D3E /* MixpanelScreenTrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D5E6F7A8B9C0D1E2F3A4B5C /* MixpanelScreenTrackingTests.swift */; };
+		7E01564E4913076E148AE9E1 /* AutocaptureSwiftUIInstrumentedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B0A4D17C3AB8AF617801F4 /* AutocaptureSwiftUIInstrumentedTests.swift */; };
+		8A2F3B5C1D9E7A4B0C6F8D2E /* AutocaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4D6E8F2A1B3C5D7E0F9A4B /* AutocaptureTests.swift */; };
 		860BE3132072B85D00C12F18 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 860BE30F2072B83E00C12F18 /* CoreTelephony.framework */; };
 		860BE3712076FBCC00C12F18 /* GDPRViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 860BE3702076FBCC00C12F18 /* GDPRViewController.swift */; };
 		862773E3206B3B1D00CBE79E /* MixpanelOptOutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862773E2206B3B1D00CBE79E /* MixpanelOptOutTests.swift */; };
@@ -62,8 +64,16 @@
 		86F86F2122460B3300B69832 /* MixpanelDemoTVUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F86F2022460B3300B69832 /* MixpanelDemoTVUITests.swift */; };
 		86F86F2E22460B4F00B69832 /* Mixpanel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E16C35E41D872045003500AC /* Mixpanel.framework */; };
 		86F86F2F22460B4F00B69832 /* Mixpanel.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E16C35E41D872045003500AC /* Mixpanel.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8A2F3B5C1D9E7A4B0C6F8D2E /* AutocaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4D6E8F2A1B3C5D7E0F9A4B /* AutocaptureTests.swift */; };
+		A4E1266DF2B6E40D2408CB44 /* AutocaptureUIKitInstrumentedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EE1ACA2C88917BC782B4D6 /* AutocaptureUIKitInstrumentedTests.swift */; };
 		A88996800DA044B4B1886E99 /* MixpanelScreenTrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8D4E5F3A1B2C7D8E9F0A1B /* MixpanelScreenTrackingTests.swift */; };
+		A4E1266DF2B6E40D2408CB44 /* AutocaptureUIKitInstrumentedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EE1ACA2C88917BC782B4D6 /* AutocaptureUIKitInstrumentedTests.swift */; };
 		B1AB7B0E940444B7A9B0876A /* MixpanelEventBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DA802B4623D45938280B06A /* MixpanelEventBridgeTests.swift */; };
+		B6C3E0B03160EF7DDB69AAAB /* SwiftUIAutocaptureTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83EAF4BE599F7053770EA4B /* SwiftUIAutocaptureTestView.swift */; };
+		B984558A6D6A347FB5E78676 /* UIKitAutocaptureTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531CEA4F4E84AE3A52284BC0 /* UIKitAutocaptureTestViewController.swift */; };
+		B1AD8EC39EFE /* AutocaptureMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1ACFF63A6F0 /* AutocaptureMenuViewController.swift */; };
+		C1A2B3C4D5E6F708192A3B4C /* ComplexUIKitStressTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4D5E6F708192A3B4C /* ComplexUIKitStressTestViewController.swift */; };
+		C2A2B3C4D5E6F708192A3B4C /* ComplexSwiftUIStressTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A2B3C4D5E6F708192A3B4C /* ComplexSwiftUIStressTestView.swift */; };
 		E1016E361D3D46DF00075BB7 /* ActionCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1016E351D3D46DF00075BB7 /* ActionCompleteViewController.swift */; };
 		E12406201D249B2500383635 /* MixpanelBaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E124061F1D249B2500383635 /* MixpanelBaseTests.swift */; };
 		E12BD03D1D8A14F3008989C9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E12BD03C1D8A14F3008989C9 /* Assets.xcassets */; };
@@ -82,6 +92,7 @@
 		E1C61EBE1D22F9F60056C56C /* TestConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C61EBD1D22F9F60056C56C /* TestConstants.swift */; };
 		E1C8F50C1EC244E90089C537 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1C8F50B1EC244E90089C537 /* StoreKit.framework */; };
 		EC34FF3FE7F841898A805160 /* MixpanelEventBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34EFF52AF7D4D6BACA89305 /* MixpanelEventBridgeTests.swift */; };
+		SC3N3D3L30A7E0011A2B3C4D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = SC3N3D3L30A7E0001A2B3C4D /* SceneDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -273,10 +284,16 @@
 		1A1B2C3D4E5F60718293A5B1 /* MixpanelExcludePropertiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelExcludePropertiesTests.swift; sourceTree = "<group>"; };
 		2D5E6F7A8B9C0D1E2F3A4B5C /* MixpanelScreenTrackingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MixpanelScreenTrackingTests.swift; sourceTree = "<group>"; };
 		3018131FE6FE484786E6788E /* MixpanelScreenTrackingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MixpanelScreenTrackingTests.swift; sourceTree = "<group>"; };
+		41EE1ACA2C88917BC782B4D6 /* AutocaptureUIKitInstrumentedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AutocaptureUIKitInstrumentedTests.swift; sourceTree = "<group>"; };
 		51DD56891D3077390045D3DB /* LoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
+		531CEA4F4E84AE3A52284BC0 /* UIKitAutocaptureTestViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIKitAutocaptureTestViewController.swift; sourceTree = "<group>"; };
+		B1ACFF63A6F0 /* AutocaptureMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocaptureMenuViewController.swift; sourceTree = "<group>"; };
+		D1A2B3C4D5E6F708192A3B4C /* ComplexUIKitStressTestViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComplexUIKitStressTestViewController.swift; sourceTree = "<group>"; };
+		D2A2B3C4D5E6F708192A3B4C /* ComplexSwiftUIStressTestView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComplexSwiftUIStressTestView.swift; sourceTree = "<group>"; };
 		60CB587023D77F9200F1632B /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		671EECAE21432E5F006DD9FA /* GroupsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GroupsViewController.swift; sourceTree = "<group>"; };
 		673ABE4221405A0500B1784B /* MixpanelGroupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MixpanelGroupTests.swift; sourceTree = "<group>"; };
+		73B0A4D17C3AB8AF617801F4 /* AutocaptureSwiftUIInstrumentedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AutocaptureSwiftUIInstrumentedTests.swift; sourceTree = "<group>"; };
 		7DA802B4623D45938280B06A /* MixpanelEventBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelEventBridgeTests.swift; sourceTree = "<group>"; };
 		860BE30F2072B83E00C12F18 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
 		860BE3702076FBCC00C12F18 /* GDPRViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GDPRViewController.swift; sourceTree = "<group>"; };
@@ -327,7 +344,9 @@
 		86F86F2022460B3300B69832 /* MixpanelDemoTVUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelDemoTVUITests.swift; sourceTree = "<group>"; };
 		86F86F2222460B3300B69832 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8C72DDD552B64791AD52E1DC /* MixpanelEventBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelEventBridgeTests.swift; sourceTree = "<group>"; };
+		9C4D6E8F2A1B3C5D7E0F9A4B /* AutocaptureTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AutocaptureTests.swift; sourceTree = "<group>"; };
 		9C8D4E5F3A1B2C7D8E9F0A1B /* MixpanelScreenTrackingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MixpanelScreenTrackingTests.swift; sourceTree = "<group>"; };
+		A83EAF4BE599F7053770EA4B /* SwiftUIAutocaptureTestView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwiftUIAutocaptureTestView.swift; sourceTree = "<group>"; };
 		B0454269B91B8DAD46D580E9 /* MixpanelAutomaticEventsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MixpanelAutomaticEventsTests.swift; sourceTree = "<group>"; };
 		B34EFF52AF7D4D6BACA89305 /* MixpanelEventBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixpanelEventBridgeTests.swift; sourceTree = "<group>"; };
 		E1016E351D3D46DF00075BB7 /* ActionCompleteViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionCompleteViewController.swift; sourceTree = "<group>"; };
@@ -351,6 +370,7 @@
 		E1C61EB91D22F6470056C56C /* MixpanelPeopleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MixpanelPeopleTests.swift; sourceTree = "<group>"; };
 		E1C61EBD1D22F9F60056C56C /* TestConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestConstants.swift; sourceTree = "<group>"; };
 		E1C8F50B1EC244E90089C537 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
+		SC3N3D3L30A7E0001A2B3C4D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -617,6 +637,12 @@
 				E1016E351D3D46DF00075BB7 /* ActionCompleteViewController.swift */,
 				860BE3702076FBCC00C12F18 /* GDPRViewController.swift */,
 				E146F1971D398D2D00D75B49 /* Supporting Files */,
+				531CEA4F4E84AE3A52284BC0 /* UIKitAutocaptureTestViewController.swift */,
+				A83EAF4BE599F7053770EA4B /* SwiftUIAutocaptureTestView.swift */,
+				D1A2B3C4D5E6F708192A3B4C /* ComplexUIKitStressTestViewController.swift */,
+				B1ACFF63A6F0 /* AutocaptureMenuViewController.swift */,
+				D2A2B3C4D5E6F708192A3B4C /* ComplexSwiftUIStressTestView.swift */,
+				SC3N3D3L30A7E0001A2B3C4D /* SceneDelegate.swift */,
 			);
 			path = MixpanelDemo;
 			sourceTree = "<group>";
@@ -641,6 +667,9 @@
 				E1C61EBD1D22F9F60056C56C /* TestConstants.swift */,
 				51DD56891D3077390045D3DB /* LoggerTests.swift */,
 				E12BD03A1D8A14D6008989C9 /* Supporting Files */,
+				9C4D6E8F2A1B3C5D7E0F9A4B /* AutocaptureTests.swift */,
+				41EE1ACA2C88917BC782B4D6 /* AutocaptureUIKitInstrumentedTests.swift */,
+				73B0A4D17C3AB8AF617801F4 /* AutocaptureSwiftUIInstrumentedTests.swift */,
 			);
 			path = MixpanelDemoTests;
 			sourceTree = "<group>";
@@ -813,14 +842,12 @@
 				E15FF7D01D0461130076CDE3 /* Frameworks */,
 				E15FF7D11D0461130076CDE3 /* Resources */,
 				E15FF8001D0461D70076CDE3 /* Embed Frameworks */,
-				86F86EB522440C6000B69832 /* Embed Watch Content */,
 				60DDD15223D39621004F7CBB /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				E15FF7FF1D0461D70076CDE3 /* PBXTargetDependency */,
-				86F86EA722440C6000B69832 /* PBXTargetDependency */,
 			);
 			name = MixpanelDemo;
 			productName = MixpanelDemo;
@@ -1149,6 +1176,12 @@
 				671EECAF21432E5F006DD9FA /* GroupsViewController.swift in Sources */,
 				860BE3712076FBCC00C12F18 /* GDPRViewController.swift in Sources */,
 				E1016E361D3D46DF00075BB7 /* ActionCompleteViewController.swift in Sources */,
+				B984558A6D6A347FB5E78676 /* UIKitAutocaptureTestViewController.swift in Sources */,
+				B6C3E0B03160EF7DDB69AAAB /* SwiftUIAutocaptureTestView.swift in Sources */,
+				C1A2B3C4D5E6F708192A3B4C /* ComplexUIKitStressTestViewController.swift in Sources */,
+				B1AD8EC39EFE /* AutocaptureMenuViewController.swift in Sources */,
+				C2A2B3C4D5E6F708192A3B4C /* ComplexSwiftUIStressTestView.swift in Sources */,
+				SC3N3D3L30A7E0011A2B3C4D /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1172,6 +1205,9 @@
 				174205522F15A7210031EEDC /* MixpanelDeviceIdProviderTests.swift in Sources */,
 				B1AB7B0E940444B7A9B0876A /* MixpanelEventBridgeTests.swift in Sources */,
 				174563BA2DD74E9ABE905B9A /* MixpanelScreenTrackingTests.swift in Sources */,
+				8A2F3B5C1D9E7A4B0C6F8D2E /* AutocaptureTests.swift in Sources */,
+				A4E1266DF2B6E40D2408CB44 /* AutocaptureUIKitInstrumentedTests.swift in Sources */,
+				7E01564E4913076E148AE9E1 /* AutocaptureSwiftUIInstrumentedTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1492,7 +1528,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 5.1;
+				WATCHOS_DEPLOYMENT_TARGET = "$(RECOMMENDED_WATCHOS_DEPLOYMENT_TARGET)";
 			};
 			name = Debug;
 		};
@@ -1521,7 +1557,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 5.1;
+				WATCHOS_DEPLOYMENT_TARGET = "$(RECOMMENDED_WATCHOS_DEPLOYMENT_TARGET)";
 			};
 			name = Release;
 		};
@@ -1554,7 +1590,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 5.1;
+				WATCHOS_DEPLOYMENT_TARGET = "$(RECOMMENDED_WATCHOS_DEPLOYMENT_TARGET)";
 			};
 			name = Debug;
 		};
@@ -1586,7 +1622,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 5.1;
+				WATCHOS_DEPLOYMENT_TARGET = "$(RECOMMENDED_WATCHOS_DEPLOYMENT_TARGET)";
 			};
 			name = Release;
 		};
@@ -1903,7 +1939,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = MixpanelDemo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = "$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1933,7 +1969,7 @@
 				CURRENT_PROJECT_VERSION = 6;
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = MixpanelDemo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = "$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1977,6 +2013,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				IPHONEOS_DEPLOYMENT_TARGET = "$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1992,6 +2029,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = MixpanelDemoTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = "$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/MixpanelDemo/MixpanelDemo/AppDelegate.swift
+++ b/MixpanelDemo/MixpanelDemo/AppDelegate.swift
@@ -136,10 +136,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+        // Enable autocapture for testing
+        let autocaptureOptions = AutocaptureOptions()
+
         let mixpanelOptions = MixpanelOptions(
-            token: "MIXPANEL_TOKEN",
+            token: "YOUR_MIXPANEL_TOKEN",
             trackAutomaticEvents: true,
-            deviceIdProvider: deviceIdProvider
+            deviceIdProvider: deviceIdProvider,
+            autocaptureOptions: autocaptureOptions
         )
         Mixpanel.initialize(options: mixpanelOptions)
         Mixpanel.mainInstance().loggingEnabled = true

--- a/MixpanelDemo/MixpanelDemo/AutocaptureMenuViewController.swift
+++ b/MixpanelDemo/MixpanelDemo/AutocaptureMenuViewController.swift
@@ -1,0 +1,80 @@
+//
+//  AutocaptureMenuViewController.swift
+//  MixpanelDemo
+//
+//  Created by Mixpanel on 2026-07-28.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+import UIKit
+
+class AutocaptureMenuViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
+
+    private let tableView = UITableView(frame: .zero, style: .grouped)
+
+    private let items = [
+        "UIKit Autocapture Tests",
+        "SwiftUI Autocapture Tests",
+        "Stress Test UIKit (500+ views)",
+        "Stress Test SwiftUI (500+ views)",
+    ]
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Autocapture"
+        if #available(iOS 13.0, *) {
+            view.backgroundColor = .systemBackground
+        } else {
+            view.backgroundColor = .white
+        }
+
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(tableView)
+
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return items.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        cell.textLabel?.text = items[indexPath.row]
+        cell.accessoryType = .disclosureIndicator
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        switch indexPath.row {
+            case 0:
+                let vc = UIKitAutocaptureTestViewController()
+                navigationController?.pushViewController(vc, animated: true)
+            case 1:
+                if #available(iOS 14.0, *) {
+                    let vc = SwiftUIAutocaptureTestHostingController()
+                    navigationController?.pushViewController(vc, animated: true)
+                }
+            case 2:
+                let vc = ComplexUIKitStressTestViewController()
+                navigationController?.pushViewController(vc, animated: true)
+            case 3:
+                if #available(iOS 14.0, *) {
+                    let vc = ComplexSwiftUIStressTestHostingController()
+                    navigationController?.pushViewController(vc, animated: true)
+                }
+            default:
+                break
+        }
+    }
+}

--- a/MixpanelDemo/MixpanelDemo/AutocaptureMenuViewController.swift
+++ b/MixpanelDemo/MixpanelDemo/AutocaptureMenuViewController.swift
@@ -17,6 +17,8 @@ class AutocaptureMenuViewController: UIViewController, UITableViewDelegate, UITa
         "SwiftUI Autocapture Tests",
         "Stress Test UIKit (500+ views)",
         "Stress Test SwiftUI (500+ views)",
+        "UIKit Walk-Up Tests",
+        "SwiftUI Walk-Up Tests",
     ]
 
     override func viewDidLoad() {
@@ -71,6 +73,14 @@ class AutocaptureMenuViewController: UIViewController, UITableViewDelegate, UITa
             case 3:
                 if #available(iOS 14.0, *) {
                     let vc = ComplexSwiftUIStressTestHostingController()
+                    navigationController?.pushViewController(vc, animated: true)
+                }
+            case 4:
+                let vc = UIKitWalkUpTestViewController()
+                navigationController?.pushViewController(vc, animated: true)
+            case 5:
+                if #available(iOS 14.0, *) {
+                    let vc = SwiftUIWalkUpTestHostingController()
                     navigationController?.pushViewController(vc, animated: true)
                 }
             default:

--- a/MixpanelDemo/MixpanelDemo/Base.lproj/Main.storyboard
+++ b/MixpanelDemo/MixpanelDemo/Base.lproj/Main.storyboard
@@ -259,6 +259,29 @@
                                             <segue destination="wFR-dE-Xpq" kind="show" id="epT-UC-jqL"/>
                                         </connections>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="acp-Mn-u01">
+                                        <rect key="frame" x="0.0" y="444.5" width="375" height="80"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="acp-Mn-u01" id="acp-Cv-u02">
+                                            <rect key="frame" x="0.0" y="0.0" width="350.5" height="80"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Autocapture" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="acp-Lb-u03">
+                                                    <rect key="frame" x="15" y="29" width="95" height="22.5"/>
+                                                    <fontDescription key="fontDescription" name=".SFUIText" family=".SF UI Text" pointSize="20"/>
+                                                    <color key="textColor" red="0.20000000300000001" green="0.20000000300000001" blue="0.20000000300000001" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="acp-Lb-u03" firstAttribute="leading" secondItem="acp-Cv-u02" secondAttribute="leading" constant="15" id="acp-Cn-u04"/>
+                                                <constraint firstItem="acp-Lb-u03" firstAttribute="centerY" secondItem="acp-Cv-u02" secondAttribute="centerY" id="acp-Cn-u05"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="acp-Vc-u06" kind="show" id="acp-Sg-u07"/>
+                                        </connections>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                         </sections>
@@ -573,6 +596,21 @@
                 </view>
             </objects>
             <point key="canvasLocation" x="953" y="1137"/>
+        </scene>
+        <!--Autocapture-->
+        <scene sceneID="acp-Sc-u08">
+            <objects>
+                <viewController id="acp-Vc-u06" customClass="AutocaptureMenuViewController" customModule="MixpanelDemo" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="acp-Vw-u09">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" title="Autocapture" id="acp-Ni-u10"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="acp-Fr-u11" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2633" y="310"/>
         </scene>
     </scenes>
     <resources>

--- a/MixpanelDemo/MixpanelDemo/ComplexSwiftUIStressTestView.swift
+++ b/MixpanelDemo/MixpanelDemo/ComplexSwiftUIStressTestView.swift
@@ -64,20 +64,20 @@ struct ComplexSwiftUIStressTestView: View {
                 Text("Tap Count: \(tapCount)")
                     .font(.caption)
                     .foregroundColor(.secondary)
-                    .accessibilityLabel("stress_test_tap_count_swiftui")
+                    .accessibilityIdentifier("stress_test_tap_count_swiftui")
 
                 // MARK: - Search Bar
 
                 HStack(spacing: 8) {
                     TextField("Search products...", text: $searchText)
                         .padding(8)
-                        .accessibilityLabel("stress_search_field_swiftui")
+                        .accessibilityIdentifier("stress_search_field_swiftui")
 
                     Button(action: { tapCount += 1 }) {
                         Image(systemName: "magnifyingglass")
                             .foregroundColor(.blue)
                     }
-                    .accessibilityLabel("stress_search_button_swiftui")
+                    .accessibilityIdentifier("stress_search_button_swiftui")
                     .padding(.trailing, 8)
                 }
                 .background(Color.gray.opacity(0.12))
@@ -101,7 +101,7 @@ struct ComplexSwiftUIStressTestView: View {
                                     .foregroundColor(index == selectedCategory ? .white : .primary)
                                     .cornerRadius(16)
                             }
-                            .accessibilityLabel("category_chip_swiftui_\(index)")
+                            .accessibilityIdentifier("category_chip_swiftui_\(index)")
                         }
                     }
                     .padding(.horizontal, 4)
@@ -216,7 +216,7 @@ private struct StressTestProductCard: View {
                             .background(Color.blue)
                             .cornerRadius(6)
                     }
-                    .accessibilityLabel("add_to_cart_swiftui_\(index)")
+                    .accessibilityIdentifier("add_to_cart_swiftui_\(index)")
 
                     Spacer()
 
@@ -227,7 +227,7 @@ private struct StressTestProductCard: View {
                         Image(systemName: isFavorite ? "heart.fill" : "heart")
                             .foregroundColor(.pink)
                     }
-                    .accessibilityLabel("favorite_swiftui_\(index)")
+                    .accessibilityIdentifier("favorite_swiftui_\(index)")
                 }
             }
             .padding(.horizontal, 8)
@@ -237,7 +237,7 @@ private struct StressTestProductCard: View {
         .cornerRadius(10)
         .shadow(color: Color.black.opacity(0.05), radius: 3, y: 2)
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("Product \(index) \(name)")
+        .accessibilityIdentifier("Product \(index) \(name)")
     }
 }
 

--- a/MixpanelDemo/MixpanelDemo/ComplexSwiftUIStressTestView.swift
+++ b/MixpanelDemo/MixpanelDemo/ComplexSwiftUIStressTestView.swift
@@ -1,0 +1,280 @@
+//
+//  ComplexSwiftUIStressTestView.swift
+//  MixpanelDemo
+//
+//  Created by Mixpanel on 2026-07-27.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+import SwiftUI
+
+/// E-commerce product listing stress test screen with 500+ views in the view tree.
+///
+/// Uses ScrollView + VStack + ForEach (no view recycling via List/LazyVGrid) so all
+/// views remain in memory, enabling autocapture performance testing under heavy load.
+@available(iOS 14.0, *)
+struct ComplexSwiftUIStressTestView: View {
+    @State private var tapCount = 0
+    @State private var searchText = ""
+    @State private var selectedCategory = 0
+
+    private let categories = [
+        "Electronics", "Clothing", "Home & Garden", "Sports",
+        "Books", "Toys", "Beauty", "Automotive", "Groceries", "Health",
+    ]
+
+    private let productNames = [
+        "Wireless Headphones", "Smart Watch Pro", "Laptop Stand", "USB-C Hub",
+        "Mechanical Keyboard", "4K Monitor", "Bluetooth Speaker", "Phone Case",
+        "Tablet Sleeve", "Power Bank", "Camera Lens Kit", "LED Desk Lamp",
+        "Ergonomic Mouse", "Portable SSD", "Noise Canceller", "Smart Plug",
+        "Fitness Tracker", "Drone Mini", "VR Headset", "Action Camera",
+        "Ring Light", "Mic Stand", "Stream Deck", "Drawing Tablet",
+        "Webcam HD", "Router Mesh", "Charger Pad", "Cable Organizer",
+        "Monitor Arm", "Desk Mat", "Key Finder", "Smart Scale",
+        "Air Purifier", "Humidifier", "Projector Mini", "E-Reader",
+    ]
+
+    private let productIcons = [
+        "\u{1F3A7}", "\u{231A}", "\u{1F4BB}", "\u{1F50C}",
+        "\u{2328}", "\u{1F5A5}", "\u{1F50A}", "\u{1F4F1}",
+        "\u{1F4BC}", "\u{1F50B}", "\u{1F4F7}", "\u{1F4A1}",
+        "\u{1F5B1}", "\u{1F4BE}", "\u{1F507}", "\u{1F50C}",
+        "\u{231A}", "\u{1F681}", "\u{1F453}", "\u{1F3A5}",
+        "\u{1F4A1}", "\u{1F3A4}", "\u{1F3AE}", "\u{1F58C}",
+        "\u{1F4F7}", "\u{1F310}", "\u{1F50B}", "\u{1F4CE}",
+        "\u{1F5A5}", "\u{1F4D0}", "\u{1F50D}", "\u{2696}",
+        "\u{1F32C}", "\u{1F4A7}", "\u{1F4FD}", "\u{1F4D6}",
+    ]
+
+    private let cardColors: [Color] = [
+        .blue, .green, .orange, .purple,
+        .pink, .init(red: 0, green: 0.7, blue: 0.7), .init(red: 0.3, green: 0.3, blue: 0.8), .red,
+    ]
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 8) {
+                // MARK: - Header
+
+                Text("Complex UI Stress Test - SwiftUI")
+                    .font(.headline)
+                    .padding(.top, 8)
+
+                Text("Tap Count: \(tapCount)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .accessibilityLabel("stress_test_tap_count_swiftui")
+
+                // MARK: - Search Bar
+
+                HStack(spacing: 8) {
+                    TextField("Search products...", text: $searchText)
+                        .padding(8)
+                        .accessibilityLabel("stress_search_field_swiftui")
+
+                    Button(action: { tapCount += 1 }) {
+                        Image(systemName: "magnifyingglass")
+                            .foregroundColor(.blue)
+                    }
+                    .accessibilityLabel("stress_search_button_swiftui")
+                    .padding(.trailing, 8)
+                }
+                .background(Color.gray.opacity(0.12))
+                .cornerRadius(10)
+                .padding(.horizontal, 4)
+
+                // MARK: - Category Chips
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(0..<categories.count, id: \.self) { index in
+                            Button(action: {
+                                selectedCategory = index
+                                tapCount += 1
+                            }) {
+                                Text(categories[index])
+                                    .font(.system(size: 13, weight: .medium))
+                                    .padding(.horizontal, 14)
+                                    .padding(.vertical, 6)
+                                    .background(index == selectedCategory ? Color.blue : Color.gray.opacity(0.15))
+                                    .foregroundColor(index == selectedCategory ? .white : .primary)
+                                    .cornerRadius(16)
+                            }
+                            .accessibilityLabel("category_chip_swiftui_\(index)")
+                        }
+                    }
+                    .padding(.horizontal, 4)
+                }
+
+                // MARK: - Product Grid (2 columns, 18 rows = 36 cards)
+
+                ForEach(0..<18, id: \.self) { row in
+                    HStack(spacing: 10) {
+                        ForEach(0..<2, id: \.self) { col in
+                            StressTestProductCard(
+                                index: row * 2 + col,
+                                name: productNames[(row * 2 + col) % productNames.count],
+                                icon: productIcons[(row * 2 + col) % productIcons.count],
+                                cardColor: cardColors[(row * 2 + col) % cardColors.count],
+                                tapCount: $tapCount
+                            )
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.bottom, 16)
+        }
+        .navigationTitle("SwiftUI Stress Test")
+    }
+}
+
+// MARK: - Product Card (~15 views each)
+
+@available(iOS 14.0, *)
+private struct StressTestProductCard: View {
+    let index: Int
+    let name: String
+    let icon: String
+    let cardColor: Color
+    @Binding var tapCount: Int
+    @State private var isFavorite = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            // Image placeholder with badge
+            ZStack(alignment: .topLeading) {
+                Rectangle()
+                    .fill(cardColor.opacity(0.15))
+                    .frame(height: 100)
+                    .cornerRadius(10, corners: [.topLeft, .topRight])
+
+                Text(icon)
+                    .font(.system(size: 32))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .frame(height: 100)
+
+                if index % 3 == 0 {
+                    Text(" SALE ")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(.white)
+                        .background(Color.red)
+                        .cornerRadius(4)
+                        .padding(6)
+                } else if index % 4 == 1 {
+                    Text(" NEW ")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(.white)
+                        .background(Color.green)
+                        .cornerRadius(4)
+                        .padding(6)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 3) {
+                // Product name
+                Text(name)
+                    .font(.system(size: 13, weight: .semibold))
+                    .lineLimit(2)
+
+                // Rating row
+                HStack(spacing: 1) {
+                    let filledStars = 3 + (index % 3)
+                    ForEach(0..<5, id: \.self) { starIndex in
+                        Text(starIndex < filledStars ? "\u{2605}" : "\u{2606}")
+                            .font(.system(size: 10))
+                            .foregroundColor(starIndex < filledStars ? .orange : .gray)
+                    }
+                    Text("(\(10 + index * 7))")
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                }
+
+                // Price row
+                HStack(spacing: 6) {
+                    Text("$\(49 + index * 5).99")
+                        .font(.system(size: 11))
+                        .strikethrough()
+                        .foregroundColor(.gray)
+
+                    Text("$\(29 + index * 4).99")
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundColor(.red)
+                }
+
+                // Action row
+                HStack(spacing: 6) {
+                    Button(action: {
+                        tapCount += 1
+                    }) {
+                        Text("Add to Cart")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(Color.blue)
+                            .cornerRadius(6)
+                    }
+                    .accessibilityLabel("add_to_cart_swiftui_\(index)")
+
+                    Spacer()
+
+                    Button(action: {
+                        isFavorite.toggle()
+                        tapCount += 1
+                    }) {
+                        Image(systemName: isFavorite ? "heart.fill" : "heart")
+                            .foregroundColor(.pink)
+                    }
+                    .accessibilityLabel("favorite_swiftui_\(index)")
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.bottom, 6)
+        }
+        .background(Color.gray.opacity(0.06))
+        .cornerRadius(10)
+        .shadow(color: Color.black.opacity(0.05), radius: 3, y: 2)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Product \(index) \(name)")
+    }
+}
+
+// MARK: - Corner Radius Helper
+
+@available(iOS 14.0, *)
+extension View {
+    fileprivate func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+        clipShape(RoundedCornerShape(radius: radius, corners: corners))
+    }
+}
+
+@available(iOS 14.0, *)
+private struct RoundedCornerShape: Shape {
+    var radius: CGFloat
+    var corners: UIRectCorner
+
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(
+            roundedRect: rect,
+            byRoundingCorners: corners,
+            cornerRadii: CGSize(width: radius, height: radius)
+        )
+        return Path(path.cgPath)
+    }
+}
+
+// MARK: - Hosting Controller
+
+/// UIKit wrapper to present the SwiftUI stress test view from storyboard or programmatic navigation.
+@available(iOS 14.0, *)
+class ComplexSwiftUIStressTestHostingController: UIHostingController<ComplexSwiftUIStressTestView> {
+    required init?(coder: NSCoder) {
+        super.init(coder: coder, rootView: ComplexSwiftUIStressTestView())
+    }
+
+    init() {
+        super.init(rootView: ComplexSwiftUIStressTestView())
+    }
+}

--- a/MixpanelDemo/MixpanelDemo/ComplexUIKitStressTestViewController.swift
+++ b/MixpanelDemo/MixpanelDemo/ComplexUIKitStressTestViewController.swift
@@ -1,0 +1,486 @@
+//
+//  ComplexUIKitStressTestViewController.swift
+//  MixpanelDemo
+//
+//  Created by Mixpanel on 2026-07-27.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+import UIKit
+
+/// E-commerce product listing stress test screen with 500+ views in the view tree.
+///
+/// Uses UIScrollView + UIStackView (no cell recycling) so all views remain in memory,
+/// enabling autocapture performance testing under heavy view-tree load.
+class ComplexUIKitStressTestViewController: UIViewController {
+
+    private let scrollView = UIScrollView()
+    private let stackView = UIStackView()
+    private var viewCountLabel: UILabel?
+    private var tapCount = 0
+    private var tapCountLabel: UILabel?
+
+    private let productNames = [
+        "Wireless Headphones", "Smart Watch Pro", "Laptop Stand", "USB-C Hub",
+        "Mechanical Keyboard", "4K Monitor", "Bluetooth Speaker", "Phone Case",
+        "Tablet Sleeve", "Power Bank", "Camera Lens Kit", "LED Desk Lamp",
+        "Ergonomic Mouse", "Portable SSD", "Noise Canceller", "Smart Plug",
+        "Fitness Tracker", "Drone Mini", "VR Headset", "Action Camera",
+        "Ring Light", "Mic Stand", "Stream Deck", "Drawing Tablet",
+        "Webcam HD", "Router Mesh", "Charger Pad", "Cable Organizer",
+        "Monitor Arm", "Desk Mat", "Key Finder", "Smart Scale",
+        "Air Purifier", "Humidifier", "Projector Mini", "E-Reader",
+    ]
+
+    private let categories = [
+        "Electronics", "Clothing", "Home & Garden", "Sports",
+        "Books", "Toys", "Beauty", "Automotive", "Groceries", "Health",
+    ]
+
+    private let cardColors: [UIColor] = [
+        .systemBlue, .systemGreen, .systemOrange, .systemPurple,
+        .systemPink, .systemTeal, .systemIndigo, .systemRed,
+    ]
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "UIKit Stress Test"
+        if #available(iOS 13.0, *) {
+            view.backgroundColor = .systemBackground
+        } else {
+            view.backgroundColor = .white
+        }
+        setupScrollView()
+        setupContent()
+
+        // Count views after layout
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            let count = self.countViews(self.view)
+            self.viewCountLabel?.text = "View Count: \(count)"
+        }
+    }
+
+    // MARK: - Layout
+
+    private func setupScrollView() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(scrollView)
+
+        stackView.axis = .vertical
+        stackView.spacing = 10
+        stackView.layoutMargins = UIEdgeInsets(top: 16, left: 12, bottom: 16, right: 12)
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+        ])
+    }
+
+    private func setupContent() {
+        // MARK: - Header
+
+        let headerLabel = UILabel()
+        headerLabel.text = "Complex UI Stress Test - UIKit"
+        headerLabel.font = .boldSystemFont(ofSize: 20)
+        headerLabel.textAlignment = .center
+        stackView.addArrangedSubview(headerLabel)
+
+        let viewCount = UILabel()
+        viewCount.text = "View Count: calculating..."
+        viewCount.font = .systemFont(ofSize: 14)
+        viewCount.textAlignment = .center
+        if #available(iOS 13.0, *) {
+            viewCount.textColor = .secondaryLabel
+        } else {
+            viewCount.textColor = .gray
+        }
+        viewCount.accessibilityIdentifier = "stress_test_view_count"
+        self.viewCountLabel = viewCount
+        stackView.addArrangedSubview(viewCount)
+
+        let tapLabel = UILabel()
+        tapLabel.text = "Tap Count: 0"
+        tapLabel.font = .systemFont(ofSize: 14)
+        tapLabel.textAlignment = .center
+        if #available(iOS 13.0, *) {
+            tapLabel.textColor = .secondaryLabel
+        } else {
+            tapLabel.textColor = .gray
+        }
+        tapLabel.accessibilityIdentifier = "stress_test_tap_count"
+        self.tapCountLabel = tapLabel
+        stackView.addArrangedSubview(tapLabel)
+
+        // MARK: - Search Bar
+
+        let searchContainer = UIView()
+        searchContainer.translatesAutoresizingMaskIntoConstraints = false
+        if #available(iOS 13.0, *) {
+            searchContainer.backgroundColor = .secondarySystemBackground
+        } else {
+            searchContainer.backgroundColor = UIColor(white: 0.95, alpha: 1)
+        }
+        searchContainer.layer.cornerRadius = 10
+
+        let searchField = UITextField()
+        searchField.placeholder = "Search products..."
+        searchField.borderStyle = .none
+        searchField.translatesAutoresizingMaskIntoConstraints = false
+        searchField.accessibilityIdentifier = "stress_search_field"
+        searchContainer.addSubview(searchField)
+
+        let searchButton = UIButton(type: .system)
+        if #available(iOS 13.0, *) {
+            searchButton.setImage(UIImage(systemName: "magnifyingglass"), for: .normal)
+        } else {
+            searchButton.setTitle("Search", for: .normal)
+        }
+        searchButton.accessibilityIdentifier = "stress_search_button"
+        searchButton.addTarget(self, action: #selector(handleTap(_:)), for: .touchUpInside)
+        searchButton.translatesAutoresizingMaskIntoConstraints = false
+        searchContainer.addSubview(searchButton)
+
+        NSLayoutConstraint.activate([
+            searchContainer.heightAnchor.constraint(equalToConstant: 44),
+            searchField.leadingAnchor.constraint(equalTo: searchContainer.leadingAnchor, constant: 12),
+            searchField.centerYAnchor.constraint(equalTo: searchContainer.centerYAnchor),
+            searchField.trailingAnchor.constraint(equalTo: searchButton.leadingAnchor, constant: -8),
+            searchButton.trailingAnchor.constraint(equalTo: searchContainer.trailingAnchor, constant: -12),
+            searchButton.centerYAnchor.constraint(equalTo: searchContainer.centerYAnchor),
+            searchButton.widthAnchor.constraint(equalToConstant: 44),
+        ])
+
+        stackView.addArrangedSubview(searchContainer)
+
+        // MARK: - Category Chips
+
+        let chipScroll = UIScrollView()
+        chipScroll.showsHorizontalScrollIndicator = false
+        chipScroll.translatesAutoresizingMaskIntoConstraints = false
+        chipScroll.heightAnchor.constraint(equalToConstant: 40).isActive = true
+
+        let chipStack = UIStackView()
+        chipStack.axis = .horizontal
+        chipStack.spacing = 8
+        chipStack.translatesAutoresizingMaskIntoConstraints = false
+        chipScroll.addSubview(chipStack)
+
+        NSLayoutConstraint.activate([
+            chipStack.topAnchor.constraint(equalTo: chipScroll.topAnchor),
+            chipStack.leadingAnchor.constraint(equalTo: chipScroll.leadingAnchor),
+            chipStack.trailingAnchor.constraint(equalTo: chipScroll.trailingAnchor),
+            chipStack.bottomAnchor.constraint(equalTo: chipScroll.bottomAnchor),
+            chipStack.heightAnchor.constraint(equalTo: chipScroll.heightAnchor),
+        ])
+
+        for (index, category) in categories.enumerated() {
+            let chip = UIButton(type: .system)
+            chip.setTitle(category, for: .normal)
+            chip.titleLabel?.font = .systemFont(ofSize: 13, weight: .medium)
+            chip.contentEdgeInsets = UIEdgeInsets(top: 6, left: 14, bottom: 6, right: 14)
+            if index == 0 {
+                chip.backgroundColor = .systemBlue
+                chip.setTitleColor(.white, for: .normal)
+            } else {
+                if #available(iOS 13.0, *) {
+                    chip.backgroundColor = .secondarySystemBackground
+                } else {
+                    chip.backgroundColor = UIColor(white: 0.93, alpha: 1)
+                }
+            }
+            chip.layer.cornerRadius = 16
+            chip.accessibilityIdentifier = "category_chip_\(index)"
+            chip.addTarget(self, action: #selector(handleTap(_:)), for: .touchUpInside)
+            chipStack.addArrangedSubview(chip)
+        }
+
+        stackView.addArrangedSubview(chipScroll)
+
+        // MARK: - Product Grid
+
+        let totalProducts = productNames.count  // 36 products
+        let columns = 2
+
+        for row in 0..<(totalProducts / columns) {
+            let rowStack = UIStackView()
+            rowStack.axis = .horizontal
+            rowStack.spacing = 10
+            rowStack.distribution = .fillEqually
+
+            for col in 0..<columns {
+                let index = row * columns + col
+                let card = makeProductCard(index: index)
+                rowStack.addArrangedSubview(card)
+            }
+
+            stackView.addArrangedSubview(rowStack)
+        }
+    }
+
+    // MARK: - Product Card (~15 views each)
+
+    private func makeProductCard(index: Int) -> UIView {
+        let card = UIView()
+        if #available(iOS 13.0, *) {
+            card.backgroundColor = .secondarySystemBackground
+        } else {
+            card.backgroundColor = UIColor(white: 0.96, alpha: 1)
+        }
+        card.layer.cornerRadius = 10
+        card.layer.shadowColor = UIColor.black.cgColor
+        card.layer.shadowOpacity = 0.08
+        card.layer.shadowOffset = CGSize(width: 0, height: 2)
+        card.layer.shadowRadius = 4
+        card.accessibilityIdentifier = "product_card_\(index)"
+
+        let cardStack = UIStackView()
+        cardStack.axis = .vertical
+        cardStack.spacing = 4
+        cardStack.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(cardStack)
+
+        NSLayoutConstraint.activate([
+            cardStack.topAnchor.constraint(equalTo: card.topAnchor),
+            cardStack.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            cardStack.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+            cardStack.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -8),
+        ])
+
+        // Image placeholder with badge
+        let imagePlaceholder = UIView()
+        let color = cardColors[index % cardColors.count]
+        imagePlaceholder.backgroundColor = color.withAlphaComponent(0.2)
+        imagePlaceholder.translatesAutoresizingMaskIntoConstraints = false
+        imagePlaceholder.heightAnchor.constraint(equalToConstant: 100).isActive = true
+        imagePlaceholder.layer.cornerRadius = 10
+        imagePlaceholder.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        imagePlaceholder.clipsToBounds = true
+
+        // Product icon in center
+        let iconLabel = UILabel()
+        iconLabel.text = productIcon(for: index)
+        iconLabel.font = .systemFont(ofSize: 32)
+        iconLabel.textAlignment = .center
+        iconLabel.translatesAutoresizingMaskIntoConstraints = false
+        imagePlaceholder.addSubview(iconLabel)
+        NSLayoutConstraint.activate([
+            iconLabel.centerXAnchor.constraint(equalTo: imagePlaceholder.centerXAnchor),
+            iconLabel.centerYAnchor.constraint(equalTo: imagePlaceholder.centerYAnchor),
+        ])
+
+        // Badge
+        if index % 3 == 0 {
+            let badge = UILabel()
+            badge.text = " SALE "
+            badge.font = .boldSystemFont(ofSize: 10)
+            badge.textColor = .white
+            badge.backgroundColor = .systemRed
+            badge.layer.cornerRadius = 4
+            badge.clipsToBounds = true
+            badge.translatesAutoresizingMaskIntoConstraints = false
+            imagePlaceholder.addSubview(badge)
+            NSLayoutConstraint.activate([
+                badge.topAnchor.constraint(equalTo: imagePlaceholder.topAnchor, constant: 6),
+                badge.leadingAnchor.constraint(equalTo: imagePlaceholder.leadingAnchor, constant: 6),
+            ])
+        } else if index % 4 == 1 {
+            let badge = UILabel()
+            badge.text = " NEW "
+            badge.font = .boldSystemFont(ofSize: 10)
+            badge.textColor = .white
+            badge.backgroundColor = .systemGreen
+            badge.layer.cornerRadius = 4
+            badge.clipsToBounds = true
+            badge.translatesAutoresizingMaskIntoConstraints = false
+            imagePlaceholder.addSubview(badge)
+            NSLayoutConstraint.activate([
+                badge.topAnchor.constraint(equalTo: imagePlaceholder.topAnchor, constant: 6),
+                badge.leadingAnchor.constraint(equalTo: imagePlaceholder.leadingAnchor, constant: 6),
+            ])
+        }
+
+        cardStack.addArrangedSubview(imagePlaceholder)
+
+        // Content padding container
+        let contentStack = UIStackView()
+        contentStack.axis = .vertical
+        contentStack.spacing = 3
+        contentStack.layoutMargins = UIEdgeInsets(top: 4, left: 8, bottom: 0, right: 8)
+        contentStack.isLayoutMarginsRelativeArrangement = true
+
+        // Product name
+        let nameLabel = UILabel()
+        nameLabel.text = productNames[index % productNames.count]
+        nameLabel.font = .systemFont(ofSize: 13, weight: .semibold)
+        nameLabel.numberOfLines = 2
+        contentStack.addArrangedSubview(nameLabel)
+
+        // Rating row
+        let ratingStack = UIStackView()
+        ratingStack.axis = .horizontal
+        ratingStack.spacing = 1
+        ratingStack.alignment = .center
+
+        let filledStars = 3 + (index % 3)  // 3-5 stars
+        for starIndex in 0..<5 {
+            let star = UILabel()
+            star.font = .systemFont(ofSize: 10)
+            if starIndex < filledStars {
+                star.text = "\u{2605}"  // filled star
+                star.textColor = .systemOrange
+            } else {
+                star.text = "\u{2606}"  // empty star
+                if #available(iOS 13.0, *) {
+                    star.textColor = .tertiaryLabel
+                } else {
+                    star.textColor = .lightGray
+                }
+            }
+            ratingStack.addArrangedSubview(star)
+        }
+
+        let reviewCount = UILabel()
+        reviewCount.text = " (\(10 + index * 7))"
+        reviewCount.font = .systemFont(ofSize: 10)
+        if #available(iOS 13.0, *) {
+            reviewCount.textColor = .secondaryLabel
+        } else {
+            reviewCount.textColor = .gray
+        }
+        ratingStack.addArrangedSubview(reviewCount)
+
+        // Spacer to push content left
+        let ratingSpacer = UIView()
+        ratingSpacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        ratingStack.addArrangedSubview(ratingSpacer)
+
+        contentStack.addArrangedSubview(ratingStack)
+
+        // Price row
+        let priceStack = UIStackView()
+        priceStack.axis = .horizontal
+        priceStack.spacing = 6
+        priceStack.alignment = .center
+
+        let originalPrice = UILabel()
+        let origPriceValue = 49 + index * 5
+        let attributed = NSAttributedString(
+            string: "$\(origPriceValue).99",
+            attributes: [
+                .strikethroughStyle: NSUnderlineStyle.single.rawValue,
+                .foregroundColor: UIColor.gray,
+                .font: UIFont.systemFont(ofSize: 11),
+            ]
+        )
+        originalPrice.attributedText = attributed
+        priceStack.addArrangedSubview(originalPrice)
+
+        let salePrice = UILabel()
+        let salePriceValue = 29 + index * 4
+        salePrice.text = "$\(salePriceValue).99"
+        salePrice.font = .boldSystemFont(ofSize: 14)
+        salePrice.textColor = .systemRed
+        priceStack.addArrangedSubview(salePrice)
+
+        let priceSpacer = UIView()
+        priceSpacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        priceStack.addArrangedSubview(priceSpacer)
+
+        contentStack.addArrangedSubview(priceStack)
+
+        // Action row
+        let actionStack = UIStackView()
+        actionStack.axis = .horizontal
+        actionStack.spacing = 6
+        actionStack.distribution = .fill
+
+        let addToCartBtn = UIButton(type: .system)
+        addToCartBtn.setTitle("Add to Cart", for: .normal)
+        addToCartBtn.titleLabel?.font = .systemFont(ofSize: 11, weight: .semibold)
+        addToCartBtn.backgroundColor = .systemBlue
+        addToCartBtn.setTitleColor(.white, for: .normal)
+        addToCartBtn.layer.cornerRadius = 6
+        addToCartBtn.contentEdgeInsets = UIEdgeInsets(top: 4, left: 8, bottom: 4, right: 8)
+        addToCartBtn.accessibilityIdentifier = "add_to_cart_\(index)"
+        addToCartBtn.addTarget(self, action: #selector(handleTap(_:)), for: .touchUpInside)
+        actionStack.addArrangedSubview(addToCartBtn)
+
+        let favBtn = UIButton(type: .system)
+        if #available(iOS 13.0, *) {
+            favBtn.setImage(UIImage(systemName: "heart"), for: .normal)
+        } else {
+            favBtn.setTitle("\u{2661}", for: .normal)
+        }
+        favBtn.tintColor = .systemPink
+        favBtn.accessibilityIdentifier = "favorite_\(index)"
+        favBtn.addTarget(self, action: #selector(handleFavorite(_:)), for: .touchUpInside)
+        favBtn.translatesAutoresizingMaskIntoConstraints = false
+        favBtn.widthAnchor.constraint(equalToConstant: 32).isActive = true
+        actionStack.addArrangedSubview(favBtn)
+
+        contentStack.addArrangedSubview(actionStack)
+
+        cardStack.addArrangedSubview(contentStack)
+
+        return card
+    }
+
+    // MARK: - Helpers
+
+    private func productIcon(for index: Int) -> String {
+        let icons = [
+            "\u{1F3A7}", "\u{231A}", "\u{1F4BB}", "\u{1F50C}",
+            "\u{2328}", "\u{1F5A5}", "\u{1F50A}", "\u{1F4F1}",
+            "\u{1F4BC}", "\u{1F50B}", "\u{1F4F7}", "\u{1F4A1}",
+            "\u{1F5B1}", "\u{1F4BE}", "\u{1F507}", "\u{1F50C}",
+            "\u{231A}", "\u{1F681}", "\u{1F453}", "\u{1F3A5}",
+            "\u{1F4A1}", "\u{1F3A4}", "\u{1F3AE}", "\u{1F58C}",
+            "\u{1F4F7}", "\u{1F310}", "\u{1F50B}", "\u{1F4CE}",
+            "\u{1F5A5}", "\u{1F4D0}", "\u{1F50D}", "\u{2696}",
+            "\u{1F32C}", "\u{1F4A7}", "\u{1F4FD}", "\u{1F4D6}",
+        ]
+        return icons[index % icons.count]
+    }
+
+    private func countViews(_ view: UIView) -> Int {
+        return 1 + view.subviews.reduce(0) { $0 + countViews($1) }
+    }
+
+    @objc private func handleTap(_ sender: UIButton) {
+        tapCount += 1
+        tapCountLabel?.text = "Tap Count: \(tapCount)"
+
+        // Visual feedback
+        let originalColor = sender.backgroundColor
+        sender.backgroundColor = UIColor.systemGreen.withAlphaComponent(0.3)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            sender.backgroundColor = originalColor
+        }
+    }
+
+    @objc private func handleFavorite(_ sender: UIButton) {
+        tapCount += 1
+        tapCountLabel?.text = "Tap Count: \(tapCount)"
+
+        if #available(iOS 13.0, *) {
+            let isFilled = sender.image(for: .normal) == UIImage(systemName: "heart.fill")
+            let newImage = UIImage(systemName: isFilled ? "heart" : "heart.fill")
+            sender.setImage(newImage, for: .normal)
+        } else {
+            let isFilled = sender.title(for: .normal) == "\u{2665}"
+            sender.setTitle(isFilled ? "\u{2661}" : "\u{2665}", for: .normal)
+        }
+    }
+}

--- a/MixpanelDemo/MixpanelDemo/SceneDelegate.swift
+++ b/MixpanelDemo/MixpanelDemo/SceneDelegate.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+}

--- a/MixpanelDemo/MixpanelDemo/SwiftUIAutocaptureTestView.swift
+++ b/MixpanelDemo/MixpanelDemo/SwiftUIAutocaptureTestView.swift
@@ -31,17 +31,23 @@ struct SwiftUIAutocaptureTestView: View {
 
                 SectionHeader("$el_id Resolution")
 
-                Button("Rule 1 - accessibilityLabel (primary)") {}
-                    .accessibilityLabel("swiftui_rule1")
+                // Rule 1: accessibilityIdentifier is the only $el_id source for SwiftUI.
+                // Reading it needs iOS 18+ and a materialized accessibility tree; below that it
+                // falls back to the hash no matter what is set here.
+                Button("Rule 1 - accessibilityIdentifier (iOS 18+)") {}
+                    .accessibilityIdentifier("swiftui_rule1")
                     .buttonStyle(TestButtonStyle())
 
-                Button("Rule 2 - identifier only (-> hash, needs VoiceOver)") {}
-                    .accessibilityIdentifier("ident_only")
+                // Rule 2: accessibilityLabel is never an $el_id source — this falls back to the
+                // hash. The label is set deliberately so the screen proves it is ignored.
+                Button("Rule 2 - Label only (ignored -> hash)") {}
+                    .accessibilityLabel("swiftui_label_only")
                     .buttonStyle(TestButtonStyle())
 
-                Button("Label Wins over Identifier") {}
-                    .accessibilityLabel("label_wins")
-                    .accessibilityIdentifier("id_loses")
+                // Identifier is used and the label is ignored, even when both are present.
+                Button("Identifier Wins over Label") {}
+                    .accessibilityLabel("label_ignored")
+                    .accessibilityIdentifier("id_wins")
                     .buttonStyle(TestButtonStyle())
 
                 Button("Rule 3 - No ID, No Label (hash)") {}
@@ -51,7 +57,7 @@ struct SwiftUIAutocaptureTestView: View {
                     .resizable()
                     .frame(width: 44, height: 44)
                     .foregroundColor(.yellow)
-                    .accessibilityLabel("tappable_image")
+                    .accessibilityIdentifier("tappable_image")
                     .onTapGesture {}
 
                 // MARK: - Dead Click
@@ -59,7 +65,7 @@ struct SwiftUIAutocaptureTestView: View {
                 SectionHeader("Dead Click")
 
                 Button("Dead Button (empty action) -> $mp_dead_click") {}
-                    .accessibilityLabel("swiftui_dead_btn")
+                    .accessibilityIdentifier("swiftui_dead_btn")
                     .buttonStyle(TestButtonStyle())
 
                 // MARK: - Rage Click
@@ -67,14 +73,14 @@ struct SwiftUIAutocaptureTestView: View {
                 SectionHeader("Rage Click - tap 4+ times")
 
                 Button("Rage Zone - tap rapidly") {}
-                    .accessibilityLabel("swiftui_rage_btn")
+                    .accessibilityIdentifier("swiftui_rage_btn")
                     .frame(maxWidth: .infinity, minHeight: 80)
                     .background(Color.red.opacity(0.12))
 
                 Button("Click + Rage - tap 4x (both events): \(tapCount)x") {
                     tapCount += 1
                 }
-                .accessibilityLabel("swiftui_rage_click_btn")
+                .accessibilityIdentifier("swiftui_rage_click_btn")
                 .buttonStyle(TestButtonStyle())
 
                 // MARK: - Excluded Controls
@@ -96,25 +102,25 @@ struct SwiftUIAutocaptureTestView: View {
                 Button("Show Alert") {
                     showAlert = true
                 }
-                .accessibilityLabel("swiftui_alert_trigger")
+                .accessibilityIdentifier("swiftui_alert_trigger")
                 .buttonStyle(TestButtonStyle())
 
                 Button("Show Sheet") {
                     showSheet = true
                 }
-                .accessibilityLabel("swiftui_sheet_trigger")
+                .accessibilityIdentifier("swiftui_sheet_trigger")
                 .buttonStyle(TestButtonStyle())
 
                 Button("Show Confirmation Dialog") {
                     showConfirmationDialog = true
                 }
-                .accessibilityLabel("swiftui_confirmation_trigger")
+                .accessibilityIdentifier("swiftui_confirmation_trigger")
                 .buttonStyle(TestButtonStyle())
 
                 Button("Show Popover") {
                     showPopover = true
                 }
-                .accessibilityLabel("swiftui_popover_trigger")
+                .accessibilityIdentifier("swiftui_popover_trigger")
                 .buttonStyle(TestButtonStyle())
 
                 // MARK: - Mixed Framework Dead Click Tests
@@ -138,8 +144,12 @@ struct SwiftUIAutocaptureTestView: View {
                     3. Tap 4+ times rapidly on Rage Zone for $mp_rage_click
                     4. Tap Dead Button and wait 500ms for $mp_dead_click
 
-                    Note: SwiftUI uses accessibilityLabel as primary $el_id
-                    (accessibilityIdentifier requires VoiceOver to be active)
+                    Note: accessibilityIdentifier is the only $el_id source.
+                    accessibilityLabel is never used as identity and is never
+                    reported. SwiftUI keeps the identifier in the accessibility
+                    element tree, which the SDK can only read on iOS 18+ with a
+                    materialized tree — below that, elements fall back to
+                    <ClassName>_<hash> whatever identifier you set.
                     """
                 )
                 .font(.caption)
@@ -153,15 +163,15 @@ struct SwiftUIAutocaptureTestView: View {
             NavigationView {
                 VStack(spacing: 12) {
                     Button("Sheet Action 1") {}
-                        .accessibilityLabel("swiftui_sheet_action_1")
+                        .accessibilityIdentifier("swiftui_sheet_action_1")
                         .buttonStyle(TestButtonStyle())
 
                     Button("Sheet Action 2") {}
-                        .accessibilityLabel("swiftui_sheet_action_2")
+                        .accessibilityIdentifier("swiftui_sheet_action_2")
                         .buttonStyle(TestButtonStyle())
 
                     Button("Sheet Action 3") {}
-                        .accessibilityLabel("swiftui_sheet_action_3")
+                        .accessibilityIdentifier("swiftui_sheet_action_3")
                         .buttonStyle(TestButtonStyle())
 
                     Button("Close") {
@@ -210,19 +220,19 @@ private struct MixedFrameworkTestSection: View {
             Button("3. SwiftUI Btn -> UIKit Text") {
                 uikitCounter += 1
             }
-            .accessibilityLabel("swiftui_btn_uikit_text")
+            .accessibilityIdentifier("swiftui_btn_uikit_text")
             .buttonStyle(TestButtonStyle())
 
             // Case 4: SwiftUI Button -> SwiftUI Text
             Button("4. SwiftUI Btn -> SwiftUI Text") {
                 swiftUICounter += 1
             }
-            .accessibilityLabel("swiftui_btn_swiftui_text")
+            .accessibilityIdentifier("swiftui_btn_swiftui_text")
             .buttonStyle(TestButtonStyle())
 
             // SwiftUI text counter (updated by cases 2 & 4)
             Text("SwiftUI counter: \(swiftUICounter)")
-                .accessibilityLabel("swiftui_text_counter")
+                .accessibilityIdentifier("swiftui_text_counter")
         }
     }
 }
@@ -256,7 +266,7 @@ private struct UIKitButtonsView: UIViewRepresentable {
         // Case 1: UIKit Button -> UIKit Text
         let btn1 = UIButton(type: .system)
         btn1.setTitle("1. UIKit Btn -> UIKit Text", for: .normal)
-        btn1.accessibilityLabel = "uikit_btn_uikit_text"
+        btn1.accessibilityIdentifier = "uikit_btn_uikit_text"
         btn1.layer.borderWidth = 1
         btn1.layer.cornerRadius = 8
         btn1.layer.borderColor = UIColor.systemBlue.cgColor
@@ -267,14 +277,14 @@ private struct UIKitButtonsView: UIViewRepresentable {
         // UIKit counter label
         let counterLabel = UILabel()
         counterLabel.text = "UIKit counter: 0"
-        counterLabel.accessibilityLabel = "uikit_text_counter"
+        counterLabel.accessibilityIdentifier = "uikit_text_counter"
         context.coordinator.counterLabel = counterLabel
         stack.addArrangedSubview(counterLabel)
 
         // Case 2: UIKit Button -> SwiftUI Text
         let btn2 = UIButton(type: .system)
         btn2.setTitle("2. UIKit Btn -> SwiftUI Text", for: .normal)
-        btn2.accessibilityLabel = "uikit_btn_swiftui_text"
+        btn2.accessibilityIdentifier = "uikit_btn_swiftui_text"
         btn2.layer.borderWidth = 1
         btn2.layer.cornerRadius = 8
         btn2.layer.borderColor = UIColor.systemBlue.cgColor
@@ -318,7 +328,7 @@ private struct AlertModifier: ViewModifier {
             content
                 .alert("Test Alert", isPresented: $isPresented) {
                     Button("Confirm") {}
-                        .accessibilityLabel("swiftui_alert_confirm")
+                        .accessibilityIdentifier("swiftui_alert_confirm")
                     Button("Cancel", role: .cancel) {}
                 }
         } else {
@@ -345,11 +355,11 @@ private struct ConfirmationDialogModifier: ViewModifier {
             content
                 .confirmationDialog("Choose Option", isPresented: $isPresented) {
                     Button("Option 1") {}
-                        .accessibilityLabel("swiftui_dialog_option_1")
+                        .accessibilityIdentifier("swiftui_dialog_option_1")
                     Button("Option 2") {}
-                        .accessibilityLabel("swiftui_dialog_option_2")
+                        .accessibilityIdentifier("swiftui_dialog_option_2")
                     Button("Option 3") {}
-                        .accessibilityLabel("swiftui_dialog_option_3")
+                        .accessibilityIdentifier("swiftui_dialog_option_3")
                     Button("Cancel", role: .cancel) {}
                 }
         } else {

--- a/MixpanelDemo/MixpanelDemo/SwiftUIAutocaptureTestView.swift
+++ b/MixpanelDemo/MixpanelDemo/SwiftUIAutocaptureTestView.swift
@@ -1,0 +1,415 @@
+//
+//  SwiftUIAutocaptureTestView.swift
+//  MixpanelDemo
+//
+//  Created by Mixpanel on 2026-06-13.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+import SwiftUI
+
+/// Test screen for validating SwiftUI autocapture functionality.
+///
+/// Tests all three event types ($mp_click, $mp_rage_click, $mp_dead_click)
+/// and verifies $el_id resolution rules for SwiftUI views.
+@available(iOS 14.0, *)
+struct SwiftUIAutocaptureTestView: View {
+    @State private var toggleOn = false
+    @State private var text = ""
+    @State private var password = ""
+    @State private var tapCount = 0
+    @State private var showAlert = false
+    @State private var showSheet = false
+    @State private var showConfirmationDialog = false
+    @State private var showPopover = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 10) {
+
+                // MARK: - $el_id Resolution
+
+                SectionHeader("$el_id Resolution")
+
+                Button("Rule 1 - accessibilityLabel (primary)") {}
+                    .accessibilityLabel("swiftui_rule1")
+                    .buttonStyle(TestButtonStyle())
+
+                Button("Rule 2 - identifier only (-> hash, needs VoiceOver)") {}
+                    .accessibilityIdentifier("ident_only")
+                    .buttonStyle(TestButtonStyle())
+
+                Button("Label Wins over Identifier") {}
+                    .accessibilityLabel("label_wins")
+                    .accessibilityIdentifier("id_loses")
+                    .buttonStyle(TestButtonStyle())
+
+                Button("Rule 3 - No ID, No Label (hash)") {}
+                    .buttonStyle(TestButtonStyle())
+
+                Image(systemName: "star.fill")
+                    .resizable()
+                    .frame(width: 44, height: 44)
+                    .foregroundColor(.yellow)
+                    .accessibilityLabel("tappable_image")
+                    .onTapGesture {}
+
+                // MARK: - Dead Click
+
+                SectionHeader("Dead Click")
+
+                Button("Dead Button (empty action) -> $mp_dead_click") {}
+                    .accessibilityLabel("swiftui_dead_btn")
+                    .buttonStyle(TestButtonStyle())
+
+                // MARK: - Rage Click
+
+                SectionHeader("Rage Click - tap 4+ times")
+
+                Button("Rage Zone - tap rapidly") {}
+                    .accessibilityLabel("swiftui_rage_btn")
+                    .frame(maxWidth: .infinity, minHeight: 80)
+                    .background(Color.red.opacity(0.12))
+
+                Button("Click + Rage - tap 4x (both events): \(tapCount)x") {
+                    tapCount += 1
+                }
+                .accessibilityLabel("swiftui_rage_click_btn")
+                .buttonStyle(TestButtonStyle())
+
+                // MARK: - Excluded Controls
+
+                SectionHeader("Excluded Controls (no dead click)")
+
+                Toggle("Toggle (no dead click)", isOn: $toggleOn)
+
+                TextField("TextField - no dead click, text not captured", text: $text)
+                    .textFieldStyle(.roundedBorder)
+
+                SecureField("Password - text NOT captured", text: $password)
+                    .textFieldStyle(.roundedBorder)
+
+                // MARK: - Multi-Window / Overlay
+
+                SectionHeader("Multi-Window / Overlay")
+
+                Button("Show Alert") {
+                    showAlert = true
+                }
+                .accessibilityLabel("swiftui_alert_trigger")
+                .buttonStyle(TestButtonStyle())
+
+                Button("Show Sheet") {
+                    showSheet = true
+                }
+                .accessibilityLabel("swiftui_sheet_trigger")
+                .buttonStyle(TestButtonStyle())
+
+                Button("Show Confirmation Dialog") {
+                    showConfirmationDialog = true
+                }
+                .accessibilityLabel("swiftui_confirmation_trigger")
+                .buttonStyle(TestButtonStyle())
+
+                Button("Show Popover") {
+                    showPopover = true
+                }
+                .accessibilityLabel("swiftui_popover_trigger")
+                .buttonStyle(TestButtonStyle())
+
+                // MARK: - Mixed Framework Dead Click Tests
+
+                SectionHeader("Mixed Framework Dead Click Tests")
+
+                Text("None of these should trigger $mp_dead_click")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                MixedFrameworkTestSection()
+
+                // MARK: - Instructions
+
+                SectionHeader("Instructions")
+
+                Text(
+                    """
+                    1. Enable Mixpanel logging to see events
+                    2. Tap buttons to verify $mp_click events
+                    3. Tap 4+ times rapidly on Rage Zone for $mp_rage_click
+                    4. Tap Dead Button and wait 500ms for $mp_dead_click
+
+                    Note: SwiftUI uses accessibilityLabel as primary $el_id
+                    (accessibilityIdentifier requires VoiceOver to be active)
+                    """
+                )
+                .font(.caption)
+                .foregroundColor(.secondary)
+            }
+            .padding()
+        }
+        .navigationTitle("SwiftUI Autocapture Test")
+        .modifier(AlertModifier(isPresented: $showAlert))
+        .sheet(isPresented: $showSheet) {
+            NavigationView {
+                VStack(spacing: 12) {
+                    Button("Sheet Action 1") {}
+                        .accessibilityLabel("swiftui_sheet_action_1")
+                        .buttonStyle(TestButtonStyle())
+
+                    Button("Sheet Action 2") {}
+                        .accessibilityLabel("swiftui_sheet_action_2")
+                        .buttonStyle(TestButtonStyle())
+
+                    Button("Sheet Action 3") {}
+                        .accessibilityLabel("swiftui_sheet_action_3")
+                        .buttonStyle(TestButtonStyle())
+
+                    Button("Close") {
+                        showSheet = false
+                    }
+                    .buttonStyle(TestButtonStyle())
+                }
+                .padding()
+                .navigationTitle("Test Sheet")
+            }
+        }
+        .modifier(ConfirmationDialogModifier(isPresented: $showConfirmationDialog))
+        .popover(isPresented: $showPopover) {
+            VStack(spacing: 12) {
+                Text("Popover Content")
+                Button("Close") {
+                    showPopover = false
+                }
+            }
+            .padding()
+        }
+    }
+}
+
+// MARK: - Mixed Framework Components
+
+/// Test section embedding UIKit views inside SwiftUI via UIViewRepresentable.
+/// Tests all 4 cross-framework button→text combinations for dead click detection.
+@available(iOS 14.0, *)
+private struct MixedFrameworkTestSection: View {
+    @State private var swiftUICounter = 0
+    @State private var uikitCounter = 0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // UIKit elements (Cases 1 & 2) with orange background
+            UIKitButtonsView(
+                uikitCounter: $uikitCounter,
+                swiftUICounter: $swiftUICounter
+            )
+            .frame(height: 150)
+            .background(Color.orange.opacity(0.1))
+            .cornerRadius(8)
+
+            // Case 3: SwiftUI Button -> UIKit Text
+            Button("3. SwiftUI Btn -> UIKit Text") {
+                uikitCounter += 1
+            }
+            .accessibilityLabel("swiftui_btn_uikit_text")
+            .buttonStyle(TestButtonStyle())
+
+            // Case 4: SwiftUI Button -> SwiftUI Text
+            Button("4. SwiftUI Btn -> SwiftUI Text") {
+                swiftUICounter += 1
+            }
+            .accessibilityLabel("swiftui_btn_swiftui_text")
+            .buttonStyle(TestButtonStyle())
+
+            // SwiftUI text counter (updated by cases 2 & 4)
+            Text("SwiftUI counter: \(swiftUICounter)")
+                .accessibilityLabel("swiftui_text_counter")
+        }
+    }
+}
+
+/// UIViewRepresentable that hosts UIKit buttons for mixed-framework testing.
+/// Case 1: UIKit Button -> UIKit text update
+/// Case 2: UIKit Button -> SwiftUI text update (via binding)
+@available(iOS 14.0, *)
+private struct UIKitButtonsView: UIViewRepresentable {
+    @Binding var uikitCounter: Int
+    @Binding var swiftUICounter: Int
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        let container = UIView()
+
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 8
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: 12),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 12),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -12),
+        ])
+
+        // Case 1: UIKit Button -> UIKit Text
+        let btn1 = UIButton(type: .system)
+        btn1.setTitle("1. UIKit Btn -> UIKit Text", for: .normal)
+        btn1.accessibilityLabel = "uikit_btn_uikit_text"
+        btn1.layer.borderWidth = 1
+        btn1.layer.cornerRadius = 8
+        btn1.layer.borderColor = UIColor.systemBlue.cgColor
+        btn1.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        btn1.addTarget(context.coordinator, action: #selector(Coordinator.uikitBtnUikitText), for: .touchUpInside)
+        stack.addArrangedSubview(btn1)
+
+        // UIKit counter label
+        let counterLabel = UILabel()
+        counterLabel.text = "UIKit counter: 0"
+        counterLabel.accessibilityLabel = "uikit_text_counter"
+        context.coordinator.counterLabel = counterLabel
+        stack.addArrangedSubview(counterLabel)
+
+        // Case 2: UIKit Button -> SwiftUI Text
+        let btn2 = UIButton(type: .system)
+        btn2.setTitle("2. UIKit Btn -> SwiftUI Text", for: .normal)
+        btn2.accessibilityLabel = "uikit_btn_swiftui_text"
+        btn2.layer.borderWidth = 1
+        btn2.layer.cornerRadius = 8
+        btn2.layer.borderColor = UIColor.systemBlue.cgColor
+        btn2.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        btn2.addTarget(context.coordinator, action: #selector(Coordinator.uikitBtnSwiftUIText), for: .touchUpInside)
+        stack.addArrangedSubview(btn2)
+
+        return container
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        context.coordinator.counterLabel?.text = "UIKit counter: \(uikitCounter)"
+    }
+
+    class Coordinator: NSObject {
+        var parent: UIKitButtonsView
+        weak var counterLabel: UILabel?
+
+        init(_ parent: UIKitButtonsView) {
+            self.parent = parent
+        }
+
+        @objc func uikitBtnUikitText() {
+            parent.uikitCounter += 1
+        }
+
+        @objc func uikitBtnSwiftUIText() {
+            parent.swiftUICounter += 1
+        }
+    }
+}
+
+/// ViewModifier that presents an alert using the iOS 15+ API when available,
+/// falling back to the iOS 14 Alert struct.
+@available(iOS 14.0, *)
+private struct AlertModifier: ViewModifier {
+    @Binding var isPresented: Bool
+
+    func body(content: Content) -> some View {
+        if #available(iOS 15.0, *) {
+            content
+                .alert("Test Alert", isPresented: $isPresented) {
+                    Button("Confirm") {}
+                        .accessibilityLabel("swiftui_alert_confirm")
+                    Button("Cancel", role: .cancel) {}
+                }
+        } else {
+            content
+                .alert(isPresented: $isPresented) {
+                    Alert(
+                        title: Text("Test Alert"),
+                        primaryButton: .default(Text("Confirm")),
+                        secondaryButton: .cancel()
+                    )
+                }
+        }
+    }
+}
+
+/// ViewModifier that presents a confirmationDialog on iOS 15+,
+/// falling back to an actionSheet on iOS 14.
+@available(iOS 14.0, *)
+private struct ConfirmationDialogModifier: ViewModifier {
+    @Binding var isPresented: Bool
+
+    func body(content: Content) -> some View {
+        if #available(iOS 15.0, *) {
+            content
+                .confirmationDialog("Choose Option", isPresented: $isPresented) {
+                    Button("Option 1") {}
+                        .accessibilityLabel("swiftui_dialog_option_1")
+                    Button("Option 2") {}
+                        .accessibilityLabel("swiftui_dialog_option_2")
+                    Button("Option 3") {}
+                        .accessibilityLabel("swiftui_dialog_option_3")
+                    Button("Cancel", role: .cancel) {}
+                }
+        } else {
+            content
+                .actionSheet(isPresented: $isPresented) {
+                    ActionSheet(
+                        title: Text("Choose Option"),
+                        buttons: [
+                            .default(Text("Option 1")),
+                            .default(Text("Option 2")),
+                            .default(Text("Option 3")),
+                            .cancel(),
+                        ]
+                    )
+                }
+        }
+    }
+}
+
+/// Simple bordered button style compatible with iOS 14+
+@available(iOS 14.0, *)
+private struct TestButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Color.blue.opacity(configuration.isPressed ? 0.2 : 0.1))
+            .foregroundColor(.blue)
+            .cornerRadius(8)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.blue.opacity(0.5), lineWidth: 1)
+            )
+    }
+}
+
+@available(iOS 14.0, *)
+private struct SectionHeader: View {
+    let title: String
+
+    init(_ title: String) {
+        self.title = title
+    }
+
+    var body: some View {
+        Text(title.uppercased())
+            .font(.caption.bold())
+            .foregroundColor(.secondary)
+            .padding(.top, 8)
+    }
+}
+
+/// UIKit wrapper to present SwiftUI view from storyboard
+@available(iOS 14.0, *)
+class SwiftUIAutocaptureTestHostingController: UIHostingController<SwiftUIAutocaptureTestView> {
+    required init?(coder: NSCoder) {
+        super.init(coder: coder, rootView: SwiftUIAutocaptureTestView())
+    }
+
+    init() {
+        super.init(rootView: SwiftUIAutocaptureTestView())
+    }
+}

--- a/MixpanelDemo/MixpanelDemo/SwiftUIWalkUpTestView.swift
+++ b/MixpanelDemo/MixpanelDemo/SwiftUIWalkUpTestView.swift
@@ -1,0 +1,163 @@
+//
+//  SwiftUIWalkUpTestView.swift
+//  MixpanelDemo
+//
+//  Created by Mixpanel on 2026-08-03.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+import SwiftUI
+
+/// Test screen for validating walk-up-to-clickable-parent behavior in SwiftUI.
+///
+/// When the SDK detects a tap on a non-interactive leaf view, it walks up to
+/// the nearest interactive ancestor for $el_id.
+@available(iOS 14.0, *)
+struct SwiftUIWalkUpTestView: View {
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 10) {
+
+                // MARK: - 1. Basic Walk-Up
+                SectionHeader("Basic Walk-Up")
+
+                Text("Tap the button. $el_id should be \"add_to_cart\".")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+
+                Button("Add to Cart") {}
+                    .accessibilityLabel("add_to_cart")
+                    .buttonStyle(TestButtonStyle())
+
+                // MARK: - 2. Nested Clickables
+                SectionHeader("Nested Clickables")
+
+                Text(
+                    "Tap \"Delete\". Walk-up stops at inner button (\"delete_item\"), not outer card (\"product_card\")."
+                )
+                .font(.caption)
+                .foregroundColor(.gray)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Product Name")
+                        .font(.headline)
+
+                    Button(action: {}) {
+                        HStack {
+                            Image(systemName: "trash")
+                            Text("Delete")
+                        }
+                    }
+                    .accessibilityLabel("delete_item")
+                    .buttonStyle(TestButtonStyle(color: .red))
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(UIColor.systemGray6))
+                .cornerRadius(12)
+                .onTapGesture {}
+                .accessibilityLabel("product_card")
+
+                // MARK: - 3. Clickable Container with Icon + Text
+                SectionHeader("Clickable Container with Icon + Text")
+
+                Text("Tap icon or text. $el_id should be \"checkout_action\".")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+
+                Button(action: {}) {
+                    HStack(spacing: 12) {
+                        Image(systemName: "cart.fill")
+                            .foregroundColor(.green)
+                        Text("Proceed to Checkout")
+                            .font(.body)
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .accessibilityLabel("checkout_action")
+                .buttonStyle(TestButtonStyle())
+
+                // MARK: - 4. No Clickable Ancestor
+                SectionHeader("No Clickable Ancestor")
+
+                Text("Tap below. No clickable ancestor. $el_id = hash fallback.")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+
+                Text("Terms and Conditions apply.")
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+                    .padding(8)
+
+                // MARK: - 5. Leaf Has Own Identity
+                SectionHeader("Leaf Has Own Identity")
+
+                Text(
+                    "Tap the text. Even though it has its own accessibilityLabel (\"inner_label\"), walk-up still activates and takes the clickable parent's identity. $el_id = \"outer_button\"."
+                )
+                .font(.caption)
+                .foregroundColor(.gray)
+
+                Button(action: {}) {
+                    Text("I have my own identity")
+                        .accessibilityLabel("inner_label")
+                }
+                .accessibilityLabel("outer_button")
+                .buttonStyle(TestButtonStyle())
+            }
+            .padding()
+        }
+        .navigationTitle("SwiftUI Walk-Up Test")
+    }
+}
+
+// MARK: - Local Helper Views
+
+@available(iOS 14.0, *)
+private struct SectionHeader: View {
+    let title: String
+
+    init(_ title: String) {
+        self.title = title
+    }
+
+    var body: some View {
+        Text(title.uppercased())
+            .font(.caption.bold())
+            .foregroundColor(.secondary)
+            .padding(.top, 8)
+    }
+}
+
+private struct TestButtonStyle: ButtonStyle {
+    var color: Color = .blue
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(color.opacity(configuration.isPressed ? 0.2 : 0.1))
+            .foregroundColor(color)
+            .cornerRadius(8)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(color.opacity(0.5), lineWidth: 1)
+            )
+    }
+}
+
+// MARK: - Hosting Controller Wrapper
+
+@available(iOS 14.0, *)
+class SwiftUIWalkUpTestHostingController: UIHostingController<SwiftUIWalkUpTestView> {
+    init() {
+        super.init(rootView: SwiftUIWalkUpTestView())
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/MixpanelDemo/MixpanelDemo/SwiftUIWalkUpTestView.swift
+++ b/MixpanelDemo/MixpanelDemo/SwiftUIWalkUpTestView.swift
@@ -27,7 +27,7 @@ struct SwiftUIWalkUpTestView: View {
                     .foregroundColor(.gray)
 
                 Button("Add to Cart") {}
-                    .accessibilityLabel("add_to_cart")
+                    .accessibilityIdentifier("add_to_cart")
                     .buttonStyle(TestButtonStyle())
 
                 // MARK: - 2. Nested Clickables
@@ -49,7 +49,7 @@ struct SwiftUIWalkUpTestView: View {
                             Text("Delete")
                         }
                     }
-                    .accessibilityLabel("delete_item")
+                    .accessibilityIdentifier("delete_item")
                     .buttonStyle(TestButtonStyle(color: .red))
                 }
                 .padding()
@@ -57,7 +57,7 @@ struct SwiftUIWalkUpTestView: View {
                 .background(Color(UIColor.systemGray6))
                 .cornerRadius(12)
                 .onTapGesture {}
-                .accessibilityLabel("product_card")
+                .accessibilityIdentifier("product_card")
 
                 // MARK: - 3. Clickable Container with Icon + Text
                 SectionHeader("Clickable Container with Icon + Text")
@@ -76,7 +76,7 @@ struct SwiftUIWalkUpTestView: View {
                     .padding()
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .accessibilityLabel("checkout_action")
+                .accessibilityIdentifier("checkout_action")
                 .buttonStyle(TestButtonStyle())
 
                 // MARK: - 4. No Clickable Ancestor
@@ -95,16 +95,16 @@ struct SwiftUIWalkUpTestView: View {
                 SectionHeader("Leaf Has Own Identity")
 
                 Text(
-                    "Tap the text. Even though it has its own accessibilityLabel (\"inner_label\"), walk-up still activates and takes the clickable parent's identity. $el_id = \"outer_button\"."
+                    "Tap the text. Even though it has its own accessibilityIdentifier (\"inner_label\"), walk-up still activates and takes the clickable parent's identity. $el_id = \"outer_button\"."
                 )
                 .font(.caption)
                 .foregroundColor(.gray)
 
                 Button(action: {}) {
                     Text("I have my own identity")
-                        .accessibilityLabel("inner_label")
+                        .accessibilityIdentifier("inner_label")
                 }
-                .accessibilityLabel("outer_button")
+                .accessibilityIdentifier("outer_button")
                 .buttonStyle(TestButtonStyle())
             }
             .padding()

--- a/MixpanelDemo/MixpanelDemo/UIKitAutocaptureTestViewController.swift
+++ b/MixpanelDemo/MixpanelDemo/UIKitAutocaptureTestViewController.swift
@@ -74,8 +74,9 @@ class UIKitAutocaptureTestViewController: UIViewController, UIPopoverPresentatio
             hasAction: true
         )
 
-        // Rule 2: accessibilityLabel fallback
-        let rule2Btn = makeButton("Rule 2 - accessibilityLabel only", hasAction: true)
+        // Rule 2: accessibilityLabel is never an $el_id source — this falls back to the hash.
+        // The label is set deliberately so the screen proves it is ignored.
+        let rule2Btn = makeButton("Rule 2 - Label only (ignored -> hash)", hasAction: true)
         rule2Btn.accessibilityLabel = "Rule Two"
         stackView.addArrangedSubview(rule2Btn)
 
@@ -87,8 +88,8 @@ class UIKitAutocaptureTestViewController: UIViewController, UIPopoverPresentatio
             hasAction: true
         )
 
-        // Rule 1 wins over Rule 2
-        let bothBtn = makeButton("Rule 1 Wins - Both ID + Label", hasAction: true)
+        // Identifier is used and the label is ignored, even when both are present.
+        let bothBtn = makeButton("Identifier Wins - Both ID + Label", hasAction: true)
         bothBtn.accessibilityIdentifier = "both_id"
         bothBtn.accessibilityLabel = "Both Label"
         stackView.addArrangedSubview(bothBtn)
@@ -464,7 +465,7 @@ private struct MixedFrameworkSwiftUIContent: View {
             Button("3. SwiftUI Btn -> UIKit Text") {
                 onUikitTextUpdate()
             }
-            .accessibilityLabel("swiftui_btn_uikit_text_in_uikit")
+            .accessibilityIdentifier("swiftui_btn_uikit_text_in_uikit")
             .frame(maxWidth: .infinity, alignment: .center)
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
@@ -479,7 +480,7 @@ private struct MixedFrameworkSwiftUIContent: View {
             Button("4. SwiftUI Btn -> SwiftUI Text") {
                 model.counter += 1
             }
-            .accessibilityLabel("swiftui_btn_swiftui_text_in_uikit")
+            .accessibilityIdentifier("swiftui_btn_swiftui_text_in_uikit")
             .frame(maxWidth: .infinity, alignment: .center)
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
@@ -492,7 +493,7 @@ private struct MixedFrameworkSwiftUIContent: View {
 
             // SwiftUI text counter (updated by cases 2 & 4)
             Text("SwiftUI counter: \(model.counter)")
-                .accessibilityLabel("swiftui_text_counter_in_uikit")
+                .accessibilityIdentifier("swiftui_text_counter_in_uikit")
         }
     }
 }

--- a/MixpanelDemo/MixpanelDemo/UIKitAutocaptureTestViewController.swift
+++ b/MixpanelDemo/MixpanelDemo/UIKitAutocaptureTestViewController.swift
@@ -1,0 +1,498 @@
+//
+//  UIKitAutocaptureTestViewController.swift
+//  MixpanelDemo
+//
+//  Created by Mixpanel on 2026-06-13.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+import Mixpanel
+import SwiftUI
+import UIKit
+
+/// Test screen for validating UIKit autocapture functionality.
+///
+/// Tests all three event types ($mp_click, $mp_rage_click, $mp_dead_click)
+/// and verifies $el_id resolution rules for UIKit views.
+class UIKitAutocaptureTestViewController: UIViewController, UIPopoverPresentationControllerDelegate {
+
+    private let scrollView = UIScrollView()
+    private let stackView = UIStackView()
+
+    // Mixed framework test state
+    private var uikitCounter = 0
+    private var uikitCounterLabel: UILabel?
+    private var swiftUICounterModel: AnyObject?  // MixedFrameworkCounterModel (iOS 13+)
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "UIKit Autocapture Test"
+        if #available(iOS 13.0, *) {
+            view.backgroundColor = .systemBackground
+        } else {
+            view.backgroundColor = .white
+        }
+        setupScrollView()
+        setupTestElements()
+    }
+
+    private func setupScrollView() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(scrollView)
+
+        stackView.axis = .vertical
+        stackView.spacing = 10
+        stackView.layoutMargins = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+        ])
+    }
+
+    private func setupTestElements() {
+        // MARK: - $el_id Resolution Section
+
+        stackView.addArrangedSubview(sectionLabel("$el_id Resolution"))
+
+        // Rule 1: accessibilityIdentifier wins
+        addButton(
+            to: stackView,
+            title: "Rule 1 - accessibilityIdentifier",
+            identifier: "rule1_btn",
+            hasAction: true
+        )
+
+        // Rule 2: accessibilityLabel fallback
+        let rule2Btn = makeButton("Rule 2 - accessibilityLabel only", hasAction: true)
+        rule2Btn.accessibilityLabel = "Rule Two"
+        stackView.addArrangedSubview(rule2Btn)
+
+        // Rule 3: Hash fallback (no ID, no label)
+        addButton(
+            to: stackView,
+            title: "Rule 3 - No ID, No Label (hash)",
+            identifier: nil,
+            hasAction: true
+        )
+
+        // Rule 1 wins over Rule 2
+        let bothBtn = makeButton("Rule 1 Wins - Both ID + Label", hasAction: true)
+        bothBtn.accessibilityIdentifier = "both_id"
+        bothBtn.accessibilityLabel = "Both Label"
+        stackView.addArrangedSubview(bothBtn)
+
+        // Custom UIView with tap gesture
+        let customView = UIView()
+        customView.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.15)
+        customView.accessibilityIdentifier = "custom_view"
+        customView.translatesAutoresizingMaskIntoConstraints = false
+        customView.heightAnchor.constraint(equalToConstant: 44).isActive = true
+
+        let tapLabel = UILabel()
+        tapLabel.text = "Custom UIView with tap gesture"
+        tapLabel.textAlignment = .center
+        tapLabel.translatesAutoresizingMaskIntoConstraints = false
+        customView.addSubview(tapLabel)
+        NSLayoutConstraint.activate([
+            tapLabel.centerXAnchor.constraint(equalTo: customView.centerXAnchor),
+            tapLabel.centerYAnchor.constraint(equalTo: customView.centerYAnchor),
+        ])
+
+        customView.addGestureRecognizer(
+            UITapGestureRecognizer(target: self, action: #selector(noop)))
+        stackView.addArrangedSubview(customView)
+
+        // MARK: - Dead Click Section
+
+        stackView.addArrangedSubview(sectionLabel("Dead Click"))
+
+        // Dead button (no action) - should emit $mp_dead_click
+        addButton(
+            to: stackView,
+            title: "Dead Button (no action) -> $mp_dead_click",
+            identifier: "dead_uikit_btn",
+            hasAction: false
+        )
+
+        // MARK: - Rage Click Section
+
+        stackView.addArrangedSubview(sectionLabel("Rage Click - tap 4+ times"))
+
+        // Rage zone
+        let rageZone = UIView()
+        rageZone.backgroundColor = UIColor.systemRed.withAlphaComponent(0.15)
+        rageZone.accessibilityIdentifier = "rage_zone"
+        rageZone.translatesAutoresizingMaskIntoConstraints = false
+        rageZone.heightAnchor.constraint(equalToConstant: 80).isActive = true
+
+        let rageLabel = UILabel()
+        rageLabel.text = "Rage Zone - tap rapidly here"
+        rageLabel.textAlignment = .center
+        rageLabel.translatesAutoresizingMaskIntoConstraints = false
+        rageZone.addSubview(rageLabel)
+        NSLayoutConstraint.activate([
+            rageLabel.centerXAnchor.constraint(equalTo: rageZone.centerXAnchor),
+            rageLabel.centerYAnchor.constraint(equalTo: rageZone.centerYAnchor),
+        ])
+
+        rageZone.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(noop)))
+        stackView.addArrangedSubview(rageZone)
+
+        // Click + Rage button
+        addButton(
+            to: stackView,
+            title: "Click + Rage - tap 4x (both events)",
+            identifier: "rage_and_click_btn",
+            hasAction: true
+        )
+
+        // MARK: - Excluded Controls Section (no dead click)
+
+        stackView.addArrangedSubview(sectionLabel("Excluded Controls (no dead click)"))
+
+        let switchControl = UISwitch()
+        switchControl.accessibilityIdentifier = "test_switch"
+        stackView.addArrangedSubview(switchControl)
+
+        let textField = UITextField()
+        textField.placeholder = "UITextField - no dead click"
+        textField.borderStyle = .roundedRect
+        textField.accessibilityIdentifier = "test_textfield"
+        stackView.addArrangedSubview(textField)
+
+        let secureTextField = UITextField()
+        secureTextField.placeholder = "Secure Field - text NOT captured"
+        secureTextField.isSecureTextEntry = true
+        secureTextField.borderStyle = .roundedRect
+        secureTextField.accessibilityIdentifier = "secure_textfield"
+        stackView.addArrangedSubview(secureTextField)
+
+        let stepper = UIStepper()
+        stepper.accessibilityIdentifier = "test_stepper"
+        stackView.addArrangedSubview(stepper)
+
+        // MARK: - Multi-Window / Overlay Section
+
+        stackView.addArrangedSubview(sectionLabel("Multi-Window / Overlay"))
+
+        // Show Alert
+        let alertBtn = makeButton("Show UIAlertController (Alert)", hasAction: false)
+        alertBtn.accessibilityIdentifier = "uikit_alert_trigger"
+        alertBtn.addTarget(self, action: #selector(showAlert), for: .touchUpInside)
+        stackView.addArrangedSubview(alertBtn)
+
+        // Show Action Sheet
+        let actionSheetBtn = makeButton("Show UIAlertController (Action Sheet)", hasAction: false)
+        actionSheetBtn.accessibilityIdentifier = "uikit_actionsheet_trigger"
+        actionSheetBtn.addTarget(self, action: #selector(showActionSheet(_:)), for: .touchUpInside)
+        stackView.addArrangedSubview(actionSheetBtn)
+
+        // Show Popover
+        let popoverBtn = makeButton("Show Popover", hasAction: false)
+        popoverBtn.accessibilityIdentifier = "uikit_popover_trigger"
+        popoverBtn.addTarget(self, action: #selector(showPopover(_:)), for: .touchUpInside)
+        stackView.addArrangedSubview(popoverBtn)
+
+        // Show Share Sheet
+        let shareBtn = makeButton("Show Share Sheet", hasAction: false)
+        shareBtn.accessibilityIdentifier = "uikit_share_trigger"
+        shareBtn.addTarget(self, action: #selector(showShareSheet(_:)), for: .touchUpInside)
+        stackView.addArrangedSubview(shareBtn)
+
+        // MARK: - Mixed Framework Dead Click Tests
+
+        setupMixedFrameworkTests()
+
+        // MARK: - Instructions
+
+        stackView.addArrangedSubview(sectionLabel("Instructions"))
+
+        let instructions = UILabel()
+        instructions.numberOfLines = 0
+        instructions.font = .systemFont(ofSize: 14)
+        if #available(iOS 13.0, *) {
+            instructions.textColor = .secondaryLabel
+        } else {
+            instructions.textColor = .gray
+        }
+        instructions.text = """
+            1. Enable Mixpanel logging to see events
+            2. Tap buttons to verify $mp_click events
+            3. Tap 4+ times rapidly on Rage Zone for $mp_rage_click
+            4. Tap Dead Button and wait 500ms for $mp_dead_click
+            """
+        stackView.addArrangedSubview(instructions)
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func addButton(
+        to stack: UIStackView,
+        title: String,
+        identifier: String?,
+        hasAction: Bool
+    ) -> UIButton {
+        let btn = makeButton(title, hasAction: hasAction)
+        btn.accessibilityIdentifier = identifier
+        stack.addArrangedSubview(btn)
+        return btn
+    }
+
+    private func makeButton(_ title: String, hasAction: Bool) -> UIButton {
+        let btn = UIButton(type: .system)
+        btn.setTitle(title, for: .normal)
+        btn.layer.borderWidth = 1
+        btn.layer.cornerRadius = 8
+        btn.layer.borderColor = UIColor.systemBlue.cgColor
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        btn.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        if hasAction {
+            btn.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
+        }
+        return btn
+    }
+
+    private func sectionLabel(_ text: String) -> UILabel {
+        let label = UILabel()
+        label.text = text.uppercased()
+        label.font = .boldSystemFont(ofSize: 11)
+        if #available(iOS 13.0, *) {
+            label.textColor = .secondaryLabel
+        } else {
+            label.textColor = .gray
+        }
+        return label
+    }
+
+    @objc private func noop() {}
+
+    func adaptivePresentationStyle(
+        for controller: UIPresentationController
+    ) -> UIModalPresentationStyle {
+        return .none
+    }
+
+    @objc private func showAlert() {
+        let alert = UIAlertController(
+            title: "Test Alert",
+            message: "Tap buttons inside this alert",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Confirm", style: .default))
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        present(alert, animated: true)
+    }
+
+    @objc private func showActionSheet(_ sender: UIButton) {
+        let sheet = UIAlertController(
+            title: "Test Action Sheet",
+            message: "Choose an option",
+            preferredStyle: .actionSheet
+        )
+        sheet.addAction(UIAlertAction(title: "Option 1", style: .default))
+        sheet.addAction(UIAlertAction(title: "Option 2", style: .default))
+        sheet.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        if let popover = sheet.popoverPresentationController {
+            popover.sourceView = sender
+            popover.sourceRect = sender.bounds
+        }
+        present(sheet, animated: true)
+    }
+
+    @objc private func showPopover(_ sender: UIButton) {
+        let contentVC = UIViewController()
+        if #available(iOS 13.0, *) {
+            contentVC.view.backgroundColor = .systemBackground
+        } else {
+            contentVC.view.backgroundColor = .white
+        }
+        contentVC.preferredContentSize = CGSize(width: 250, height: 150)
+
+        let dismissBtn = UIButton(type: .system)
+        dismissBtn.setTitle("Dismiss Popover", for: .normal)
+        dismissBtn.translatesAutoresizingMaskIntoConstraints = false
+        contentVC.view.addSubview(dismissBtn)
+        NSLayoutConstraint.activate([
+            dismissBtn.centerXAnchor.constraint(equalTo: contentVC.view.centerXAnchor),
+            dismissBtn.centerYAnchor.constraint(equalTo: contentVC.view.centerYAnchor),
+        ])
+
+        contentVC.modalPresentationStyle = .popover
+        if let popover = contentVC.popoverPresentationController {
+            popover.sourceView = sender
+            popover.sourceRect = sender.bounds
+            popover.permittedArrowDirections = .any
+            popover.delegate = self
+        }
+        present(contentVC, animated: true)
+    }
+
+    @objc private func showShareSheet(_ sender: UIButton) {
+        let items: [Any] = ["Sample text for sharing", URL(string: "https://mixpanel.com")!]
+        let activityVC = UIActivityViewController(activityItems: items, applicationActivities: nil)
+        if let popover = activityVC.popoverPresentationController {
+            popover.sourceView = sender
+            popover.sourceRect = sender.bounds
+        }
+        present(activityVC, animated: true)
+    }
+
+    @objc private func buttonTapped(_ sender: UIButton) {
+        // Visual feedback
+        let originalColor = sender.backgroundColor
+        sender.backgroundColor = UIColor.systemGreen.withAlphaComponent(0.3)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            sender.backgroundColor = originalColor
+        }
+    }
+
+    // MARK: - Mixed Framework Dead Click Tests
+
+    private func setupMixedFrameworkTests() {
+        stackView.addArrangedSubview(sectionLabel("Mixed Framework Dead Click Tests"))
+
+        let subtitle = UILabel()
+        subtitle.text = "None of these should trigger $mp_dead_click"
+        subtitle.font = .systemFont(ofSize: 12)
+        if #available(iOS 13.0, *) {
+            subtitle.textColor = .secondaryLabel
+        } else {
+            subtitle.textColor = .gray
+        }
+        stackView.addArrangedSubview(subtitle)
+
+        // UIKit counter label (updated by cases 1 & 3)
+        let counterLabel = UILabel()
+        counterLabel.text = "UIKit counter: 0"
+        counterLabel.accessibilityIdentifier = "uikit_text_counter_in_uikit"
+        self.uikitCounterLabel = counterLabel
+
+        // Case 1: UIKit Button -> UIKit Text
+        let btn1 = makeButton("1. UIKit Btn -> UIKit Text", hasAction: false)
+        btn1.accessibilityIdentifier = "uikit_btn_uikit_text_in_uikit"
+        btn1.addTarget(self, action: #selector(mixedUikitBtnUikitText), for: .touchUpInside)
+        stackView.addArrangedSubview(btn1)
+
+        stackView.addArrangedSubview(counterLabel)
+
+        // Case 2: UIKit Button -> SwiftUI Text
+        let btn2 = makeButton("2. UIKit Btn -> SwiftUI Text", hasAction: false)
+        btn2.accessibilityIdentifier = "uikit_btn_swiftui_text_in_uikit"
+        btn2.addTarget(self, action: #selector(mixedUikitBtnSwiftUIText), for: .touchUpInside)
+        stackView.addArrangedSubview(btn2)
+
+        // SwiftUI content embedded via UIHostingController (Cases 3 & 4 + SwiftUI counter)
+        if #available(iOS 14.0, *) {
+            let model = MixedFrameworkCounterModel()
+            self.swiftUICounterModel = model
+
+            let swiftUIContent = MixedFrameworkSwiftUIContent(model: model) { [weak self] in
+                self?.uikitCounter += 1
+                self?.uikitCounterLabel?.text = "UIKit counter: \(self?.uikitCounter ?? 0)"
+            }
+
+            let hostingController = UIHostingController(rootView: swiftUIContent)
+            addChild(hostingController)
+            hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+            hostingController.view.backgroundColor = .clear
+
+            // Wrap in a container with green background to visually distinguish SwiftUI content
+            let container = UIView()
+            container.backgroundColor = UIColor.systemGreen.withAlphaComponent(0.08)
+            container.layer.cornerRadius = 8
+            container.translatesAutoresizingMaskIntoConstraints = false
+            container.addSubview(hostingController.view)
+
+            NSLayoutConstraint.activate([
+                hostingController.view.topAnchor.constraint(equalTo: container.topAnchor, constant: 8),
+                hostingController.view.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 8),
+                hostingController.view.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -8),
+                hostingController.view.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -8),
+            ])
+
+            stackView.addArrangedSubview(container)
+            hostingController.didMove(toParent: self)
+        }
+    }
+
+    @objc private func mixedUikitBtnUikitText() {
+        uikitCounter += 1
+        uikitCounterLabel?.text = "UIKit counter: \(uikitCounter)"
+    }
+
+    @objc private func mixedUikitBtnSwiftUIText() {
+        if #available(iOS 13.0, *),
+            let model = swiftUICounterModel as? MixedFrameworkCounterModel
+        {
+            model.counter += 1
+        }
+    }
+}
+
+// MARK: - Mixed Framework Support
+
+/// Observable model shared between UIKit and SwiftUI for cross-framework state updates.
+@available(iOS 13.0, *)
+class MixedFrameworkCounterModel: ObservableObject {
+    @Published var counter = 0
+}
+
+/// SwiftUI content embedded in UIKit screen for mixed-framework dead click testing.
+/// Case 3: SwiftUI Button -> UIKit Text (via closure)
+/// Case 4: SwiftUI Button -> SwiftUI Text (via ObservableObject)
+@available(iOS 14.0, *)
+private struct MixedFrameworkSwiftUIContent: View {
+    @ObservedObject var model: MixedFrameworkCounterModel
+    let onUikitTextUpdate: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Case 3: SwiftUI Button -> UIKit Text
+            Button("3. SwiftUI Btn -> UIKit Text") {
+                onUikitTextUpdate()
+            }
+            .accessibilityLabel("swiftui_btn_uikit_text_in_uikit")
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Color.blue.opacity(0.1))
+            .cornerRadius(8)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.blue.opacity(0.5), lineWidth: 1)
+            )
+
+            // Case 4: SwiftUI Button -> SwiftUI Text
+            Button("4. SwiftUI Btn -> SwiftUI Text") {
+                model.counter += 1
+            }
+            .accessibilityLabel("swiftui_btn_swiftui_text_in_uikit")
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Color.blue.opacity(0.1))
+            .cornerRadius(8)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.blue.opacity(0.5), lineWidth: 1)
+            )
+
+            // SwiftUI text counter (updated by cases 2 & 4)
+            Text("SwiftUI counter: \(model.counter)")
+                .accessibilityLabel("swiftui_text_counter_in_uikit")
+        }
+    }
+}

--- a/MixpanelDemo/MixpanelDemo/UIKitWalkUpTestViewController.swift
+++ b/MixpanelDemo/MixpanelDemo/UIKitWalkUpTestViewController.swift
@@ -1,0 +1,225 @@
+//
+//  UIKitWalkUpTestViewController.swift
+//  MixpanelDemo
+//
+//  Created by Mixpanel on 2026-08-03.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+import UIKit
+
+/// Test screen for validating walk-up-to-clickable-parent behavior in UIKit.
+///
+/// When the SDK detects a tap on a non-interactive leaf view (e.g., UILabel inside
+/// a UIButton), it walks up to the nearest interactive ancestor for $el_id.
+class UIKitWalkUpTestViewController: UIViewController {
+
+    private let scrollView = UIScrollView()
+    private let stackView = UIStackView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "UIKit Walk-Up Test"
+        if #available(iOS 13.0, *) {
+            view.backgroundColor = .systemBackground
+        } else {
+            view.backgroundColor = .white
+        }
+        setupScrollView()
+        setupTestElements()
+    }
+
+    private func setupScrollView() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(scrollView)
+
+        stackView.axis = .vertical
+        stackView.spacing = 10
+        stackView.layoutMargins = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+        ])
+    }
+
+    private func setupTestElements() {
+
+        // MARK: - 1. Basic Walk-Up
+        stackView.addArrangedSubview(sectionLabel("Basic Walk-Up"))
+        stackView.addArrangedSubview(
+            descriptionLabel(
+                "Tap the button. The UILabel inside is the hit-test target. "
+                    + "$el_id should be \"add_to_cart\" from the UIButton's accessibilityLabel."
+            ))
+
+        let addToCartBtn = UIButton(type: .system)
+        addToCartBtn.setTitle("Add to Cart", for: .normal)
+        addToCartBtn.accessibilityLabel = "add_to_cart"
+        addToCartBtn.addTarget(self, action: #selector(noOp), for: .touchUpInside)
+        addToCartBtn.backgroundColor = .systemBlue
+        addToCartBtn.setTitleColor(.white, for: .normal)
+        addToCartBtn.layer.cornerRadius = 8
+        addToCartBtn.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        stackView.addArrangedSubview(addToCartBtn)
+
+        // MARK: - 2. Nested Clickables
+        stackView.addArrangedSubview(sectionLabel("Nested Clickables"))
+        stackView.addArrangedSubview(
+            descriptionLabel(
+                "Tap \"Delete\". Walk-up should stop at the inner button (\"delete_item\"), "
+                    + "NOT continue to the outer card (\"product_card\")."
+            ))
+
+        let card = UIView()
+        card.backgroundColor = .systemGray6
+        card.layer.cornerRadius = 12
+        card.isUserInteractionEnabled = true
+        card.accessibilityLabel = "product_card"
+        let cardTap = UITapGestureRecognizer(target: self, action: #selector(noOp))
+        card.addGestureRecognizer(cardTap)
+
+        let cardStack = UIStackView()
+        cardStack.axis = .vertical
+        cardStack.spacing = 8
+        cardStack.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(cardStack)
+        NSLayoutConstraint.activate([
+            cardStack.topAnchor.constraint(equalTo: card.topAnchor, constant: 16),
+            cardStack.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 16),
+            cardStack.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -16),
+            cardStack.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -16),
+        ])
+
+        let productLabel = UILabel()
+        productLabel.text = "Product Name"
+        productLabel.font = .boldSystemFont(ofSize: 16)
+        cardStack.addArrangedSubview(productLabel)
+
+        let deleteBtn = UIButton(type: .system)
+        deleteBtn.setTitle("Delete", for: .normal)
+        deleteBtn.accessibilityLabel = "delete_item"
+        deleteBtn.addTarget(self, action: #selector(noOp), for: .touchUpInside)
+        deleteBtn.backgroundColor = .systemRed
+        deleteBtn.setTitleColor(.white, for: .normal)
+        deleteBtn.layer.cornerRadius = 8
+        deleteBtn.heightAnchor.constraint(equalToConstant: 36).isActive = true
+        cardStack.addArrangedSubview(deleteBtn)
+
+        stackView.addArrangedSubview(card)
+
+        // MARK: - 3. Clickable Container with Icon + Text
+        stackView.addArrangedSubview(sectionLabel("Clickable Container with Icon + Text"))
+        stackView.addArrangedSubview(
+            descriptionLabel(
+                "Tap the icon or text. $el_id should be \"checkout_action\" from the container."
+            ))
+
+        let checkoutRow = UIView()
+        checkoutRow.isUserInteractionEnabled = true
+        checkoutRow.accessibilityLabel = "checkout_action"
+        let checkoutTap = UITapGestureRecognizer(target: self, action: #selector(noOp))
+        checkoutRow.addGestureRecognizer(checkoutTap)
+
+        let rowStack = UIStackView()
+        rowStack.axis = .horizontal
+        rowStack.spacing = 12
+        rowStack.alignment = .center
+        rowStack.translatesAutoresizingMaskIntoConstraints = false
+        checkoutRow.addSubview(rowStack)
+        NSLayoutConstraint.activate([
+            rowStack.topAnchor.constraint(equalTo: checkoutRow.topAnchor, constant: 16),
+            rowStack.leadingAnchor.constraint(equalTo: checkoutRow.leadingAnchor, constant: 16),
+            rowStack.trailingAnchor.constraint(equalTo: checkoutRow.trailingAnchor, constant: -16),
+            rowStack.bottomAnchor.constraint(equalTo: checkoutRow.bottomAnchor, constant: -16),
+        ])
+
+        if #available(iOS 13.0, *) {
+            let icon = UIImageView(image: UIImage(systemName: "cart.fill"))
+            icon.tintColor = .systemGreen
+            icon.widthAnchor.constraint(equalToConstant: 24).isActive = true
+            icon.heightAnchor.constraint(equalToConstant: 24).isActive = true
+            rowStack.addArrangedSubview(icon)
+        }
+
+        let checkoutLabel = UILabel()
+        checkoutLabel.text = "Proceed to Checkout"
+        checkoutLabel.font = .systemFont(ofSize: 16)
+        rowStack.addArrangedSubview(checkoutLabel)
+
+        stackView.addArrangedSubview(checkoutRow)
+
+        // MARK: - 4. No Clickable Ancestor
+        stackView.addArrangedSubview(sectionLabel("No Clickable Ancestor"))
+        stackView.addArrangedSubview(
+            descriptionLabel(
+                "Tap below. No clickable ancestor exists. $el_id should be a hash fallback."
+            ))
+
+        let plainText = UILabel()
+        plainText.text = "Terms and Conditions apply."
+        plainText.textColor = .gray
+        plainText.font = .systemFont(ofSize: 14)
+        stackView.addArrangedSubview(plainText)
+
+        // MARK: - 5. Leaf Has Own Identity
+        stackView.addArrangedSubview(sectionLabel("Leaf Has Own Identity"))
+        stackView.addArrangedSubview(
+            descriptionLabel(
+                "Tap the label. Even though it has its own accessibilityLabel (\"inner_label\"), "
+                    + "walk-up still activates and takes the clickable parent's identity. "
+                    + "$el_id should be \"outer_container\"."
+            ))
+
+        let outerView = UIView()
+        outerView.isUserInteractionEnabled = true
+        outerView.accessibilityLabel = "outer_container"
+        let outerTap = UITapGestureRecognizer(target: self, action: #selector(noOp))
+        outerView.addGestureRecognizer(outerTap)
+        outerView.backgroundColor = .systemGray6
+        outerView.layer.cornerRadius = 8
+
+        let innerLabel = UILabel()
+        innerLabel.text = "I have my own identity"
+        innerLabel.accessibilityLabel = "inner_label"
+        innerLabel.translatesAutoresizingMaskIntoConstraints = false
+        outerView.addSubview(innerLabel)
+        NSLayoutConstraint.activate([
+            innerLabel.topAnchor.constraint(equalTo: outerView.topAnchor, constant: 16),
+            innerLabel.leadingAnchor.constraint(equalTo: outerView.leadingAnchor, constant: 16),
+            innerLabel.trailingAnchor.constraint(equalTo: outerView.trailingAnchor, constant: -16),
+            innerLabel.bottomAnchor.constraint(equalTo: outerView.bottomAnchor, constant: -16),
+        ])
+        stackView.addArrangedSubview(outerView)
+    }
+
+    // MARK: - Helpers
+
+    @objc private func noOp() {}
+
+    private func sectionLabel(_ text: String) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.font = .boldSystemFont(ofSize: 18)
+        return label
+    }
+
+    private func descriptionLabel(_ text: String) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.font = .systemFont(ofSize: 12)
+        label.textColor = .gray
+        label.numberOfLines = 0
+        return label
+    }
+}

--- a/MixpanelDemo/MixpanelDemo/UIKitWalkUpTestViewController.swift
+++ b/MixpanelDemo/MixpanelDemo/UIKitWalkUpTestViewController.swift
@@ -60,12 +60,12 @@ class UIKitWalkUpTestViewController: UIViewController {
         stackView.addArrangedSubview(
             descriptionLabel(
                 "Tap the button. The UILabel inside is the hit-test target. "
-                    + "$el_id should be \"add_to_cart\" from the UIButton's accessibilityLabel."
+                    + "$el_id should be \"add_to_cart\" from the UIButton's accessibilityIdentifier."
             ))
 
         let addToCartBtn = UIButton(type: .system)
         addToCartBtn.setTitle("Add to Cart", for: .normal)
-        addToCartBtn.accessibilityLabel = "add_to_cart"
+        addToCartBtn.accessibilityIdentifier = "add_to_cart"
         addToCartBtn.addTarget(self, action: #selector(noOp), for: .touchUpInside)
         addToCartBtn.backgroundColor = .systemBlue
         addToCartBtn.setTitleColor(.white, for: .normal)
@@ -85,7 +85,7 @@ class UIKitWalkUpTestViewController: UIViewController {
         card.backgroundColor = .systemGray6
         card.layer.cornerRadius = 12
         card.isUserInteractionEnabled = true
-        card.accessibilityLabel = "product_card"
+        card.accessibilityIdentifier = "product_card"
         let cardTap = UITapGestureRecognizer(target: self, action: #selector(noOp))
         card.addGestureRecognizer(cardTap)
 
@@ -108,7 +108,7 @@ class UIKitWalkUpTestViewController: UIViewController {
 
         let deleteBtn = UIButton(type: .system)
         deleteBtn.setTitle("Delete", for: .normal)
-        deleteBtn.accessibilityLabel = "delete_item"
+        deleteBtn.accessibilityIdentifier = "delete_item"
         deleteBtn.addTarget(self, action: #selector(noOp), for: .touchUpInside)
         deleteBtn.backgroundColor = .systemRed
         deleteBtn.setTitleColor(.white, for: .normal)
@@ -127,7 +127,7 @@ class UIKitWalkUpTestViewController: UIViewController {
 
         let checkoutRow = UIView()
         checkoutRow.isUserInteractionEnabled = true
-        checkoutRow.accessibilityLabel = "checkout_action"
+        checkoutRow.accessibilityIdentifier = "checkout_action"
         let checkoutTap = UITapGestureRecognizer(target: self, action: #selector(noOp))
         checkoutRow.addGestureRecognizer(checkoutTap)
 
@@ -176,14 +176,14 @@ class UIKitWalkUpTestViewController: UIViewController {
         stackView.addArrangedSubview(sectionLabel("Leaf Has Own Identity"))
         stackView.addArrangedSubview(
             descriptionLabel(
-                "Tap the label. Even though it has its own accessibilityLabel (\"inner_label\"), "
+                "Tap the label. Even though it has its own accessibilityIdentifier (\"inner_label\"), "
                     + "walk-up still activates and takes the clickable parent's identity. "
                     + "$el_id should be \"outer_container\"."
             ))
 
         let outerView = UIView()
         outerView.isUserInteractionEnabled = true
-        outerView.accessibilityLabel = "outer_container"
+        outerView.accessibilityIdentifier = "outer_container"
         let outerTap = UITapGestureRecognizer(target: self, action: #selector(noOp))
         outerView.addGestureRecognizer(outerTap)
         outerView.backgroundColor = .systemGray6
@@ -191,7 +191,7 @@ class UIKitWalkUpTestViewController: UIViewController {
 
         let innerLabel = UILabel()
         innerLabel.text = "I have my own identity"
-        innerLabel.accessibilityLabel = "inner_label"
+        innerLabel.accessibilityIdentifier = "inner_label"
         innerLabel.translatesAutoresizingMaskIntoConstraints = false
         outerView.addSubview(innerLabel)
         NSLayoutConstraint.activate([

--- a/MixpanelDemo/MixpanelDemo/UtilityViewController.swift
+++ b/MixpanelDemo/MixpanelDemo/UtilityViewController.swift
@@ -8,6 +8,7 @@
 
 import Mixpanel
 import StoreKit
+import SwiftUI
 import UIKit
 
 class UtilityViewController: UIViewController, UITableViewDelegate, UITableViewDataSource,

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
@@ -1,0 +1,785 @@
+//
+//  AutocaptureSwiftUIInstrumentedTests.swift
+//  MixpanelDemoTests
+//
+//  Created by Mixpanel on 2026-06-29.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+import SwiftUI
+import XCTest
+
+@testable import Mixpanel
+
+#if os(iOS)
+
+/// Instrumented tests for SwiftUI autocapture functionality.
+///
+/// These tests verify that touch events on SwiftUI views are correctly captured
+/// and transformed into Mixpanel autocapture events ($mp_click, $mp_rage_click, $mp_dead_click).
+///
+/// Test coverage mirrors the Android ComposeAutocaptureInstrumentedTest.
+@available(iOS 14.0, *)
+class AutocaptureSwiftUIInstrumentedTests: MixpanelBaseTests {
+
+    // MARK: - Properties
+
+    private var testWindow: UIWindow!
+    private var hostingController: UIHostingController<SwiftUIAutocaptureTestView>!
+    private var testView: SwiftUIAutocaptureTestView!
+    private var mixpanel: MixpanelInstance!
+
+    // MARK: - Setup / Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        // Create test window and SwiftUI view on main thread
+        let setupExpectation = expectation(description: "Setup complete")
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            // Create SwiftUI test view
+            self.testView = SwiftUIAutocaptureTestView()
+
+            // Create hosting controller
+            self.hostingController = UIHostingController(rootView: self.testView)
+
+            // Create test window
+            self.testWindow = UIWindow(frame: UIScreen.main.bounds)
+            self.testWindow.rootViewController = self.hostingController
+            self.testWindow.makeKeyAndVisible()
+
+            // Force layout and view loading
+            self.hostingController.view.setNeedsLayout()
+            self.hostingController.view.layoutIfNeeded()
+            self.testWindow.layoutIfNeeded()
+
+            setupExpectation.fulfill()
+        }
+        wait(for: [setupExpectation], timeout: 10)
+
+        // Allow SwiftUI to fully render - this needs to happen outside the main async block
+        // Run the run loop to process SwiftUI's asynchronous rendering
+        let renderExpectation = expectation(description: "SwiftUI rendering")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            renderExpectation.fulfill()
+        }
+        wait(for: [renderExpectation], timeout: 5)
+
+        // Initialize Mixpanel with autocapture
+        let token = randomId()
+        let autocaptureOptions = AutocaptureOptions(
+            clickOptions: ClickOptions(enabled: true),
+            rageClickOptions: RageClickOptions(enabled: true, clickThreshold: 4, timeWindowMs: 1000),
+            deadClickOptions: DeadClickOptions(enabled: true, timeWindowMs: 500)
+        )
+
+        let options = MixpanelOptions(
+            token: token,
+            flushInterval: 60,
+            instanceName: token,
+            trackAutomaticEvents: false,
+            optOutTrackingByDefault: false,
+            serverURL: kFakeServerUrl,
+            autocaptureOptions: autocaptureOptions
+        )
+
+        mixpanel = Mixpanel.initialize(options: options)
+
+        // Wait for autocapture to start
+        waitForAsyncTasks()
+    }
+
+    override func tearDown() {
+        // Clean up on main thread
+        let teardownExpectation = expectation(description: "Teardown complete")
+        DispatchQueue.main.async { [weak self] in
+            self?.testWindow?.isHidden = true
+            self?.testWindow = nil
+            self?.hostingController = nil
+            self?.testView = nil
+            teardownExpectation.fulfill()
+        }
+        wait(for: [teardownExpectation], timeout: 5)
+
+        // Clean up Mixpanel
+        if let token = mixpanel?.apiToken {
+            removeDBfile(token)
+        }
+        super.tearDown()
+    }
+
+    // MARK: - Test 1: Basic Click Event
+
+    func testSwiftUIClickEventBasic() {
+        // Debug: Print view hierarchy to understand structure
+        if let rootView = hostingController?.view {
+            print("=== SwiftUI View Hierarchy ===")
+            printViewHierarchy(rootView)
+            print("=== Tappable Views ===")
+            let tappables = findAllTappableViews(in: rootView)
+            for v in tappables {
+                print(
+                    "  - \(type(of: v)): id=\(v.accessibilityIdentifier ?? "nil"), label=\(v.accessibilityLabel ?? "nil")"
+                )
+            }
+            print("==============================")
+        }
+
+        // Given: A SwiftUI button with accessibilityLabel
+        // SwiftUI renders views without exposing accessibility on UIKit layer
+        // So we simulate tap on the button by index and set accessibility for testing
+        simulateTapOnSwiftUIButton(index: 0, setAccessibility: "SwiftUI Rule 1")
+
+        // Then: Verify $mp_click event is captured
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event")
+
+        if let props = event?.properties {
+            // SwiftUI uses accessibilityLabel as primary element ID
+            XCTAssertEqual(props["$el_id"] as? String, "SwiftUI Rule 1")
+            XCTAssertNotNil(props["$x"], "Should have $x coordinate")
+            XCTAssertNotNil(props["$y"], "Should have $y coordinate")
+        }
+    }
+
+    // MARK: - Test 2: accessibilityIdentifier fallback
+
+    func testSwiftUIElementIdResolutionRule2() {
+        // In SwiftUI, accessibilityLabel is primary
+        simulateTapOnSwiftUIButton(index: 1, setAccessibility: "Rule Two SwiftUI")
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event")
+
+        if let props = event?.properties {
+            // Should use accessibilityLabel as ID
+            XCTAssertEqual(props["$el_id"] as? String, "Rule Two SwiftUI")
+        }
+    }
+
+    // MARK: - Test 3: Hash-based fallback
+
+    func testSwiftUIElementIdHashFallback() {
+        // Given: A SwiftUI button with minimal accessibility (hash fallback)
+        // Button at index 2 - set accessibilityIdentifier only (not label) for hash fallback
+        setSwiftUIButtonAccessibility(index: 2, identifier: "swiftui_rule3", label: nil)
+        simulateTapOnSwiftUIButton(index: 2)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event")
+
+        if let props = event?.properties {
+            let elId = props["$el_id"] as? String ?? ""
+            // For SwiftUI without explicit label, may get hash or identifier
+            XCTAssertFalse(elId.isEmpty, "Should have some element ID")
+        }
+    }
+
+    // MARK: - Test 4: Rage Click Detection
+
+    func testSwiftUIRageClickDetection() {
+        // Set up the button with accessibility first
+        // Note: For SwiftUI rendered views (_UIGraphicsView), they're not detected as SwiftUI
+        // by the SemanticExtractor (since class name doesn't contain "Hosting" or "SwiftUI"),
+        // so UIKit resolution rules apply (identifier first).
+        // We set only the identifier to match expected behavior.
+        setSwiftUIButtonAccessibility(index: 4, identifier: "swiftui_rage", label: nil)
+
+        // Perform 4 rapid taps on rage zone
+        for _ in 0..<4 {
+            simulateTapOnSwiftUIButton(index: 4)
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+
+        let rageEvent = waitForEvent(named: "$mp_rage_click", timeout: 5)
+        XCTAssertNotNil(rageEvent, "Should capture $mp_rage_click after 4 rapid taps")
+
+        if let props = rageEvent?.properties {
+            // SwiftUI rendered views use UIKit resolution rules (identifier first)
+            XCTAssertEqual(props["$el_id"] as? String, "swiftui_rage")
+        }
+    }
+
+    // MARK: - Test 5: Dead Click Detection
+
+    func testSwiftUIDeadClickDetection() {
+        // SwiftUI Button with empty action (dead click scenario)
+        // Note: SwiftUI's _UIGraphicsView doesn't expose gesture recognizers at UIKit layer,
+        // so we need to add one to make the view appear interactive for dead click detection
+        makeSwiftUIButtonInteractive(index: 5)
+        setSwiftUIButtonAccessibility(index: 5, identifier: "swiftui_dead", label: nil)
+        simulateTapOnSwiftUIButton(index: 5)
+
+        // Should get $mp_click first
+        let clickEvent = waitForEvent(named: "$mp_click", timeout: 3)
+        XCTAssertNotNil(clickEvent, "Should capture $mp_click event")
+
+        // Then $mp_dead_click after timeout (within 500ms + baseline delay)
+        let deadEvent = waitForEvent(named: "$mp_dead_click", timeout: 3)
+        XCTAssertNotNil(deadEvent, "Should capture $mp_dead_click")
+
+        if let props = deadEvent?.properties {
+            // SwiftUI rendered views use UIKit resolution rules
+            XCTAssertEqual(props["$el_id"] as? String, "swiftui_dead")
+        }
+    }
+
+    // MARK: - Test 6: Multiple Clicks Generate Multiple Events
+
+    func testSwiftUIMultipleClicksGenerateMultipleEvents() {
+        simulateTapOnSwiftUIButton(index: 0, setAccessibility: "SwiftUI Rule 1")
+        Thread.sleep(forTimeInterval: 0.3)
+
+        simulateTapOnSwiftUIButton(index: 1, setAccessibility: "Rule Two SwiftUI")
+        Thread.sleep(forTimeInterval: 0.3)
+
+        simulateTapOnSwiftUIButton(index: 3, setAccessibility: "Both Label SwiftUI")
+
+        Thread.sleep(forTimeInterval: 0.5)
+        waitForTrackingQueue(mixpanel)
+        let events = eventQueue(token: mixpanel.apiToken)
+        let clickEvents = events.filter { ($0["event"] as? String) == "$mp_click" }
+        XCTAssertEqual(clickEvents.count, 3, "Should capture exactly 3 click events")
+    }
+
+    // MARK: - Test 7: Standard Properties Included
+
+    func testSwiftUIClickEventHasTokenProperty() {
+        simulateTapOnSwiftUIButton(index: 0, setAccessibility: "SwiftUI Rule 1")
+
+        waitForTrackingQueue(mixpanel)
+
+        let events = eventQueue(token: mixpanel.apiToken)
+        let clickEvents = events.filter {
+            ($0["event"] as? String)?.hasPrefix("$mp_") == true
+        }
+
+        XCTAssertFalse(clickEvents.isEmpty, "Should have autocapture events in queue")
+
+        if let firstEvent = clickEvents.first,
+            let props = firstEvent["properties"] as? [String: Any]
+        {
+            XCTAssertNotNil(props["distinct_id"], "Should have distinct_id")
+            XCTAssertNotNil(props["token"], "Should have token")
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    /// Simulate a tap on a SwiftUI view by finding it via accessibility label
+    private func simulateTapOnView(withLabel label: String) {
+        let tapExpectation = expectation(description: "Tap simulated")
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self,
+                let window = self.testWindow,
+                let rootView = self.hostingController?.view
+            else {
+                tapExpectation.fulfill()
+                return
+            }
+
+            // For SwiftUI, use accessibility system to find elements
+            if let (targetView, frame) = self.findAccessibilityElement(withLabel: label, in: rootView) {
+                let center = CGPoint(x: frame.midX, y: frame.midY)
+                self.mixpanel.autocaptureManager?.handleTouch(at: center, view: targetView, window: window)
+            } else if let targetView = self.findSwiftUIView(withAccessibilityLabel: label, in: rootView) {
+                // Fallback to direct view search
+                let center =
+                    targetView.superview?.convert(targetView.center, to: window)
+                    ?? targetView.center
+                self.mixpanel.autocaptureManager?.handleTouch(at: center, view: targetView, window: window)
+            }
+
+            tapExpectation.fulfill()
+        }
+
+        wait(for: [tapExpectation], timeout: 2)
+    }
+
+    /// Simulate a tap on a SwiftUI view by finding it via accessibility identifier
+    private func simulateTapOnView(withIdentifier identifier: String) {
+        let tapExpectation = expectation(description: "Tap simulated")
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self,
+                let window = self.testWindow,
+                let rootView = self.hostingController?.view
+            else {
+                tapExpectation.fulfill()
+                return
+            }
+
+            // For SwiftUI, use accessibility system to find elements
+            if let (targetView, frame) = self.findAccessibilityElement(withIdentifier: identifier, in: rootView) {
+                let center = CGPoint(x: frame.midX, y: frame.midY)
+                self.mixpanel.autocaptureManager?.handleTouch(at: center, view: targetView, window: window)
+            } else if let targetView = self.findSwiftUIView(
+                withAccessibilityIdentifier: identifier, in: rootView)
+            {
+                // Fallback to direct view search
+                let center =
+                    targetView.superview?.convert(targetView.center, to: window)
+                    ?? targetView.center
+                self.mixpanel.autocaptureManager?.handleTouch(at: center, view: targetView, window: window)
+            }
+
+            tapExpectation.fulfill()
+        }
+
+        wait(for: [tapExpectation], timeout: 2)
+    }
+
+    /// Find an accessibility element by label and return the view it's attached to with its frame
+    private func findAccessibilityElement(withLabel label: String, in view: UIView) -> (UIView, CGRect)? {
+        // Check if this view's accessibility label matches
+        if view.accessibilityLabel == label {
+            let frame = view.superview?.convert(view.frame, to: testWindow) ?? view.frame
+            return (view, frame)
+        }
+
+        // Check accessibility elements container
+        if let elements = view.accessibilityElements {
+            for element in elements {
+                if let accessibilityElement = element as? UIAccessibilityElement,
+                    accessibilityElement.accessibilityLabel == label
+                {
+                    // Get the frame from the accessibility element
+                    let frame = accessibilityElement.accessibilityFrame
+                    // Find the containing view - use the closest subview at that location
+                    if let containingView = findViewContaining(frame: frame, in: view) {
+                        return (containingView, frame)
+                    }
+                    return (view, frame)
+                }
+            }
+        }
+
+        // Recursively search subviews
+        for subview in view.subviews {
+            if let result = findAccessibilityElement(withLabel: label, in: subview) {
+                return result
+            }
+        }
+
+        return nil
+    }
+
+    /// Find an accessibility element by identifier and return the view it's attached to with its frame
+    private func findAccessibilityElement(withIdentifier identifier: String, in view: UIView) -> (UIView, CGRect)? {
+        // Check if this view's accessibility identifier matches
+        if view.accessibilityIdentifier == identifier {
+            let frame = view.superview?.convert(view.frame, to: testWindow) ?? view.frame
+            return (view, frame)
+        }
+
+        // Check accessibility elements container
+        if let elements = view.accessibilityElements {
+            for element in elements {
+                if let accessibilityElement = element as? UIAccessibilityElement,
+                    accessibilityElement.accessibilityIdentifier == identifier
+                {
+                    let frame = accessibilityElement.accessibilityFrame
+                    if let containingView = findViewContaining(frame: frame, in: view) {
+                        return (containingView, frame)
+                    }
+                    return (view, frame)
+                }
+            }
+        }
+
+        // Recursively search subviews
+        for subview in view.subviews {
+            if let result = findAccessibilityElement(withIdentifier: identifier, in: subview) {
+                return result
+            }
+        }
+
+        return nil
+    }
+
+    /// Find the deepest view containing a given frame
+    private func findViewContaining(frame: CGRect, in view: UIView) -> UIView? {
+        let viewFrame = view.superview?.convert(view.frame, to: testWindow) ?? view.frame
+
+        // Check if this view contains the target frame
+        if viewFrame.intersects(frame) {
+            // Try to find a more specific subview
+            for subview in view.subviews.reversed() {
+                if let found = findViewContaining(frame: frame, in: subview) {
+                    return found
+                }
+            }
+            // If no subview contains it, return this view
+            return view
+        }
+
+        return nil
+    }
+
+    /// Recursively find a view with the given accessibility identifier
+    private func findSwiftUIView(withAccessibilityIdentifier identifier: String, in view: UIView)
+        -> UIView?
+    {
+        if view.accessibilityIdentifier == identifier {
+            return view
+        }
+
+        for subview in view.subviews {
+            if let found = findSwiftUIView(withAccessibilityIdentifier: identifier, in: subview) {
+                return found
+            }
+        }
+
+        return nil
+    }
+
+    /// Find a view by accessibility label
+    private func findSwiftUIView(withAccessibilityLabel label: String, in view: UIView) -> UIView? {
+        if view.accessibilityLabel == label {
+            return view
+        }
+
+        for subview in view.subviews {
+            if let found = findSwiftUIView(withAccessibilityLabel: label, in: subview) {
+                return found
+            }
+        }
+
+        return nil
+    }
+
+    /// Debug helper to print the view hierarchy with accessibility info
+    private func printViewHierarchy(_ view: UIView, indent: Int = 0) {
+        let prefix = String(repeating: "  ", count: indent)
+        let typeName = String(describing: type(of: view))
+        let id = view.accessibilityIdentifier ?? "nil"
+        let label = view.accessibilityLabel ?? "nil"
+        let traits = view.accessibilityTraits
+        var traitsStr = ""
+        if traits.contains(.button) { traitsStr += "button," }
+        if traits.contains(.link) { traitsStr += "link," }
+        if traits.contains(.staticText) { traitsStr += "text," }
+        print("\(prefix)\(typeName) - id: \(id), label: \(label), traits: [\(traitsStr)]")
+
+        // Print accessibility elements if any
+        if let elements = view.accessibilityElements {
+            for (index, element) in elements.enumerated() {
+                if let accEl = element as? UIAccessibilityElement {
+                    print(
+                        "\(prefix)  [AX\(index)] label: \(accEl.accessibilityLabel ?? "nil"), id: \(accEl.accessibilityIdentifier ?? "nil")"
+                    )
+                }
+            }
+        }
+
+        for subview in view.subviews {
+            printViewHierarchy(subview, indent: indent + 1)
+        }
+    }
+
+    /// Find any button-like view in the hierarchy (for SwiftUI which doesn't expose accessibility easily)
+    private func findAllTappableViews(in view: UIView) -> [UIView] {
+        var result: [UIView] = []
+
+        // Check if this view has accessibility traits or is a button type
+        let typeName = String(describing: type(of: view))
+        if typeName.contains("Button") || view.accessibilityTraits.contains(.button) {
+            result.append(view)
+        }
+
+        // Check accessibility elements
+        if let elements = view.accessibilityElements {
+            for element in elements {
+                if let accEl = element as? UIAccessibilityElement,
+                    accEl.accessibilityTraits.contains(.button)
+                {
+                    // Add the container view since UIAccessibilityElement isn't a view
+                    result.append(view)
+                }
+            }
+        }
+
+        for subview in view.subviews {
+            result.append(contentsOf: findAllTappableViews(in: subview))
+        }
+
+        return result
+    }
+
+    /// Print all accessibility elements in the hierarchy
+    private func printAccessibilityElements(_ view: UIView, indent: Int = 0) {
+        let prefix = String(repeating: "  ", count: indent)
+
+        // Get all accessibility elements from UIAccessibility
+        var elementIndex = 0
+        var accessibilityElement: Any? = view.accessibilityElement(at: elementIndex)
+        while accessibilityElement != nil {
+            if let element = accessibilityElement as? NSObject {
+                let label = element.accessibilityLabel ?? "nil"
+                // accessibilityIdentifier is from UIAccessibilityIdentification protocol
+                let id = (element as? UIAccessibilityIdentification)?.accessibilityIdentifier ?? "nil"
+                print("\(prefix)Accessibility[\(elementIndex)]: label=\(label), id=\(id)")
+            }
+            elementIndex += 1
+            accessibilityElement = view.accessibilityElement(at: elementIndex)
+        }
+
+        for subview in view.subviews {
+            printAccessibilityElements(subview, indent: indent + 1)
+        }
+    }
+
+    /// Wait for an autocapture event with the given name
+    private func waitForEvent(named eventName: String, timeout: TimeInterval) -> (
+        name: String, properties: [String: Any]
+    )? {
+        let startTime = Date()
+
+        while Date().timeIntervalSince(startTime) < timeout {
+            // Wait for tracking queue to flush to persistence
+            waitForTrackingQueue(mixpanel)
+
+            // Read events from persistence queue
+            let events = eventQueue(token: mixpanel.apiToken)
+            if let match = events.first(where: { ($0["event"] as? String) == eventName }),
+                let props = match["properties"] as? [String: Any]
+            {
+                return (name: eventName, properties: props)
+            }
+
+            // Run loop to allow async operations
+            RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.1))
+        }
+
+        return nil
+    }
+
+    // MARK: - Accessibility-Based Button Finding (OS-version agnostic)
+
+    /// Accessibility labels for each button index in the VStack.
+    /// These are set via `.accessibilityLabel()` in SwiftUIAutocaptureTestView
+    /// and are stable across iOS versions, unlike internal UIKit class names.
+    private static let buttonLabels = [
+        "SwiftUI Rule 1",  // 0
+        "Rule Two SwiftUI",  // 1
+        "Rule 3 SwiftUI Button",  // 2 (no explicit accessibilityLabel — uses title)
+        "Both Label SwiftUI",  // 3
+        "Rage Zone SwiftUI",  // 4
+        "Dead Button SwiftUI",  // 5
+    ]
+
+    /// Find the center point and hit-test view for a SwiftUI button by probing the VStack layout.
+    ///
+    /// SwiftUI's internal view hierarchy and accessibility tree vary across iOS versions.
+    /// This approach calculates approximate button positions from the known VStack layout,
+    /// then uses `accessibilityHitTest` to verify a button exists at that point, and
+    /// `window.hitTest` to get the actual UIKit view — mirroring real touch handling.
+    private func findSwiftUIButton(label: String, in window: UIWindow, hostingView: UIView) -> (
+        view: UIView, center: CGPoint
+    )? {
+        guard let index = Self.buttonLabels.firstIndex(of: label) else { return nil }
+
+        // Calculate approximate center of button in the VStack.
+        // Layout: ScrollView > VStack(spacing: 16) with .padding() on each button and the VStack.
+        // Each button is roughly 44pt tall with 8pt vertical padding = ~60pt per button.
+        let buttonHeight: CGFloat = 60
+        let spacing: CGFloat = 16
+        let topPadding: CGFloat = 16  // VStack .padding()
+        let safeAreaTop: CGFloat = window.safeAreaInsets.top
+
+        let buttonCenterY = safeAreaTop + topPadding + CGFloat(index) * (buttonHeight + spacing) + buttonHeight / 2
+        let centerX = window.bounds.midX
+        let windowPoint = CGPoint(x: centerX, y: buttonCenterY)
+
+        // Debug: verify there's a button at this position using accessibility (iOS 18+)
+        if #available(iOS 18.0, *) {
+            let screenPoint = window.convert(windowPoint, to: window.screen.coordinateSpace)
+            if let element = hostingView.accessibilityHitTest(screenPoint, event: nil) as? NSObject {
+                let elementLabel = element.accessibilityLabel ?? ""
+                print(
+                    "[Test] accessibilityHitTest at \(windowPoint) found: '\(elementLabel)' (looking for: '\(label)')")
+            }
+        }
+
+        // Use UIKit hitTest to get the actual view — same path as real touch handling
+        if let hitView = window.hitTest(windowPoint, with: nil) {
+            return (view: hitView, center: windowPoint)
+        }
+        return nil
+    }
+
+    /// Simulate tap on a SwiftUI button by index (maps to accessibility label).
+    /// Optionally overrides the accessibility label on the hit-test view for assertion purposes.
+    private func simulateTapOnSwiftUIButton(index: Int, setAccessibility: String? = nil) {
+        let tapExpectation = expectation(description: "Tap simulated")
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self,
+                let window = self.testWindow,
+                let rootView = self.hostingController?.view
+            else {
+                tapExpectation.fulfill()
+                return
+            }
+
+            let label = Self.buttonLabels[index]
+            if let result = self.findSwiftUIButton(label: label, in: window, hostingView: rootView) {
+                if let overrideLabel = setAccessibility {
+                    result.view.accessibilityLabel = overrideLabel
+                }
+                print(
+                    "[Test] Simulating tap on button \(index) ('\(label)') at \(result.center), view: \(type(of: result.view))"
+                )
+                self.mixpanel.autocaptureManager?.handleTouch(at: result.center, view: result.view, window: window)
+            } else {
+                print("[Test] Could not find button at index \(index) with label '\(label)'")
+            }
+
+            tapExpectation.fulfill()
+        }
+
+        wait(for: [tapExpectation], timeout: 2)
+    }
+
+    /// Set accessibility properties on a SwiftUI button by index.
+    private func setSwiftUIButtonAccessibility(index: Int, identifier: String?, label: String?) {
+        let setupExpectation = expectation(description: "Accessibility setup")
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self,
+                let window = self.testWindow,
+                let rootView = self.hostingController?.view
+            else {
+                setupExpectation.fulfill()
+                return
+            }
+
+            let buttonLabel = Self.buttonLabels[index]
+            if let result = self.findSwiftUIButton(label: buttonLabel, in: window, hostingView: rootView) {
+                if let id = identifier {
+                    result.view.accessibilityIdentifier = id
+                }
+                if let lbl = label {
+                    result.view.accessibilityLabel = lbl
+                }
+            }
+
+            setupExpectation.fulfill()
+        }
+
+        wait(for: [setupExpectation], timeout: 2)
+    }
+
+    /// Make a SwiftUI button appear interactive by adding a tap gesture recognizer.
+    /// Needed for dead click detection on views that lack UIKit interactivity signals.
+    private func makeSwiftUIButtonInteractive(index: Int) {
+        let setupExpectation = expectation(description: "Make interactive")
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self,
+                let window = self.testWindow,
+                let rootView = self.hostingController?.view
+            else {
+                setupExpectation.fulfill()
+                return
+            }
+
+            let label = Self.buttonLabels[index]
+            if let result = self.findSwiftUIButton(label: label, in: window, hostingView: rootView) {
+                let tapGesture = UITapGestureRecognizer(target: nil, action: nil)
+                tapGesture.isEnabled = true
+                result.view.addGestureRecognizer(tapGesture)
+            }
+
+            setupExpectation.fulfill()
+        }
+
+        wait(for: [setupExpectation], timeout: 2)
+    }
+}
+
+// MARK: - SwiftUI Test View
+
+/// A SwiftUI view with test elements for autocapture testing.
+@available(iOS 14.0, *)
+struct SwiftUIAutocaptureTestView: View {
+    @State private var tapCount = 0
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                // Rule 1: Button with accessibilityLabel (primary in SwiftUI)
+                Button("Rule 1 SwiftUI Button") {
+                    tapCount += 1
+                }
+                .accessibilityIdentifier("swiftui_rule1")
+                .accessibilityLabel("SwiftUI Rule 1")
+                .padding()
+                .background(Color.blue)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+
+                // Rule 2: Button with only accessibilityLabel
+                Button("Rule 2 SwiftUI Button") {
+                    tapCount += 1
+                }
+                .accessibilityIdentifier("swiftui_rule2")
+                .accessibilityLabel("Rule Two SwiftUI")
+                .padding()
+                .background(Color.green)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+
+                // Rule 3: Button with minimal accessibility (hash fallback)
+                Button("Rule 3 SwiftUI Button") {
+                    tapCount += 1
+                }
+                .accessibilityIdentifier("swiftui_rule3")
+                // No accessibilityLabel - will use hash fallback
+                .padding()
+                .background(Color.orange)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+
+                // Both: Button with both identifier and label
+                Button("Both SwiftUI Button") {
+                    tapCount += 1
+                }
+                .accessibilityIdentifier("swiftui_both")
+                .accessibilityLabel("Both Label SwiftUI")
+                .padding()
+                .background(Color.purple)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+
+                // Rage click zone
+                Button("Rage Zone SwiftUI") {
+                    tapCount += 1
+                }
+                .accessibilityIdentifier("swiftui_rage")
+                .accessibilityLabel("Rage Zone SwiftUI")
+                .padding()
+                .background(Color.red)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+
+                // Dead click button (empty action)
+                Button("Dead Button SwiftUI") {
+                    // Empty action - dead click scenario
+                }
+                .accessibilityIdentifier("swiftui_dead")
+                .accessibilityLabel("Dead Button SwiftUI")
+                .padding()
+                .background(Color.gray)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+            }
+            .padding()
+        }
+    }
+}
+
+#endif

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
@@ -137,8 +137,10 @@ class AutocaptureSwiftUIInstrumentedTests: MixpanelBaseTests {
         XCTAssertNotNil(event, "Should capture $mp_click event")
 
         if let props = event?.properties {
-            // SwiftUI uses accessibilityLabel as primary element ID
-            XCTAssertEqual(props["$el_id"] as? String, "SwiftUI Rule 1")
+            // The label is not an identity source: identity falls back to the structural hash.
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertFalse(elId.contains("SwiftUI Rule 1"), "Label must not leak into $el_id")
+            XCTAssertNil(props["$attr-aria-label"], "Labels are never reported")
             XCTAssertNotNil(props["$x"], "Should have $x coordinate")
             XCTAssertNotNil(props["$y"], "Should have $y coordinate")
         }
@@ -165,22 +167,24 @@ class AutocaptureSwiftUIInstrumentedTests: MixpanelBaseTests {
 
         if let props = event?.properties {
             XCTAssertEqual(props["$el_id"] as? String, "swiftui_both_id")
-            XCTAssertEqual(props["$attr-aria-label"] as? String, "Both Label SwiftUI")
+            XCTAssertNil(props["$attr-aria-label"], "Labels are never reported")
         }
     }
 
     // MARK: - Test 2: accessibilityLabel fallback (no identifier on the view)
 
-    func testSwiftUIElementIdResolutionRule2() {
-        // With no accessibilityIdentifier on the backing view, the label is next in line.
+    func testSwiftUIElementIdResolutionRule2_LabelIsNotUsed() {
+        // With no accessibilityIdentifier on the backing view, resolution falls to the structural
+        // hash — a localized label cannot serve as a stable identifier.
         simulateTapOnSwiftUIButton(index: 1, setAccessibility: "Rule Two SwiftUI")
 
         let event = waitForEvent(named: "$mp_click", timeout: 5)
         XCTAssertNotNil(event, "Should capture $mp_click event")
 
         if let props = event?.properties {
-            // Should use accessibilityLabel as ID
-            XCTAssertEqual(props["$el_id"] as? String, "Rule Two SwiftUI")
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertFalse(elId.contains("Rule Two"), "Label must not leak into $el_id")
+            XCTAssertNil(props["$attr-aria-label"], "Labels are never reported")
         }
     }
 

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
@@ -177,6 +177,127 @@ class AutocaptureSwiftUIInstrumentedTests: MixpanelBaseTests {
         }
     }
 
+    // MARK: - Visibility Tests (SwiftUI)
+
+    /// A hidden SwiftUI Button (.hidden() modifier) must not produce autocapture
+    /// events with its identity. The view is not drawn at all.
+    func testSwiftUIHiddenView_NoEventCaptured() {
+        simulateTapOnSwiftUIButton(index: 6)
+
+        Thread.sleep(forTimeInterval: 0.5)
+        waitForTrackingQueue(mixpanel)
+        let events = eventQueue(token: mixpanel.apiToken)
+        let matchingEvents = events.filter {
+            guard let props = $0["properties"] as? [String: Any],
+                let elId = props["$el_id"] as? String
+            else { return false }
+            return elId.contains("Hidden SwiftUI")
+        }
+
+        XCTAssertEqual(
+            matchingEvents.count, 0,
+            "Hidden SwiftUI view must not produce autocapture events with its identity")
+    }
+
+    /// A zero-opacity SwiftUI Button (.opacity(0)) must not produce autocapture
+    /// events with its identity. The view is fully transparent.
+    func testSwiftUIZeroOpacity_NoEventCaptured() {
+        simulateTapOnSwiftUIButton(index: 7)
+
+        Thread.sleep(forTimeInterval: 0.5)
+        waitForTrackingQueue(mixpanel)
+        let events = eventQueue(token: mixpanel.apiToken)
+        let matchingEvents = events.filter {
+            guard let props = $0["properties"] as? [String: Any],
+                let elId = props["$el_id"] as? String
+            else { return false }
+            return elId.contains("Zero Opacity")
+        }
+
+        XCTAssertEqual(
+            matchingEvents.count, 0,
+            "Zero-opacity SwiftUI view must not produce autocapture events with its identity")
+    }
+
+    // MARK: - Accessibility Guard Tests (SwiftUI)
+
+    /// Scenario 1 & 2: SwiftUI Button with no explicit accessibilityLabel.
+    /// SwiftUI auto-derives label from the title Text — this is the developer's
+    /// intentional choice (analogous to UIButton.title, which is always captured
+    /// via the known-control bypass). The auto-derived label SHOULD be captured.
+    ///
+    /// Note: SwiftUI only fully materializes its accessibility element tree when VoiceOver
+    /// (or another assistive technology) is active. Without VoiceOver, the label falls back
+    /// to the UIKit host view's hash-based ID. This test validates that an event IS captured
+    /// and that the $el_id is either the expected label or a valid fallback.
+    func testSwiftUIButtonNoLabel_AutoDerivedIsCaptured() {
+        simulateTapOnSwiftUIButton(index: 8)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Click event should be captured")
+
+        if let props = event?.properties {
+            let elId = props["$el_id"] as? String ?? ""
+            // When VoiceOver is active, SwiftUI auto-derived label is captured.
+            // Without VoiceOver, falls back to UIKit host view hash.
+            // Either way, $el_id must not be empty.
+            XCTAssertFalse(elId.isEmpty, "$el_id should not be empty")
+            // The label is either the auto-derived title or a PlatformGroupContainer hash
+            let hasExpectedLabel = elId == "Sensitive Account 1234"
+            let hasFallbackId = elId.contains("PlatformGroupContainer")
+            XCTAssertTrue(
+                hasExpectedLabel || hasFallbackId,
+                "$el_id should be auto-derived label or hash fallback. Got: \(elId)")
+        }
+    }
+
+    /// Scenario 4: SwiftUI view with .accessibilityHidden(true).
+    /// Even though an explicit accessibilityLabel is set, the element is hidden
+    /// from accessibility — the label should NOT be captured.
+    func testSwiftUIAccessibilityHidden_LabelDoesNotLeak() {
+        simulateTapOnSwiftUIButton(index: 9)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Click event should still be captured")
+
+        if let props = event?.properties {
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertFalse(
+                elId.contains("Sensitive") || elId.contains("9999"),
+                "$el_id should not contain label from hidden element. Got: \(elId)")
+
+            XCTAssertNil(
+                props["$attr-aria-label"],
+                "$attr-aria-label must not be present for accessibility-hidden element")
+        }
+    }
+
+    /// Positive case: SwiftUI Button with explicit accessibilityLabel.
+    /// The label SHOULD be captured in $el_id and $attr-aria-label.
+    ///
+    /// Note: SwiftUI only fully materializes its accessibility element tree when VoiceOver
+    /// (or another assistive technology) is active. Without VoiceOver, the label falls back
+    /// to the UIKit host view's hash-based ID. This test validates the event is captured
+    /// and either the explicit label or a valid fallback is used.
+    func testSwiftUIButtonWithLabel_LabelIsCaptured() {
+        simulateTapOnSwiftUIButton(index: 10)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Click event should be captured")
+
+        if let props = event?.properties {
+            let elId = props["$el_id"] as? String ?? ""
+            // When VoiceOver is active, the explicit accessibilityLabel is captured.
+            // Without VoiceOver, falls back to UIKit host view hash.
+            XCTAssertFalse(elId.isEmpty, "$el_id should not be empty")
+            let hasExpectedLabel = elId == "Intended Label"
+            let hasFallbackId = elId.contains("PlatformGroupContainer")
+            XCTAssertTrue(
+                hasExpectedLabel || hasFallbackId,
+                "$el_id should be explicit label or hash fallback. Got: \(elId)")
+        }
+    }
+
     // MARK: - Test 4: Rage Click Detection
 
     func testSwiftUIRageClickDetection() {
@@ -569,6 +690,11 @@ class AutocaptureSwiftUIInstrumentedTests: MixpanelBaseTests {
         "Both Label SwiftUI",  // 3
         "Rage Zone SwiftUI",  // 4
         "Dead Button SwiftUI",  // 5
+        "Hidden SwiftUI Btn",  // 6 (hidden — .hidden() modifier)
+        "Zero Opacity SwiftUI Btn",  // 7 (zero opacity — .opacity(0))
+        "Sensitive Account 1234",  // 8 (no explicit label — auto-derived from title)
+        "Sensitive Account 9999",  // 9 (hidden from accessibility, has explicit label)
+        "Intended Label",  // 10 (explicit label — positive case)
     ]
 
     /// Find the center point and hit-test view for a SwiftUI button by probing the VStack layout.
@@ -774,6 +900,66 @@ struct SwiftUIAutocaptureTestView: View {
                 .accessibilityLabel("Dead Button SwiftUI")
                 .padding()
                 .background(Color.gray)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+
+                // ============ Visibility Test Elements ============
+
+                // Hidden Button — .hidden() modifier, not drawn at all
+                Button("Hidden SwiftUI Button") {
+                    tapCount += 1
+                }
+                .accessibilityLabel("Hidden SwiftUI Btn")
+                .hidden()
+                .padding()
+                .background(Color.gray)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+
+                // Zero-opacity Button — fully transparent
+                Button("Zero Opacity SwiftUI Button") {
+                    tapCount += 1
+                }
+                .accessibilityLabel("Zero Opacity SwiftUI Btn")
+                .opacity(0)
+                .padding()
+                .background(Color.gray)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+
+                // ============ Accessibility Guard Test Elements ============
+
+                // Scenario 1 & 2: Button with no explicit accessibilityLabel.
+                // SwiftUI auto-derives label from title Text — this is the developer's
+                // intentional choice (like UIButton.title), so capture is correct.
+                Button("Sensitive Account 1234") {
+                    tapCount += 1
+                }
+                // NO .accessibilityLabel() — auto-derived from title
+                .padding()
+                .background(Color.cyan)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+
+                // Scenario 4: Button hidden from accessibility with explicit label.
+                // .accessibilityHidden(true) should prevent label capture.
+                Button("Hidden Button") {
+                    tapCount += 1
+                }
+                .accessibilityHidden(true)
+                .accessibilityLabel("Sensitive Account 9999")
+                .padding()
+                .background(Color.brown)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+
+                // Positive case: Button with explicit accessibilityLabel.
+                Button("Positive Case Button") {
+                    tapCount += 1
+                }
+                .accessibilityLabel("Intended Label")
+                .padding()
+                .background(Color.teal)
                 .foregroundColor(.white)
                 .cornerRadius(8)
             }

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
@@ -966,7 +966,7 @@ struct SwiftUIAutocaptureTestView: View {
                 }
                 // NO .accessibilityLabel() — auto-derived from title
                 .padding()
-                .background(Color.cyan)
+                .background(Color(UIColor.cyan))
                 .foregroundColor(.white)
                 .cornerRadius(8)
 
@@ -978,7 +978,7 @@ struct SwiftUIAutocaptureTestView: View {
                 .accessibilityHidden(true)
                 .accessibilityLabel("Sensitive Account 9999")
                 .padding()
-                .background(Color.brown)
+                .background(Color(UIColor.brown))
                 .foregroundColor(.white)
                 .cornerRadius(8)
 
@@ -988,7 +988,7 @@ struct SwiftUIAutocaptureTestView: View {
                 }
                 .accessibilityLabel("Intended Label")
                 .padding()
-                .background(Color.teal)
+                .background(Color(UIColor.systemTeal))
                 .foregroundColor(.white)
                 .cornerRadius(8)
             }

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureSwiftUIInstrumentedTests.swift
@@ -144,10 +144,35 @@ class AutocaptureSwiftUIInstrumentedTests: MixpanelBaseTests {
         }
     }
 
-    // MARK: - Test 2: accessibilityIdentifier fallback
+    // MARK: - Test 2a: accessibilityIdentifier outranks accessibilityLabel
+
+    /// On a SwiftUI-rendered view (`PlatformGroupContainer`), an accessibilityIdentifier must win
+    /// $el_id over the label: it is developer-assigned and never user-visible, so it cannot carry
+    /// PII the way a label can. The label still travels as $attr-aria-label.
+    ///
+    /// Note both properties are stamped onto the backing UIView here, exactly as the other SwiftUI
+    /// tests do. SwiftUI keeps `.accessibilityIdentifier(…)` / `.accessibilityLabel(…)` in its own
+    /// accessibility element tree, which is only populated while an accessibility client is
+    /// attached — never in this test host, where `accessibilityHitTest` returns nil.
+    func testSwiftUIElementIdIdentifierWinsOverLabel() {
+        setSwiftUIButtonAccessibility(
+            index: 3, identifier: "swiftui_both_id", label: "Both Label SwiftUI")
+
+        simulateTapOnSwiftUIButton(index: 3)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event")
+
+        if let props = event?.properties {
+            XCTAssertEqual(props["$el_id"] as? String, "swiftui_both_id")
+            XCTAssertEqual(props["$attr-aria-label"] as? String, "Both Label SwiftUI")
+        }
+    }
+
+    // MARK: - Test 2: accessibilityLabel fallback (no identifier on the view)
 
     func testSwiftUIElementIdResolutionRule2() {
-        // In SwiftUI, accessibilityLabel is primary
+        // With no accessibilityIdentifier on the backing view, the label is next in line.
         simulateTapOnSwiftUIButton(index: 1, setAccessibility: "Rule Two SwiftUI")
 
         let event = waitForEvent(named: "$mp_click", timeout: 5)
@@ -964,6 +989,310 @@ struct SwiftUIAutocaptureTestView: View {
                 .cornerRadius(8)
             }
             .padding()
+        }
+    }
+}
+
+// MARK: - SwiftUI accessibilityLabel Auto-Derivation Verification Tests
+
+/// These tests verify how SwiftUI controls expose accessibilityLabel on their
+/// UIKit backing views when no explicit .accessibilityLabel() modifier is set.
+///
+/// SwiftUI renders through internal UIKit views (PlatformGroupContainer, _UIGraphicsView, etc.).
+/// We host each SwiftUI view, find the UIKit backing view via hitTest, and check
+/// whether view.accessibilityLabel is populated or nil.
+@available(iOS 14.0, *)
+class SwiftUIAccessibilityLabelDerivationTests: XCTestCase {
+
+    private var testWindow: UIWindow!
+
+    override func setUp() {
+        super.setUp()
+        let setupExpectation = expectation(description: "Setup")
+        DispatchQueue.main.async {
+            self.testWindow = UIWindow(frame: UIScreen.main.bounds)
+            self.testWindow.makeKeyAndVisible()
+            setupExpectation.fulfill()
+        }
+        wait(for: [setupExpectation], timeout: 2)
+    }
+
+    override func tearDown() {
+        let teardownExpectation = expectation(description: "Teardown")
+        DispatchQueue.main.async {
+            self.testWindow?.isHidden = true
+            self.testWindow = nil
+            teardownExpectation.fulfill()
+        }
+        wait(for: [teardownExpectation], timeout: 2)
+        super.tearDown()
+    }
+
+    /// Host a SwiftUI view and return the UIKit backing view at the center point.
+    private func hostAndFindBackingView<V: View>(_ swiftUIView: V) -> UIView? {
+        var result: UIView?
+        let exp = expectation(description: "Host view")
+
+        DispatchQueue.main.async {
+            let hostingController = UIHostingController(rootView: swiftUIView)
+            hostingController.view.frame = self.testWindow.bounds
+            self.testWindow.rootViewController = hostingController
+            self.testWindow.makeKeyAndVisible()
+
+            // Force layout
+            hostingController.view.setNeedsLayout()
+            hostingController.view.layoutIfNeeded()
+
+            // Allow SwiftUI rendering to complete
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                let center = hostingController.view.center
+                let hitView = hostingController.view.hitTest(center, with: nil)
+                result = hitView
+                exp.fulfill()
+            }
+        }
+
+        wait(for: [exp], timeout: 3)
+        return result
+    }
+
+    // MARK: - Button
+
+    func testSwiftUIButton_NoLabel_CheckDerivation() {
+        let view = hostAndFindBackingView(
+            Button("Card 4111-1111-1111-1234") {}
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI Button backing view: \(className)")
+            print("SwiftUI Button accessibilityLabel (no modifier): \(label ?? "nil")")
+            print("SwiftUI Button isAccessibilityElement: \(view.isAccessibilityElement)")
+        }
+    }
+
+    func testSwiftUIButton_WithLabel_CheckDerivation() {
+        let view = hostAndFindBackingView(
+            Button("Card 4111-1111-1111-1234") {}
+                .accessibilityLabel("Safe Label")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI Button (with label) backing view: \(className)")
+            print("SwiftUI Button (with label) accessibilityLabel: \(label ?? "nil")")
+        }
+    }
+
+    // MARK: - Text
+
+    func testSwiftUIText_NoLabel_CheckDerivation() {
+        let view = hostAndFindBackingView(
+            Text("Account 9876-5432")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI Text backing view: \(className)")
+            print("SwiftUI Text accessibilityLabel (no modifier): \(label ?? "nil")")
+            print("SwiftUI Text isAccessibilityElement: \(view.isAccessibilityElement)")
+        }
+    }
+
+    // MARK: - Toggle (equivalent of UISwitch)
+
+    func testSwiftUIToggle_NoLabel_CheckDerivation() {
+        let view = hostAndFindBackingView(
+            Toggle("Enable notifications", isOn: .constant(true))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding()
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI Toggle backing view: \(className)")
+            print("SwiftUI Toggle accessibilityLabel (no modifier): \(label ?? "nil")")
+            print("SwiftUI Toggle isAccessibilityElement: \(view.isAccessibilityElement)")
+        }
+    }
+
+    // MARK: - Slider
+
+    func testSwiftUISlider_NoLabel_CheckDerivation() {
+        let view = hostAndFindBackingView(
+            Slider(value: .constant(0.5))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding()
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI Slider backing view: \(className)")
+            print("SwiftUI Slider accessibilityLabel (no modifier): \(label ?? "nil")")
+        }
+    }
+
+    // MARK: - TextField
+
+    func testSwiftUITextField_NoLabel_WithTypedText() {
+        let view = hostAndFindBackingView(
+            TextField("Enter email", text: .constant("john.doe@example.com"))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding()
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let value = view.accessibilityValue
+            let className = String(describing: type(of: view))
+            print("SwiftUI TextField backing view: \(className)")
+            print("SwiftUI TextField accessibilityLabel: \(label ?? "nil")")
+            print("SwiftUI TextField accessibilityValue: \(value ?? "nil")")
+            if let label = label {
+                let typedTextLeaks = label.contains("john.doe") || label.contains("example.com")
+                print("SwiftUI TextField typed text leaks into label: \(typedTextLeaks)")
+            }
+        }
+    }
+
+    // MARK: - TextEditor (equivalent of UITextView)
+
+    func testSwiftUITextEditor_NoLabel_WithText() {
+        let view = hostAndFindBackingView(
+            TextEditor(text: .constant("SSN: 123-45-6789"))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding()
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let value = view.accessibilityValue
+            let className = String(describing: type(of: view))
+            print("SwiftUI TextEditor backing view: \(className)")
+            print("SwiftUI TextEditor accessibilityLabel: \(label ?? "nil")")
+            print("SwiftUI TextEditor accessibilityValue: \(value ?? "nil")")
+        }
+    }
+
+    // MARK: - Picker (equivalent of UISegmentedControl)
+
+    func testSwiftUIPicker_Segmented_NoLabel_CheckDerivation() {
+        let view = hostAndFindBackingView(
+            Picker("Account Type", selection: .constant(0)) {
+                Text("Personal").tag(0)
+                Text("Business").tag(1)
+                Text("Account 1234").tag(2)
+            }
+            .pickerStyle(.segmented)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding()
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI Picker (segmented) backing view: \(className)")
+            print("SwiftUI Picker accessibilityLabel: \(label ?? "nil")")
+        }
+    }
+
+    // MARK: - Stepper
+
+    func testSwiftUIStepper_NoLabel_CheckDerivation() {
+        let view = hostAndFindBackingView(
+            Stepper("Quantity", value: .constant(5), in: 0...10)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding()
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI Stepper backing view: \(className)")
+            print("SwiftUI Stepper accessibilityLabel: \(label ?? "nil")")
+        }
+    }
+
+    // MARK: - Image
+
+    func testSwiftUIImage_NoLabel_CheckDerivation() {
+        let view = hostAndFindBackingView(
+            Image(systemName: "star.fill")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI Image backing view: \(className)")
+            print("SwiftUI Image accessibilityLabel: \(label ?? "nil")")
+        }
+    }
+
+    // MARK: - VStack with child Text (container scenario)
+
+    func testSwiftUIVStack_WithChildText_NoLabel() {
+        let view = hostAndFindBackingView(
+            VStack {
+                Text("Sensitive Account 1234")
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .onTapGesture {}
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI VStack (tappable) backing view: \(className)")
+            print("SwiftUI VStack accessibilityLabel: \(label ?? "nil")")
+            print("SwiftUI VStack isAccessibilityElement: \(view.isAccessibilityElement)")
+            if let label = label {
+                let childTextLeaks = label.contains("Sensitive") || label.contains("1234")
+                print("SwiftUI VStack child text leaks: \(childTextLeaks)")
+            }
+        }
+    }
+
+    // MARK: - List row (common pattern for PII display)
+
+    func testSwiftUIListRow_WithSensitiveText() {
+        let view = hostAndFindBackingView(
+            List {
+                HStack {
+                    Text("Card ending")
+                    Spacer()
+                    Text("4111-1111-1111-1234")
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        )
+
+        XCTAssertNotNil(view, "Should find a UIKit backing view")
+        if let view = view {
+            let label = view.accessibilityLabel
+            let className = String(describing: type(of: view))
+            print("SwiftUI List row backing view: \(className)")
+            print("SwiftUI List row accessibilityLabel: \(label ?? "nil")")
+            print("SwiftUI List row isAccessibilityElement: \(view.isAccessibilityElement)")
         }
     }
 }

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
@@ -291,7 +291,6 @@ class ClickEventTests: XCTestCase {
             y: 200,
             elementId: "test_button",
             tagName: "UIButton",
-            accessibleLabel: "Test Button",
             role: "Button",
             elements: "UIButton > UIView"
         )
@@ -302,7 +301,7 @@ class ClickEventTests: XCTestCase {
         XCTAssertEqual(props["$y"] as? Int, 200)
         XCTAssertEqual(props["$el_id"] as? String, "test_button")
         XCTAssertEqual(props["$el_tag_name"] as? String, "UIButton")
-        XCTAssertEqual(props["$attr-aria-label"] as? String, "Test Button")
+        XCTAssertNil(props["$attr-aria-label"], "Accessibility labels are never reported")
         XCTAssertEqual(props["$attr-role"] as? String, "Button")
         XCTAssertEqual(props["$elements"] as? String, "UIButton > UIView")
     }
@@ -345,7 +344,8 @@ private final class ConstantElementIdExtractor: ElementIdExtractor {
 }
 
 /// Tests the `$el_id` resolution order implemented by `DefaultElementIdExtractor`:
-/// React Native `nativeID` > `accessibilityIdentifier` > `accessibilityLabel` > `<ClassName>_<hash>`.
+/// React Native `nativeID` > `accessibilityIdentifier` > `<ClassName>_<hash>`. Accessibility labels
+/// are never a source: they are localized and can carry user data.
 class DefaultElementIdExtractorTests: XCTestCase {
 
     /// Matches the anonymous fallback: ClassName_hexHash.
@@ -389,8 +389,8 @@ class DefaultElementIdExtractorTests: XCTestCase {
 
     // MARK: - Priority 2: accessibilityIdentifier
 
-    func testIdentifierWinsOverLabel() {
-        // The identifier is stable and never user-visible, so it outranks the label.
+    func testIdentifierIsUsedAndLabelIsIgnored() {
+        // The identifier is stable and never user-visible; the label is neither.
         let button = UIButton()
         button.accessibilityIdentifier = "checkout_identifier"
         button.accessibilityLabel = "Checkout"
@@ -398,61 +398,42 @@ class DefaultElementIdExtractorTests: XCTestCase {
         XCTAssertEqual(extractor.extractElementId(from: button), "checkout_identifier")
     }
 
-    func testEmptyIdentifierFallsThroughToLabel() {
+    func testEmptyIdentifierFallsThroughToTheStructuralHash() {
         let button = UIButton()
         button.accessibilityIdentifier = ""
         button.accessibilityLabel = "Checkout"
 
-        XCTAssertEqual(extractor.extractElementId(from: button), "Checkout")
+        let elementId = extractor.extractElementId(from: button) ?? ""
+        assertMatchesHashFallback(elementId)
+        XCTAssertFalse(elementId.contains("Checkout"), "Labels are never used as identity")
     }
 
     func testInternalIdentifiersAreSkipped() {
         for internalIdentifier in ["_privateThing", "AXID-42", "UITransitionView-1"] {
             let button = UIButton()
             button.accessibilityIdentifier = internalIdentifier
-            button.accessibilityLabel = "Checkout"
 
-            XCTAssertEqual(
-                extractor.extractElementId(from: button), "Checkout",
+            assertMatchesHashFallback(
+                extractor.extractElementId(from: button) ?? "",
                 "Framework-internal identifier \(internalIdentifier) should be skipped")
         }
     }
 
-    // MARK: - Priority 3: accessibilityLabel
+    // MARK: - Accessibility labels are never used
 
-    func testLabelUsedWhenNothingElseResolves() {
-        let label = UILabel()
-        label.accessibilityLabel = "Order Total"
+    func testLabelIsNeverUsedAsIdentity() {
+        // Localized text would give the same element a different id per language, and a label can
+        // carry user data, so no view shape may resolve to it.
+        for view in [UILabel(), UIButton(), UIView()] as [UIView] {
+            view.isAccessibilityElement = true
+            view.accessibilityLabel = "Account ending 4321"
 
-        XCTAssertEqual(extractor.extractElementId(from: label), "Order Total")
-    }
-
-    func testLabelOnGenericContainerIgnoredUnlessAccessibilityElement() {
-        // UIKit auto-derives container labels from child text, which can carry user data. A generic
-        // container (e.g. React Native's RCTView) is only trusted when the developer marked it as an
-        // accessibility element — `accessible={true}` in React Native.
-        let container = UIView()
-        container.accessibilityLabel = "Account ending 4321"
-        container.isAccessibilityElement = false
-
-        let elementId = extractor.extractElementId(from: container) ?? ""
-        assertMatchesHashFallback(elementId)
-        XCTAssertFalse(elementId.contains("4321"), "Derived label must not leak into $el_id")
-    }
-
-    func testLabelOnGenericContainerUsedWhenAccessibilityElement() {
-        let container = UIView()
-        container.accessibilityLabel = "Explicit Label"
-        container.isAccessibilityElement = true
-
-        XCTAssertEqual(extractor.extractElementId(from: container), "Explicit Label")
-    }
-
-    func testEmptyLabelFallsThroughToHash() {
-        let button = UIButton()
-        button.accessibilityLabel = ""
-
-        assertMatchesHashFallback(extractor.extractElementId(from: button) ?? "")
+            let elementId = extractor.extractElementId(from: view) ?? ""
+            assertMatchesHashFallback(elementId)
+            XCTAssertFalse(
+                elementId.contains("4321"),
+                "\(type(of: view)) leaked its label into $el_id")
+        }
     }
 
     // MARK: - Priority 4: hash fallback
@@ -465,16 +446,34 @@ class DefaultElementIdExtractorTests: XCTestCase {
             "Expected UIButton_<hash>, got: \(elementId)")
     }
 
-    func testHashFallbackIsStablePerViewAndDistinctAcrossViews() {
-        let first = UIButton()
-        let second = UIButton()
+    func testHashFallbackIsStableForTheSameStructure() {
+        // The hash describes where the view sits, not which instance it is, so an identical layout
+        // built twice — as on every launch — resolves to the same id.
+        func buildLeaf() -> UIView {
+            let root = UIView()
+            let row = UIView()
+            let leaf = UIButton()
+            row.addSubview(leaf)
+            root.addSubview(row)
+            return leaf
+        }
 
         XCTAssertEqual(
-            extractor.extractElementId(from: first), extractor.extractElementId(from: first),
-            "Same view must resolve to the same id")
+            extractor.extractElementId(from: buildLeaf()),
+            extractor.extractElementId(from: buildLeaf()),
+            "The same structure must resolve to the same id")
+    }
+
+    func testHashFallbackDistinguishesSiblingPositions() {
+        let root = UIView()
+        let first = UIButton()
+        let second = UIButton()
+        root.addSubview(first)
+        root.addSubview(second)
+
         XCTAssertNotEqual(
             extractor.extractElementId(from: first), extractor.extractElementId(from: second),
-            "Different views must resolve to different ids")
+            "Siblings at different positions must resolve to different ids")
     }
 
     func testAnonymousIdMatchesTheDefaultChainFallback() {
@@ -494,11 +493,9 @@ class DefaultElementIdExtractorTests: XCTestCase {
 
         XCTAssertEqual(
             extractor.elementId(
-                for: view,
-                accessibilityIdentifierFallback: "swiftui_checkout",
-                accessibilityLabelFallback: "Checkout From Tree"),
+                for: view, accessibilityIdentifierFallback: "swiftui_checkout"),
             "swiftui_checkout",
-            "Identifier fallback must outrank the label fallback")
+            "The SwiftUI identifier read from the accessibility tree is used")
     }
 
     func testViewIdentifierWinsOverIdentifierFallback() {
@@ -506,41 +503,31 @@ class DefaultElementIdExtractorTests: XCTestCase {
         view.accessibilityIdentifier = "own_identifier"
 
         XCTAssertEqual(
-            extractor.elementId(
-                for: view,
-                accessibilityIdentifierFallback: "tree_identifier",
-                accessibilityLabelFallback: nil),
+            extractor.elementId(for: view, accessibilityIdentifierFallback: "tree_identifier"),
             "own_identifier")
     }
 
-    func testLabelFallbackUsedWhenNoIdentifierAnywhere() {
+    func testStructuralHashUsedWhenNoIdentifierAnywhere() {
         let view = UIView()
 
-        XCTAssertEqual(
-            extractor.elementId(
-                for: view,
-                accessibilityIdentifierFallback: nil,
-                accessibilityLabelFallback: "Checkout From Tree"),
-            "Checkout From Tree")
+        assertMatchesHashFallback(
+            extractor.elementId(for: view, accessibilityIdentifierFallback: nil))
     }
 
     func testInternalIdentifierFallbackIsSkipped() {
         let view = UIView()
 
         let elementId = extractor.elementId(
-            for: view,
-            accessibilityIdentifierFallback: "_UIKitInternal",
-            accessibilityLabelFallback: nil)
+            for: view, accessibilityIdentifierFallback: "_UIKitInternal")
 
         assertMatchesHashFallback(elementId)
     }
 
-    func testEmptyFallbacksResolveToHash() {
+    func testEmptyIdentifierFallbackResolvesToHash() {
         let view = UIView()
 
         assertMatchesHashFallback(
-            extractor.elementId(
-                for: view, accessibilityIdentifierFallback: "", accessibilityLabelFallback: ""))
+            extractor.elementId(for: view, accessibilityIdentifierFallback: ""))
     }
 }
 
@@ -601,8 +588,8 @@ class SemanticExtractorElementIdTests: XCTestCase {
             DefaultElementIdExtractor.anonymousId(for: button))
     }
 
-    func testAccessibilityLabelStillReportedSeparatelyFromElementId() {
-        // The identifier wins $el_id, but the label must still travel as $attr-aria-label.
+    func testAccessibilityLabelIsNeverReported() {
+        // The identifier wins $el_id, and the label is not reported anywhere.
         let button = UIButton()
         button.accessibilityIdentifier = "checkout_identifier"
         button.accessibilityLabel = "Checkout"
@@ -611,7 +598,9 @@ class SemanticExtractorElementIdTests: XCTestCase {
             .extractSemantics(from: button, at: point)
 
         XCTAssertEqual(event.elementId, "checkout_identifier")
-        XCTAssertEqual(event.accessibleLabel, "Checkout")
+        XCTAssertNil(
+            event.toProperties()["$attr-aria-label"],
+            "Accessibility labels are localized and can carry user data — never reported")
     }
 }
 

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
@@ -47,6 +47,55 @@ class AutocaptureOptionsTests: XCTestCase {
         XCTAssertEqual(options.radius, 60)
     }
 
+    // MARK: - RageClickOptions Clamping Tests
+
+    func testRageClickThresholdClampedToMinimum() {
+        // Below 2, `nearbyCount >= clickThreshold - 1` is satisfied by the very first
+        // tap, so every tap would be reported as a rage click.
+        XCTAssertEqual(RageClickOptions(clickThreshold: 1).clickThreshold, 2)
+        XCTAssertEqual(RageClickOptions(clickThreshold: 0).clickThreshold, 2)
+        XCTAssertEqual(RageClickOptions(clickThreshold: -5).clickThreshold, 2)
+    }
+
+    func testRageClickThresholdAtOrAboveMinimumIsUnchanged() {
+        XCTAssertEqual(RageClickOptions(clickThreshold: 2).clickThreshold, 2)
+        XCTAssertEqual(RageClickOptions(clickThreshold: 10).clickThreshold, 10)
+    }
+
+    func testRageClickTimeWindowClampedToMinimum() {
+        XCTAssertEqual(RageClickOptions(timeWindowMs: 0).timeWindowMs, 1)
+        XCTAssertEqual(RageClickOptions(timeWindowMs: -1000).timeWindowMs, 1)
+        XCTAssertEqual(RageClickOptions(timeWindowMs: 1).timeWindowMs, 1)
+    }
+
+    func testRageClickRadiusClampedToNonNegative() {
+        XCTAssertEqual(RageClickOptions(radius: -10).radius, 0)
+        XCTAssertEqual(RageClickOptions(radius: 0).radius, 0)
+        XCTAssertEqual(RageClickOptions(radius: 60).radius, 60)
+    }
+
+    func testClampedRageClickThresholdDoesNotFireOnASingleTap() {
+        // Guards the actual symptom, not just the stored value.
+        let tracker = RageClickTracker(options: RageClickOptions(clickThreshold: 0))
+        XCTAssertFalse(
+            tracker.trackClick(x: 100, y: 100).isRageClick,
+            "A single tap must never be a rage click, whatever threshold was requested")
+    }
+
+    // MARK: - DeadClickOptions Clamping Tests
+
+    func testDeadClickTimeWindowClampedToMinimum() {
+        // A negative window traps when converted to an unsigned nanosecond count for
+        // Task.sleep; zero would check before the UI can respond.
+        XCTAssertEqual(DeadClickOptions(timeWindowMs: -1).timeWindowMs, 1)
+        XCTAssertEqual(DeadClickOptions(timeWindowMs: 0).timeWindowMs, 1)
+    }
+
+    func testDeadClickTimeWindowAtOrAboveMinimumIsUnchanged() {
+        XCTAssertEqual(DeadClickOptions(timeWindowMs: 1).timeWindowMs, 1)
+        XCTAssertEqual(DeadClickOptions(timeWindowMs: 500).timeWindowMs, 500)
+    }
+
     // MARK: - DeadClickOptions Tests
 
     func testDeadClickOptionsDefaults() {

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
@@ -74,6 +74,18 @@ class AutocaptureOptionsTests: XCTestCase {
         XCTAssertTrue(options.deadClickOptions.enabled)
     }
 
+    func testAutocaptureOptionsDefaultToNoElementIdExtractor() {
+        XCTAssertNil(AutocaptureOptions().elementIdExtractor)
+    }
+
+    func testAutocaptureOptionsRetainTheElementIdExtractor() {
+        let extractor = ConstantElementIdExtractor("custom_el_id")
+        let options = AutocaptureOptions(elementIdExtractor: extractor)
+
+        XCTAssertNotNil(options.elementIdExtractor)
+        XCTAssertEqual(options.elementIdExtractor?.extractElementId(from: UIView()), "custom_el_id")
+    }
+
     func testAutocaptureOptionsIsEnabledWhenAnyFeatureEnabled() {
         // Only click enabled
         let clickOnly = AutocaptureOptions(
@@ -308,6 +320,486 @@ class ClickEventTests: XCTestCase {
         XCTAssertNil(props["$attr-aria-label"])
         XCTAssertNil(props["$attr-role"])
         XCTAssertNil(props["$elements"])
+    }
+}
+
+// MARK: - Element ID Resolution Order
+
+/// Stands in for React Native's `RCTView`: an `@objc` `nativeID` property makes `responds(to:)` and
+/// `value(forKey:)` behave exactly as they do on a real React Native view.
+private final class FakeReactNativeView: UIView {
+    @objc var nativeID: String?
+}
+
+/// Returns a fixed identifier for every view.
+private final class ConstantElementIdExtractor: ElementIdExtractor {
+    let identifier: String?
+
+    init(_ identifier: String?) {
+        self.identifier = identifier
+    }
+
+    func extractElementId(from view: UIView) -> String? {
+        return identifier
+    }
+}
+
+/// Tests the `$el_id` resolution order implemented by `DefaultElementIdExtractor`:
+/// React Native `nativeID` > `accessibilityIdentifier` > `accessibilityLabel` > `<ClassName>_<hash>`.
+class DefaultElementIdExtractorTests: XCTestCase {
+
+    /// Matches the anonymous fallback: ClassName_hexHash.
+    private let hashIdPattern = "^[A-Za-z0-9_]+_[0-9a-f]+$"
+
+    private let extractor = DefaultElementIdExtractor.shared
+
+    private func assertMatchesHashFallback(_ elementId: String, _ message: String = "") {
+        XCTAssertNotNil(
+            elementId.range(of: hashIdPattern, options: .regularExpression),
+            "Expected <ClassName>_<hash>, got: \(elementId). \(message)")
+    }
+
+    // MARK: - Priority 1: React Native nativeID
+
+    func testNativeIdWinsOverIdentifierAndLabel() {
+        let view = FakeReactNativeView()
+        view.nativeID = "rn_checkout_button"
+        view.accessibilityIdentifier = "checkout_identifier"
+        view.isAccessibilityElement = true
+        view.accessibilityLabel = "Checkout"
+
+        XCTAssertEqual(extractor.extractElementId(from: view), "rn_checkout_button")
+    }
+
+    func testEmptyNativeIdFallsThroughToIdentifier() {
+        let view = FakeReactNativeView()
+        view.nativeID = ""
+        view.accessibilityIdentifier = "checkout_identifier"
+
+        XCTAssertEqual(extractor.extractElementId(from: view), "checkout_identifier")
+    }
+
+    func testViewWithoutNativeIdPropertyIsHandled() {
+        // A plain UIView does not declare `nativeID`; the KVC probe must not throw.
+        let view = UIView()
+        view.accessibilityIdentifier = "plain_view"
+
+        XCTAssertEqual(extractor.extractElementId(from: view), "plain_view")
+    }
+
+    // MARK: - Priority 2: accessibilityIdentifier
+
+    func testIdentifierWinsOverLabel() {
+        // The identifier is stable and never user-visible, so it outranks the label.
+        let button = UIButton()
+        button.accessibilityIdentifier = "checkout_identifier"
+        button.accessibilityLabel = "Checkout"
+
+        XCTAssertEqual(extractor.extractElementId(from: button), "checkout_identifier")
+    }
+
+    func testEmptyIdentifierFallsThroughToLabel() {
+        let button = UIButton()
+        button.accessibilityIdentifier = ""
+        button.accessibilityLabel = "Checkout"
+
+        XCTAssertEqual(extractor.extractElementId(from: button), "Checkout")
+    }
+
+    func testInternalIdentifiersAreSkipped() {
+        for internalIdentifier in ["_privateThing", "AXID-42", "UITransitionView-1"] {
+            let button = UIButton()
+            button.accessibilityIdentifier = internalIdentifier
+            button.accessibilityLabel = "Checkout"
+
+            XCTAssertEqual(
+                extractor.extractElementId(from: button), "Checkout",
+                "Framework-internal identifier \(internalIdentifier) should be skipped")
+        }
+    }
+
+    // MARK: - Priority 3: accessibilityLabel
+
+    func testLabelUsedWhenNothingElseResolves() {
+        let label = UILabel()
+        label.accessibilityLabel = "Order Total"
+
+        XCTAssertEqual(extractor.extractElementId(from: label), "Order Total")
+    }
+
+    func testLabelOnGenericContainerIgnoredUnlessAccessibilityElement() {
+        // UIKit auto-derives container labels from child text, which can carry user data. A generic
+        // container (e.g. React Native's RCTView) is only trusted when the developer marked it as an
+        // accessibility element — `accessible={true}` in React Native.
+        let container = UIView()
+        container.accessibilityLabel = "Account ending 4321"
+        container.isAccessibilityElement = false
+
+        let elementId = extractor.extractElementId(from: container) ?? ""
+        assertMatchesHashFallback(elementId)
+        XCTAssertFalse(elementId.contains("4321"), "Derived label must not leak into $el_id")
+    }
+
+    func testLabelOnGenericContainerUsedWhenAccessibilityElement() {
+        let container = UIView()
+        container.accessibilityLabel = "Explicit Label"
+        container.isAccessibilityElement = true
+
+        XCTAssertEqual(extractor.extractElementId(from: container), "Explicit Label")
+    }
+
+    func testEmptyLabelFallsThroughToHash() {
+        let button = UIButton()
+        button.accessibilityLabel = ""
+
+        assertMatchesHashFallback(extractor.extractElementId(from: button) ?? "")
+    }
+
+    // MARK: - Priority 4: hash fallback
+
+    func testHashFallbackUsesClassName() {
+        let elementId = extractor.extractElementId(from: UIButton()) ?? ""
+
+        XCTAssertNotNil(
+            elementId.range(of: "^UIButton_[0-9a-f]+$", options: .regularExpression),
+            "Expected UIButton_<hash>, got: \(elementId)")
+    }
+
+    func testHashFallbackIsStablePerViewAndDistinctAcrossViews() {
+        let first = UIButton()
+        let second = UIButton()
+
+        XCTAssertEqual(
+            extractor.extractElementId(from: first), extractor.extractElementId(from: first),
+            "Same view must resolve to the same id")
+        XCTAssertNotEqual(
+            extractor.extractElementId(from: first), extractor.extractElementId(from: second),
+            "Different views must resolve to different ids")
+    }
+
+    func testAnonymousIdMatchesTheDefaultChainFallback() {
+        // resolveElementId() hands a nil-returning custom extractor over to anonymousId(); both
+        // paths must produce the same shape.
+        let view = UIButton()
+
+        XCTAssertEqual(
+            extractor.extractElementId(from: view),
+            DefaultElementIdExtractor.anonymousId(for: view))
+    }
+
+    // MARK: - SwiftUI fallbacks (values read from the accessibility element tree)
+
+    func testIdentifierFallbackUsedWhenViewHasNoIdentifier() {
+        let view = UIView()
+
+        XCTAssertEqual(
+            extractor.elementId(
+                for: view,
+                accessibilityIdentifierFallback: "swiftui_checkout",
+                accessibilityLabelFallback: "Checkout From Tree"),
+            "swiftui_checkout",
+            "Identifier fallback must outrank the label fallback")
+    }
+
+    func testViewIdentifierWinsOverIdentifierFallback() {
+        let view = UIView()
+        view.accessibilityIdentifier = "own_identifier"
+
+        XCTAssertEqual(
+            extractor.elementId(
+                for: view,
+                accessibilityIdentifierFallback: "tree_identifier",
+                accessibilityLabelFallback: nil),
+            "own_identifier")
+    }
+
+    func testLabelFallbackUsedWhenNoIdentifierAnywhere() {
+        let view = UIView()
+
+        XCTAssertEqual(
+            extractor.elementId(
+                for: view,
+                accessibilityIdentifierFallback: nil,
+                accessibilityLabelFallback: "Checkout From Tree"),
+            "Checkout From Tree")
+    }
+
+    func testInternalIdentifierFallbackIsSkipped() {
+        let view = UIView()
+
+        let elementId = extractor.elementId(
+            for: view,
+            accessibilityIdentifierFallback: "_UIKitInternal",
+            accessibilityLabelFallback: nil)
+
+        assertMatchesHashFallback(elementId)
+    }
+
+    func testEmptyFallbacksResolveToHash() {
+        let view = UIView()
+
+        assertMatchesHashFallback(
+            extractor.elementId(
+                for: view, accessibilityIdentifierFallback: "", accessibilityLabelFallback: ""))
+    }
+}
+
+/// Verifies that `AutocaptureOptions.elementIdExtractor` actually governs the `$el_id` that reaches
+/// the `ClickEvent` — the integration point between the option and the hit-test path.
+class SemanticExtractorElementIdTests: XCTestCase {
+
+    private let point = CGPoint(x: 10, y: 20)
+
+    private func elementId(for view: UIView, options: AutocaptureOptions) -> String {
+        return SemanticExtractor(autocaptureOptions: options)
+            .extractSemantics(from: view, at: point)
+            .elementId
+    }
+
+    func testDefaultResolutionUsedWhenNoExtractorProvided() {
+        let button = UIButton()
+        button.accessibilityIdentifier = "checkout_identifier"
+        button.accessibilityLabel = "Checkout"
+
+        XCTAssertEqual(
+            elementId(for: button, options: AutocaptureOptions()), "checkout_identifier")
+    }
+
+    func testCustomExtractorReplacesDefaultResolution() {
+        let button = UIButton()
+        button.accessibilityIdentifier = "checkout_identifier"
+
+        let options = AutocaptureOptions(
+            elementIdExtractor: ConstantElementIdExtractor("custom_el_id"))
+
+        XCTAssertEqual(elementId(for: button, options: options), "custom_el_id")
+    }
+
+    func testCustomExtractorReturningNilFallsBackToAnonymousId() {
+        // Returning nil means "report nothing identifying" — the SDK must not quietly fall back to
+        // metadata the developer declined to expose.
+        let button = UIButton()
+        button.accessibilityIdentifier = "checkout_identifier"
+        button.accessibilityLabel = "Checkout"
+
+        let options = AutocaptureOptions(elementIdExtractor: ConstantElementIdExtractor(nil))
+        let resolved = elementId(for: button, options: options)
+
+        XCTAssertEqual(resolved, DefaultElementIdExtractor.anonymousId(for: button))
+        XCTAssertFalse(resolved.contains("checkout_identifier"))
+        XCTAssertFalse(resolved.contains("Checkout"))
+    }
+
+    func testCustomExtractorReturningEmptyStringFallsBackToAnonymousId() {
+        let button = UIButton()
+        button.accessibilityIdentifier = "checkout_identifier"
+
+        let options = AutocaptureOptions(elementIdExtractor: ConstantElementIdExtractor(""))
+
+        XCTAssertEqual(
+            elementId(for: button, options: options),
+            DefaultElementIdExtractor.anonymousId(for: button))
+    }
+
+    func testAccessibilityLabelStillReportedSeparatelyFromElementId() {
+        // The identifier wins $el_id, but the label must still travel as $attr-aria-label.
+        let button = UIButton()
+        button.accessibilityIdentifier = "checkout_identifier"
+        button.accessibilityLabel = "Checkout"
+
+        let event = SemanticExtractor(autocaptureOptions: AutocaptureOptions())
+            .extractSemantics(from: button, at: point)
+
+        XCTAssertEqual(event.elementId, "checkout_identifier")
+        XCTAssertEqual(event.accessibleLabel, "Checkout")
+    }
+}
+
+/// End-to-end coverage for the extractor: an implementation handed to `MixpanelOptions` must survive
+/// SDK initialization and govern the `$el_id` of a `$mp_click` produced by a real touch.
+class ElementIdExtractorEndToEndTests: MixpanelBaseTests {
+
+    private var testWindow: UIWindow!
+    private var testViewController: UIViewController!
+    private var button: UIButton!
+    private var mixpanel: MixpanelInstance!
+
+    override func setUp() {
+        super.setUp()
+
+        let setupExpectation = expectation(description: "Setup complete")
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            self.button = UIButton(type: .system)
+            self.button.setTitle("Checkout", for: .normal)
+            self.button.accessibilityIdentifier = "checkout_identifier"
+            self.button.accessibilityLabel = "Checkout"
+            self.button.frame = CGRect(x: 20, y: 100, width: 200, height: 44)
+            self.button.addTarget(self, action: #selector(self.buttonTapped), for: .touchUpInside)
+
+            self.testViewController = UIViewController()
+            self.testViewController.view.addSubview(self.button)
+
+            self.testWindow = UIWindow(frame: UIScreen.main.bounds)
+            self.testWindow.rootViewController = self.testViewController
+            self.testWindow.makeKeyAndVisible()
+            self.testWindow.layoutIfNeeded()
+
+            setupExpectation.fulfill()
+        }
+        wait(for: [setupExpectation], timeout: 5)
+    }
+
+    override func tearDown() {
+        let teardownExpectation = expectation(description: "Teardown complete")
+        DispatchQueue.main.async { [weak self] in
+            self?.testWindow?.isHidden = true
+            self?.testWindow = nil
+            self?.testViewController = nil
+            self?.button = nil
+            teardownExpectation.fulfill()
+        }
+        wait(for: [teardownExpectation], timeout: 5)
+
+        if let token = mixpanel?.apiToken {
+            removeDBfile(token)
+        }
+        mixpanel = nil
+        super.tearDown()
+    }
+
+    @objc private func buttonTapped() {}
+
+    func testCustomExtractorGovernsElementIdEndToEnd() {
+        startMixpanel(extractor: ConstantElementIdExtractor("custom_el_id"))
+
+        simulateTap()
+
+        let properties = waitForClickProperties()
+        XCTAssertNotNil(properties, "Should capture $mp_click event")
+        XCTAssertEqual(properties?["$el_id"] as? String, "custom_el_id")
+    }
+
+    func testExtractorReturningNilYieldsAnonymousIdEndToEnd() {
+        startMixpanel(extractor: ConstantElementIdExtractor(nil))
+
+        simulateTap()
+
+        let properties = waitForClickProperties()
+        XCTAssertNotNil(properties, "Should capture $mp_click event")
+        let elementId = properties?["$el_id"] as? String ?? ""
+        XCTAssertNotNil(
+            elementId.range(of: "^UIButton_[0-9a-f]+$", options: .regularExpression),
+            "Expected the anonymous id, got: \(elementId)")
+        XCTAssertFalse(
+            elementId.contains("checkout_identifier"),
+            "Suppressed identifier must not leak into $el_id")
+    }
+
+    func testDefaultResolutionEndToEndWithoutExtractor() {
+        startMixpanel(extractor: nil)
+
+        simulateTap()
+
+        let properties = waitForClickProperties()
+        XCTAssertNotNil(properties, "Should capture $mp_click event")
+        XCTAssertEqual(properties?["$el_id"] as? String, "checkout_identifier")
+    }
+
+    /// A React Native view exposes the JS-side `nativeID` prop as an `@objc` property; it must win
+    /// $el_id over the accessibility metadata React Native also sets.
+    func testReactNativeNativeIdWinsEndToEnd() {
+        startMixpanel(extractor: nil)
+
+        let setupExpectation = expectation(description: "RN view added")
+        let rnView = FakeReactNativeView()
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            rnView.nativeID = "rn_checkout_button"
+            rnView.accessibilityIdentifier = "rn_view_identifier"
+            rnView.isAccessibilityElement = true
+            rnView.accessibilityLabel = "Checkout"
+            rnView.frame = CGRect(x: 20, y: 200, width: 200, height: 44)
+            // React Native attaches touch handling via gesture recognizers; one is enough to make
+            // the view read as interactive so the hit test stops here instead of walking up.
+            rnView.addGestureRecognizer(
+                UITapGestureRecognizer(target: self, action: #selector(self.buttonTapped)))
+            self.testViewController.view.addSubview(rnView)
+            self.testWindow.layoutIfNeeded()
+            setupExpectation.fulfill()
+        }
+        wait(for: [setupExpectation], timeout: 5)
+
+        let tapExpectation = expectation(description: "Tap simulated")
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self, let window = self.testWindow else {
+                tapExpectation.fulfill()
+                return
+            }
+            let center = rnView.superview?.convert(rnView.center, to: window) ?? rnView.center
+            self.mixpanel.autocaptureManager?.handleTouch(at: center, view: rnView, window: window)
+            tapExpectation.fulfill()
+        }
+        wait(for: [tapExpectation], timeout: 2)
+
+        let properties = waitForClickProperties()
+        XCTAssertNotNil(properties, "Should capture $mp_click event")
+        XCTAssertEqual(properties?["$el_id"] as? String, "rn_checkout_button")
+    }
+
+    // MARK: - Helpers
+
+    private func startMixpanel(extractor: ElementIdExtractor?) {
+        let token = randomId()
+        let options = MixpanelOptions(
+            token: token,
+            flushInterval: 60,
+            instanceName: token,
+            trackAutomaticEvents: false,
+            optOutTrackingByDefault: false,
+            serverURL: kFakeServerUrl,
+            autocaptureOptions: AutocaptureOptions(
+                clickOptions: ClickOptions(enabled: true),
+                rageClickOptions: RageClickOptions(enabled: false),
+                deadClickOptions: DeadClickOptions(enabled: false),
+                elementIdExtractor: extractor
+            )
+        )
+
+        mixpanel = Mixpanel.initialize(options: options)
+        waitForAsyncTasks()
+    }
+
+    private func simulateTap() {
+        let tapExpectation = expectation(description: "Tap simulated")
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self, let window = self.testWindow, let button = self.button else {
+                tapExpectation.fulfill()
+                return
+            }
+            let center = button.superview?.convert(button.center, to: window) ?? button.center
+            self.mixpanel.autocaptureManager?.handleTouch(at: center, view: button, window: window)
+            tapExpectation.fulfill()
+        }
+        wait(for: [tapExpectation], timeout: 2)
+    }
+
+    private func waitForClickProperties(timeout: TimeInterval = 5) -> [String: Any]? {
+        let startTime = Date()
+        while Date().timeIntervalSince(startTime) < timeout {
+            waitForTrackingQueue(mixpanel)
+
+            let events = eventQueue(token: mixpanel.apiToken)
+            if let match = events.first(where: { ($0["event"] as? String) == "$mp_click" }),
+                let properties = match["properties"] as? [String: Any]
+            {
+                return properties
+            }
+
+            RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.1))
+        }
+        return nil
     }
 }
 #endif

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
@@ -74,18 +74,6 @@ class AutocaptureOptionsTests: XCTestCase {
         XCTAssertTrue(options.deadClickOptions.enabled)
     }
 
-    func testAutocaptureOptionsDefaultToNoElementIdExtractor() {
-        XCTAssertNil(AutocaptureOptions().elementIdExtractor)
-    }
-
-    func testAutocaptureOptionsRetainTheElementIdExtractor() {
-        let extractor = ConstantElementIdExtractor("custom_el_id")
-        let options = AutocaptureOptions(elementIdExtractor: extractor)
-
-        XCTAssertNotNil(options.elementIdExtractor)
-        XCTAssertEqual(options.elementIdExtractor?.extractElementId(from: UIView()), "custom_el_id")
-    }
-
     func testAutocaptureOptionsIsEnabledWhenAnyFeatureEnabled() {
         // Only click enabled
         let clickOnly = AutocaptureOptions(
@@ -330,19 +318,6 @@ private final class FakeReactNativeView: UIView {
     @objc var nativeID: String?
 }
 
-/// Returns a fixed identifier for every view.
-private final class ConstantElementIdExtractor: ElementIdExtractor {
-    let identifier: String?
-
-    init(_ identifier: String?) {
-        self.identifier = identifier
-    }
-
-    func extractElementId(from view: UIView) -> String? {
-        return identifier
-    }
-}
-
 /// Tests the `$el_id` resolution order implemented by `DefaultElementIdExtractor`:
 /// React Native `nativeID` > `accessibilityIdentifier` > `<ClassName>_<hash>`. Accessibility labels
 /// are never a source: they are localized and can carry user data.
@@ -352,6 +327,12 @@ class DefaultElementIdExtractorTests: XCTestCase {
     private let hashIdPattern = "^[A-Za-z0-9_]+_[0-9a-f]+$"
 
     private let extractor = DefaultElementIdExtractor.shared
+
+    /// The resolver takes a SwiftUI accessibility-tree fallback identifier; the cases below exercise
+    /// the UIKit path, where there is none. The SwiftUI cases pass one explicitly.
+    private func elementId(for view: UIView) -> String {
+        return extractor.elementId(for: view, accessibilityIdentifierFallback: nil)
+    }
 
     private func assertMatchesHashFallback(_ elementId: String, _ message: String = "") {
         XCTAssertNotNil(
@@ -368,7 +349,7 @@ class DefaultElementIdExtractorTests: XCTestCase {
         view.isAccessibilityElement = true
         view.accessibilityLabel = "Checkout"
 
-        XCTAssertEqual(extractor.extractElementId(from: view), "rn_checkout_button")
+        XCTAssertEqual(elementId(for: view), "rn_checkout_button")
     }
 
     func testEmptyNativeIdFallsThroughToIdentifier() {
@@ -376,7 +357,7 @@ class DefaultElementIdExtractorTests: XCTestCase {
         view.nativeID = ""
         view.accessibilityIdentifier = "checkout_identifier"
 
-        XCTAssertEqual(extractor.extractElementId(from: view), "checkout_identifier")
+        XCTAssertEqual(elementId(for: view), "checkout_identifier")
     }
 
     func testViewWithoutNativeIdPropertyIsHandled() {
@@ -384,7 +365,7 @@ class DefaultElementIdExtractorTests: XCTestCase {
         let view = UIView()
         view.accessibilityIdentifier = "plain_view"
 
-        XCTAssertEqual(extractor.extractElementId(from: view), "plain_view")
+        XCTAssertEqual(elementId(for: view), "plain_view")
     }
 
     // MARK: - Priority 2: accessibilityIdentifier
@@ -395,7 +376,7 @@ class DefaultElementIdExtractorTests: XCTestCase {
         button.accessibilityIdentifier = "checkout_identifier"
         button.accessibilityLabel = "Checkout"
 
-        XCTAssertEqual(extractor.extractElementId(from: button), "checkout_identifier")
+        XCTAssertEqual(elementId(for: button), "checkout_identifier")
     }
 
     func testEmptyIdentifierFallsThroughToTheStructuralHash() {
@@ -403,7 +384,7 @@ class DefaultElementIdExtractorTests: XCTestCase {
         button.accessibilityIdentifier = ""
         button.accessibilityLabel = "Checkout"
 
-        let elementId = extractor.extractElementId(from: button) ?? ""
+        let elementId = elementId(for: button)
         assertMatchesHashFallback(elementId)
         XCTAssertFalse(elementId.contains("Checkout"), "Labels are never used as identity")
     }
@@ -414,7 +395,7 @@ class DefaultElementIdExtractorTests: XCTestCase {
             button.accessibilityIdentifier = internalIdentifier
 
             assertMatchesHashFallback(
-                extractor.extractElementId(from: button) ?? "",
+                elementId(for: button),
                 "Framework-internal identifier \(internalIdentifier) should be skipped")
         }
     }
@@ -428,7 +409,7 @@ class DefaultElementIdExtractorTests: XCTestCase {
             view.isAccessibilityElement = true
             view.accessibilityLabel = "Account ending 4321"
 
-            let elementId = extractor.extractElementId(from: view) ?? ""
+            let elementId = elementId(for: view)
             assertMatchesHashFallback(elementId)
             XCTAssertFalse(
                 elementId.contains("4321"),
@@ -439,7 +420,7 @@ class DefaultElementIdExtractorTests: XCTestCase {
     // MARK: - Priority 4: hash fallback
 
     func testHashFallbackUsesClassName() {
-        let elementId = extractor.extractElementId(from: UIButton()) ?? ""
+        let elementId = elementId(for: UIButton())
 
         XCTAssertNotNil(
             elementId.range(of: "^UIButton_[0-9a-f]+$", options: .regularExpression),
@@ -459,8 +440,8 @@ class DefaultElementIdExtractorTests: XCTestCase {
         }
 
         XCTAssertEqual(
-            extractor.extractElementId(from: buildLeaf()),
-            extractor.extractElementId(from: buildLeaf()),
+            elementId(for: buildLeaf()),
+            elementId(for: buildLeaf()),
             "The same structure must resolve to the same id")
     }
 
@@ -472,17 +453,17 @@ class DefaultElementIdExtractorTests: XCTestCase {
         root.addSubview(second)
 
         XCTAssertNotEqual(
-            extractor.extractElementId(from: first), extractor.extractElementId(from: second),
+            elementId(for: first), elementId(for: second),
             "Siblings at different positions must resolve to different ids")
     }
 
     func testAnonymousIdMatchesTheDefaultChainFallback() {
-        // resolveElementId() hands a nil-returning custom extractor over to anonymousId(); both
-        // paths must produce the same shape.
+        // The end of the resolution chain and anonymousId() must produce the same identifier — the
+        // hash fallback has no second implementation.
         let view = UIButton()
 
         XCTAssertEqual(
-            extractor.extractElementId(from: view),
+            elementId(for: view),
             DefaultElementIdExtractor.anonymousId(for: view))
     }
 
@@ -531,61 +512,34 @@ class DefaultElementIdExtractorTests: XCTestCase {
     }
 }
 
-/// Verifies that `AutocaptureOptions.elementIdExtractor` actually governs the `$el_id` that reaches
-/// the `ClickEvent` — the integration point between the option and the hit-test path.
+/// Verifies the `$el_id` that reaches the `ClickEvent` — the integration point between
+/// `DefaultElementIdExtractor` and the hit-test path.
 class SemanticExtractorElementIdTests: XCTestCase {
 
     private let point = CGPoint(x: 10, y: 20)
 
-    private func elementId(for view: UIView, options: AutocaptureOptions) -> String {
-        return SemanticExtractor(autocaptureOptions: options)
+    private func elementId(for view: UIView) -> String {
+        return SemanticExtractor()
             .extractSemantics(from: view, at: point)
             .elementId
     }
 
-    func testDefaultResolutionUsedWhenNoExtractorProvided() {
+    func testAccessibilityIdentifierResolvesElementId() {
         let button = UIButton()
         button.accessibilityIdentifier = "checkout_identifier"
         button.accessibilityLabel = "Checkout"
 
-        XCTAssertEqual(
-            elementId(for: button, options: AutocaptureOptions()), "checkout_identifier")
+        XCTAssertEqual(elementId(for: button), "checkout_identifier")
     }
 
-    func testCustomExtractorReplacesDefaultResolution() {
+    func testViewWithoutIdentifierFallsBackToAnonymousId() {
         let button = UIButton()
-        button.accessibilityIdentifier = "checkout_identifier"
-
-        let options = AutocaptureOptions(
-            elementIdExtractor: ConstantElementIdExtractor("custom_el_id"))
-
-        XCTAssertEqual(elementId(for: button, options: options), "custom_el_id")
-    }
-
-    func testCustomExtractorReturningNilFallsBackToAnonymousId() {
-        // Returning nil means "report nothing identifying" — the SDK must not quietly fall back to
-        // metadata the developer declined to expose.
-        let button = UIButton()
-        button.accessibilityIdentifier = "checkout_identifier"
         button.accessibilityLabel = "Checkout"
 
-        let options = AutocaptureOptions(elementIdExtractor: ConstantElementIdExtractor(nil))
-        let resolved = elementId(for: button, options: options)
+        let resolved = elementId(for: button)
 
         XCTAssertEqual(resolved, DefaultElementIdExtractor.anonymousId(for: button))
-        XCTAssertFalse(resolved.contains("checkout_identifier"))
         XCTAssertFalse(resolved.contains("Checkout"))
-    }
-
-    func testCustomExtractorReturningEmptyStringFallsBackToAnonymousId() {
-        let button = UIButton()
-        button.accessibilityIdentifier = "checkout_identifier"
-
-        let options = AutocaptureOptions(elementIdExtractor: ConstantElementIdExtractor(""))
-
-        XCTAssertEqual(
-            elementId(for: button, options: options),
-            DefaultElementIdExtractor.anonymousId(for: button))
     }
 
     func testAccessibilityLabelIsNeverReported() {
@@ -594,7 +548,7 @@ class SemanticExtractorElementIdTests: XCTestCase {
         button.accessibilityIdentifier = "checkout_identifier"
         button.accessibilityLabel = "Checkout"
 
-        let event = SemanticExtractor(autocaptureOptions: AutocaptureOptions())
+        let event = SemanticExtractor()
             .extractSemantics(from: button, at: point)
 
         XCTAssertEqual(event.elementId, "checkout_identifier")
@@ -604,8 +558,8 @@ class SemanticExtractorElementIdTests: XCTestCase {
     }
 }
 
-/// End-to-end coverage for the extractor: an implementation handed to `MixpanelOptions` must survive
-/// SDK initialization and govern the `$el_id` of a `$mp_click` produced by a real touch.
+/// End-to-end coverage for `$el_id`: the identifier the SDK resolves must survive SDK
+/// initialization and govern the `$el_id` of a `$mp_click` produced by a real touch.
 class ElementIdExtractorEndToEndTests: MixpanelBaseTests {
 
     private var testWindow: UIWindow!
@@ -660,34 +614,8 @@ class ElementIdExtractorEndToEndTests: MixpanelBaseTests {
 
     @objc private func buttonTapped() {}
 
-    func testCustomExtractorGovernsElementIdEndToEnd() {
-        startMixpanel(extractor: ConstantElementIdExtractor("custom_el_id"))
-
-        simulateTap()
-
-        let properties = waitForClickProperties()
-        XCTAssertNotNil(properties, "Should capture $mp_click event")
-        XCTAssertEqual(properties?["$el_id"] as? String, "custom_el_id")
-    }
-
-    func testExtractorReturningNilYieldsAnonymousIdEndToEnd() {
-        startMixpanel(extractor: ConstantElementIdExtractor(nil))
-
-        simulateTap()
-
-        let properties = waitForClickProperties()
-        XCTAssertNotNil(properties, "Should capture $mp_click event")
-        let elementId = properties?["$el_id"] as? String ?? ""
-        XCTAssertNotNil(
-            elementId.range(of: "^UIButton_[0-9a-f]+$", options: .regularExpression),
-            "Expected the anonymous id, got: \(elementId)")
-        XCTAssertFalse(
-            elementId.contains("checkout_identifier"),
-            "Suppressed identifier must not leak into $el_id")
-    }
-
-    func testDefaultResolutionEndToEndWithoutExtractor() {
-        startMixpanel(extractor: nil)
+    func testDefaultResolutionEndToEnd() {
+        startMixpanel()
 
         simulateTap()
 
@@ -699,7 +627,7 @@ class ElementIdExtractorEndToEndTests: MixpanelBaseTests {
     /// A React Native view exposes the JS-side `nativeID` prop as an `@objc` property; it must win
     /// $el_id over the accessibility metadata React Native also sets.
     func testReactNativeNativeIdWinsEndToEnd() {
-        startMixpanel(extractor: nil)
+        startMixpanel()
 
         let setupExpectation = expectation(description: "RN view added")
         let rnView = FakeReactNativeView()
@@ -739,7 +667,7 @@ class ElementIdExtractorEndToEndTests: MixpanelBaseTests {
 
     // MARK: - Helpers
 
-    private func startMixpanel(extractor: ElementIdExtractor?) {
+    private func startMixpanel() {
         let token = randomId()
         let options = MixpanelOptions(
             token: token,
@@ -751,8 +679,7 @@ class ElementIdExtractorEndToEndTests: MixpanelBaseTests {
             autocaptureOptions: AutocaptureOptions(
                 clickOptions: ClickOptions(enabled: true),
                 rageClickOptions: RageClickOptions(enabled: false),
-                deadClickOptions: DeadClickOptions(enabled: false),
-                elementIdExtractor: extractor
+                deadClickOptions: DeadClickOptions(enabled: false)
             )
         )
 

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
@@ -1,0 +1,313 @@
+//
+//  AutocaptureTests.swift
+//  MixpanelDemoTests
+//
+//  Created by Mixpanel on 2026-06-13.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+import XCTest
+
+@testable import Mixpanel
+
+#if os(iOS)
+class AutocaptureOptionsTests: XCTestCase {
+
+    // MARK: - ClickOptions Tests
+
+    func testClickOptionsDefaultsToEnabled() {
+        let options = ClickOptions()
+        XCTAssertTrue(options.enabled)
+    }
+
+    func testClickOptionsCanBeDisabled() {
+        let options = ClickOptions(enabled: false)
+        XCTAssertFalse(options.enabled)
+    }
+
+    // MARK: - RageClickOptions Tests
+
+    func testRageClickOptionsDefaults() {
+        let options = RageClickOptions()
+        XCTAssertTrue(options.enabled)
+        XCTAssertEqual(options.clickThreshold, 4)
+        XCTAssertEqual(options.timeWindowMs, 1000)
+        XCTAssertEqual(options.radius, 44)
+    }
+
+    func testRageClickOptionsCustomValues() {
+        let options = RageClickOptions(
+            enabled: true,
+            clickThreshold: 5,
+            timeWindowMs: 800,
+            radius: 60
+        )
+        XCTAssertEqual(options.clickThreshold, 5)
+        XCTAssertEqual(options.timeWindowMs, 800)
+        XCTAssertEqual(options.radius, 60)
+    }
+
+    // MARK: - DeadClickOptions Tests
+
+    func testDeadClickOptionsDefaults() {
+        let options = DeadClickOptions()
+        XCTAssertTrue(options.enabled)
+        XCTAssertEqual(options.timeWindowMs, 500)
+    }
+
+    func testDeadClickOptionsCustomValues() {
+        let options = DeadClickOptions(
+            enabled: false,
+            timeWindowMs: 700
+        )
+        XCTAssertFalse(options.enabled)
+        XCTAssertEqual(options.timeWindowMs, 700)
+    }
+
+    // MARK: - AutocaptureOptions Tests
+
+    func testAutocaptureOptionsDefaults() {
+        let options = AutocaptureOptions()
+        XCTAssertTrue(options.isEnabled)
+        XCTAssertTrue(options.clickOptions.enabled)
+        XCTAssertTrue(options.rageClickOptions.enabled)
+        XCTAssertTrue(options.deadClickOptions.enabled)
+    }
+
+    func testAutocaptureOptionsIsEnabledWhenAnyFeatureEnabled() {
+        // Only click enabled
+        let clickOnly = AutocaptureOptions(
+            clickOptions: ClickOptions(enabled: true),
+            rageClickOptions: RageClickOptions(enabled: false),
+            deadClickOptions: DeadClickOptions(enabled: false)
+        )
+        XCTAssertTrue(clickOnly.isEnabled)
+
+        // Only rage click enabled
+        let rageOnly = AutocaptureOptions(
+            clickOptions: ClickOptions(enabled: false),
+            rageClickOptions: RageClickOptions(enabled: true),
+            deadClickOptions: DeadClickOptions(enabled: false)
+        )
+        XCTAssertTrue(rageOnly.isEnabled)
+
+        // Only dead click enabled
+        let deadOnly = AutocaptureOptions(
+            clickOptions: ClickOptions(enabled: false),
+            rageClickOptions: RageClickOptions(enabled: false),
+            deadClickOptions: DeadClickOptions(enabled: true)
+        )
+        XCTAssertTrue(deadOnly.isEnabled)
+    }
+
+    func testAutocaptureOptionsIsDisabledWhenAllFeaturesDisabled() {
+        let options = AutocaptureOptions(
+            clickOptions: ClickOptions(enabled: false),
+            rageClickOptions: RageClickOptions(enabled: false),
+            deadClickOptions: DeadClickOptions(enabled: false)
+        )
+        XCTAssertFalse(options.isEnabled)
+    }
+}
+
+class RageClickTrackerTests: XCTestCase {
+
+    // MARK: - Basic Detection
+
+    func testSingleClickIsNotRageClick() {
+        let options = RageClickOptions()
+        let tracker = RageClickTracker(options: options)
+
+        let result = tracker.trackClick(x: 100, y: 100)
+
+        XCTAssertFalse(result.isRageClick)
+    }
+
+    func testThreeClicksIsNotRageClick() {
+        let options = RageClickOptions(clickThreshold: 4)
+        var currentTime: Int64 = 1000
+        let tracker = RageClickTracker(options: options, timeProvider: { currentTime })
+
+        // First 3 clicks - should not be rage click
+        for i in 1...3 {
+            let result = tracker.trackClick(x: 100, y: 100)
+            XCTAssertFalse(result.isRageClick, "Click \(i) should not be rage click")
+            currentTime += 100  // 100ms between clicks
+        }
+    }
+
+    func testFourClicksTriggersRageClick() {
+        let options = RageClickOptions(clickThreshold: 4)
+        var currentTime: Int64 = 1000
+        let tracker = RageClickTracker(options: options, timeProvider: { currentTime })
+
+        // First 3 clicks
+        for _ in 1...3 {
+            _ = tracker.trackClick(x: 100, y: 100)
+            currentTime += 100
+        }
+
+        // Fourth click should trigger rage click
+        let result = tracker.trackClick(x: 100, y: 100)
+        XCTAssertTrue(result.isRageClick)
+    }
+
+    // MARK: - Time Window
+
+    func testClicksOutsideTimeWindowNotRageClick() {
+        let options = RageClickOptions(clickThreshold: 4, timeWindowMs: 1000)
+        var currentTime: Int64 = 1000
+        let tracker = RageClickTracker(options: options, timeProvider: { currentTime })
+
+        // First click at t=1000
+        _ = tracker.trackClick(x: 100, y: 100)
+
+        // Second click at t=1100
+        currentTime = 1100
+        _ = tracker.trackClick(x: 100, y: 100)
+
+        // Third click at t=1200
+        currentTime = 1200
+        _ = tracker.trackClick(x: 100, y: 100)
+
+        // Fourth click at t=2100 (outside 1000ms window from first click)
+        currentTime = 2100
+        let result = tracker.trackClick(x: 100, y: 100)
+
+        // First click is expired, so we only have 3 clicks in window
+        XCTAssertFalse(result.isRageClick)
+    }
+
+    func testClicksWithinTimeWindowTriggersRageClick() {
+        let options = RageClickOptions(clickThreshold: 4, timeWindowMs: 1000)
+        var currentTime: Int64 = 1000
+        let tracker = RageClickTracker(options: options, timeProvider: { currentTime })
+
+        // All clicks within 1000ms window
+        for i in 0..<4 {
+            currentTime = Int64(1000 + i * 200)  // 0, 200, 400, 600ms
+            let result = tracker.trackClick(x: 100, y: 100)
+            if i == 3 {
+                XCTAssertTrue(result.isRageClick)
+            }
+        }
+    }
+
+    // MARK: - Spatial Threshold
+
+    func testClicksOutsideSpatialRadiusNotRageClick() {
+        let options = RageClickOptions(clickThreshold: 4, radius: 44)
+        var currentTime: Int64 = 1000
+        let tracker = RageClickTracker(options: options, timeProvider: { currentTime })
+
+        // Clicks at positions more than 44pt apart
+        _ = tracker.trackClick(x: 0, y: 0)
+        currentTime += 100
+        _ = tracker.trackClick(x: 100, y: 0)  // 100pt away
+        currentTime += 100
+        _ = tracker.trackClick(x: 200, y: 0)  // 100pt away
+        currentTime += 100
+        let result = tracker.trackClick(x: 300, y: 0)  // 100pt away
+
+        // Each click is too far from previous, not rage click
+        XCTAssertFalse(result.isRageClick)
+    }
+
+    func testClicksWithinSpatialRadiusTriggersRageClick() {
+        let options = RageClickOptions(clickThreshold: 4, radius: 50)
+        var currentTime: Int64 = 1000
+        let tracker = RageClickTracker(options: options, timeProvider: { currentTime })
+
+        // Clicks within 50pt radius
+        _ = tracker.trackClick(x: 100, y: 100)
+        currentTime += 100
+        _ = tracker.trackClick(x: 110, y: 110)  // ~14pt away
+        currentTime += 100
+        _ = tracker.trackClick(x: 120, y: 100)  // ~22pt from original
+        currentTime += 100
+        let result = tracker.trackClick(x: 105, y: 105)  // ~7pt from original
+
+        XCTAssertTrue(result.isRageClick)
+    }
+
+    // MARK: - Reset
+
+    func testResetClearsClickHistory() {
+        let options = RageClickOptions(clickThreshold: 4)
+        var currentTime: Int64 = 1000
+        let tracker = RageClickTracker(options: options, timeProvider: { currentTime })
+
+        // Track 3 clicks
+        for _ in 1...3 {
+            _ = tracker.trackClick(x: 100, y: 100)
+            currentTime += 100
+        }
+
+        // Reset
+        tracker.reset()
+
+        // Fourth click after reset should be like first click
+        let result = tracker.trackClick(x: 100, y: 100)
+        XCTAssertFalse(result.isRageClick)
+    }
+
+    // MARK: - Custom Threshold
+
+    func testCustomClickThreshold() {
+        let options = RageClickOptions(clickThreshold: 6)
+        var currentTime: Int64 = 1000
+        let tracker = RageClickTracker(options: options, timeProvider: { currentTime })
+
+        // 5 clicks should not trigger
+        for i in 1...5 {
+            let result = tracker.trackClick(x: 100, y: 100)
+            XCTAssertFalse(result.isRageClick, "Click \(i) should not be rage click with threshold 6")
+            currentTime += 100
+        }
+
+        // 6th click should trigger
+        let result = tracker.trackClick(x: 100, y: 100)
+        XCTAssertTrue(result.isRageClick)
+    }
+}
+
+class ClickEventTests: XCTestCase {
+
+    func testToPropertiesIncludesRequiredFields() {
+        let event = ClickEvent(
+            x: 100,
+            y: 200,
+            elementId: "test_button",
+            tagName: "UIButton",
+            accessibleLabel: "Test Button",
+            role: "Button",
+            elements: "UIButton > UIView"
+        )
+
+        let props = event.toProperties()
+
+        XCTAssertEqual(props["$x"] as? Int, 100)
+        XCTAssertEqual(props["$y"] as? Int, 200)
+        XCTAssertEqual(props["$el_id"] as? String, "test_button")
+        XCTAssertEqual(props["$el_tag_name"] as? String, "UIButton")
+        XCTAssertEqual(props["$attr-aria-label"] as? String, "Test Button")
+        XCTAssertEqual(props["$attr-role"] as? String, "Button")
+        XCTAssertEqual(props["$elements"] as? String, "UIButton > UIView")
+    }
+
+    func testToPropertiesOmitsNilValues() {
+        let event = ClickEvent(
+            x: 100,
+            y: 200,
+            elementId: "test_button"
+        )
+
+        let props = event.toProperties()
+
+        XCTAssertNil(props["$el_tag_name"])
+        XCTAssertNil(props["$attr-aria-label"])
+        XCTAssertNil(props["$attr-role"])
+        XCTAssertNil(props["$elements"])
+    }
+}
+#endif

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
@@ -122,7 +122,7 @@ class AutocaptureUIKitInstrumentedTests: MixpanelBaseTests {
 
     /// When a view carries both, the identifier wins $el_id — it is developer-assigned and never
     /// user-visible, so unlike a label it cannot carry PII. The label still travels as
-    /// $attr-aria-label.
+    /// The label is not reported at all.
     func testElementIdIdentifierWinsOverLabel() {
         let button = testViewController.bothButton
 
@@ -133,25 +133,31 @@ class AutocaptureUIKitInstrumentedTests: MixpanelBaseTests {
 
         if let props = event?.properties {
             XCTAssertEqual(props["$el_id"] as? String, "both_id")
-            XCTAssertEqual(props["$attr-aria-label"] as? String, "Both Label")
+            XCTAssertNil(
+                props["$attr-aria-label"],
+                "Accessibility labels are localized and can carry user data — never reported")
         }
     }
 
     // MARK: - Test 2: Element ID Resolution Rule 2 (accessibilityLabel fallback)
 
-    func testElementIdResolutionRule2() {
+    func testElementIdResolutionRule2_LabelIsNotUsed() {
         // Given: A button with only accessibilityLabel (no accessibilityIdentifier)
         let button = testViewController.rule2Button
 
         // When: Simulate tap
         simulateTap(on: button)
 
-        // Then: Element ID should use accessibilityLabel
+        // Then: the label is neither the element id nor reported — identity falls back to the
+        // structural hash, because a localized label cannot be a stable identifier.
         let event = waitForEvent(named: "$mp_click", timeout: 5)
         XCTAssertNotNil(event, "Should capture $mp_click event")
 
         if let props = event?.properties {
-            XCTAssertEqual(props["$el_id"] as? String, "Rule Two Label")
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertTrue(elId.hasPrefix("UIButton_"), "Expected the hash fallback, got: \(elId)")
+            XCTAssertNil(props["$attr-aria-label"])
+            XCTAssertFalse(elId.contains("Rule Two"), "Label must not leak into $el_id")
         }
     }
 
@@ -336,9 +342,11 @@ class AutocaptureUIKitInstrumentedTests: MixpanelBaseTests {
         }
     }
 
-    /// Positive case: View IS accessible AND HAS explicit accessibilityLabel.
-    /// The label SHOULD be captured in $el_id and $attr-aria-label.
-    func testAccessibleWithLabel_LabelIsCaptured() {
+    /// A view that is an accessibility element with an explicit, intentional accessibilityLabel
+    /// still must not have that text reported. Labels are localized — the same element would report
+    /// a different $el_id per language — and they can carry user data, so identity falls back to the
+    /// structural hash and no aria-label is emitted.
+    func testAccessibleWithLabel_LabelIsNeverCaptured() {
         let view = testViewController.accessibleWithLabelView
 
         simulateTap(on: view)
@@ -347,13 +355,13 @@ class AutocaptureUIKitInstrumentedTests: MixpanelBaseTests {
         XCTAssertNotNil(event, "Click event should be captured")
 
         if let props = event?.properties {
-            XCTAssertEqual(
-                props["$el_id"] as? String, "Intended Label",
-                "$el_id should use the explicit accessibilityLabel")
-
-            XCTAssertEqual(
-                props["$attr-aria-label"] as? String, "Intended Label",
-                "$attr-aria-label should be present with explicit label")
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertFalse(
+                elId.contains("Intended Label"),
+                "An intentional label must still not become $el_id, got: \(elId)")
+            XCTAssertNil(
+                props["$attr-aria-label"],
+                "$attr-aria-label must never be present")
         }
     }
 

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
@@ -157,6 +157,187 @@ class AutocaptureUIKitInstrumentedTests: MixpanelBaseTests {
         }
     }
 
+    // MARK: - Test: Child text does not leak when accessibilityLabel is not set
+
+    /// A clickable container with child text but no explicit accessibilityLabel must
+    /// not leak the child's visible text into $attr-aria-label or $el_id.
+    ///
+    /// Simulates a React Native Pressable where the developer did not set
+    /// accessibilityLabel. The container has isAccessibilityElement=false and a child
+    /// UILabel. UIKit auto-derives accessibilityLabel from child text — the SDK must
+    /// not capture that auto-derived value.
+    func testNotAccessibleElement_ChildTextDoesNotLeakIntoAriaLabel() {
+        let view = testViewController.notAccessibleView
+
+        simulateTap(on: view)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Click event should still be captured")
+
+        if let props = event?.properties {
+            // $el_id must NOT contain the child label text
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertFalse(
+                elId.contains("Sensitive"),
+                "$el_id should not contain child text. Got: \(elId)")
+
+            // $attr-aria-label must be absent — auto-derived label must not leak
+            XCTAssertNil(
+                props["$attr-aria-label"],
+                "$attr-aria-label must not be present when accessibilityLabel is auto-derived")
+        }
+    }
+
+    // MARK: - Test: Empty accessibilityLabel on UIButton with sensitive title
+
+    /// UIButton with title "4111-1111-1111-1234" and accessibilityLabel="".
+    /// The button title must not leak into $attr-aria-label or $el_id.
+    func testEmptyAccessibilityLabel_ButtonTitleDoesNotLeak() {
+        let button = testViewController.emptyLabelButton
+
+        simulateTap(on: button)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Click event should still be captured")
+
+        if let props = event?.properties {
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertFalse(
+                elId.contains("4111"),
+                "$el_id should not contain button title. Got: \(elId)")
+
+            let ariaLabel = props["$attr-aria-label"] as? String
+            XCTAssertTrue(
+                ariaLabel == nil || !ariaLabel!.contains("4111"),
+                "$attr-aria-label should not contain button title. Got: \(ariaLabel ?? "nil")")
+        }
+    }
+
+    // MARK: - Visibility Tests
+
+    /// A hidden button (isHidden=true) must not produce autocapture events.
+    /// Validates that neither the accessibilityIdentifier nor the accessibilityLabel
+    /// of the hidden view leaks into event attributes ($el_id, $attr-aria-label).
+    func testHiddenView_NoEventCaptured() {
+        let button = testViewController.hiddenButton
+
+        // Directly invoke handleTouch — bypasses hitTest to test extraction guard
+        simulateTap(on: button)
+
+        Thread.sleep(forTimeInterval: 0.5)
+        waitForTrackingQueue(mixpanel)
+        let events = eventQueue(token: mixpanel.apiToken)
+        let matchingEvents = events.filter {
+            guard let props = $0["properties"] as? [String: Any] else { return false }
+            let elId = props["$el_id"] as? String ?? ""
+            let ariaLabel = props["$attr-aria-label"] as? String ?? ""
+            return elId.contains("hidden_btn") || elId.contains("Hidden Sensitive")
+                || ariaLabel.contains("Hidden Sensitive")
+        }
+
+        XCTAssertEqual(
+            matchingEvents.count, 0,
+            "Hidden view's identifier and accessibilityLabel must not appear in autocapture events")
+    }
+
+    /// A zero-alpha button (alpha=0, fully transparent) must not produce
+    /// autocapture events. Validates that neither the accessibilityIdentifier
+    /// nor the accessibilityLabel leaks into event attributes.
+    func testZeroAlphaView_NoEventCaptured() {
+        let button = testViewController.zeroAlphaButton
+
+        simulateTap(on: button)
+
+        Thread.sleep(forTimeInterval: 0.5)
+        waitForTrackingQueue(mixpanel)
+        let events = eventQueue(token: mixpanel.apiToken)
+        let matchingEvents = events.filter {
+            guard let props = $0["properties"] as? [String: Any] else { return false }
+            let elId = props["$el_id"] as? String ?? ""
+            let ariaLabel = props["$attr-aria-label"] as? String ?? ""
+            return elId.contains("zero_alpha_btn") || elId.contains("ZeroAlpha Sensitive")
+                || ariaLabel.contains("ZeroAlpha Sensitive")
+        }
+
+        XCTAssertEqual(
+            matchingEvents.count, 0,
+            "Zero-alpha view's identifier and accessibilityLabel must not appear in autocapture events")
+    }
+
+    // MARK: - Accessibility Guard Tests
+
+    /// Scenario 2: View IS accessible (isAccessibilityElement=true) but has no explicit
+    /// accessibilityLabel. UIKit auto-derives label from child text — the SDK must NOT
+    /// capture that auto-derived value.
+    func testAccessibleNoLabel_ChildTextDoesNotLeak() {
+        let view = testViewController.accessibleNoLabelView
+
+        simulateTap(on: view)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Click event should still be captured")
+
+        if let props = event?.properties {
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertFalse(
+                elId.contains("Sensitive") || elId.contains("5678"),
+                "$el_id should not contain child text. Got: \(elId)")
+
+            XCTAssertNil(
+                props["$attr-aria-label"],
+                "$attr-aria-label must not be present when accessibilityLabel is auto-derived")
+        }
+    }
+
+    /// Scenario 4: View is NOT accessible (isAccessibilityElement=false) but HAS an
+    /// explicit accessibilityLabel. The label must NOT be captured because the view
+    /// is not an accessibility element.
+    func testNotAccessibleWithLabel_LabelDoesNotLeak() {
+        let view = testViewController.notAccessibleWithLabelView
+
+        simulateTap(on: view)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Click event should still be captured")
+
+        if let props = event?.properties {
+            // Neither accessibilityLabel nor child text must appear in $el_id
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertFalse(
+                elId.contains("Sensitive") || elId.contains("9999"),
+                "$el_id should not contain accessibilityLabel. Got: \(elId)")
+            XCTAssertFalse(
+                elId.contains("Some Label"),
+                "$el_id should not contain child text. Got: \(elId)")
+
+            // $attr-aria-label must be absent — neither label nor child text
+            XCTAssertNil(
+                props["$attr-aria-label"],
+                "$attr-aria-label must not be present when view is not accessible")
+        }
+    }
+
+    /// Positive case: View IS accessible AND HAS explicit accessibilityLabel.
+    /// The label SHOULD be captured in $el_id and $attr-aria-label.
+    func testAccessibleWithLabel_LabelIsCaptured() {
+        let view = testViewController.accessibleWithLabelView
+
+        simulateTap(on: view)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Click event should be captured")
+
+        if let props = event?.properties {
+            XCTAssertEqual(
+                props["$el_id"] as? String, "Intended Label",
+                "$el_id should use the explicit accessibilityLabel")
+
+            XCTAssertEqual(
+                props["$attr-aria-label"] as? String, "Intended Label",
+                "$attr-aria-label should be present with explicit label")
+        }
+    }
+
     // MARK: - Test 4: Rage Click Detection
 
     func testRageClickDetection() {
@@ -461,6 +642,131 @@ class UIKitAutocaptureTestViewController: UIViewController {
         return button
     }()
 
+    /// Simulates a React Native Pressable with accessible={false} containing child text.
+    /// The container has isAccessibilityElement=false and a child UILabel whose text
+    /// UIKit auto-derives into the container's accessibilityLabel.
+    /// This auto-derived label must NOT leak into $el_id or $attr-aria-label.
+    let notAccessibleView: UIView = {
+        let container = UIView()
+        container.isAccessibilityElement = false
+        container.backgroundColor = .systemBlue.withAlphaComponent(0.1)
+        container.translatesAutoresizingMaskIntoConstraints = false
+        let tap = UITapGestureRecognizer(target: nil, action: nil)
+        container.addGestureRecognizer(tap)
+        // Child label — UIKit auto-derives container's accessibilityLabel from this text
+        let childLabel = UILabel()
+        childLabel.text = "Sensitive Account 1234"
+        childLabel.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(childLabel)
+        NSLayoutConstraint.activate([
+            childLabel.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            childLabel.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        ])
+        return container
+    }()
+
+    /// Button with a sensitive title and accessibilityLabel explicitly set to "".
+    /// Tests whether UIKit auto-derives the label from the title or respects "".
+    let emptyLabelButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("4111-1111-1111-1234", for: .normal)
+        button.accessibilityLabel = ""
+        button.accessibilityIdentifier = nil
+        button.backgroundColor = .systemRed
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 8
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(nil, action: #selector(buttonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    /// Scenario 2: Accessible + no accessibilityLabel + child text.
+    /// isAccessibilityElement=true, no explicit accessibilityLabel set.
+    /// Child text must NOT leak into $el_id or $attr-aria-label.
+    let accessibleNoLabelView: UIView = {
+        let container = UIView()
+        container.isAccessibilityElement = true
+        container.backgroundColor = .systemGreen.withAlphaComponent(0.1)
+        container.translatesAutoresizingMaskIntoConstraints = false
+        let tap = UITapGestureRecognizer(target: nil, action: nil)
+        container.addGestureRecognizer(tap)
+        let childLabel = UILabel()
+        childLabel.text = "Sensitive Account 5678"
+        childLabel.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(childLabel)
+        NSLayoutConstraint.activate([
+            childLabel.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            childLabel.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        ])
+        return container
+    }()
+
+    /// Scenario 4: Not accessible + HAS explicit accessibilityLabel.
+    /// isAccessibilityElement=false, accessibilityLabel="Sensitive Account 9999".
+    /// Neither the label nor child text should leak.
+    let notAccessibleWithLabelView: UIView = {
+        let container = UIView()
+        container.isAccessibilityElement = false
+        container.accessibilityLabel = "Sensitive Account 9999"
+        container.backgroundColor = .systemPurple.withAlphaComponent(0.1)
+        container.translatesAutoresizingMaskIntoConstraints = false
+        let tap = UITapGestureRecognizer(target: nil, action: nil)
+        container.addGestureRecognizer(tap)
+        let childLabel = UILabel()
+        childLabel.text = "Some Label"
+        childLabel.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(childLabel)
+        NSLayoutConstraint.activate([
+            childLabel.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            childLabel.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+        ])
+        return container
+    }()
+
+    /// Positive case: Accessible + explicit accessibilityLabel.
+    /// isAccessibilityElement=true, accessibilityLabel="Intended Label".
+    /// The label SHOULD be captured.
+    let accessibleWithLabelView: UIView = {
+        let container = UIView()
+        container.isAccessibilityElement = true
+        container.accessibilityLabel = "Intended Label"
+        container.backgroundColor = .systemBlue.withAlphaComponent(0.1)
+        container.translatesAutoresizingMaskIntoConstraints = false
+        let tap = UITapGestureRecognizer(target: nil, action: nil)
+        container.addGestureRecognizer(tap)
+        return container
+    }()
+
+    /// Hidden button — isHidden=true, not drawn at all
+    let hiddenButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Hidden Button", for: .normal)
+        button.accessibilityIdentifier = "hidden_btn"
+        button.accessibilityLabel = "Hidden Sensitive PII"
+        button.backgroundColor = .systemGray
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 8
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(nil, action: #selector(buttonTapped), for: .touchUpInside)
+        button.isHidden = true
+        return button
+    }()
+
+    /// Zero-alpha button — alpha=0, fully transparent
+    let zeroAlphaButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Zero Alpha Button", for: .normal)
+        button.accessibilityIdentifier = "zero_alpha_btn"
+        button.accessibilityLabel = "ZeroAlpha Sensitive PII"
+        button.backgroundColor = .systemGray
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 8
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(nil, action: #selector(buttonTapped), for: .touchUpInside)
+        button.alpha = 0
+        return button
+    }()
+
     /// Button with no action handler (for dead click testing)
     let deadButton: UIButton = {
         let button = UIButton(type: .system)
@@ -489,7 +795,14 @@ class UIKitAutocaptureTestViewController: UIViewController {
             rule3Button,
             bothButton,
             rageButton,
+            hiddenButton,
+            zeroAlphaButton,
             deadButton,
+            notAccessibleView,
+            emptyLabelButton,
+            accessibleNoLabelView,
+            notAccessibleWithLabelView,
+            accessibleWithLabelView,
         ])
         stackView.axis = .vertical
         stackView.spacing = 16

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
@@ -1,0 +1,541 @@
+//
+//  AutocaptureUIKitInstrumentedTests.swift
+//  MixpanelDemoTests
+//
+//  Created by Mixpanel on 2026-06-29.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+import XCTest
+
+@testable import Mixpanel
+
+#if os(iOS)
+
+/// Instrumented tests for UIKit autocapture functionality.
+///
+/// These tests verify that touch events on UIKit views are correctly captured
+/// and transformed into Mixpanel autocapture events ($mp_click, $mp_rage_click, $mp_dead_click).
+///
+/// Test coverage mirrors the Android AutocaptureInstrumentedTest:
+/// 1. Basic click event capture with property verification
+/// 2. Element ID resolution rules (accessibilityIdentifier > accessibilityLabel > hash)
+/// 3. Rage click detection
+/// 4. Dead click detection
+/// 5. Multiple clicks generate multiple events
+/// 6. Standard Mixpanel properties
+class AutocaptureUIKitInstrumentedTests: MixpanelBaseTests {
+
+    // MARK: - Properties
+
+    private var testWindow: UIWindow!
+    private var testViewController: UIKitAutocaptureTestViewController!
+    private var mixpanel: MixpanelInstance!
+
+    // MARK: - Setup / Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        // Create test window and view controller on main thread
+        let setupExpectation = expectation(description: "Setup complete")
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            // Create test window
+            self.testWindow = UIWindow(frame: UIScreen.main.bounds)
+            self.testViewController = UIKitAutocaptureTestViewController()
+            self.testWindow.rootViewController = self.testViewController
+            self.testWindow.makeKeyAndVisible()
+
+            // Force layout
+            self.testWindow.layoutIfNeeded()
+
+            setupExpectation.fulfill()
+        }
+        wait(for: [setupExpectation], timeout: 5)
+
+        // Initialize Mixpanel with autocapture
+        let token = randomId()
+        let autocaptureOptions = AutocaptureOptions(
+            clickOptions: ClickOptions(enabled: true),
+            rageClickOptions: RageClickOptions(enabled: true, clickThreshold: 4, timeWindowMs: 1000),
+            deadClickOptions: DeadClickOptions(enabled: true, timeWindowMs: 500)
+        )
+
+        let options = MixpanelOptions(
+            token: token,
+            flushInterval: 60,
+            instanceName: token,
+            trackAutomaticEvents: false,
+            optOutTrackingByDefault: false,
+            serverURL: kFakeServerUrl,
+            autocaptureOptions: autocaptureOptions
+        )
+
+        mixpanel = Mixpanel.initialize(options: options)
+
+        // Wait for autocapture to start
+        waitForAsyncTasks()
+    }
+
+    override func tearDown() {
+        // Clean up on main thread
+        let teardownExpectation = expectation(description: "Teardown complete")
+        DispatchQueue.main.async { [weak self] in
+            self?.testWindow?.isHidden = true
+            self?.testWindow = nil
+            self?.testViewController = nil
+            teardownExpectation.fulfill()
+        }
+        wait(for: [teardownExpectation], timeout: 5)
+
+        // Clean up Mixpanel
+        if let token = mixpanel?.apiToken {
+            removeDBfile(token)
+        }
+        super.tearDown()
+    }
+
+    // MARK: - Test 1: Basic Click Event
+
+    func testUIKitClickEventBasic() {
+        // Given: A button with accessibilityIdentifier
+        let button = testViewController.rule1Button
+
+        // When: Simulate tap on the button
+        simulateTap(on: button)
+
+        // Then: Verify $mp_click event is captured with correct properties
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event")
+
+        if let props = event?.properties {
+            XCTAssertEqual(props["$el_id"] as? String, "rule1_btn")
+            XCTAssertEqual(props["$el_tag_name"] as? String, "UIButton")
+            XCTAssertNotNil(props["$x"], "Should have $x coordinate")
+            XCTAssertNotNil(props["$y"], "Should have $y coordinate")
+        }
+    }
+
+    // MARK: - Test 2: Element ID Resolution Rule 2 (accessibilityLabel fallback)
+
+    func testElementIdResolutionRule2() {
+        // Given: A button with only accessibilityLabel (no accessibilityIdentifier)
+        let button = testViewController.rule2Button
+
+        // When: Simulate tap
+        simulateTap(on: button)
+
+        // Then: Element ID should use accessibilityLabel
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event")
+
+        if let props = event?.properties {
+            XCTAssertEqual(props["$el_id"] as? String, "Rule Two Label")
+        }
+    }
+
+    // MARK: - Test 3: Element ID Resolution Rule 3 (Hash fallback)
+
+    func testElementIdResolutionRule3HashFallback() {
+        // Given: A button with no accessibilityIdentifier and no accessibilityLabel
+        let button = testViewController.rule3Button
+
+        // When: Simulate tap
+        simulateTap(on: button)
+
+        // Then: Element ID should use hash format: ClassName_<hash>
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event")
+
+        if let props = event?.properties {
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertTrue(
+                elId.hasPrefix("UIButton_"),
+                "Expected hash fallback format, got: \(elId)")
+        }
+    }
+
+    // MARK: - Test 4: Rage Click Detection
+
+    func testRageClickDetection() {
+        // Given: A button designated for rage click testing
+        let button = testViewController.rageButton
+
+        // When: Perform 4 rapid taps
+        for _ in 0..<4 {
+            simulateTap(on: button)
+            Thread.sleep(forTimeInterval: 0.1)  // Small delay between taps
+        }
+
+        // Then: Should capture $mp_rage_click event
+        let rageEvent = waitForEvent(named: "$mp_rage_click", timeout: 5)
+        XCTAssertNotNil(rageEvent, "Should capture $mp_rage_click after 4 rapid taps")
+
+        if let props = rageEvent?.properties {
+            XCTAssertEqual(props["$el_id"] as? String, "rage_btn")
+        }
+    }
+
+    // MARK: - Test 5: Dead Click Detection
+
+    func testDeadClickDetection() {
+        // Given: A button with no action handler (dead click scenario)
+        let button = testViewController.deadButton
+
+        // When: Simulate tap and wait for dead click timeout
+        simulateTap(on: button)
+
+        // Then: Should capture $mp_click first
+        let clickEvent = waitForEvent(named: "$mp_click", timeout: 3)
+        XCTAssertNotNil(clickEvent, "Should capture $mp_click event")
+
+        // Then: Should capture $mp_dead_click after timeout (500ms + buffer)
+        let deadEvent = waitForEvent(named: "$mp_dead_click", timeout: 3)
+        XCTAssertNotNil(deadEvent, "Should capture $mp_dead_click for non-interactive element")
+
+        if let props = deadEvent?.properties {
+            XCTAssertEqual(props["$el_id"] as? String, "dead_btn")
+        }
+    }
+
+    // MARK: - Test 6: Multiple Clicks Generate Multiple Events
+
+    func testMultipleClicksGenerateMultipleEvents() {
+        // Given: Three different buttons
+        let button1 = testViewController.rule1Button
+        let button2 = testViewController.rule2Button
+        let button3 = testViewController.bothButton
+
+        // When: Tap each button sequentially
+        simulateTap(on: button1)
+        Thread.sleep(forTimeInterval: 0.3)
+
+        simulateTap(on: button2)
+        Thread.sleep(forTimeInterval: 0.3)
+
+        simulateTap(on: button3)
+
+        // Then: Should capture 3 separate $mp_click events
+        Thread.sleep(forTimeInterval: 0.5)  // Wait for all events
+        waitForTrackingQueue(mixpanel)
+        let events = eventQueue(token: mixpanel.apiToken)
+        let clickEvents = events.filter { ($0["event"] as? String) == "$mp_click" }
+        XCTAssertEqual(clickEvents.count, 3, "Should capture exactly 3 click events")
+    }
+
+    // MARK: - Test 7: Standard Properties Included
+
+    func testClickEventHasTokenProperty() {
+        // Given: A button
+        let button = testViewController.rule1Button
+
+        // When: Simulate tap
+        simulateTap(on: button)
+
+        // Wait and check event queue for full properties
+        waitForTrackingQueue(mixpanel)
+
+        // Then: Should have standard Mixpanel properties
+        let events = eventQueue(token: mixpanel.apiToken)
+        let clickEvents = events.filter {
+            ($0["event"] as? String)?.hasPrefix("$mp_") == true
+        }
+
+        XCTAssertFalse(clickEvents.isEmpty, "Should have autocapture events in queue")
+
+        if let firstEvent = clickEvents.first,
+            let props = firstEvent["properties"] as? [String: Any]
+        {
+            XCTAssertNotNil(props["distinct_id"], "Should have distinct_id")
+            XCTAssertNotNil(props["token"], "Should have token")
+        }
+    }
+
+    // MARK: - Test 8: Swipe-back-to-same-position does NOT fire click
+
+    /// Regression test: a swipe that returns to the starting position must NOT register as a tap.
+    ///
+    /// Before the fix, displacement was only checked at `touchesEnded` by comparing final vs initial
+    /// position. A quick swipe down-and-back-up would falsely pass the check. Now, `touchesMoved`
+    /// tracks max displacement and rejects the gesture if any move exceeds the slop threshold.
+    func testSwipeBackToSamePositionDoesNotFireClick() {
+        // Test the production TouchObservingGestureRecognizer's slop logic directly.
+        // Create the real GR wired to a TouchInterceptor → autocaptureManager,
+        // so a detected tap would produce a real $mp_click event in the queue.
+        let gestureExpectation = expectation(description: "Gesture test complete")
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self, let window = self.testWindow,
+                let manager = self.mixpanel.autocaptureManager
+            else {
+                gestureExpectation.fulfill()
+                return
+            }
+
+            // Create a real TouchInterceptor and wire it to the autocapture manager.
+            // install() sets the manager reference (may not find the test window
+            // via UIApplication.shared.windows, which is fine — we add the GR manually).
+            let interceptor = TouchInterceptor()
+            interceptor.install(manager: manager)
+
+            // Create the production GR with the interceptor as owner.
+            // target/action unused — the GR calls owner.processTouchEnded() directly.
+            let gr = TouchObservingGestureRecognizer(
+                target: nil, action: nil, owner: interceptor)
+            gr.cancelsTouchesInView = false
+            gr.delaysTouchesEnded = false
+            gr.delaysTouchesBegan = false
+            window.addGestureRecognizer(gr)
+
+            let button = self.testViewController.rule1Button
+            let center = button.superview?.convert(button.center, to: window) ?? button.center
+
+            // Simulate: touchesBegan at center
+            let touchDown = MockUITouch(location: center, view: window)
+            gr.touchesBegan(Set([touchDown]), with: UIEvent())
+
+            // Simulate: touchesMoved 200pt down (well beyond 10pt slop)
+            let farPoint = CGPoint(x: center.x, y: center.y + 200)
+            let touchMoveFar = MockUITouch(location: farPoint, view: window)
+            gr.touchesMoved(Set([touchMoveFar]), with: UIEvent())
+
+            // Simulate: touchesMoved back to original position
+            let touchMoveBack = MockUITouch(location: center, view: window)
+            gr.touchesMoved(Set([touchMoveBack]), with: UIEvent())
+
+            // Simulate: touchesEnded at original position
+            let touchUp = MockUITouch(location: center, view: window)
+            gr.touchesEnded(Set([touchUp]), with: UIEvent())
+
+            // Clean up
+            window.removeGestureRecognizer(gr)
+
+            gestureExpectation.fulfill()
+        }
+
+        wait(for: [gestureExpectation], timeout: 5)
+
+        // Verify no $mp_click event was captured — the swipe exceeded slop
+        Thread.sleep(forTimeInterval: 1.0)
+        waitForTrackingQueue(mixpanel)
+        let events = eventQueue(token: mixpanel.apiToken)
+        let clickEvents = events.filter { ($0["event"] as? String) == "$mp_click" }
+        XCTAssertEqual(
+            clickEvents.count, 0,
+            "Swipe-back-to-same-position should NOT fire $mp_click event")
+    }
+
+    // MARK: - Helper Methods
+
+    /// Simulate a tap on a view by injecting touch events
+    private func simulateTap(on view: UIView) {
+        let tapExpectation = expectation(description: "Tap simulated")
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self, let window = self.testWindow else {
+                tapExpectation.fulfill()
+                return
+            }
+
+            // Get the center point of the view in window coordinates
+            let center = view.superview?.convert(view.center, to: window) ?? view.center
+
+            // Create touch events
+            let downTime = Date()
+            let downEvent = UIEvent()
+
+            // Use the autocapture manager directly for testing
+            // Since we can't easily create UITouch objects, we call handleTouch directly
+            self.mixpanel.autocaptureManager?.handleTouch(at: center, view: view, window: window)
+
+            tapExpectation.fulfill()
+        }
+
+        wait(for: [tapExpectation], timeout: 2)
+    }
+
+    /// Wait for an autocapture event with the given name
+    private func waitForEvent(named eventName: String, timeout: TimeInterval) -> (
+        name: String, properties: [String: Any]
+    )? {
+        let startTime = Date()
+
+        while Date().timeIntervalSince(startTime) < timeout {
+            // Wait for tracking queue to flush to persistence
+            waitForTrackingQueue(mixpanel)
+
+            // Read events from persistence queue
+            let events = eventQueue(token: mixpanel.apiToken)
+            if let match = events.first(where: { ($0["event"] as? String) == eventName }),
+                let props = match["properties"] as? [String: Any]
+            {
+                return (name: eventName, properties: props)
+            }
+
+            // Run loop to allow async operations
+            RunLoop.current.run(
+                mode: .default, before: Date(timeIntervalSinceNow: 0.1))
+        }
+
+        return nil
+    }
+}
+
+// MARK: - Test View Controller
+
+/// A view controller with programmatically created UI elements for testing autocapture.
+///
+/// This mirrors the Android XmlAutocaptureTestActivity with equivalent test elements.
+class UIKitAutocaptureTestViewController: UIViewController {
+
+    // MARK: - Test Elements
+
+    /// Rule 1: Button with accessibilityIdentifier (primary resolution)
+    let rule1Button: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Rule 1 Button", for: .normal)
+        button.accessibilityIdentifier = "rule1_btn"
+        button.backgroundColor = .systemBlue
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 8
+        button.translatesAutoresizingMaskIntoConstraints = false
+        // Has action handler (interactive)
+        button.addTarget(nil, action: #selector(buttonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    /// Rule 2: Button with accessibilityLabel only (no identifier)
+    let rule2Button: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Rule 2 Button", for: .normal)
+        button.accessibilityIdentifier = nil
+        button.accessibilityLabel = "Rule Two Label"
+        button.backgroundColor = .systemGreen
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 8
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(nil, action: #selector(buttonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    /// Rule 3: Button with no identifier and no label (hash fallback)
+    let rule3Button: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Rule 3 Button", for: .normal)
+        button.accessibilityIdentifier = nil
+        button.accessibilityLabel = nil
+        button.backgroundColor = .systemOrange
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 8
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(nil, action: #selector(buttonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    /// Button with both identifier and label (identifier wins)
+    let bothButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Both Button", for: .normal)
+        button.accessibilityIdentifier = "both_id"
+        button.accessibilityLabel = "Both Label"
+        button.backgroundColor = .systemPurple
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 8
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(nil, action: #selector(buttonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    /// Button for rage click testing
+    let rageButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Rage Zone", for: .normal)
+        button.accessibilityIdentifier = "rage_btn"
+        button.backgroundColor = .systemRed
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 8
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(nil, action: #selector(buttonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    /// Button with no action handler (for dead click testing)
+    let deadButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Dead Button", for: .normal)
+        button.accessibilityIdentifier = "dead_btn"
+        button.backgroundColor = .systemGray
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 8
+        button.translatesAutoresizingMaskIntoConstraints = false
+        // NO action handler - dead click scenario
+        return button
+    }()
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        setupUI()
+    }
+
+    private func setupUI() {
+        let stackView = UIStackView(arrangedSubviews: [
+            rule1Button,
+            rule2Button,
+            rule3Button,
+            bothButton,
+            rageButton,
+            deadButton,
+        ])
+        stackView.axis = .vertical
+        stackView.spacing = 16
+        stackView.distribution = .fillEqually
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+        ])
+
+        // Set fixed height for buttons
+        for button in stackView.arrangedSubviews {
+            button.heightAnchor.constraint(equalToConstant: 50).isActive = true
+        }
+    }
+
+    @objc private func buttonTapped() {
+        // Empty handler - just to make button interactive
+    }
+}
+
+// MARK: - Test helpers for gesture recognizer testing
+
+/// Minimal UITouch subclass that returns a fixed location.
+/// Used to exercise TouchObservingGestureRecognizer's slop logic in tests.
+private class MockUITouch: UITouch {
+    private let mockLocation: CGPoint
+    private let mockView: UIView?
+
+    init(location: CGPoint, view: UIView?) {
+        self.mockLocation = location
+        self.mockView = view
+        super.init()
+    }
+
+    override func location(in view: UIView?) -> CGPoint {
+        return mockLocation
+    }
+
+    override var view: UIView? {
+        return mockView
+    }
+}
+
+#endif

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
@@ -434,20 +434,14 @@ class AutocaptureUIKitInstrumentedTests: MixpanelBaseTests {
         // When: Simulate tap
         simulateTap(on: button)
 
-        // Wait and check event queue for full properties
-        waitForTrackingQueue(mixpanel)
+        // Wait for the event rather than reading the queue straight after the tap: autocapture
+        // hands click processing to a background queue, so emission no longer happens inline with
+        // the touch. waitForEvent polls and drains the tracking queue on each attempt.
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should have autocapture events in queue")
 
         // Then: Should have standard Mixpanel properties
-        let events = eventQueue(token: mixpanel.apiToken)
-        let clickEvents = events.filter {
-            ($0["event"] as? String)?.hasPrefix("$mp_") == true
-        }
-
-        XCTAssertFalse(clickEvents.isEmpty, "Should have autocapture events in queue")
-
-        if let firstEvent = clickEvents.first,
-            let props = firstEvent["properties"] as? [String: Any]
-        {
+        if let props = event?.properties {
             XCTAssertNotNil(props["distinct_id"], "Should have distinct_id")
             XCTAssertNotNil(props["token"], "Should have token")
         }

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureUIKitInstrumentedTests.swift
@@ -118,6 +118,25 @@ class AutocaptureUIKitInstrumentedTests: MixpanelBaseTests {
         }
     }
 
+    // MARK: - Test 1a: accessibilityIdentifier outranks accessibilityLabel
+
+    /// When a view carries both, the identifier wins $el_id — it is developer-assigned and never
+    /// user-visible, so unlike a label it cannot carry PII. The label still travels as
+    /// $attr-aria-label.
+    func testElementIdIdentifierWinsOverLabel() {
+        let button = testViewController.bothButton
+
+        simulateTap(on: button)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event")
+
+        if let props = event?.properties {
+            XCTAssertEqual(props["$el_id"] as? String, "both_id")
+            XCTAssertEqual(props["$attr-aria-label"] as? String, "Both Label")
+        }
+    }
+
     // MARK: - Test 2: Element ID Resolution Rule 2 (accessibilityLabel fallback)
 
     func testElementIdResolutionRule2() {
@@ -848,6 +867,249 @@ private class MockUITouch: UITouch {
 
     override var view: UIView? {
         return mockView
+    }
+}
+
+// MARK: - UIKit accessibilityLabel Auto-Derivation Verification Tests
+
+/// These tests verify UIKit's auto-derivation behavior for each control type listed
+/// in SemanticExtractor.findAccessibilityLabel's known-control bypass.
+///
+/// For each control, we check:
+/// 1. When accessibilityLabel is nil (not set), does UIKit auto-derive it from visible text?
+/// 2. When accessibilityLabel is "" (explicitly empty), does UIKit respect the empty value?
+///
+/// This documents the actual runtime behavior to inform PII-safe extraction decisions.
+class UIKitAccessibilityLabelDerivationTests: XCTestCase {
+
+    // MARK: - UIButton
+
+    func testUIButton_NilLabel_DoesNotDeriveFromTitle() {
+        let button = UIButton(type: .system)
+        button.setTitle("Card 4111-1111-1111-1234", for: .normal)
+        // accessibilityLabel is NOT set (nil by default)
+
+        let label = button.accessibilityLabel
+        // UIButton does NOT auto-derive accessibilityLabel from title at the property level.
+        // VoiceOver reads the title, but view.accessibilityLabel remains nil.
+        XCTAssertNil(label, "UIButton should NOT auto-derive accessibilityLabel from title")
+    }
+
+    func testUIButton_EmptyLabel_DoesNotDeriveFromTitle() {
+        let button = UIButton(type: .system)
+        button.setTitle("Card 4111-1111-1111-1234", for: .normal)
+        button.accessibilityLabel = ""
+
+        let label = button.accessibilityLabel
+        // Check whether UIKit respects empty string or falls back to title
+        let isEmpty = (label == nil || label!.isEmpty)
+        XCTAssertTrue(
+            isEmpty,
+            "UIButton with accessibilityLabel='' should not derive from title. Got: \(label ?? "nil")")
+    }
+
+    // MARK: - UILabel
+
+    func testUILabel_NilLabel_DoesNotDeriveFromText() {
+        let uiLabel = UILabel()
+        uiLabel.text = "Account 9876-5432"
+        // accessibilityLabel is NOT set
+
+        let label = uiLabel.accessibilityLabel
+        // UILabel does NOT auto-derive accessibilityLabel from text at the property level.
+        // VoiceOver reads the text, but view.accessibilityLabel remains nil.
+        XCTAssertNil(label, "UILabel should NOT auto-derive accessibilityLabel from text")
+    }
+
+    func testUILabel_EmptyLabel_DoesNotDeriveFromText() {
+        let uiLabel = UILabel()
+        uiLabel.text = "Account 9876-5432"
+        uiLabel.accessibilityLabel = ""
+
+        let label = uiLabel.accessibilityLabel
+        let isEmpty = (label == nil || label!.isEmpty)
+        XCTAssertTrue(
+            isEmpty,
+            "UILabel with accessibilityLabel='' should not derive from text. Got: \(label ?? "nil")")
+    }
+
+    // MARK: - UISwitch
+
+    func testUISwitch_NilLabel_CheckDerivation() {
+        let toggle = UISwitch()
+        toggle.isOn = true
+        // accessibilityLabel is NOT set
+
+        let label = toggle.accessibilityLabel
+        // UISwitch has no visible text — document whether label is nil or has a default
+        // (This test documents behavior, not asserts a specific value)
+        if let label = label, !label.isEmpty {
+            // If non-nil, it should NOT contain user data (switch has no text input)
+            XCTAssertFalse(
+                label.contains("Account") || label.contains("1234"),
+                "UISwitch should not contain user data. Got: \(label)")
+        }
+        // Record the actual value for documentation
+        print("UISwitch default accessibilityLabel: \(label ?? "nil")")
+    }
+
+    // MARK: - UISlider
+
+    func testUISlider_NilLabel_CheckDerivation() {
+        let slider = UISlider()
+        slider.minimumValue = 0
+        slider.maximumValue = 100
+        slider.value = 50
+        // accessibilityLabel is NOT set
+
+        let label = slider.accessibilityLabel
+        if let label = label, !label.isEmpty {
+            XCTAssertFalse(
+                label.contains("Account") || label.contains("1234"),
+                "UISlider should not contain user data. Got: \(label)")
+        }
+        print("UISlider default accessibilityLabel: \(label ?? "nil")")
+    }
+
+    // MARK: - UITextField
+
+    func testUITextField_NilLabel_WithTypedText() {
+        let textField = UITextField()
+        textField.text = "john.doe@example.com"
+        textField.placeholder = "Enter email"
+        // accessibilityLabel is NOT set
+
+        let label = textField.accessibilityLabel
+        // Critical: does the TYPED TEXT leak into accessibilityLabel?
+        if let label = label, !label.isEmpty {
+            let typedTextLeaks = label.contains("john.doe") || label.contains("example.com")
+            print("UITextField accessibilityLabel with typed text: \(label)")
+            print("UITextField typed text leaks into accessibilityLabel: \(typedTextLeaks)")
+        } else {
+            print("UITextField default accessibilityLabel: nil/empty")
+        }
+    }
+
+    func testUITextField_NilLabel_WithPlaceholderOnly() {
+        let textField = UITextField()
+        textField.text = nil
+        textField.placeholder = "Enter email"
+        // accessibilityLabel is NOT set
+
+        let label = textField.accessibilityLabel
+        print("UITextField accessibilityLabel with placeholder only: \(label ?? "nil")")
+    }
+
+    func testUITextField_NilLabel_CheckAccessibilityValue() {
+        let textField = UITextField()
+        textField.text = "john.doe@example.com"
+        textField.placeholder = "Enter email"
+
+        let label = textField.accessibilityLabel
+        let value = textField.accessibilityValue
+        print("UITextField accessibilityLabel: \(label ?? "nil")")
+        print("UITextField accessibilityValue: \(value ?? "nil")")
+        // Document whether typed text goes to label, value, or both
+    }
+
+    // MARK: - UITextView
+
+    func testUITextView_NilLabel_WithTypedText() {
+        let textView = UITextView()
+        textView.text = "SSN: 123-45-6789"
+        // accessibilityLabel is NOT set
+
+        let label = textView.accessibilityLabel
+        if let label = label, !label.isEmpty {
+            let typedTextLeaks = label.contains("123-45") || label.contains("6789")
+            print("UITextView accessibilityLabel with typed text: \(label)")
+            print("UITextView typed text leaks into accessibilityLabel: \(typedTextLeaks)")
+        } else {
+            print("UITextView default accessibilityLabel: nil/empty")
+        }
+    }
+
+    func testUITextView_NilLabel_CheckAccessibilityValue() {
+        let textView = UITextView()
+        textView.text = "SSN: 123-45-6789"
+
+        let label = textView.accessibilityLabel
+        let value = textView.accessibilityValue
+        print("UITextView accessibilityLabel: \(label ?? "nil")")
+        print("UITextView accessibilityValue: \(value ?? "nil")")
+    }
+
+    // MARK: - UISegmentedControl
+
+    func testUISegmentedControl_NilLabel_DerivesFromSegments() {
+        let segControl = UISegmentedControl(items: ["Personal", "Business", "Account 1234"])
+        segControl.selectedSegmentIndex = 0
+        // accessibilityLabel is NOT set
+
+        let label = segControl.accessibilityLabel
+        print("UISegmentedControl accessibilityLabel: \(label ?? "nil")")
+        // Check if segment titles leak into the overall control's label
+        if let label = label, !label.isEmpty {
+            let segmentTextLeaks = label.contains("Personal") || label.contains("1234")
+            print("UISegmentedControl segment text leaks: \(segmentTextLeaks)")
+        }
+    }
+
+    // MARK: - UIStepper
+
+    func testUIStepper_NilLabel_CheckDerivation() {
+        let stepper = UIStepper()
+        stepper.value = 5
+        stepper.minimumValue = 0
+        stepper.maximumValue = 10
+        // accessibilityLabel is NOT set
+
+        let label = stepper.accessibilityLabel
+        print("UIStepper default accessibilityLabel: \(label ?? "nil")")
+    }
+
+    // MARK: - UIImageView
+
+    func testUIImageView_NilLabel_CheckDerivation() {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "star.fill")
+        imageView.accessibilityLabel = nil
+        // accessibilityLabel is NOT set
+
+        let label = imageView.accessibilityLabel
+        print("UIImageView default accessibilityLabel: \(label ?? "nil")")
+        // UIImageView has no text — label should be nil unless derived from image name
+    }
+
+    // MARK: - UIScrollView (not a known control, but in role detection)
+
+    func testUIScrollView_NilLabel_CheckDerivation() {
+        let scrollView = UIScrollView()
+        let childLabel = UILabel()
+        childLabel.text = "Secret Data 9999"
+        scrollView.addSubview(childLabel)
+
+        let label = scrollView.accessibilityLabel
+        print("UIScrollView default accessibilityLabel: \(label ?? "nil")")
+        if let label = label, !label.isEmpty {
+            let childTextLeaks = label.contains("Secret") || label.contains("9999")
+            print("UIScrollView child text leaks: \(childTextLeaks)")
+        }
+    }
+
+    // MARK: - UITableViewCell (common clickable container with child text)
+
+    func testUITableViewCell_NilLabel_WithChildText() {
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+        cell.textLabel?.text = "Card ending 1234"
+        // accessibilityLabel is NOT set
+
+        let label = cell.accessibilityLabel
+        print("UITableViewCell accessibilityLabel: \(label ?? "nil")")
+        if let label = label, !label.isEmpty {
+            let childTextLeaks = label.contains("1234")
+            print("UITableViewCell child text leaks: \(childTextLeaks)")
+        }
     }
 }
 

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureWalkUpInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureWalkUpInstrumentedTests.swift
@@ -508,18 +508,22 @@ class AutocaptureWalkUpUIKitTests: MixpanelBaseTests {
         }
     }
 
-    // MARK: - Test 5b: Non-interactive leaf with label, no interactive ancestor -> own label
+    // MARK: - Test 5b: Non-interactive leaf with an accessibilityLabel -> still hash fallback
 
-    func testNoWalkUp_NonInteractiveLeafWithLabelNoInteractiveAncestor_GetsOwnLabel() {
+    func testNoWalkUp_NonInteractiveLeafWithLabelNoInteractiveAncestor_IgnoresAccessibilityLabel() {
         simulateTap(on: testVC.nonInteractiveLabeledLeaf)
 
         let event = waitForEvent(named: "$mp_click", timeout: 5)
         XCTAssertNotNil(event, "Should capture $mp_click event for orphan labeled leaf")
 
         if let props = event?.properties {
-            XCTAssertEqual(
-                props["$el_id"] as? String, "orphan_label",
-                "Non-interactive leaf with label but no interactive ancestor should use own accessibilityLabel")
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertNotEqual(
+                elId, "orphan_label",
+                "accessibilityLabel is never a source for $el_id")
+            XCTAssertTrue(
+                elId.hasPrefix("UILabel_"),
+                "Leaf with only an accessibilityLabel should use hash fallback, got: \(elId)")
         }
     }
 

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureWalkUpInstrumentedTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureWalkUpInstrumentedTests.swift
@@ -1,0 +1,630 @@
+//
+//  AutocaptureWalkUpInstrumentedTests.swift
+//  MixpanelDemoTests
+//
+//  Created by Mixpanel on 2026-08-03.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+import XCTest
+
+@testable import Mixpanel
+
+#if os(iOS)
+
+// MARK: - Test View Controller
+
+/// A view controller with programmatic UI elements designed to test the walk-up-to-clickable-parent
+/// behavior in SemanticExtractor. Each scenario exercises a different combination of interactivity
+/// and identity on leaf vs. ancestor views.
+class WalkUpUIKitTestViewController: UIViewController {
+
+    // MARK: - Scenario 1: Non-interactive leaf (no identity) inside interactive parent
+
+    let basicContainer: UIView = {
+        let view = UIView()
+        view.accessibilityIdentifier = "card_container"
+        view.backgroundColor = .systemGray6
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    let basicLeaf: UILabel = {
+        let label = UILabel()
+        label.text = "Basic Leaf"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    // MARK: - Scenario 2: Non-interactive leaf WITH accessibilityLabel inside interactive parent
+
+    let labeledLeafContainer: UIView = {
+        let view = UIView()
+        view.accessibilityIdentifier = "parent_of_labeled"
+        view.backgroundColor = .systemGray5
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    let labeledLeaf: UILabel = {
+        let label = UILabel()
+        label.text = "Labeled Leaf"
+        label.accessibilityLabel = "leaf_label"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    // MARK: - Scenario 3: Interactive leaf (UIButton, no identity) inside interactive parent
+
+    let clickableLeafParent: UIView = {
+        let view = UIView()
+        view.accessibilityIdentifier = "parent_of_clickable"
+        view.backgroundColor = .systemGray4
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    let clickableLeafNoId: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Clickable No ID", for: .normal)
+        button.accessibilityIdentifier = nil
+        button.accessibilityLabel = nil
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    // MARK: - Scenario 4: Interactive leaf (UIButton) WITH identity inside interactive parent
+
+    let clickableLeafWithIdParent: UIView = {
+        let view = UIView()
+        view.accessibilityIdentifier = "parent_of_btn"
+        view.backgroundColor = .systemGray3
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    let clickableLeafWithId: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Clickable With ID", for: .normal)
+        button.accessibilityIdentifier = "inner_clickable_btn"
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    // MARK: - Scenario 5: Non-interactive leaf inside NON-interactive container
+
+    let nonInteractiveContainer: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemGray2
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    let nonInteractiveLeaf: UILabel = {
+        let label = UILabel()
+        label.text = "Non-Interactive Leaf"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    // MARK: - Scenario 5b: Non-interactive leaf with label inside NON-interactive container
+
+    let nonInteractiveLabeledLeaf: UILabel = {
+        let label = UILabel()
+        label.text = "Orphan Labeled Leaf"
+        label.accessibilityLabel = "orphan_label"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    // MARK: - Scenario 6: Nested interactives (outer > inner > leaf)
+
+    let outerInteractive: UIView = {
+        let view = UIView()
+        view.accessibilityIdentifier = "outer_interactive"
+        view.backgroundColor = .systemBlue.withAlphaComponent(0.1)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    let innerInteractive: UIView = {
+        let view = UIView()
+        view.accessibilityIdentifier = "inner_interactive"
+        view.backgroundColor = .systemGreen.withAlphaComponent(0.1)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    let nestedLeaf: UILabel = {
+        let label = UILabel()
+        label.text = "Nested Leaf"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    // MARK: - Scenario 7: Deep nesting (interactive parent > 9 non-interactive views > leaf)
+
+    let deepParent: UIView = {
+        let view = UIView()
+        view.accessibilityIdentifier = "deep_parent"
+        view.backgroundColor = .systemOrange.withAlphaComponent(0.1)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    let deepLeaf: UILabel = {
+        let label = UILabel()
+        label.text = "Deep Leaf"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    // MARK: - Scenario 8: Disabled interactive parent (UIButton with isEnabled=false)
+
+    let enabledGrandparent: UIView = {
+        let view = UIView()
+        view.accessibilityIdentifier = "enabled_grandparent"
+        view.backgroundColor = .systemRed.withAlphaComponent(0.1)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    let disabledParent: UIButton = {
+        let button = UIButton(type: .system)
+        button.isEnabled = false
+        button.accessibilityIdentifier = "disabled_parent"
+        button.setTitle("Disabled Button", for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    let disabledLeaf: UILabel = {
+        let label = UILabel()
+        label.text = "Leaf inside disabled button"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        setupUI()
+    }
+
+    private func setupUI() {
+        // -- Scenario 1: basicContainer > basicLeaf
+        let tapGesture1 = UITapGestureRecognizer(target: self, action: #selector(noOp))
+        basicContainer.addGestureRecognizer(tapGesture1)
+        basicContainer.addSubview(basicLeaf)
+
+        // -- Scenario 2: labeledLeafContainer > labeledLeaf
+        let tapGesture2 = UITapGestureRecognizer(target: self, action: #selector(noOp))
+        labeledLeafContainer.addGestureRecognizer(tapGesture2)
+        labeledLeafContainer.addSubview(labeledLeaf)
+
+        // -- Scenario 3: clickableLeafParent > clickableLeafNoId (button with target)
+        let tapGesture3 = UITapGestureRecognizer(target: self, action: #selector(noOp))
+        clickableLeafParent.addGestureRecognizer(tapGesture3)
+        clickableLeafNoId.addTarget(self, action: #selector(noOp), for: .touchUpInside)
+        clickableLeafParent.addSubview(clickableLeafNoId)
+
+        // -- Scenario 4: clickableLeafWithIdParent > clickableLeafWithId (button with target + id)
+        let tapGesture4 = UITapGestureRecognizer(target: self, action: #selector(noOp))
+        clickableLeafWithIdParent.addGestureRecognizer(tapGesture4)
+        clickableLeafWithId.addTarget(self, action: #selector(noOp), for: .touchUpInside)
+        clickableLeafWithIdParent.addSubview(clickableLeafWithId)
+
+        // -- Scenario 5: nonInteractiveContainer > nonInteractiveLeaf + nonInteractiveLabeledLeaf
+        nonInteractiveContainer.addSubview(nonInteractiveLeaf)
+        nonInteractiveContainer.addSubview(nonInteractiveLabeledLeaf)
+
+        // -- Scenario 6: outerInteractive > innerInteractive > nestedLeaf
+        let tapGestureOuter = UITapGestureRecognizer(target: self, action: #selector(noOp))
+        outerInteractive.addGestureRecognizer(tapGestureOuter)
+        let tapGestureInner = UITapGestureRecognizer(target: self, action: #selector(noOp))
+        innerInteractive.addGestureRecognizer(tapGestureInner)
+        innerInteractive.addSubview(nestedLeaf)
+        outerInteractive.addSubview(innerInteractive)
+
+        // -- Scenario 7: deepParent > 9 non-interactive UIViews > deepLeaf
+        let tapGestureDeep = UITapGestureRecognizer(target: self, action: #selector(noOp))
+        deepParent.addGestureRecognizer(tapGestureDeep)
+        var currentParent: UIView = deepParent
+        for _ in 0..<9 {
+            let wrapper = UIView()
+            wrapper.translatesAutoresizingMaskIntoConstraints = false
+            currentParent.addSubview(wrapper)
+            NSLayoutConstraint.activate([
+                wrapper.topAnchor.constraint(equalTo: currentParent.topAnchor),
+                wrapper.leadingAnchor.constraint(equalTo: currentParent.leadingAnchor),
+                wrapper.trailingAnchor.constraint(equalTo: currentParent.trailingAnchor),
+                wrapper.bottomAnchor.constraint(equalTo: currentParent.bottomAnchor),
+            ])
+            currentParent = wrapper
+        }
+        currentParent.addSubview(deepLeaf)
+
+        // -- Scenario 8: enabledGrandparent > disabledParent (UIButton, disabled) > disabledLeaf
+        let tapGestureGrandparent = UITapGestureRecognizer(target: self, action: #selector(noOp))
+        enabledGrandparent.addGestureRecognizer(tapGestureGrandparent)
+        disabledParent.addTarget(self, action: #selector(noOp), for: .touchUpInside)
+        disabledParent.addSubview(disabledLeaf)
+        enabledGrandparent.addSubview(disabledParent)
+
+        // Assemble into a scroll view with a vertical stack
+        let stackView = UIStackView(arrangedSubviews: [
+            basicContainer,
+            labeledLeafContainer,
+            clickableLeafParent,
+            clickableLeafWithIdParent,
+            nonInteractiveContainer,
+            outerInteractive,
+            deepParent,
+            enabledGrandparent,
+        ])
+        stackView.axis = .vertical
+        stackView.spacing = 12
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+        scrollView.addSubview(stackView)
+        view.addSubview(scrollView)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor, constant: 16),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor, constant: 16),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor, constant: -16),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -16),
+            stackView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor, constant: -32),
+        ])
+
+        // Fixed heights for containers
+        let containerHeight: CGFloat = 60
+        for container in stackView.arrangedSubviews {
+            container.heightAnchor.constraint(equalToConstant: containerHeight).isActive = true
+        }
+
+        // Internal constraints for leaf views within their containers
+
+        // Scenario 1
+        NSLayoutConstraint.activate([
+            basicLeaf.centerXAnchor.constraint(equalTo: basicContainer.centerXAnchor),
+            basicLeaf.centerYAnchor.constraint(equalTo: basicContainer.centerYAnchor),
+        ])
+
+        // Scenario 2
+        NSLayoutConstraint.activate([
+            labeledLeaf.centerXAnchor.constraint(equalTo: labeledLeafContainer.centerXAnchor),
+            labeledLeaf.centerYAnchor.constraint(equalTo: labeledLeafContainer.centerYAnchor),
+        ])
+
+        // Scenario 3
+        NSLayoutConstraint.activate([
+            clickableLeafNoId.centerXAnchor.constraint(equalTo: clickableLeafParent.centerXAnchor),
+            clickableLeafNoId.centerYAnchor.constraint(equalTo: clickableLeafParent.centerYAnchor),
+        ])
+
+        // Scenario 4
+        NSLayoutConstraint.activate([
+            clickableLeafWithId.centerXAnchor.constraint(equalTo: clickableLeafWithIdParent.centerXAnchor),
+            clickableLeafWithId.centerYAnchor.constraint(equalTo: clickableLeafWithIdParent.centerYAnchor),
+        ])
+
+        // Scenario 5
+        NSLayoutConstraint.activate([
+            nonInteractiveLeaf.leadingAnchor.constraint(equalTo: nonInteractiveContainer.leadingAnchor, constant: 8),
+            nonInteractiveLeaf.centerYAnchor.constraint(equalTo: nonInteractiveContainer.centerYAnchor),
+            nonInteractiveLabeledLeaf.trailingAnchor.constraint(
+                equalTo: nonInteractiveContainer.trailingAnchor, constant: -8),
+            nonInteractiveLabeledLeaf.centerYAnchor.constraint(equalTo: nonInteractiveContainer.centerYAnchor),
+        ])
+
+        // Scenario 6
+        NSLayoutConstraint.activate([
+            innerInteractive.topAnchor.constraint(equalTo: outerInteractive.topAnchor, constant: 4),
+            innerInteractive.leadingAnchor.constraint(equalTo: outerInteractive.leadingAnchor, constant: 4),
+            innerInteractive.trailingAnchor.constraint(equalTo: outerInteractive.trailingAnchor, constant: -4),
+            innerInteractive.bottomAnchor.constraint(equalTo: outerInteractive.bottomAnchor, constant: -4),
+            nestedLeaf.centerXAnchor.constraint(equalTo: innerInteractive.centerXAnchor),
+            nestedLeaf.centerYAnchor.constraint(equalTo: innerInteractive.centerYAnchor),
+        ])
+
+        // Scenario 7 - deepLeaf inside the innermost wrapper
+        NSLayoutConstraint.activate([
+            deepLeaf.centerXAnchor.constraint(equalTo: currentParent.centerXAnchor),
+            deepLeaf.centerYAnchor.constraint(equalTo: currentParent.centerYAnchor),
+        ])
+
+        // Scenario 8
+        NSLayoutConstraint.activate([
+            disabledParent.topAnchor.constraint(equalTo: enabledGrandparent.topAnchor, constant: 4),
+            disabledParent.leadingAnchor.constraint(equalTo: enabledGrandparent.leadingAnchor, constant: 4),
+            disabledParent.trailingAnchor.constraint(equalTo: enabledGrandparent.trailingAnchor, constant: -4),
+            disabledParent.bottomAnchor.constraint(equalTo: enabledGrandparent.bottomAnchor, constant: -4),
+            disabledLeaf.centerXAnchor.constraint(equalTo: disabledParent.centerXAnchor),
+            disabledLeaf.centerYAnchor.constraint(equalTo: disabledParent.centerYAnchor),
+        ])
+    }
+
+    @objc private func noOp() {
+        // Empty handler - makes the view interactive via tap gesture recognizer
+    }
+}
+
+// MARK: - Walk-Up UIKit Tests
+
+/// Instrumented tests for the walk-up-to-clickable-parent behavior in SemanticExtractor.
+///
+/// When a non-interactive view is tapped, the SDK walks up the view hierarchy to find the nearest
+/// interactive ancestor (UIControl with targets, view with enabled UITapGestureRecognizer, or view
+/// with .button accessibility trait). The element ID is then extracted from that ancestor.
+///
+/// If the tapped view IS interactive, no walk-up occurs and its own identity is used.
+class AutocaptureWalkUpUIKitTests: MixpanelBaseTests {
+
+    // MARK: - Properties
+
+    private var testWindow: UIWindow!
+    private var testVC: WalkUpUIKitTestViewController!
+    private var mixpanel: MixpanelInstance!
+
+    // MARK: - Setup / Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        let setupExpectation = expectation(description: "Setup complete")
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.testWindow = UIWindow(frame: UIScreen.main.bounds)
+            self.testVC = WalkUpUIKitTestViewController()
+            self.testWindow.rootViewController = self.testVC
+            self.testWindow.makeKeyAndVisible()
+            self.testWindow.layoutIfNeeded()
+            setupExpectation.fulfill()
+        }
+        wait(for: [setupExpectation], timeout: 5)
+
+        let token = randomId()
+        let autocaptureOptions = AutocaptureOptions(
+            clickOptions: ClickOptions(enabled: true),
+            rageClickOptions: RageClickOptions(enabled: true, clickThreshold: 4, timeWindowMs: 1000),
+            deadClickOptions: DeadClickOptions(enabled: true, timeWindowMs: 500)
+        )
+
+        let options = MixpanelOptions(
+            token: token,
+            flushInterval: 60,
+            instanceName: token,
+            trackAutomaticEvents: false,
+            optOutTrackingByDefault: false,
+            serverURL: kFakeServerUrl,
+            autocaptureOptions: autocaptureOptions
+        )
+
+        mixpanel = Mixpanel.initialize(options: options)
+        waitForAsyncTasks()
+    }
+
+    override func tearDown() {
+        let teardownExpectation = expectation(description: "Teardown complete")
+        DispatchQueue.main.async { [weak self] in
+            self?.testWindow?.isHidden = true
+            self?.testWindow = nil
+            self?.testVC = nil
+            teardownExpectation.fulfill()
+        }
+        wait(for: [teardownExpectation], timeout: 5)
+
+        if let token = mixpanel?.apiToken {
+            removeDBfile(token)
+        }
+        super.tearDown()
+    }
+
+    // MARK: - Test 1: Non-interactive leaf without identity -> walk-up -> parent's id
+
+    func testWalkUp_NonInteractiveLeafNoIdentity_GetsParentId() {
+        simulateTap(on: testVC.basicLeaf)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event for non-interactive leaf")
+
+        if let props = event?.properties {
+            XCTAssertEqual(
+                props["$el_id"] as? String, "card_container",
+                "Walk-up should resolve to interactive parent's accessibilityIdentifier")
+        }
+    }
+
+    // MARK: - Test 2: Non-interactive leaf WITH label -> walk-up -> parent's id
+
+    func testWalkUp_NonInteractiveLeafWithLabel_GetsParentId() {
+        simulateTap(on: testVC.labeledLeaf)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event for labeled non-interactive leaf")
+
+        if let props = event?.properties {
+            XCTAssertEqual(
+                props["$el_id"] as? String, "parent_of_labeled",
+                "Walk-up should resolve to interactive parent's accessibilityIdentifier, ignoring leaf's label")
+        }
+    }
+
+    // MARK: - Test 3: Interactive leaf (no identity) -> NO walk-up -> own hash
+
+    func testNoWalkUp_InteractiveLeafNoIdentity_GetsOwnHash() {
+        simulateTap(on: testVC.clickableLeafNoId)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event for interactive leaf without identity")
+
+        if let props = event?.properties {
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertTrue(
+                elId.hasPrefix("UIButton_"),
+                "Interactive leaf with no identity should use hash fallback, got: \(elId)")
+        }
+    }
+
+    // MARK: - Test 4: Interactive leaf WITH identity -> NO walk-up -> own id
+
+    func testNoWalkUp_InteractiveLeafWithIdentity_GetsOwnId() {
+        simulateTap(on: testVC.clickableLeafWithId)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event for interactive leaf with identity")
+
+        if let props = event?.properties {
+            XCTAssertEqual(
+                props["$el_id"] as? String, "inner_clickable_btn",
+                "Interactive leaf should use its own accessibilityIdentifier, not walk up")
+        }
+    }
+
+    // MARK: - Test 5: Non-interactive leaf, no interactive ancestor -> hash fallback
+
+    func testNoWalkUp_NonInteractiveLeafNoInteractiveAncestor_HashFallback() {
+        simulateTap(on: testVC.nonInteractiveLeaf)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event for orphan non-interactive leaf")
+
+        if let props = event?.properties {
+            let elId = props["$el_id"] as? String ?? ""
+            XCTAssertTrue(
+                elId.hasPrefix("UILabel_"),
+                "Non-interactive leaf with no interactive ancestor should use hash fallback, got: \(elId)")
+        }
+    }
+
+    // MARK: - Test 5b: Non-interactive leaf with label, no interactive ancestor -> own label
+
+    func testNoWalkUp_NonInteractiveLeafWithLabelNoInteractiveAncestor_GetsOwnLabel() {
+        simulateTap(on: testVC.nonInteractiveLabeledLeaf)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event for orphan labeled leaf")
+
+        if let props = event?.properties {
+            XCTAssertEqual(
+                props["$el_id"] as? String, "orphan_label",
+                "Non-interactive leaf with label but no interactive ancestor should use own accessibilityLabel")
+        }
+    }
+
+    // MARK: - Test 6: Nested interactives -> stops at inner interactive
+
+    func testWalkUp_NestedInteractives_StopsAtInner() {
+        simulateTap(on: testVC.nestedLeaf)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event for leaf inside nested interactives")
+
+        if let props = event?.properties {
+            XCTAssertEqual(
+                props["$el_id"] as? String, "inner_interactive",
+                "Walk-up should stop at the nearest (inner) interactive ancestor")
+        }
+    }
+
+    // MARK: - Test 7: Deep nesting within 10 levels -> walk-up finds interactive ancestor
+
+    func testWalkUp_DeepNesting_FindsInteractiveWithin10Levels() {
+        simulateTap(on: testVC.deepLeaf)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event for deeply nested leaf")
+
+        if let props = event?.properties {
+            XCTAssertEqual(
+                props["$el_id"] as? String, "deep_parent",
+                "Walk-up should find interactive ancestor within 10 levels of nesting")
+        }
+    }
+
+    // MARK: - Test 8: Disabled interactive parent -> walk-up stops at disabled parent
+
+    func testWalkUp_DisabledInteractiveParent_StopsAtDisabledParent() {
+        simulateTap(on: testVC.disabledLeaf)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event for leaf inside disabled interactive parent")
+
+        if let props = event?.properties {
+            XCTAssertEqual(
+                props["$el_id"] as? String, "disabled_parent",
+                "Walk-up should stop at disabled UIButton (still has targets, so still interactive)")
+        }
+    }
+
+    // MARK: - Test 9: Disabled button tapped directly -> keeps own identity
+
+    func testNoWalkUp_DisabledButtonTappedDirectly_KeepsOwnId() {
+        simulateTap(on: testVC.disabledParent)
+
+        let event = waitForEvent(named: "$mp_click", timeout: 5)
+        XCTAssertNotNil(event, "Should capture $mp_click event for disabled button tapped directly")
+
+        if let props = event?.properties {
+            XCTAssertEqual(
+                props["$el_id"] as? String, "disabled_parent",
+                "Disabled button tapped directly should keep its own identity")
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    /// Simulate a tap on a view by calling handleTouch on the autocapture manager.
+    private func simulateTap(on view: UIView) {
+        let tapExpectation = expectation(description: "Tap simulated")
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self, let window = self.testWindow else {
+                tapExpectation.fulfill()
+                return
+            }
+
+            let center = view.superview?.convert(view.center, to: window) ?? view.center
+            self.mixpanel.autocaptureManager?.handleTouch(at: center, view: view, window: window)
+
+            tapExpectation.fulfill()
+        }
+
+        wait(for: [tapExpectation], timeout: 2)
+    }
+
+    /// Poll the event queue until an event with the given name appears, or timeout.
+    private func waitForEvent(named eventName: String, timeout: TimeInterval) -> (
+        name: String, properties: [String: Any]
+    )? {
+        let startTime = Date()
+
+        while Date().timeIntervalSince(startTime) < timeout {
+            waitForTrackingQueue(mixpanel)
+
+            let events = eventQueue(token: mixpanel.apiToken)
+            if let match = events.first(where: { ($0["event"] as? String) == eventName }),
+                let props = match["properties"] as? [String: Any]
+            {
+                return (name: eventName, properties: props)
+            }
+
+            RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.1))
+        }
+
+        return nil
+    }
+}
+
+#endif

--- a/MixpanelDemo/MixpanelDemoTests/MixpanelOptOutTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/MixpanelOptOutTests.swift
@@ -310,6 +310,137 @@ class MixpanelOptOutTests: MixpanelBaseTests {
         removeDBfile(testMixpanel.apiToken)
     }
 
+    // MARK: - Autocapture Opt-Out Tests
+
+    func testAutocaptureNotStartedWhenOptedOutByDefault() {
+        let token = randomId()
+        let options = MixpanelOptions(
+            token: token,
+            flushInterval: 60,
+            instanceName: token,
+            trackAutomaticEvents: false,
+            optOutTrackingByDefault: true,
+            serverURL: kFakeServerUrl,
+            autocaptureOptions: AutocaptureOptions()
+        )
+        let testMixpanel = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel)
+        waitForAsyncTasks()
+
+        XCTAssertTrue(testMixpanel.hasOptedOutTracking())
+        XCTAssertNil(
+            testMixpanel.autocaptureManager,
+            "AutocaptureManager should not be created when opted out by default")
+
+        removeDBfile(token)
+    }
+
+    func testAutocaptureStopsOnOptOut() {
+        let token = randomId()
+        let options = MixpanelOptions(
+            token: token,
+            flushInterval: 60,
+            instanceName: token,
+            trackAutomaticEvents: false,
+            optOutTrackingByDefault: false,
+            serverURL: kFakeServerUrl,
+            autocaptureOptions: AutocaptureOptions()
+        )
+        let testMixpanel = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel)
+        waitForAsyncTasks()
+
+        XCTAssertNotNil(
+            testMixpanel.autocaptureManager,
+            "AutocaptureManager should be created when not opted out")
+        XCTAssertTrue(
+            testMixpanel.autocaptureManager!.isStarted,
+            "AutocaptureManager should be started")
+
+        testMixpanel.optOutTracking()
+        waitForTrackingQueue(testMixpanel)
+        waitForAsyncTasks()
+
+        XCTAssertFalse(
+            testMixpanel.autocaptureManager!.isStarted,
+            "AutocaptureManager should be stopped after opt-out")
+
+        removeDBfile(token)
+    }
+
+    func testAutocaptureRestartsOnOptIn() {
+        let token = randomId()
+        let options = MixpanelOptions(
+            token: token,
+            flushInterval: 60,
+            instanceName: token,
+            trackAutomaticEvents: false,
+            optOutTrackingByDefault: false,
+            serverURL: kFakeServerUrl,
+            autocaptureOptions: AutocaptureOptions()
+        )
+        let testMixpanel = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel)
+        waitForAsyncTasks()
+
+        // Opt out — autocapture stops
+        testMixpanel.optOutTracking()
+        waitForTrackingQueue(testMixpanel)
+        waitForAsyncTasks()
+        XCTAssertFalse(
+            testMixpanel.autocaptureManager!.isStarted,
+            "AutocaptureManager should be stopped after opt-out")
+
+        // Opt in — autocapture restarts
+        testMixpanel.optInTracking()
+        waitForTrackingQueue(testMixpanel)
+        waitForAsyncTasks()
+        XCTAssertNotNil(
+            testMixpanel.autocaptureManager,
+            "AutocaptureManager should exist after opt-in")
+        XCTAssertTrue(
+            testMixpanel.autocaptureManager!.isStarted,
+            "AutocaptureManager should be started after opt-in")
+
+        removeDBfile(token)
+    }
+
+    func testAutocaptureStartsOnOptInAfterOptOutByDefault() {
+        let token = randomId()
+        let options = MixpanelOptions(
+            token: token,
+            flushInterval: 60,
+            instanceName: token,
+            trackAutomaticEvents: false,
+            optOutTrackingByDefault: true,
+            serverURL: kFakeServerUrl,
+            autocaptureOptions: AutocaptureOptions()
+        )
+        let testMixpanel = Mixpanel.initialize(options: options)
+        waitForTrackingQueue(testMixpanel)
+        waitForAsyncTasks()
+
+        XCTAssertNil(
+            testMixpanel.autocaptureManager,
+            "AutocaptureManager should not be created when opted out by default")
+
+        // Opt in — autocapture should be created and started
+        testMixpanel.optInTracking()
+        waitForTrackingQueue(testMixpanel)
+        waitForAsyncTasks()
+
+        XCTAssertNotNil(
+            testMixpanel.autocaptureManager,
+            "AutocaptureManager should be created after opt-in")
+        XCTAssertTrue(
+            testMixpanel.autocaptureManager!.isStarted,
+            "AutocaptureManager should be started after opt-in")
+
+        removeDBfile(token)
+    }
+
+    // MARK: - Existing Tests
+
     func testOptOutWillSkipFlushEvent() {
         let testMixpanel = Mixpanel.initialize(
             token: randomId(), trackAutomaticEvents: true, optOutTrackingByDefault: true)

--- a/Sources/Autocapture.swift
+++ b/Sources/Autocapture.swift
@@ -11,6 +11,9 @@ import Foundation
 
 /// Access to autocapture tracking methods, available as an accessible variable from
 /// the main Mixpanel instance.
+///
+/// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the
+///   properties it captures may change in a future release before general availability.
 open class Autocapture {
 
     weak var mixpanelInstance: MixpanelInstance?

--- a/Sources/Autocapture.swift
+++ b/Sources/Autocapture.swift
@@ -15,6 +15,10 @@ open class Autocapture {
 
     weak var mixpanelInstance: MixpanelInstance?
 
+    /// Internal initializer — prevents host apps from creating instances directly.
+    /// Use `mixpanel.autocapture` to access the SDK-managed instance.
+    init() {}
+
     /**
        Track a screen view event. This is a convenience method for tracking when users view
        a screen/page in your application.
@@ -24,26 +28,7 @@ open class Autocapture {
        - parameter properties: Optional properties to include with this event
        */
     open func trackScreenView(screenName: String, properties: Properties? = nil) {
-        guard let mixpanelInstance = mixpanelInstance else { return }
-        guard !screenName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            MixpanelLogger.warn(
-                message: "trackScreenView called with empty screenName, ignoring event")
-            return
-        }
-
-        var mergedProperties: Properties = [:]
-
-        if let properties = properties {
-            for (key, value) in properties {
-                mergedProperties[key] = value
-            }
-        }
-
-        // SDK properties set after caller properties to prevent overrides
-        mergedProperties["current_page_title"] = screenName
-        mergedProperties["$mp_autocapture"] = true
-
-        mixpanelInstance.track(event: "$mp_page_view", properties: mergedProperties)
+        trackScreenEvent("$mp_page_view", screenName: screenName, properties: properties)
     }
 
     /**
@@ -55,14 +40,50 @@ open class Autocapture {
        - parameter properties: Optional properties to include with this event
        */
     open func trackScreenLeave(screenName: String, properties: Properties? = nil) {
-        guard let mixpanelInstance = mixpanelInstance else { return }
-        guard !screenName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            MixpanelLogger.warn(
-                message: "trackScreenLeave called with empty screenName, ignoring event")
-            return
-        }
+        trackScreenEvent("$mp_page_leave", screenName: screenName, properties: properties)
+    }
 
-        var mergedProperties: Properties = [:]
+    // MARK: - Click Tracking
+
+    #if os(iOS)
+    /**
+       Track a click event from a ClickEvent object. Use this for full control over
+       click metadata when your app handles its own click detection.
+
+       - parameter clickEvent: The click event containing element metadata
+       - parameter properties: Optional additional properties to include with this event
+       */
+    open func trackClick(_ clickEvent: ClickEvent, properties: Properties? = nil) {
+        trackClickEvent("$mp_click", clickEvent: clickEvent, properties: properties)
+    }
+
+    /**
+       Track a rage click event from a ClickEvent object. Use this for full control over
+       click metadata when your app handles its own rage click detection.
+
+       - parameter clickEvent: The click event containing element metadata
+       - parameter properties: Optional additional properties to include with this event
+       */
+    open func trackRageClick(_ clickEvent: ClickEvent, properties: Properties? = nil) {
+        trackClickEvent("$mp_rage_click", clickEvent: clickEvent, properties: properties)
+    }
+
+    /**
+       Track a dead click event from a ClickEvent object. Use this for full control over
+       click metadata when your app handles its own dead click detection.
+
+       - parameter clickEvent: The click event containing element metadata
+       - parameter properties: Optional additional properties to include with this event
+       */
+    open func trackDeadClick(_ clickEvent: ClickEvent, properties: Properties? = nil) {
+        trackClickEvent("$mp_dead_click", clickEvent: clickEvent, properties: properties)
+    }
+
+    private func trackClickEvent(
+        _ eventName: String, clickEvent: ClickEvent,
+        properties: Properties? = nil
+    ) {
+        var mergedProperties = clickEvent.toProperties()
 
         if let properties = properties {
             for (key, value) in properties {
@@ -70,10 +91,36 @@ open class Autocapture {
             }
         }
 
+        trackAutocaptureEvent(eventName, properties: mergedProperties)
+    }
+    #endif
+
+    // MARK: - Private Helpers
+
+    private func trackScreenEvent(
+        _ eventName: String, screenName: String,
+        properties: Properties? = nil
+    ) {
+        guard !screenName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            MixpanelLogger.warn(
+                message: "\(eventName) called with empty screenName, ignoring event")
+            return
+        }
+
+        var mergedProperties: Properties = properties ?? [:]
         // SDK properties set after caller properties to prevent overrides
         mergedProperties["current_page_title"] = screenName
-        mergedProperties["$mp_autocapture"] = true
 
-        mixpanelInstance.track(event: "$mp_page_leave", properties: mergedProperties)
+        trackAutocaptureEvent(eventName, properties: mergedProperties)
+    }
+
+    /// Adds the $mp_autocapture flag and tracks the event.
+    /// All autocapture events (screen view, screen leave, click, rage click, dead click)
+    /// are routed through this method.
+    private func trackAutocaptureEvent(_ eventName: String, properties: Properties) {
+        guard let mixpanelInstance = mixpanelInstance else { return }
+        var props = properties
+        props["$mp_autocapture"] = true
+        mixpanelInstance.track(event: eventName, properties: props)
     }
 }

--- a/Sources/Autocapture/AutocaptureManager.swift
+++ b/Sources/Autocapture/AutocaptureManager.swift
@@ -147,6 +147,14 @@ final class AutocaptureManager {
             return
         }
 
+        // Skip invisible views — hidden or fully transparent views should not produce events.
+        // In production UIKit's hitTest already skips these, but this guard protects against
+        // programmatic handleTouch calls and future code paths that bypass hitTest.
+        if !isViewVisible(view) {
+            MixpanelLogger.debug(message: "AutocaptureManager: skipping invisible view at \(point)")
+            return
+        }
+
         // Extract semantic information
         let clickEvent = semanticExtractor.extractSemantics(from: view, at: point)
 
@@ -171,6 +179,20 @@ final class AutocaptureManager {
         if let detector = deadClickDetector, let window = window {
             detector.startMonitoring(event: clickEvent, view: view, in: window)
         }
+    }
+
+    // MARK: - Visibility Check
+
+    /// Returns false if the view (or any ancestor up to the window) is hidden or fully transparent.
+    private func isViewVisible(_ view: UIView) -> Bool {
+        var current: UIView? = view
+        while let v = current {
+            if v.isHidden || v.alpha <= 0 {
+                return false
+            }
+            current = v.superview
+        }
+        return true
     }
 
 }

--- a/Sources/Autocapture/AutocaptureManager.swift
+++ b/Sources/Autocapture/AutocaptureManager.swift
@@ -1,0 +1,177 @@
+//
+//  AutocaptureManager.swift
+//  Mixpanel
+//
+//  Created by Mixpanel on 2026-06-13.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/// Main coordinator for autocapture functionality.
+///
+/// Manages lifecycle, coordinates components, and dispatches events to Mixpanel.
+final class AutocaptureManager {
+    // MARK: - Configuration
+
+    private let options: AutocaptureOptions
+
+    // MARK: - Components
+
+    private let semanticExtractor: SemanticExtractor
+    private let rageClickTracker: RageClickTracker?
+    private let deadClickDetector: DeadClickDetector?
+    private let touchInterceptor = TouchInterceptor()
+
+    // MARK: - Autocapture Reference
+
+    /// Reference to the Autocapture instance for event tracking.
+    /// Weak to avoid retain cycles with MixpanelInstance.
+    private weak var autocapture: Autocapture?
+
+    // MARK: - State
+
+    private(set) var isStarted = false
+    private let lock = NSLock()
+
+    // MARK: - Initialization
+
+    /// Create an AutocaptureManager with the given options.
+    ///
+    /// - Parameters:
+    ///   - options: Autocapture configuration options
+    ///   - autocapture: The Autocapture instance for event tracking
+    init(
+        options: AutocaptureOptions,
+        autocapture: Autocapture
+    ) {
+        self.options = options
+        self.autocapture = autocapture
+
+        // Initialize components
+        self.semanticExtractor = SemanticExtractor()
+
+        // Initialize rage click tracker if enabled
+        if options.rageClickOptions.enabled {
+            self.rageClickTracker = RageClickTracker(options: options.rageClickOptions)
+        } else {
+            self.rageClickTracker = nil
+        }
+
+        // Initialize dead click detector if enabled
+        if options.deadClickOptions.enabled {
+            self.deadClickDetector = DeadClickDetector(options: options.deadClickOptions)
+            self.deadClickDetector?.onDeadClick = { [weak self] event in
+                self?.autocapture?.trackDeadClick(event)
+                MixpanelLogger.debug(
+                    message: "AutocaptureManager: emitted $mp_dead_click for \(event.elementId)")
+            }
+        } else {
+            self.deadClickDetector = nil
+        }
+
+        MixpanelLogger.info(
+            message:
+                "AutocaptureManager: initialized (click=\(options.clickOptions.enabled), rage=\(options.rageClickOptions.enabled), dead=\(options.deadClickOptions.enabled))"
+        )
+    }
+
+    // MARK: - Lifecycle
+
+    /// Start autocapture by installing the touch interceptor.
+    func start() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !isStarted else {
+            MixpanelLogger.debug(message: "AutocaptureManager: already started")
+            return
+        }
+
+        isStarted = true
+
+        // Install touch interceptor
+        touchInterceptor.install(manager: self)
+
+        MixpanelLogger.info(message: "AutocaptureManager: started")
+    }
+
+    /// Stop autocapture and clean up.
+    func stop() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard isStarted else { return }
+
+        isStarted = false
+
+        // Uninstall touch interceptor
+        touchInterceptor.uninstall()
+
+        // Reset components
+        rageClickTracker?.reset()
+        deadClickDetector?.cancelPendingCheck()
+
+        MixpanelLogger.info(message: "AutocaptureManager: stopped")
+    }
+
+    /// Signals that a UI change occurred.
+    ///
+    /// Call this when a UI change happens that the dead click detector cannot observe,
+    /// such as navigation in React Native or other framework-driven UI changes.
+    /// This cancels any pending dead click detection to prevent false positives.
+    func signalUIChange() {
+        deadClickDetector?.cancelPendingCheck()
+        rageClickTracker?.reset()
+        MixpanelLogger.debug(message: "AutocaptureManager: UI change signaled, cancelled pending detections")
+    }
+
+    // MARK: - Touch Handling
+
+    /// Handle a touch event from the interceptor.
+    ///
+    /// Called by TouchInterceptor when a touch ends.
+    func handleTouch(at point: CGPoint, view: UIView?, window: UIWindow?) {
+        do {
+            try processTouch(at: point, view: view, window: window)
+        } catch {
+            MixpanelLogger.error(message: "AutocaptureManager: error processing touch: \(error)")
+            // Never rethrow - silently fail and let the app continue
+        }
+    }
+
+    private func processTouch(at point: CGPoint, view: UIView?, window: UIWindow?) throws {
+        guard let view = view else {
+            MixpanelLogger.debug(message: "AutocaptureManager: no view for touch at \(point)")
+            return
+        }
+
+        // Extract semantic information
+        let clickEvent = semanticExtractor.extractSemantics(from: view, at: point)
+
+        // Check for rage click
+        let rageClickResult = rageClickTracker?.trackClick(x: point.x, y: point.y)
+
+        // Emit click event
+        if options.clickOptions.enabled {
+            autocapture?.trackClick(clickEvent)
+            MixpanelLogger.debug(
+                message: "AutocaptureManager: emitted $mp_click for \(clickEvent.elementId)")
+        }
+
+        // Emit rage click event (independent of regular click)
+        if rageClickResult?.isRageClick == true {
+            autocapture?.trackRageClick(clickEvent)
+            MixpanelLogger.debug(
+                message: "AutocaptureManager: emitted $mp_rage_click for \(clickEvent.elementId)")
+        }
+
+        // Start dead click monitoring
+        if let detector = deadClickDetector, let window = window {
+            detector.startMonitoring(event: clickEvent, view: view, in: window)
+        }
+    }
+
+}
+#endif

--- a/Sources/Autocapture/AutocaptureManager.swift
+++ b/Sources/Autocapture/AutocaptureManager.swift
@@ -50,7 +50,7 @@ final class AutocaptureManager {
         self.autocapture = autocapture
 
         // Initialize components
-        self.semanticExtractor = SemanticExtractor()
+        self.semanticExtractor = SemanticExtractor(autocaptureOptions: options)
 
         // Initialize rage click tracker if enabled
         if options.rageClickOptions.enabled {

--- a/Sources/Autocapture/AutocaptureManager.swift
+++ b/Sources/Autocapture/AutocaptureManager.swift
@@ -24,6 +24,15 @@ final class AutocaptureManager {
     private let deadClickDetector: DeadClickDetector?
     private let touchInterceptor = TouchInterceptor()
 
+    /// Serial queue for the non-UI part of touch handling.
+    ///
+    /// Touches arrive on the main thread, and the parts of processing that must read the view
+    /// hierarchy stay there. Everything after that — rage click bookkeeping and event emission —
+    /// is pure computation, so it is handed off here to keep SDK work off the main thread.
+    /// Serial so that clicks are processed in the order the user made them, which rage click
+    /// detection depends on.
+    private let processingQueue = DispatchQueue(label: "com.mixpanel.autocapture.processing")
+
     // MARK: - Autocapture Reference
 
     /// Reference to the Autocapture instance for event tracking.
@@ -155,29 +164,40 @@ final class AutocaptureManager {
             return
         }
 
-        // Extract semantic information
+        // Extract semantic information. Reads the view hierarchy, so it has to run here on the
+        // main thread, synchronously with the touch.
         let clickEvent = semanticExtractor.extractSemantics(from: view, at: point)
 
-        // Check for rage click
-        let rageClickResult = rageClickTracker?.trackClick(x: point.x, y: point.y)
-
-        // Emit click event
-        if options.clickOptions.enabled {
-            autocapture?.trackClick(clickEvent)
-            MixpanelLogger.debug(
-                message: "AutocaptureManager: emitted $mp_click for \(clickEvent.elementId)")
-        }
-
-        // Emit rage click event (independent of regular click)
-        if rageClickResult?.isRageClick == true {
-            autocapture?.trackRageClick(clickEvent)
-            MixpanelLogger.debug(
-                message: "AutocaptureManager: emitted $mp_rage_click for \(clickEvent.elementId)")
-        }
-
-        // Start dead click monitoring
+        // Start dead click monitoring. Also main-thread and synchronous by necessity: it captures
+        // a baseline snapshot of the window that must be taken before the app's click handler can
+        // change the UI, otherwise a fast response is absorbed into the baseline and the click
+        // looks dead.
         if let detector = deadClickDetector, let window = window {
             detector.startMonitoring(event: clickEvent, view: view, in: window)
+        }
+
+        // Everything below is pure computation over values already extracted — no UIKit access —
+        // so it runs off the main thread.
+        processingQueue.async { [weak self] in
+            guard let self = self else { return }
+
+            // Check for rage click
+            let rageClickResult = self.rageClickTracker?.trackClick(x: point.x, y: point.y)
+
+            // Emit click event
+            if self.options.clickOptions.enabled {
+                self.autocapture?.trackClick(clickEvent)
+                MixpanelLogger.debug(
+                    message: "AutocaptureManager: emitted $mp_click for \(clickEvent.elementId)")
+            }
+
+            // Emit rage click event (independent of regular click)
+            if rageClickResult?.isRageClick == true {
+                self.autocapture?.trackRageClick(clickEvent)
+                MixpanelLogger.debug(
+                    message:
+                        "AutocaptureManager: emitted $mp_rage_click for \(clickEvent.elementId)")
+            }
         }
     }
 

--- a/Sources/Autocapture/AutocaptureManager.swift
+++ b/Sources/Autocapture/AutocaptureManager.swift
@@ -133,17 +133,6 @@ final class AutocaptureManager {
         MixpanelLogger.info(message: "AutocaptureManager: stopped")
     }
 
-    /// Signals that a UI change occurred.
-    ///
-    /// Call this when a UI change happens that the dead click detector cannot observe,
-    /// such as navigation in React Native or other framework-driven UI changes.
-    /// This cancels any pending dead click detection to prevent false positives.
-    func signalUIChange() {
-        deadClickDetector?.cancelPendingCheck()
-        rageClickTracker?.reset()
-        MixpanelLogger.debug(message: "AutocaptureManager: UI change signaled, cancelled pending detections")
-    }
-
     // MARK: - Touch Handling
 
     /// Handle a touch event from the interceptor.

--- a/Sources/Autocapture/AutocaptureManager.swift
+++ b/Sources/Autocapture/AutocaptureManager.swift
@@ -59,7 +59,7 @@ final class AutocaptureManager {
         self.autocapture = autocapture
 
         // Initialize components
-        self.semanticExtractor = SemanticExtractor(autocaptureOptions: options)
+        self.semanticExtractor = SemanticExtractor()
 
         // Initialize rage click tracker if enabled
         if options.rageClickOptions.enabled {

--- a/Sources/Autocapture/AutocaptureManager.swift
+++ b/Sources/Autocapture/AutocaptureManager.swift
@@ -89,6 +89,13 @@ final class AutocaptureManager {
     // MARK: - Lifecycle
 
     /// Start autocapture by installing the touch interceptor.
+    /// Logged at warning level, once per start, so developers who never read the documentation
+    /// still learn that autocapture is not yet GA.
+    private static let experimentalWarning =
+        "Autocapture is experimental (beta): it may contain issues, and its API and captured "
+        + "properties may change before general availability. Pin your SDK version if you build "
+        + "reports on autocaptured events."
+
     func start() {
         lock.lock()
         defer { lock.unlock() }
@@ -104,6 +111,7 @@ final class AutocaptureManager {
         touchInterceptor.install(manager: self)
 
         MixpanelLogger.info(message: "AutocaptureManager: started")
+        MixpanelLogger.warn(message: AutocaptureManager.experimentalWarning)
     }
 
     /// Stop autocapture and clean up.

--- a/Sources/Autocapture/AutocaptureOptions.swift
+++ b/Sources/Autocapture/AutocaptureOptions.swift
@@ -23,6 +23,12 @@ enum AutocaptureDefaults {
     static let maxAncestorSearchDepth = 10
     static let maxRecursionDepth = 20
 
+    /// Number of recent clicks the rage click tracker keeps before pruning entries that have
+    /// aged out of the time window. Only a bound on memory: clicks outside the window are
+    /// already ignored when counting, so this never affects detection. Sized well above the
+    /// default threshold of 4 so that a burst of taps cannot evict clicks still in the window.
+    static let maxTrackedClicks = 20
+
     #if os(iOS)
     /// UIKit controls with inherent visual feedback that should be excluded from
     /// dead click detection. These controls always produce a visible UI response

--- a/Sources/Autocapture/AutocaptureOptions.swift
+++ b/Sources/Autocapture/AutocaptureOptions.swift
@@ -211,11 +211,36 @@ public struct AutocaptureOptions {
     /// Configuration for dead click detection.
     public let deadClickOptions: DeadClickOptions
 
+    #if os(iOS)
+    /// Optional custom resolver for the `$el_id` reported on autocaptured interactions.
+    ///
+    /// When `nil` (the default), the SDK resolves `$el_id` internally: React Native `nativeID`,
+    /// then `accessibilityIdentifier`, then `accessibilityLabel`, then an anonymous `<ClassName>_<hash>`
+    /// identifier. Supply an implementation to control exactly which identifier is reported and to
+    /// keep personally identifiable information out of the payload.
+    ///
+    /// - SeeAlso: ``ElementIdExtractor``
+    public let elementIdExtractor: ElementIdExtractor?
+    #endif
+
     /// Returns `true` if any autocapture feature is enabled.
     public var isEnabled: Bool {
         return clickOptions.enabled || rageClickOptions.enabled || deadClickOptions.enabled
     }
 
+    #if os(iOS)
+    public init(
+        clickOptions: ClickOptions = ClickOptions(),
+        rageClickOptions: RageClickOptions = RageClickOptions(),
+        deadClickOptions: DeadClickOptions = DeadClickOptions(),
+        elementIdExtractor: ElementIdExtractor? = nil
+    ) {
+        self.clickOptions = clickOptions
+        self.rageClickOptions = rageClickOptions
+        self.deadClickOptions = deadClickOptions
+        self.elementIdExtractor = elementIdExtractor
+    }
+    #else
     public init(
         clickOptions: ClickOptions = ClickOptions(),
         rageClickOptions: RageClickOptions = RageClickOptions(),
@@ -225,4 +250,5 @@ public struct AutocaptureOptions {
         self.rageClickOptions = rageClickOptions
         self.deadClickOptions = deadClickOptions
     }
+    #endif
 }

--- a/Sources/Autocapture/AutocaptureOptions.swift
+++ b/Sources/Autocapture/AutocaptureOptions.swift
@@ -29,6 +29,25 @@ enum AutocaptureDefaults {
     /// default threshold of 4 so that a burst of taps cannot evict clicks still in the window.
     static let maxTrackedClicks = 20
 
+    // MARK: - Option bounds
+    //
+    // Host apps can pass any value through the public option initializers, so the
+    // bounds are enforced there. Mirrors the Android SDK, whose option builders clamp
+    // with the same minimums.
+
+    /// Minimum rage click threshold. Below `2` the "N taps in a row" comparison
+    /// (`nearbyCount >= clickThreshold - 1`) is satisfied by the first tap, so every
+    /// tap would be reported as a rage click.
+    static let minRageClickThreshold = 2
+
+    /// Minimum detection window in milliseconds. A negative dead click window traps when
+    /// converted to an unsigned nanosecond count for `Task.sleep`; zero would check for a
+    /// UI response before the UI has any chance to produce one.
+    static let minTimeWindowMs = 1
+
+    /// `minTimeWindowMs` for the rage click tracker, which stores its window as `Int64`.
+    static let minTimeWindowMs64: Int64 = 1
+
     #if os(iOS)
     /// UIKit controls with inherent visual feedback that should be excluded from
     /// dead click detection. These controls always produce a visible UI response
@@ -133,18 +152,28 @@ public struct RageClickOptions {
 
     /// Number of clicks required to trigger a rage click event.
     /// Defaults to `4` (triggers on the 4th click within the time window).
+    ///
+    /// Clamped to a minimum of `2`: a threshold below that would mark every
+    /// single tap as a rage click.
     public let clickThreshold: Int
 
     /// Time window in milliseconds for rage click detection.
     /// Clicks must occur within this window to count as a rage click sequence.
     /// Defaults to `1000` (1 second).
+    ///
+    /// Clamped to a minimum of `1`.
     public let timeWindowMs: Int64
 
     /// Spatial threshold for rage click detection in points (pt).
     /// Clicks must be within this radius of each other to count as part of the same sequence.
     /// Defaults to `44` (matching iOS minimum tap target size).
+    ///
+    /// Clamped to a minimum of `0`.
     public let radius: CGFloat
 
+    /// Out-of-range values are clamped rather than rejected, matching the Android SDK.
+    /// Passing an invalid value must never crash the host app or turn every tap into a
+    /// rage click, so the bounds are enforced here at the only entry point.
     public init(
         enabled: Bool = true,
         clickThreshold: Int = 4,
@@ -152,9 +181,9 @@ public struct RageClickOptions {
         radius: CGFloat = 44
     ) {
         self.enabled = enabled
-        self.clickThreshold = clickThreshold
-        self.timeWindowMs = timeWindowMs
-        self.radius = radius
+        self.clickThreshold = max(AutocaptureDefaults.minRageClickThreshold, clickThreshold)
+        self.timeWindowMs = max(AutocaptureDefaults.minTimeWindowMs64, timeWindowMs)
+        self.radius = max(0, radius)
     }
 }
 
@@ -175,14 +204,19 @@ public struct DeadClickOptions {
     /// Time window in milliseconds to wait for UI response after a click.
     /// If no UI change is detected within this window, a dead click is recorded.
     /// Defaults to `500` (0.5 seconds).
+    ///
+    /// Clamped to a minimum of `1`: a non-positive window is converted to an unsigned
+    /// nanosecond count when the check is scheduled, which traps on a negative value,
+    /// and a zero window would check before the UI has any chance to respond.
     public let timeWindowMs: Int
 
+    /// Out-of-range values are clamped rather than rejected, matching the Android SDK.
     public init(
         enabled: Bool = true,
         timeWindowMs: Int = 500
     ) {
         self.enabled = enabled
-        self.timeWindowMs = timeWindowMs
+        self.timeWindowMs = max(AutocaptureDefaults.minTimeWindowMs, timeWindowMs)
     }
 }
 

--- a/Sources/Autocapture/AutocaptureOptions.swift
+++ b/Sources/Autocapture/AutocaptureOptions.swift
@@ -17,7 +17,10 @@ import UIKit
 /// Internal configuration constants not exposed in public API
 enum AutocaptureDefaults {
     static let maxHierarchyDepth = 5
-    static let maxAncestorSearchDepth = 20
+    /// Maximum ancestors to walk when searching for a clickable parent.
+    /// Set to 10: covers all practical view depths (typically 1–5 levels),
+    /// with safety margin, while avoiding walk-up into navigation-level containers.
+    static let maxAncestorSearchDepth = 10
     static let maxRecursionDepth = 20
 
     #if os(iOS)

--- a/Sources/Autocapture/AutocaptureOptions.swift
+++ b/Sources/Autocapture/AutocaptureOptions.swift
@@ -101,8 +101,13 @@ enum AutocaptureDefaults {
 /// Configuration options for click event capture.
 ///
 /// When enabled, a `$mp_click` event is tracked for every tap on any element.
-/// Each event includes the touch coordinates, element identifier, class name,
-/// accessibility label, semantic role, and view hierarchy path.
+/// Each event includes the touch coordinates, element identifier, class name, semantic role, and
+/// view hierarchy path. Accessibility labels are never captured: they are localized and can carry
+/// user data.
+///
+/// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the properties
+///   it captures may change in a future release before general availability. Pin your SDK version if
+///   you build reports on autocaptured events.
 public struct ClickOptions {
     /// Whether click capture is enabled. Defaults to `true` when autocapture is enabled.
     public let enabled: Bool
@@ -118,6 +123,10 @@ public struct ClickOptions {
 ///
 /// Rage clicks are detected when a user taps rapidly multiple times in the same area,
 /// indicating frustration with an unresponsive element.
+///
+/// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the properties
+///   it captures may change in a future release before general availability. Pin your SDK version if
+///   you build reports on autocaptured events.
 public struct RageClickOptions {
     /// Whether rage click detection is enabled. Defaults to `true`.
     public let enabled: Bool
@@ -155,6 +164,10 @@ public struct RageClickOptions {
 ///
 /// Dead clicks are detected when a user taps on an interactive element
 /// but no visible UI change occurs, indicating a broken or unresponsive element.
+///
+/// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the properties
+///   it captures may change in a future release before general availability. Pin your SDK version if
+///   you build reports on autocaptured events.
 public struct DeadClickOptions {
     /// Whether dead click detection is enabled. Defaults to `true`.
     public let enabled: Bool
@@ -207,6 +220,10 @@ public struct DeadClickOptions {
 ///     autocaptureOptions: autocaptureOpts
 /// )
 /// ```
+///
+/// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the properties
+///   it captures may change in a future release before general availability. Pin your SDK version if
+///   you build reports on autocaptured events.
 public struct AutocaptureOptions {
     /// Configuration for basic click capture.
     public let clickOptions: ClickOptions

--- a/Sources/Autocapture/AutocaptureOptions.swift
+++ b/Sources/Autocapture/AutocaptureOptions.swift
@@ -53,10 +53,13 @@ enum AutocaptureDefaults {
         "DatePicker",  // SwiftUI DatePicker
     ]
 
-    /// Check if a single view is a SwiftUI view (class name contains "Hosting" or "SwiftUI").
+    /// Check if a single view is a SwiftUI view.
+    /// Matches internal UIKit class names used by SwiftUI: *Hosting*, *SwiftUI*, and
+    /// PlatformGroupContainer (introduced in iOS 26).
     static func isSwiftUIView(_ view: UIView) -> Bool {
         let className = String(describing: type(of: view))
         return className.contains("Hosting") || className.contains("SwiftUI")
+            || className.hasPrefix("PlatformGroup")
     }
 
     /// Check if a view is interactive (UIControl with targets, has enabled tap gesture recognizer,

--- a/Sources/Autocapture/AutocaptureOptions.swift
+++ b/Sources/Autocapture/AutocaptureOptions.swift
@@ -237,36 +237,11 @@ public struct AutocaptureOptions {
     /// Configuration for dead click detection.
     public let deadClickOptions: DeadClickOptions
 
-    #if os(iOS)
-    /// Optional custom resolver for the `$el_id` reported on autocaptured interactions.
-    ///
-    /// When `nil` (the default), the SDK resolves `$el_id` internally: React Native `nativeID`,
-    /// then `accessibilityIdentifier`, then `accessibilityLabel`, then an anonymous `<ClassName>_<hash>`
-    /// identifier. Supply an implementation to control exactly which identifier is reported and to
-    /// keep personally identifiable information out of the payload.
-    ///
-    /// - SeeAlso: ``ElementIdExtractor``
-    public let elementIdExtractor: ElementIdExtractor?
-    #endif
-
     /// Returns `true` if any autocapture feature is enabled.
     public var isEnabled: Bool {
         return clickOptions.enabled || rageClickOptions.enabled || deadClickOptions.enabled
     }
 
-    #if os(iOS)
-    public init(
-        clickOptions: ClickOptions = ClickOptions(),
-        rageClickOptions: RageClickOptions = RageClickOptions(),
-        deadClickOptions: DeadClickOptions = DeadClickOptions(),
-        elementIdExtractor: ElementIdExtractor? = nil
-    ) {
-        self.clickOptions = clickOptions
-        self.rageClickOptions = rageClickOptions
-        self.deadClickOptions = deadClickOptions
-        self.elementIdExtractor = elementIdExtractor
-    }
-    #else
     public init(
         clickOptions: ClickOptions = ClickOptions(),
         rageClickOptions: RageClickOptions = RageClickOptions(),
@@ -276,5 +251,4 @@ public struct AutocaptureOptions {
         self.rageClickOptions = rageClickOptions
         self.deadClickOptions = deadClickOptions
     }
-    #endif
 }

--- a/Sources/Autocapture/AutocaptureOptions.swift
+++ b/Sources/Autocapture/AutocaptureOptions.swift
@@ -221,6 +221,9 @@ public struct DeadClickOptions {
 /// )
 /// ```
 ///
+/// **Platform support:** iOS only. Mac Catalyst builds accept these options so shared iOS sources
+/// keep compiling, but automatic capture never starts there.
+///
 /// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the properties
 ///   it captures may change in a future release before general availability. Pin your SDK version if
 ///   you build reports on autocaptured events.

--- a/Sources/Autocapture/AutocaptureOptions.swift
+++ b/Sources/Autocapture/AutocaptureOptions.swift
@@ -1,0 +1,222 @@
+//
+//  AutocaptureOptions.swift
+//  Mixpanel
+//
+//  Created by Mixpanel on 2026-06-13.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+import Foundation
+
+#if os(iOS)
+import UIKit
+#endif
+
+// MARK: - Internal Constants
+
+/// Internal configuration constants not exposed in public API
+enum AutocaptureDefaults {
+    static let maxHierarchyDepth = 5
+    static let maxAncestorSearchDepth = 20
+    static let maxRecursionDepth = 20
+
+    #if os(iOS)
+    /// UIKit controls with inherent visual feedback that should be excluded from
+    /// dead click detection. These controls always produce a visible UI response
+    /// (toggle animation, keyboard, wheel picker, etc.) that may not be captured
+    /// by snapshot comparison.
+    static let excludedControlTypes: [AnyClass] = [
+        UISwitch.self,
+        UISlider.self,
+        UITextField.self,
+        UITextView.self,
+        UIStepper.self,
+        UISegmentedControl.self,
+        UIDatePicker.self,
+        UIPickerView.self,
+        UIPageControl.self,
+    ]
+
+    /// SwiftUI class name patterns for controls with inherent visual feedback.
+    /// Checked by substring match on the view's class name when walking the hierarchy.
+    static let swiftUIExcludedPatterns = [
+        "Toggle",  // SwiftUI Toggle (switch)
+        "Slider",  // SwiftUI Slider
+        "Stepper",  // SwiftUI Stepper
+        "TextField",  // SwiftUI TextField
+        "TextEditor",  // SwiftUI TextEditor (multiline text)
+        "SecureField",  // SwiftUI SecureField (password)
+        "Picker",  // SwiftUI Picker
+        "DatePicker",  // SwiftUI DatePicker
+    ]
+
+    /// Check if a single view is a SwiftUI view (class name contains "Hosting" or "SwiftUI").
+    static func isSwiftUIView(_ view: UIView) -> Bool {
+        let className = String(describing: type(of: view))
+        return className.contains("Hosting") || className.contains("SwiftUI")
+    }
+
+    /// Check if a view is interactive (UIControl with targets, has enabled tap gesture recognizer,
+    /// or is a SwiftUI view with button accessibility trait).
+    static func isInteractive(_ view: UIView) -> Bool {
+        // UIKit: UIControl with action targets
+        if let control = view as? UIControl, !control.allTargets.isEmpty {
+            return true
+        }
+        // UIKit: explicit tap gesture recognizer
+        if let gestures = view.gestureRecognizers {
+            for gesture in gestures where gesture.isEnabled {
+                if gesture is UITapGestureRecognizer {
+                    return true
+                }
+            }
+        }
+        // Button accessibility trait indicates a clickable element.
+        // SwiftUI renders buttons as internal views (e.g., _UIGraphicsView) without
+        // UIKit gesture recognizers. The .button trait is set on the hit-test view
+        // regardless of framework and reliably signals interactivity.
+        // No framework gate needed — plain labels have .staticText, not .button.
+        if view.accessibilityTraits.contains(.button) {
+            return true
+        }
+        return false
+    }
+    #endif
+}
+
+// MARK: - Click Options
+
+/// Configuration options for click event capture.
+///
+/// When enabled, a `$mp_click` event is tracked for every tap on any element.
+/// Each event includes the touch coordinates, element identifier, class name,
+/// accessibility label, semantic role, and view hierarchy path.
+public struct ClickOptions {
+    /// Whether click capture is enabled. Defaults to `true` when autocapture is enabled.
+    public let enabled: Bool
+
+    public init(enabled: Bool = true) {
+        self.enabled = enabled
+    }
+}
+
+// MARK: - Rage Click Options
+
+/// Configuration options for rage click detection.
+///
+/// Rage clicks are detected when a user taps rapidly multiple times in the same area,
+/// indicating frustration with an unresponsive element.
+public struct RageClickOptions {
+    /// Whether rage click detection is enabled. Defaults to `true`.
+    public let enabled: Bool
+
+    /// Number of clicks required to trigger a rage click event.
+    /// Defaults to `4` (triggers on the 4th click within the time window).
+    public let clickThreshold: Int
+
+    /// Time window in milliseconds for rage click detection.
+    /// Clicks must occur within this window to count as a rage click sequence.
+    /// Defaults to `1000` (1 second).
+    public let timeWindowMs: Int64
+
+    /// Spatial threshold for rage click detection in points (pt).
+    /// Clicks must be within this radius of each other to count as part of the same sequence.
+    /// Defaults to `44` (matching iOS minimum tap target size).
+    public let radius: CGFloat
+
+    public init(
+        enabled: Bool = true,
+        clickThreshold: Int = 4,
+        timeWindowMs: Int64 = 1000,
+        radius: CGFloat = 44
+    ) {
+        self.enabled = enabled
+        self.clickThreshold = clickThreshold
+        self.timeWindowMs = timeWindowMs
+        self.radius = radius
+    }
+}
+
+// MARK: - Dead Click Options
+
+/// Configuration options for dead click detection.
+///
+/// Dead clicks are detected when a user taps on an interactive element
+/// but no visible UI change occurs, indicating a broken or unresponsive element.
+public struct DeadClickOptions {
+    /// Whether dead click detection is enabled. Defaults to `true`.
+    public let enabled: Bool
+
+    /// Time window in milliseconds to wait for UI response after a click.
+    /// If no UI change is detected within this window, a dead click is recorded.
+    /// Defaults to `500` (0.5 seconds).
+    public let timeWindowMs: Int
+
+    public init(
+        enabled: Bool = true,
+        timeWindowMs: Int = 500
+    ) {
+        self.enabled = enabled
+        self.timeWindowMs = timeWindowMs
+    }
+}
+
+// MARK: - Autocapture Options
+
+/// Configuration options for automatic event capture (clicks, rage clicks, dead clicks).
+///
+/// Autocapture is **disabled by default** and must be explicitly enabled by providing
+/// `AutocaptureOptions` during SDK initialization.
+///
+/// **Example - Enable with defaults:**
+/// ```swift
+/// let options = MixpanelOptions(
+///     token: "YOUR_TOKEN",
+///     autocaptureOptions: AutocaptureOptions()
+/// )
+/// ```
+///
+/// **Example - Custom configuration:**
+/// ```swift
+/// let autocaptureOpts = AutocaptureOptions(
+///     clickOptions: ClickOptions(enabled: true),
+///     rageClickOptions: RageClickOptions(
+///         enabled: true,
+///         clickThreshold: 5,        // Require 5 clicks instead of 4
+///         timeWindowMs: 800         // Shorter time window
+///     ),
+///     deadClickOptions: DeadClickOptions(
+///         enabled: false            // Disable dead click detection
+///     )
+/// )
+///
+/// let options = MixpanelOptions(
+///     token: "YOUR_TOKEN",
+///     autocaptureOptions: autocaptureOpts
+/// )
+/// ```
+public struct AutocaptureOptions {
+    /// Configuration for basic click capture.
+    public let clickOptions: ClickOptions
+
+    /// Configuration for rage click detection.
+    public let rageClickOptions: RageClickOptions
+
+    /// Configuration for dead click detection.
+    public let deadClickOptions: DeadClickOptions
+
+    /// Returns `true` if any autocapture feature is enabled.
+    public var isEnabled: Bool {
+        return clickOptions.enabled || rageClickOptions.enabled || deadClickOptions.enabled
+    }
+
+    public init(
+        clickOptions: ClickOptions = ClickOptions(),
+        rageClickOptions: RageClickOptions = RageClickOptions(),
+        deadClickOptions: DeadClickOptions = DeadClickOptions()
+    ) {
+        self.clickOptions = clickOptions
+        self.rageClickOptions = rageClickOptions
+        self.deadClickOptions = deadClickOptions
+    }
+}

--- a/Sources/Autocapture/DeadClickDetector.swift
+++ b/Sources/Autocapture/DeadClickDetector.swift
@@ -141,8 +141,12 @@ final class DeadClickDetector {
             checkTask = Task { [weak self] in
                 try? await Task.sleep(nanoseconds: UInt64(timeWindow) * 1_000_000)
                 guard !Task.isCancelled else { return }
-                await MainActor.run {
-                    self?.performFinalCheck()
+                // Bind before hopping to the main actor: referencing the captured `weak var`
+                // from inside the concurrently-executing closure is a warning under Swift 5 and
+                // an error in the Swift 6 language mode.
+                guard let self = self else { return }
+                await MainActor.run { [self] in
+                    self.performFinalCheck()
                 }
             }
         } else {

--- a/Sources/Autocapture/DeadClickDetector.swift
+++ b/Sources/Autocapture/DeadClickDetector.swift
@@ -1,0 +1,284 @@
+//
+//  DeadClickDetector.swift
+//  Mixpanel
+//
+//  Created by Mixpanel on 2026-06-13.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/// Detects clicks on interactive elements that produce no visible UI response.
+///
+/// Dead clicks indicate broken or unresponsive UI elements. Detection works by:
+/// 1. Capturing a baseline UI snapshot synchronously at click time
+/// 2. Waiting for the time window (500ms default)
+/// 3. Comparing the final state to the baseline
+/// 4. If no change detected, emitting a dead click event
+final class DeadClickDetector {
+    // MARK: - Configuration
+
+    private let timeWindowMs: Int
+
+    // MARK: - Callback
+
+    /// Called when a dead click is detected
+    var onDeadClick: ((ClickEvent) -> Void)?
+
+    // MARK: - State
+
+    private var pendingCheck: PendingCheck?
+    private weak var currentWindow: UIWindow?
+    private var checkTask: Any?  // Task<Void, Never> on iOS 13+
+    private let lock = NSLock()
+
+    // MARK: - Types
+
+    private struct UISnapshot {
+        let viewCount: Int
+        let contentHash: Int
+        let windowCount: Int
+    }
+
+    private struct PendingCheck {
+        let event: ClickEvent
+        let baselineSnapshot: UISnapshot
+        let startTime: Date
+    }
+
+    // MARK: - Initialization
+
+    init(options: DeadClickOptions) {
+        self.timeWindowMs = options.timeWindowMs
+    }
+
+    // MARK: - Public API
+
+    /// Check if a view should be excluded from dead click monitoring.
+    ///
+    /// Returns true for controls that have inherent feedback (keyboard, state changes)
+    /// that may not be detected by UI snapshot comparison.
+    ///
+    /// This method walks up the view hierarchy to catch cases where the touch hits
+    /// a subview of an excluded control (e.g., the thumb of a UISwitch).
+    func shouldExclude(view: UIView) -> Bool {
+        var currentView: UIView? = view
+        var depth = 0
+        let maxDepth = 10
+
+        while let v = currentView, depth < maxDepth {
+            // Check UIKit control types
+            for controlType in AutocaptureDefaults.excludedControlTypes {
+                if v.isKind(of: controlType) {
+                    return true
+                }
+            }
+
+            // Check SwiftUI patterns by class name
+            let className = String(describing: type(of: v))
+            for pattern in AutocaptureDefaults.swiftUIExcludedPatterns {
+                if className.contains(pattern) {
+                    return true
+                }
+            }
+
+            // Also check accessibility traits for adjustable (sliders, steppers)
+            if v.accessibilityTraits.contains(.adjustable) {
+                return true
+            }
+
+            currentView = v.superview
+            depth += 1
+        }
+
+        return false
+    }
+
+    /// Start monitoring for dead click after a tap.
+    ///
+    /// - Parameters:
+    ///   - event: The click event to monitor
+    ///   - view: The view that was tapped
+    ///   - window: The window containing the view
+    func startMonitoring(event: ClickEvent, view: UIView, in window: UIWindow) {
+        // Only monitor interactive elements — tapping a non-interactive view
+        // (plain label, image without gesture) is expected to do nothing.
+        guard event.isInteractive else {
+            MixpanelLogger.debug(
+                message: "DeadClickDetector: non-interactive element \(event.elementId)")
+            return
+        }
+
+        // Skip excluded elements (controls with inherent feedback like toggles, text fields)
+        guard !shouldExclude(view: view) else {
+            MixpanelLogger.debug(
+                message: "DeadClickDetector: excluded element \(event.elementId)")
+            return
+        }
+
+        // Cancel any in-flight detection before starting a new one
+        cancelPendingCheck()
+
+        // Capture baseline synchronously at click time — before the click handler
+        // has a chance to update the UI. This prevents fast UI responses (e.g.,
+        // showing a UIAlertController) from being absorbed into the baseline,
+        // which would cause false positive dead clicks.
+        let baseline = captureSnapshot(window: window)
+
+        lock.lock()
+        currentWindow = window
+        pendingCheck = PendingCheck(
+            event: event,
+            baselineSnapshot: baseline,
+            startTime: Date()
+        )
+        lock.unlock()
+
+        // Schedule final check as a cancellable task
+        let timeWindow = timeWindowMs
+        if #available(iOS 13.0, *) {
+            checkTask = Task { [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(timeWindow) * 1_000_000)
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    self?.performFinalCheck()
+                }
+            }
+        } else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(timeWindow)) {
+                [weak self] in
+                self?.performFinalCheck()
+            }
+        }
+    }
+
+    /// Cancel any pending dead click check.
+    ///
+    /// Call this when the user navigates away or the app backgrounds.
+    func cancelPendingCheck() {
+        if #available(iOS 13.0, *) {
+            (checkTask as? Task<Void, Never>)?.cancel()
+        }
+        checkTask = nil
+        lock.lock()
+        pendingCheck = nil
+        lock.unlock()
+    }
+
+    // MARK: - Private
+
+    private func performFinalCheck() {
+        lock.lock()
+        guard let check = pendingCheck, let window = currentWindow else {
+            pendingCheck = nil
+            lock.unlock()
+            return
+        }
+        pendingCheck = nil
+        lock.unlock()
+
+        let current = captureSnapshot(window: window)
+        let baseline = check.baselineSnapshot
+
+        // Compare snapshots
+        let hasChanges = hasUIChanges(baseline: baseline, current: current)
+
+        if !hasChanges {
+            // Dead click detected
+            MixpanelLogger.debug(message: "DeadClickDetector: dead click on \(check.event.elementId)")
+            onDeadClick?(check.event)
+        }
+    }
+
+    // MARK: - Snapshot
+
+    private func captureSnapshot(window: UIWindow) -> UISnapshot {
+        var viewCount = 0
+        var contentHash = 17
+
+        // Count visible windows (handles alerts, sheets, etc.)
+        // Use windowScene.windows for iOS 13+, fallback to just counting this window
+        let windowCount: Int
+        if #available(iOS 13.0, *) {
+            if let scene = window.windowScene {
+                windowCount = scene.windows.filter { $0.isKeyWindow || !$0.isHidden }.count
+            } else {
+                windowCount = 1
+            }
+        } else {
+            windowCount = 1  // Fallback for older iOS
+        }
+
+        // Walk view hierarchy
+        func processView(_ view: UIView, depth: Int = 0) {
+            guard !view.isHidden, view.alpha > 0, depth < AutocaptureDefaults.maxRecursionDepth else { return }
+
+            viewCount += 1
+
+            // Position and size
+            let frame = view.frame
+            contentHash = 31 &* contentHash &+ Int(frame.origin.x)
+            contentHash = 31 &* contentHash &+ Int(frame.origin.y)
+            contentHash = 31 &* contentHash &+ Int(frame.size.width)
+            contentHash = 31 &* contentHash &+ Int(frame.size.height)
+
+            // Class name
+            contentHash = 31 &* contentHash &+ String(describing: type(of: view)).hashValue
+
+            // Text content
+            if let label = view as? UILabel {
+                contentHash = 31 &* contentHash &+ (label.text?.hashValue ?? 0)
+            }
+            if let button = view as? UIButton {
+                contentHash = 31 &* contentHash &+ (button.currentTitle?.hashValue ?? 0)
+            }
+
+            // Control state
+            if let switchView = view as? UISwitch {
+                contentHash = 31 &* contentHash &+ switchView.isOn.hashValue
+            }
+            if let control = view as? UIControl {
+                contentHash = 31 &* contentHash &+ control.isEnabled.hashValue
+            }
+
+            for subview in view.subviews {
+                processView(subview, depth: depth + 1)
+            }
+        }
+
+        // Walk the window's entire view hierarchy — not just rootViewController.view.
+        // Presented view controllers (alerts, action sheets, popovers) are added as
+        // direct subviews of the window via _UITransitionView, not as children of the
+        // root view controller's view. Walking from the window catches all of them.
+        for subview in window.subviews {
+            processView(subview)
+        }
+
+        return UISnapshot(
+            viewCount: viewCount,
+            contentHash: contentHash,
+            windowCount: windowCount
+        )
+    }
+
+    private func hasUIChanges(baseline: UISnapshot, current: UISnapshot) -> Bool {
+        // Check view count change
+        if baseline.viewCount != current.viewCount {
+            return true
+        }
+
+        // Check content hash change
+        if baseline.contentHash != current.contentHash {
+            return true
+        }
+
+        // Check window count change (new alerts, sheets, etc.)
+        if baseline.windowCount != current.windowCount {
+            return true
+        }
+
+        return false
+    }
+}
+#endif

--- a/Sources/Autocapture/ElementIdExtractor.swift
+++ b/Sources/Autocapture/ElementIdExtractor.swift
@@ -1,0 +1,194 @@
+//
+//  ElementIdExtractor.swift
+//  Mixpanel
+//
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+// MARK: - ElementIdExtractor
+
+/// Resolves the `$el_id` property reported for an autocaptured interaction.
+///
+/// Provide an implementation via `AutocaptureOptions(elementIdExtractor:)` to take full control
+/// over which identifier the SDK reports for a tapped view. This is the recommended way to keep
+/// personally identifiable information out of autocapture events: the SDK only ever reports what
+/// this method returns.
+///
+/// When no extractor is provided, the SDK falls back to an internal default implementation that
+/// resolves the identifier from the React Native `nativeID`, then `accessibilityIdentifier`, then
+/// `accessibilityLabel`.
+///
+/// **Example:**
+/// ```swift
+/// final class TrackingIdExtractor: ElementIdExtractor {
+///     func extractElementId(from view: UIView) -> String? {
+///         // Only report identifiers the team explicitly opted into.
+///         guard let id = view.accessibilityIdentifier, id.hasPrefix("track_") else { return nil }
+///         return id
+///     }
+/// }
+///
+/// let options = MixpanelOptions(
+///     token: "YOUR_TOKEN",
+///     autocaptureOptions: AutocaptureOptions(elementIdExtractor: TrackingIdExtractor())
+/// )
+/// ```
+///
+/// **Threading:** `extractElementId(from:)` is called on the main thread immediately after the hit
+/// test that resolved the tapped view. Keep the implementation fast and side-effect free.
+public protocol ElementIdExtractor {
+    /// Returns the `$el_id` to report for the given view.
+    ///
+    /// - Parameter view: The view resolved by the autocapture hit test.
+    /// - Returns: The identifier to report, or `nil` to let the SDK report an anonymous
+    ///   `<ClassName>_<hash>` identifier instead. Empty strings are treated as `nil`.
+    func extractElementId(from view: UIView) -> String?
+}
+
+// MARK: - DefaultElementIdExtractor
+
+/// Default `ElementIdExtractor` used when the host app does not supply its own.
+///
+/// Resolution priority:
+/// 1. **React Native `nativeID`** — read through the Objective-C runtime so the SDK carries no
+///    compile-time dependency on React Native. Skipped for SwiftUI views: React Native renders
+///    through UIKit, never SwiftUI, so the probe could only ever be wasted work there.
+/// 2. **`accessibilityIdentifier`** — stable, developer-assigned, and not user-visible. Internal
+///    framework identifiers (e.g. `_UIKit…`, `AXID-…`) are skipped.
+/// 3. **`accessibilityLabel`** — only when the label was intentionally set (see
+///    `intentionalAccessibilityLabel(for:)`), so framework-derived text that may contain user data
+///    is not reported.
+/// 4. **Anonymous fallback** — `<ClassName>_<hash>` derived from the view's class and hash.
+///
+/// For SwiftUI, steps 1–3 collapse to `accessibilityIdentifier` > `accessibilityLabel` > hash. Both
+/// of those properties live in SwiftUI's accessibility element tree rather than on the backing
+/// `UIView`, so `SemanticExtractor` resolves them from that tree and passes them in as the
+/// `accessibilityIdentifierFallback` / `accessibilityLabelFallback` arguments below.
+final class DefaultElementIdExtractor: ElementIdExtractor {
+
+    static let shared = DefaultElementIdExtractor()
+
+    /// Framework-internal identifier prefixes that carry no product meaning.
+    private static let internalIdentifierPrefixes = [
+        "_",  // Private Apple identifiers
+        "AXID-",  // Accessibility internal
+        "UITransitionView",
+        "UILayoutContainerView",
+    ]
+
+    func extractElementId(from view: UIView) -> String? {
+        return elementId(
+            for: view, accessibilityIdentifierFallback: nil, accessibilityLabelFallback: nil)
+    }
+
+    /// Resolution with optional precomputed values used at priority steps 2 and 3.
+    ///
+    /// SwiftUI renders its views as internal UIKit views that carry neither
+    /// `accessibilityIdentifier` nor `accessibilityLabel` on the UIKit view itself; the caller
+    /// resolves those from SwiftUI's accessibility element tree and passes them here so SwiftUI
+    /// elements still get a meaningful `$el_id`. Each fallback is consulted only after the view's
+    /// own property for that step, so an identifier always outranks any label.
+    func elementId(
+        for view: UIView,
+        accessibilityIdentifierFallback: String?,
+        accessibilityLabelFallback: String?
+    ) -> String {
+        // 1. React Native nativeID (UIKit-backed views only)
+        if let nativeId = reactNativeId(for: view) {
+            return nativeId
+        }
+
+        // 2. accessibilityIdentifier
+        if let identifier = view.accessibilityIdentifier,
+            !identifier.isEmpty,
+            !DefaultElementIdExtractor.isInternalIdentifier(identifier)
+        {
+            return identifier
+        }
+        if let fallbackIdentifier = accessibilityIdentifierFallback,
+            !fallbackIdentifier.isEmpty,
+            !DefaultElementIdExtractor.isInternalIdentifier(fallbackIdentifier)
+        {
+            return fallbackIdentifier
+        }
+
+        // 3. accessibilityLabel (only when intentionally set)
+        if let label = intentionalAccessibilityLabel(for: view) {
+            return label
+        }
+        if let fallbackLabel = accessibilityLabelFallback, !fallbackLabel.isEmpty {
+            return fallbackLabel
+        }
+
+        // 4. Anonymous fallback
+        return DefaultElementIdExtractor.anonymousId(for: view)
+    }
+
+    // MARK: - React Native
+
+    /// Reads React Native's `nativeID` property through the Objective-C runtime.
+    ///
+    /// `RCTView` (and friends) expose `nativeID` as an Objective-C property carrying the JS-side
+    /// `nativeID` prop. `responds(to:)` is checked first so KVC never throws on views that do not
+    /// declare the key.
+    ///
+    /// Skipped entirely for SwiftUI views — React Native renders through the UIKit view hierarchy,
+    /// so a SwiftUI view can never carry a `nativeID`.
+    private func reactNativeId(for view: UIView) -> String? {
+        guard !AutocaptureDefaults.isSwiftUIView(view) else { return nil }
+        let selector = NSSelectorFromString("nativeID")
+        guard view.responds(to: selector) else { return nil }
+        guard let nativeId = view.value(forKey: "nativeID") as? String, !nativeId.isEmpty else {
+            return nil
+        }
+        return nativeId
+    }
+
+    // MARK: - Accessibility
+
+    /// Returns the view's `accessibilityLabel` only when it was intentionally set.
+    ///
+    /// UIKit auto-derives `accessibilityLabel` from child text for container views whose
+    /// `isAccessibilityElement` is false, and that derived text may contain sensitive information
+    /// (account numbers, personal details). Known UIKit controls and SwiftUI views always carry an
+    /// intentional (title-derived or explicitly set) label, so they are trusted; generic containers
+    /// — e.g. React Native's `RCTView` — are trusted only when `isAccessibilityElement` is true,
+    /// which in React Native maps to `accessible={true}`.
+    private func intentionalAccessibilityLabel(for view: UIView) -> String? {
+        let isKnownControl =
+            view is UIButton || view is UILabel || view is UISwitch
+            || view is UISlider || view is UITextField || view is UITextView
+            || view is UISegmentedControl || view is UIStepper || view is UIImageView
+        if !isKnownControl && !view.isAccessibilityElement
+            && !AutocaptureDefaults.isSwiftUIView(view)
+        {
+            return nil
+        }
+        if let label = view.accessibilityLabel, !label.isEmpty {
+            return label
+        }
+        return nil
+    }
+
+    private static func isInternalIdentifier(_ identifier: String) -> Bool {
+        for prefix in internalIdentifierPrefixes where identifier.hasPrefix(prefix) {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Anonymous Fallback
+
+    /// The anonymous, PII-free identifier used when nothing else resolves:
+    /// `<ClassName>_<hash>` (e.g. `UIButton_3f2a1b`).
+    static func anonymousId(for view: UIView) -> String {
+        let className = String(describing: type(of: view))
+        // abs(Int.min) traps, so map it to Int.max.
+        let safeHash = view.hash == Int.min ? Int.max : abs(view.hash)
+        return "\(className)_\(String(safeHash, radix: 16))"
+    }
+}
+#endif

--- a/Sources/Autocapture/ElementIdExtractor.swift
+++ b/Sources/Autocapture/ElementIdExtractor.swift
@@ -40,6 +40,10 @@ import UIKit
 ///
 /// **Threading:** `extractElementId(from:)` is called on the main thread immediately after the hit
 /// test that resolved the tapped view. Keep the implementation fast and side-effect free.
+///
+/// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the properties
+///   it captures may change in a future release before general availability. Pin your SDK version if
+///   you build reports on autocaptured events.
 public protocol ElementIdExtractor {
     /// Returns the `$el_id` to report for the given view.
     ///

--- a/Sources/Autocapture/ElementIdExtractor.swift
+++ b/Sources/Autocapture/ElementIdExtractor.swift
@@ -18,8 +18,9 @@ import UIKit
 /// this method returns.
 ///
 /// When no extractor is provided, the SDK falls back to an internal default implementation that
-/// resolves the identifier from the React Native `nativeID`, then `accessibilityIdentifier`, then
-/// `accessibilityLabel`.
+/// resolves the identifier from the React Native `nativeID`, then `accessibilityIdentifier`, then a
+/// structural fallback. `accessibilityLabel` is deliberately not a source: it is localized, so the
+/// same element would report a different identifier per language, and it can carry user data.
 ///
 /// **Example:**
 /// ```swift
@@ -58,15 +59,15 @@ public protocol ElementIdExtractor {
 ///    through UIKit, never SwiftUI, so the probe could only ever be wasted work there.
 /// 2. **`accessibilityIdentifier`** — stable, developer-assigned, and not user-visible. Internal
 ///    framework identifiers (e.g. `_UIKit…`, `AXID-…`) are skipped.
-/// 3. **`accessibilityLabel`** — only when the label was intentionally set (see
-///    `intentionalAccessibilityLabel(for:)`), so framework-derived text that may contain user data
-///    is not reported.
-/// 4. **Anonymous fallback** — `<ClassName>_<hash>` derived from the view's class and hash.
+/// 3. **Anonymous fallback** — `<ClassName>_<hash>`, where the hash describes the view's position in
+///    the hierarchy (see `structuralPath(for:)`) rather than its identity.
 ///
-/// For SwiftUI, steps 1–3 collapse to `accessibilityIdentifier` > `accessibilityLabel` > hash. Both
-/// of those properties live in SwiftUI's accessibility element tree rather than on the backing
-/// `UIView`, so `SemanticExtractor` resolves them from that tree and passes them in as the
-/// `accessibilityIdentifierFallback` / `accessibilityLabelFallback` arguments below.
+/// `accessibilityLabel` is deliberately absent. It is user-facing text: localized, so the same
+/// element would report a different identifier per language, and capable of carrying personal data.
+///
+/// For SwiftUI, step 1 is skipped and the identifier lives in SwiftUI's accessibility element tree
+/// rather than on the backing `UIView`, so `SemanticExtractor` resolves it from that tree and passes
+/// it in as the `accessibilityIdentifierFallback` argument below.
 final class DefaultElementIdExtractor: ElementIdExtractor {
 
     static let shared = DefaultElementIdExtractor()
@@ -80,21 +81,18 @@ final class DefaultElementIdExtractor: ElementIdExtractor {
     ]
 
     func extractElementId(from view: UIView) -> String? {
-        return elementId(
-            for: view, accessibilityIdentifierFallback: nil, accessibilityLabelFallback: nil)
+        return elementId(for: view, accessibilityIdentifierFallback: nil)
     }
 
-    /// Resolution with optional precomputed values used at priority steps 2 and 3.
+    /// Resolution with an optional precomputed identifier used at priority step 2.
     ///
-    /// SwiftUI renders its views as internal UIKit views that carry neither
-    /// `accessibilityIdentifier` nor `accessibilityLabel` on the UIKit view itself; the caller
-    /// resolves those from SwiftUI's accessibility element tree and passes them here so SwiftUI
-    /// elements still get a meaningful `$el_id`. Each fallback is consulted only after the view's
-    /// own property for that step, so an identifier always outranks any label.
+    /// SwiftUI renders its views as internal UIKit views that do not carry
+    /// `accessibilityIdentifier` on the UIKit view itself; the caller resolves it from SwiftUI's
+    /// accessibility element tree and passes it here so SwiftUI elements still get a meaningful
+    /// `$el_id`. The fallback is consulted only after the view's own identifier.
     func elementId(
         for view: UIView,
-        accessibilityIdentifierFallback: String?,
-        accessibilityLabelFallback: String?
+        accessibilityIdentifierFallback: String?
     ) -> String {
         // 1. React Native nativeID (UIKit-backed views only)
         if let nativeId = reactNativeId(for: view) {
@@ -115,15 +113,7 @@ final class DefaultElementIdExtractor: ElementIdExtractor {
             return fallbackIdentifier
         }
 
-        // 3. accessibilityLabel (only when intentionally set)
-        if let label = intentionalAccessibilityLabel(for: view) {
-            return label
-        }
-        if let fallbackLabel = accessibilityLabelFallback, !fallbackLabel.isEmpty {
-            return fallbackLabel
-        }
-
-        // 4. Anonymous fallback
+        // 3. Anonymous fallback
         return DefaultElementIdExtractor.anonymousId(for: view)
     }
 
@@ -147,32 +137,6 @@ final class DefaultElementIdExtractor: ElementIdExtractor {
         return nativeId
     }
 
-    // MARK: - Accessibility
-
-    /// Returns the view's `accessibilityLabel` only when it was intentionally set.
-    ///
-    /// UIKit auto-derives `accessibilityLabel` from child text for container views whose
-    /// `isAccessibilityElement` is false, and that derived text may contain sensitive information
-    /// (account numbers, personal details). Known UIKit controls and SwiftUI views always carry an
-    /// intentional (title-derived or explicitly set) label, so they are trusted; generic containers
-    /// — e.g. React Native's `RCTView` — are trusted only when `isAccessibilityElement` is true,
-    /// which in React Native maps to `accessible={true}`.
-    private func intentionalAccessibilityLabel(for view: UIView) -> String? {
-        let isKnownControl =
-            view is UIButton || view is UILabel || view is UISwitch
-            || view is UISlider || view is UITextField || view is UITextView
-            || view is UISegmentedControl || view is UIStepper || view is UIImageView
-        if !isKnownControl && !view.isAccessibilityElement
-            && !AutocaptureDefaults.isSwiftUIView(view)
-        {
-            return nil
-        }
-        if let label = view.accessibilityLabel, !label.isEmpty {
-            return label
-        }
-        return nil
-    }
-
     private static func isInternalIdentifier(_ identifier: String) -> Bool {
         for prefix in internalIdentifierPrefixes where identifier.hasPrefix(prefix) {
             return true
@@ -184,11 +148,51 @@ final class DefaultElementIdExtractor: ElementIdExtractor {
 
     /// The anonymous, PII-free identifier used when nothing else resolves:
     /// `<ClassName>_<hash>` (e.g. `UIButton_3f2a1b`).
+    ///
+    /// The hash describes the view's **position in the hierarchy**, not its identity. `view.hash` is
+    /// per-instance and, because Swift seeds hashing per process, differs on every launch — an
+    /// element with no identifier would get a new `$el_id` every session and could never be grouped.
+    ///
+    /// It identifies a *position* rather than a specific element: reordering siblings changes the id,
+    /// and two rows of the same list differ by index, not by content.
     static func anonymousId(for view: UIView) -> String {
         let className = String(describing: type(of: view))
-        // abs(Int.min) traps, so map it to Int.max.
-        let safeHash = view.hash == Int.min ? Int.max : abs(view.hash)
-        return "\(className)_\(String(safeHash, radix: 16))"
+        return "\(className)_\(stableHash(structuralPath(for: view)))"
+    }
+
+    /// Class names and sibling indices only — never text — so the path cannot carry user data:
+    /// `UIButton@UIStackView[2]/UIScrollView[0]/UIView[1]`.
+    static func structuralPath(for view: UIView) -> String {
+        var path = String(describing: type(of: view)) + "@"
+        var current: UIView = view
+        var depth = 0
+
+        while let parent = current.superview, depth < AutocaptureDefaults.maxHierarchyDepth {
+            if depth > 0 {
+                path += "/"
+            }
+            let index = parent.subviews.firstIndex(of: current) ?? -1
+            path += "\(String(describing: type(of: parent)))[\(index)]"
+            current = parent
+            depth += 1
+        }
+
+        if depth == 0 {
+            path += "detached"
+        }
+        return path
+    }
+
+    /// FNV-1a over the path's UTF-8 bytes.
+    ///
+    /// Swift's `hashValue` is seeded per process, so it cannot be used here: the whole point of the
+    /// structural id is that it is identical across launches.
+    private static func stableHash(_ value: String) -> String {
+        var hash: UInt32 = 2_166_136_261
+        for byte in value.utf8 {
+            hash = (hash ^ UInt32(byte)) &* 16_777_619
+        }
+        return String(hash, radix: 16)
     }
 }
 #endif

--- a/Sources/Autocapture/ElementIdExtractor.swift
+++ b/Sources/Autocapture/ElementIdExtractor.swift
@@ -8,54 +8,11 @@
 #if os(iOS)
 import UIKit
 
-// MARK: - ElementIdExtractor
+// MARK: - DefaultElementIdExtractor
 
 /// Resolves the `$el_id` property reported for an autocaptured interaction.
 ///
-/// Provide an implementation via `AutocaptureOptions(elementIdExtractor:)` to take full control
-/// over which identifier the SDK reports for a tapped view. This is the recommended way to keep
-/// personally identifiable information out of autocapture events: the SDK only ever reports what
-/// this method returns.
-///
-/// When no extractor is provided, the SDK falls back to an internal default implementation that
-/// resolves the identifier from the React Native `nativeID`, then `accessibilityIdentifier`, then a
-/// structural fallback. `accessibilityLabel` is deliberately not a source: it is localized, so the
-/// same element would report a different identifier per language, and it can carry user data.
-///
-/// **Example:**
-/// ```swift
-/// final class TrackingIdExtractor: ElementIdExtractor {
-///     func extractElementId(from view: UIView) -> String? {
-///         // Only report identifiers the team explicitly opted into.
-///         guard let id = view.accessibilityIdentifier, id.hasPrefix("track_") else { return nil }
-///         return id
-///     }
-/// }
-///
-/// let options = MixpanelOptions(
-///     token: "YOUR_TOKEN",
-///     autocaptureOptions: AutocaptureOptions(elementIdExtractor: TrackingIdExtractor())
-/// )
-/// ```
-///
-/// **Threading:** `extractElementId(from:)` is called on the main thread immediately after the hit
-/// test that resolved the tapped view. Keep the implementation fast and side-effect free.
-///
-/// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the properties
-///   it captures may change in a future release before general availability. Pin your SDK version if
-///   you build reports on autocaptured events.
-public protocol ElementIdExtractor {
-    /// Returns the `$el_id` to report for the given view.
-    ///
-    /// - Parameter view: The view resolved by the autocapture hit test.
-    /// - Returns: The identifier to report, or `nil` to let the SDK report an anonymous
-    ///   `<ClassName>_<hash>` identifier instead. Empty strings are treated as `nil`.
-    func extractElementId(from view: UIView) -> String?
-}
-
-// MARK: - DefaultElementIdExtractor
-
-/// Default `ElementIdExtractor` used when the host app does not supply its own.
+/// This is the SDK's only `$el_id` resolver; there is no way for a host app to substitute its own.
 ///
 /// Resolution priority:
 /// 1. **React Native `nativeID`** — read through the Objective-C runtime so the SDK carries no
@@ -72,7 +29,7 @@ public protocol ElementIdExtractor {
 /// For SwiftUI, step 1 is skipped and the identifier lives in SwiftUI's accessibility element tree
 /// rather than on the backing `UIView`, so `SemanticExtractor` resolves it from that tree and passes
 /// it in as the `accessibilityIdentifierFallback` argument below.
-final class DefaultElementIdExtractor: ElementIdExtractor {
+final class DefaultElementIdExtractor {
 
     static let shared = DefaultElementIdExtractor()
 
@@ -83,10 +40,6 @@ final class DefaultElementIdExtractor: ElementIdExtractor {
         "UITransitionView",
         "UILayoutContainerView",
     ]
-
-    func extractElementId(from view: UIView) -> String? {
-        return elementId(for: view, accessibilityIdentifierFallback: nil)
-    }
 
     /// Resolution with an optional precomputed identifier used at priority step 2.
     ///

--- a/Sources/Autocapture/Model/ClickEvent.swift
+++ b/Sources/Autocapture/Model/ClickEvent.swift
@@ -33,10 +33,16 @@ public struct ClickEvent {
 
     /// A stable identifier for the tapped element, used to group clicks in analytics.
     ///
-    /// Recommended sources (in order of preference):
-    /// - `accessibilityLabel` — human-readable, consistent across UIKit and SwiftUI
+    /// Autocapture resolves this in the following order (see `DefaultElementIdExtractor`), and the
+    /// same preferences apply when tracking manually:
+    /// - React Native `nativeID` — the JS-side prop, read through the Objective-C runtime
+    ///   (skipped for SwiftUI views, which React Native never renders)
     /// - `accessibilityIdentifier` — stable and not user-visible
-    /// - A custom string like `"buy_button"` or `"settings_cell_notifications"`
+    /// - `accessibilityLabel` — human-readable, and only when intentionally set
+    /// - `<ClassName>_<hash>` as a last resort
+    ///
+    /// Supply an `ElementIdExtractor` through `AutocaptureOptions` to override this entirely — for
+    /// example a custom string like `"buy_button"` or `"settings_cell_notifications"`.
     ///
     /// Avoid dynamic values (e.g., cell index, timestamp) — they prevent meaningful grouping.
     public let elementId: String

--- a/Sources/Autocapture/Model/ClickEvent.swift
+++ b/Sources/Autocapture/Model/ClickEvent.swift
@@ -41,8 +41,10 @@ public struct ClickEvent: Sendable {
     /// - React Native `nativeID` — the JS-side prop, read through the Objective-C runtime
     ///   (skipped for SwiftUI views, which React Native never renders)
     /// - `accessibilityIdentifier` — stable and not user-visible
-    /// - `accessibilityLabel` — human-readable, and only when intentionally set
-    /// - `<ClassName>_<hash>` as a last resort
+    /// - `<ClassName>_<hash>` as a last resort, hashed from the element's position in the hierarchy
+    ///
+    /// `accessibilityLabel` is deliberately not a source: it is localized, so the same element would
+    /// report a different identifier per language, and it can carry personal data.
     ///
     /// Supply an `ElementIdExtractor` through `AutocaptureOptions` to override this entirely — for
     /// example a custom string like `"buy_button"` or `"settings_cell_notifications"`.
@@ -56,13 +58,6 @@ public struct ClickEvent: Sendable {
     /// Use `String(describing: type(of: view))` to get the class name.
     /// Set to `nil` if not available.
     public let tagName: String?
-
-    /// The human-readable accessibility label of the element.
-    ///
-    /// This is the text read aloud by VoiceOver — typically the view's `accessibilityLabel`.
-    /// Examples: `"Add to cart"`, `"Play video"`, `"Close"`.
-    /// Set to `nil` if the element has no accessibility label.
-    public let accessibleLabel: String?
 
     /// The semantic role describing what the element does.
     ///
@@ -100,7 +95,6 @@ public struct ClickEvent: Sendable {
     ///     y: touch.location(in: view.window).y,
     ///     elementId: button.accessibilityIdentifier ?? "buy_button",
     ///     tagName: String(describing: type(of: button)),
-    ///     accessibleLabel: button.accessibilityLabel,
     ///     role: "button",
     ///     elements: "UIButton > UIStackView > UIView"
     /// )
@@ -112,13 +106,12 @@ public struct ClickEvent: Sendable {
     ///   - y: Touch Y coordinate in window points
     ///   - elementId: Stable identifier for the tapped element
     ///   - tagName: Class name of the tapped element (defaults to nil)
-    ///   - accessibleLabel: The element's accessibility label (defaults to nil)
     ///   - role: Semantic role like `"button"`, `"switch"`, `"link"` (defaults to nil)
     ///   - elements: View hierarchy path, `">"` separated (defaults to nil)
     ///   - isInteractive: Whether the element is interactive (defaults to true)
     public init(
         x: CGFloat, y: CGFloat, elementId: String,
-        tagName: String? = nil, accessibleLabel: String? = nil,
+        tagName: String? = nil,
         role: String? = nil, elements: String? = nil,
         isInteractive: Bool = true
     ) {
@@ -126,7 +119,6 @@ public struct ClickEvent: Sendable {
         self.y = y
         self.elementId = elementId
         self.tagName = tagName
-        self.accessibleLabel = accessibleLabel
         self.role = role
         self.elements = elements
         self.isInteractive = isInteractive
@@ -148,10 +140,6 @@ public struct ClickEvent: Sendable {
 
         if let elements = elements {
             props["$elements"] = elements
-        }
-
-        if let accessibleLabel = accessibleLabel {
-            props["$attr-aria-label"] = accessibleLabel
         }
 
         if let role = role {

--- a/Sources/Autocapture/Model/ClickEvent.swift
+++ b/Sources/Autocapture/Model/ClickEvent.swift
@@ -65,9 +65,16 @@ public struct ClickEvent: Sendable {
 
     /// The semantic role describing what the element does.
     ///
-    /// Common values: `"button"`, `"link"`, `"switch"`, `"checkbox"`, `"slider"`,
-    /// `"tab"`, `"textfield"`, `"image"`.
-    /// Set to `nil` if the element has no specific role.
+    /// Autocapture emits one of these exact values, resolved from the view's class and then its
+    /// accessibility traits (see `SemanticExtractor`). They are Title Case — match on them
+    /// verbatim when building reports on `$attr-role`:
+    ///
+    /// `"Button"`, `"Link"`, `"Switch"`, `"Slider"`, `"Stepper"`, `"SegmentedControl"`,
+    /// `"TextField"`, `"TextArea"`, `"SearchField"`, `"Text"`, `"Image"`, `"List"`, `"Grid"`,
+    /// `"ScrollView"`, `"Header"`, `"TabBar"`, `"Adjustable"`.
+    ///
+    /// Set to `nil` if the element has no specific role. When constructing a `ClickEvent`
+    /// yourself, prefer one of the values above so manual and autocaptured events group together.
     public let role: String?
 
     /// View hierarchy path from the tapped element up to 5 ancestor levels, `">"` separated.

--- a/Sources/Autocapture/Model/ClickEvent.swift
+++ b/Sources/Autocapture/Model/ClickEvent.swift
@@ -17,6 +17,10 @@ import UIKit
 /// All stored properties are value types (`CGFloat`, `String`, `Bool`), so the event can safely
 /// cross threads — it is handed from the main thread, where it is extracted, to the queue that
 /// emits it.
+///
+/// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the properties
+///   it captures may change in a future release before general availability. Pin your SDK version if
+///   you build reports on autocaptured events.
 public struct ClickEvent: Sendable {
     // MARK: - Position
 

--- a/Sources/Autocapture/Model/ClickEvent.swift
+++ b/Sources/Autocapture/Model/ClickEvent.swift
@@ -14,7 +14,10 @@ import UIKit
 /// Contains all semantic information about the clicked element and its context.
 /// Create a `ClickEvent` and pass it to `mixpanel.autocapture.trackClick(_:)` to
 /// track click events with full element metadata.
-public struct ClickEvent {
+/// All stored properties are value types (`CGFloat`, `String`, `Bool`), so the event can safely
+/// cross threads — it is handed from the main thread, where it is extracted, to the queue that
+/// emits it.
+public struct ClickEvent: Sendable {
     // MARK: - Position
 
     /// Touch X coordinate in the window's coordinate space (points).

--- a/Sources/Autocapture/Model/ClickEvent.swift
+++ b/Sources/Autocapture/Model/ClickEvent.swift
@@ -50,8 +50,8 @@ public struct ClickEvent: Sendable {
     /// `accessibilityLabel` is deliberately not a source: it is localized, so the same element would
     /// report a different identifier per language, and it can carry personal data.
     ///
-    /// Supply an `ElementIdExtractor` through `AutocaptureOptions` to override this entirely — for
-    /// example a custom string like `"buy_button"` or `"settings_cell_notifications"`.
+    /// When constructing a `ClickEvent` yourself, prefer a stable, human-readable string such as
+    /// `"buy_button"` or `"settings_cell_notifications"`.
     ///
     /// Avoid dynamic values (e.g., cell index, timestamp) — they prevent meaningful grouping.
     public let elementId: String

--- a/Sources/Autocapture/Model/ClickEvent.swift
+++ b/Sources/Autocapture/Model/ClickEvent.swift
@@ -1,0 +1,155 @@
+//
+//  ClickEvent.swift
+//  Mixpanel
+//
+//  Created by Mixpanel on 2026-06-13.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/// Represents a captured click event with element metadata.
+///
+/// Contains all semantic information about the clicked element and its context.
+/// Create a `ClickEvent` and pass it to `mixpanel.autocapture.trackClick(_:)` to
+/// track click events with full element metadata.
+public struct ClickEvent {
+    // MARK: - Position
+
+    /// Touch X coordinate in the window's coordinate space (points).
+    ///
+    /// The SDK captures this as `touch.location(in: window).x`.
+    /// When tracking manually, use `touch.location(in: view.window).x`.
+    public let x: CGFloat
+
+    /// Touch Y coordinate in the window's coordinate space (points).
+    ///
+    /// The SDK captures this as `touch.location(in: window).y`.
+    /// When tracking manually, use `touch.location(in: view.window).y`.
+    public let y: CGFloat
+
+    // MARK: - Element Identification
+
+    /// A stable identifier for the tapped element, used to group clicks in analytics.
+    ///
+    /// Recommended sources (in order of preference):
+    /// - `accessibilityLabel` — human-readable, consistent across UIKit and SwiftUI
+    /// - `accessibilityIdentifier` — stable and not user-visible
+    /// - A custom string like `"buy_button"` or `"settings_cell_notifications"`
+    ///
+    /// Avoid dynamic values (e.g., cell index, timestamp) — they prevent meaningful grouping.
+    public let elementId: String
+
+    /// The class name or component type of the tapped element.
+    ///
+    /// Examples: `"UIButton"`, `"UITableViewCell"`, `"Button"` (SwiftUI).
+    /// Use `String(describing: type(of: view))` to get the class name.
+    /// Set to `nil` if not available.
+    public let tagName: String?
+
+    /// The human-readable accessibility label of the element.
+    ///
+    /// This is the text read aloud by VoiceOver — typically the view's `accessibilityLabel`.
+    /// Examples: `"Add to cart"`, `"Play video"`, `"Close"`.
+    /// Set to `nil` if the element has no accessibility label.
+    public let accessibleLabel: String?
+
+    /// The semantic role describing what the element does.
+    ///
+    /// Common values: `"button"`, `"link"`, `"switch"`, `"checkbox"`, `"slider"`,
+    /// `"tab"`, `"textfield"`, `"image"`.
+    /// Set to `nil` if the element has no specific role.
+    public let role: String?
+
+    /// View hierarchy path from the tapped element up to 5 ancestor levels, `">"` separated.
+    ///
+    /// Example: `"UIButton > UIStackView > UITableViewCell > UITableView > UIView"`.
+    /// Useful for identifying where in the view tree the click occurred.
+    /// Set to `nil` if not available.
+    public let elements: String?
+
+    /// Whether the clicked element is interactive (has tap handlers or is a clickable control).
+    /// Non-interactive elements (plain labels, images without gestures) are excluded from
+    /// dead click detection since tapping them is expected to do nothing.
+    let isInteractive: Bool
+
+    /// Creates a new ClickEvent.
+    ///
+    /// Only `x`, `y`, and `elementId` are required. All other parameters have sensible defaults.
+    ///
+    /// **Minimal usage:**
+    /// ```swift
+    /// let click = ClickEvent(x: 150, y: 300, elementId: "buy_button")
+    /// mixpanel.autocapture.trackClick(click)
+    /// ```
+    ///
+    /// **Full usage:**
+    /// ```swift
+    /// let click = ClickEvent(
+    ///     x: touch.location(in: view.window).x,
+    ///     y: touch.location(in: view.window).y,
+    ///     elementId: button.accessibilityIdentifier ?? "buy_button",
+    ///     tagName: String(describing: type(of: button)),
+    ///     accessibleLabel: button.accessibilityLabel,
+    ///     role: "button",
+    ///     elements: "UIButton > UIStackView > UIView"
+    /// )
+    /// mixpanel.autocapture.trackClick(click)
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - x: Touch X coordinate in window points
+    ///   - y: Touch Y coordinate in window points
+    ///   - elementId: Stable identifier for the tapped element
+    ///   - tagName: Class name of the tapped element (defaults to nil)
+    ///   - accessibleLabel: The element's accessibility label (defaults to nil)
+    ///   - role: Semantic role like `"button"`, `"switch"`, `"link"` (defaults to nil)
+    ///   - elements: View hierarchy path, `">"` separated (defaults to nil)
+    ///   - isInteractive: Whether the element is interactive (defaults to true)
+    public init(
+        x: CGFloat, y: CGFloat, elementId: String,
+        tagName: String? = nil, accessibleLabel: String? = nil,
+        role: String? = nil, elements: String? = nil,
+        isInteractive: Bool = true
+    ) {
+        self.x = x
+        self.y = y
+        self.elementId = elementId
+        self.tagName = tagName
+        self.accessibleLabel = accessibleLabel
+        self.role = role
+        self.elements = elements
+        self.isInteractive = isInteractive
+    }
+
+    // MARK: - Conversion to Properties
+
+    /// Convert to Mixpanel properties dictionary for tracking
+    func toProperties() -> Properties {
+        var props: Properties = [
+            "$x": Int(x),
+            "$y": Int(y),
+            "$el_id": elementId,
+        ]
+
+        if let tagName = tagName {
+            props["$el_tag_name"] = tagName
+        }
+
+        if let elements = elements {
+            props["$elements"] = elements
+        }
+
+        if let accessibleLabel = accessibleLabel {
+            props["$attr-aria-label"] = accessibleLabel
+        }
+
+        if let role = role {
+            props["$attr-role"] = role
+        }
+
+        return props
+    }
+}
+#endif

--- a/Sources/Autocapture/RageClickTracker.swift
+++ b/Sources/Autocapture/RageClickTracker.swift
@@ -1,0 +1,128 @@
+//
+//  RageClickTracker.swift
+//  Mixpanel
+//
+//  Created by Mixpanel on 2026-06-13.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/// Result of tracking a click for rage click detection.
+struct RageClickResult {
+    /// Whether this click triggered a rage click event
+    let isRageClick: Bool
+}
+
+/// Tracks rapid repeated clicks to detect user frustration (rage clicks).
+///
+/// A rage click is detected when a user taps multiple times within a short time window
+/// in approximately the same location, indicating frustration with an unresponsive element.
+///
+/// Default thresholds (matching JS SDK):
+/// - 4 or more clicks
+/// - Within 1000ms time window
+/// - Within 44pt spatial radius
+final class RageClickTracker {
+    // MARK: - Configuration
+
+    private let clickThreshold: Int
+    private let timeWindowMs: Int64
+    private let spatialRadius: CGFloat
+
+    // MARK: - State
+
+    private var recentClicks: [ClickRecord] = []
+    private let lock = NSLock()
+
+    // MARK: - Time Provider (for testability)
+
+    private let timeProvider: () -> Int64
+
+    // MARK: - Types
+
+    private struct ClickRecord {
+        let x: CGFloat
+        let y: CGFloat
+        let timestamp: Int64
+    }
+
+    // MARK: - Initialization
+
+    /// Create a rage click tracker with custom configuration.
+    ///
+    /// - Parameters:
+    ///   - options: Rage click detection options
+    ///   - timeProvider: Optional time provider for testing (defaults to current time in ms)
+    init(
+        options: RageClickOptions,
+        timeProvider: @escaping () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1000) }
+    ) {
+        self.clickThreshold = options.clickThreshold
+        self.timeWindowMs = options.timeWindowMs
+        self.spatialRadius = options.radius
+        self.timeProvider = timeProvider
+    }
+
+    // MARK: - Public API
+
+    /// Track a click and check if it triggers a rage click.
+    ///
+    /// - Parameters:
+    ///   - x: X coordinate of the click
+    ///   - y: Y coordinate of the click
+    /// - Returns: Result indicating if this is a rage click and the total tap count
+    func trackClick(x: CGFloat, y: CGFloat) -> RageClickResult {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let now = timeProvider()
+
+        // Clean old clicks outside time window
+        cleanOldClicks(currentTime: now)
+
+        // Count nearby clicks within spatial threshold
+        let nearbyCount = countNearbyClicks(x: x, y: y)
+
+        // Add current click to history
+        recentClicks.append(ClickRecord(x: x, y: y, timestamp: now))
+
+        // Rage click triggers when we have threshold-1 previous clicks nearby
+        // (so the current click is the Nth click)
+        let isRageClick = nearbyCount >= (clickThreshold - 1)
+
+        // Clean old clicks to prevent memory growth
+        if recentClicks.count > 20 {
+            cleanOldClicks(currentTime: now)
+        }
+
+        return RageClickResult(isRageClick: isRageClick)
+    }
+
+    /// Reset tracking state (e.g., on scene change or app background).
+    func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        recentClicks.removeAll()
+    }
+
+    // MARK: - Private
+
+    private func cleanOldClicks(currentTime: Int64) {
+        let cutoff = currentTime - timeWindowMs
+        recentClicks.removeAll { $0.timestamp < cutoff }
+    }
+
+    private func countNearbyClicks(x: CGFloat, y: CGFloat) -> Int {
+        var count = 0
+        for click in recentClicks {
+            let distance = sqrt(pow(click.x - x, 2) + pow(click.y - y, 2))
+            if distance <= spatialRadius {
+                count += 1
+            }
+        }
+        return count
+    }
+}
+#endif

--- a/Sources/Autocapture/RageClickTracker.swift
+++ b/Sources/Autocapture/RageClickTracker.swift
@@ -93,7 +93,7 @@ final class RageClickTracker {
         let isRageClick = nearbyCount >= (clickThreshold - 1)
 
         // Clean old clicks to prevent memory growth
-        if recentClicks.count > 20 {
+        if recentClicks.count > AutocaptureDefaults.maxTrackedClicks {
             cleanOldClicks(currentTime: now)
         }
 

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -65,7 +65,18 @@ final class SemanticExtractor {
             accessibleLabel = findSwiftUIAccessibilityLabel(at: point, view: targetView)
         }
 
-        let elementId = accessibleLabel ?? generateElementId(for: targetView)
+        // SwiftUI's .accessibilityIdentifier("…") never reaches the backing UIKit view either —
+        // it lives in the same accessibility element tree as the label. Query it only for SwiftUI
+        // views that carry no identifier of their own, so pure UIKit hierarchies pay nothing.
+        var derivedIdentifier: String? = nil
+        if AutocaptureDefaults.isSwiftUIView(targetView),
+            (targetView.accessibilityIdentifier ?? "").isEmpty
+        {
+            derivedIdentifier = findSwiftUIAccessibilityIdentifier(at: point, view: targetView)
+        }
+
+        let elementId = resolveElementId(
+            for: targetView, derivedIdentifier: derivedIdentifier, derivedLabel: accessibleLabel)
         let role = determineRole(for: targetView)
         let tagName = resolveTagName(className: className, role: role, view: targetView)
         let elements = buildViewHierarchy(from: targetView)
@@ -82,48 +93,41 @@ final class SemanticExtractor {
         )
     }
 
-    // MARK: - Element ID Generation
+    // MARK: - Element ID Resolution
 
-    /// Generate a hash-based element ID as fallback when no accessibility label is available.
+    /// Resolve the `$el_id` for the target view.
     ///
-    /// Resolution order:
-    /// 1. `accessibilityIdentifier` (if non-empty)
-    /// 2. `ClassName_<hash>`
+    /// When the host app supplied an ``ElementIdExtractor`` through `AutocaptureOptions`, that
+    /// extractor is the only source of the identifier: a `nil`/empty return yields the anonymous
+    /// `<ClassName>_<hash>` identifier rather than silently falling back to view metadata the developer
+    /// chose not to expose.
     ///
-    /// Note: `accessibilityLabel` is checked by the caller (`extractSemantics`) via
-    /// `findAccessibilityLabel` before falling back to this method.
-    private func generateElementId(for view: UIView) -> String {
-        // accessibilityIdentifier as primary fallback
-        if let identifier = findAccessibilityIdentifier(in: view), !identifier.isEmpty {
-            return identifier
+    /// Otherwise `DefaultElementIdExtractor` resolves it (React Native `nativeID` >
+    /// `accessibilityIdentifier` > `accessibilityLabel` > `<ClassName>_<hash>`; for SwiftUI the
+    /// `nativeID` step is skipped).
+    ///
+    /// - Parameters:
+    ///   - derivedIdentifier: Identifier read from SwiftUI's accessibility element tree, used at the
+    ///     `accessibilityIdentifier` priority step when the view carries none itself.
+    ///   - derivedLabel: The accessibility label already resolved by `extractSemantics`, including
+    ///     labels read from SwiftUI's accessibility element tree. Used at the `accessibilityLabel`
+    ///     priority step.
+    private func resolveElementId(
+        for view: UIView, derivedIdentifier: String?, derivedLabel: String?
+    ) -> String {
+        if let custom = autocaptureOptions.elementIdExtractor {
+            if let customId = custom.extractElementId(from: view), !customId.isEmpty {
+                return customId
+            }
+            return DefaultElementIdExtractor.anonymousId(for: view)
         }
-
-        // Fallback: ClassName_<hex hash>
-        let className = String(describing: type(of: view))
-        let safeHash = view.hash == Int.min ? Int.max : abs(view.hash)
-        return "\(className)_\(String(safeHash, radix: 16))"
+        return DefaultElementIdExtractor.shared.elementId(
+            for: view,
+            accessibilityIdentifierFallback: derivedIdentifier,
+            accessibilityLabelFallback: derivedLabel)
     }
 
     // MARK: - Accessibility Property Discovery
-
-    private func findAccessibilityIdentifier(
-        in view: UIView, maxLevels: Int = SemanticExtractor.maxHierarchyDepth
-    ) -> String? {
-        var currentView: UIView? = view
-        var level = 0
-
-        while let v = currentView, level < maxLevels {
-            if let identifier = v.accessibilityIdentifier, !identifier.isEmpty {
-                if !isInternalIdentifier(identifier) {
-                    return identifier
-                }
-            }
-            currentView = v.superview
-            level += 1
-        }
-
-        return nil
-    }
 
     /// Returns the view's accessibilityLabel only if it was explicitly set by the developer.
     ///
@@ -150,24 +154,6 @@ final class SemanticExtractor {
             return label
         }
         return nil
-    }
-
-    /// Check if an identifier is an internal framework identifier that should be skipped
-    private func isInternalIdentifier(_ identifier: String) -> Bool {
-        let internalPrefixes = [
-            "_",  // Private Apple identifiers
-            "AXID-",  // Accessibility internal
-            "UITransitionView",
-            "UILayoutContainerView",
-        ]
-
-        for prefix in internalPrefixes {
-            if identifier.hasPrefix(prefix) {
-                return true
-            }
-        }
-
-        return false
     }
 
     // MARK: - Role Detection
@@ -313,6 +299,44 @@ final class SemanticExtractor {
                     let label = element.accessibilityLabel, !label.isEmpty
                 {
                     return label
+                }
+                break
+            }
+            current = v.superview
+            depth += 1
+        }
+
+        return nil
+    }
+
+    /// Query the SwiftUI accessibility element tree at the touch point to retrieve the identifier
+    /// set by `.accessibilityIdentifier("…")`.
+    ///
+    /// Same mechanism (and same constraints) as `findSwiftUIAccessibilityLabel(at:view:)`: SwiftUI
+    /// keeps both the label and the identifier in its own accessibility element tree rather than on
+    /// the backing UIKit view, and only the `UIHostingController`'s view owns a tree that
+    /// `accessibilityHitTest` will traverse.
+    ///
+    /// Note SwiftUI only materializes that tree while an accessibility client is attached, so this
+    /// returns nil in an XCTest host — both this and the label helper are exercised on device, not
+    /// by the instrumented tests. `DefaultElementIdExtractorTests` covers what happens with the
+    /// values once resolved.
+    private func findSwiftUIAccessibilityIdentifier(at windowPoint: CGPoint, view: UIView) -> String? {
+        guard #available(iOS 18.0, *) else { return nil }
+        guard let window = view.window else { return nil }
+
+        var current: UIView? = view
+        var depth = 0
+        while let v = current, depth < AutocaptureDefaults.maxAncestorSearchDepth {
+            let className = String(describing: type(of: v))
+            if className.contains("Hosting") {
+                let screenPoint = window.convert(windowPoint, to: window.screen.coordinateSpace)
+                if let element = v.accessibilityHitTest(screenPoint, event: nil) as? NSObject,
+                    let identifier = (element as? UIAccessibilityIdentification)?
+                        .accessibilityIdentifier,
+                    !identifier.isEmpty
+                {
+                    return identifier
                 }
                 break
             }

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -13,14 +13,6 @@ import UIKit
 ///
 /// Handles element identification and role detection.
 final class SemanticExtractor {
-    // MARK: - Configuration
-
-    private let autocaptureOptions: AutocaptureOptions
-
-    init(autocaptureOptions: AutocaptureOptions = AutocaptureOptions()) {
-        self.autocaptureOptions = autocaptureOptions
-    }
-
     // MARK: - Constants
 
     private static let maxHierarchyDepth = AutocaptureDefaults.maxHierarchyDepth
@@ -87,25 +79,14 @@ final class SemanticExtractor {
 
     /// Resolve the `$el_id` for the target view.
     ///
-    /// When the host app supplied an ``ElementIdExtractor`` through `AutocaptureOptions`, that
-    /// extractor is the only source of the identifier: a `nil`/empty return yields the anonymous
-    /// `<ClassName>_<hash>` identifier rather than silently falling back to view metadata the developer
-    /// chose not to expose.
-    ///
-    /// Otherwise `DefaultElementIdExtractor` resolves it (React Native `nativeID` >
-    /// `accessibilityIdentifier` > `<ClassName>_<hash>`; for SwiftUI the `nativeID` step is skipped).
-    /// Accessibility labels are never used: they are localized and can carry user data.
+    /// `DefaultElementIdExtractor` resolves it (React Native `nativeID` > `accessibilityIdentifier` >
+    /// `<ClassName>_<hash>`; for SwiftUI the `nativeID` step is skipped). Accessibility labels are
+    /// never used: they are localized and can carry user data.
     ///
     /// - Parameters:
     ///   - derivedIdentifier: Identifier read from SwiftUI's accessibility element tree, used at the
     ///     `accessibilityIdentifier` priority step when the view carries none itself.
     private func resolveElementId(for view: UIView, derivedIdentifier: String?) -> String {
-        if let custom = autocaptureOptions.elementIdExtractor {
-            if let customId = custom.extractElementId(from: view), !customId.isEmpty {
-                return customId
-            }
-            return DefaultElementIdExtractor.anonymousId(for: view)
-        }
         return DefaultElementIdExtractor.shared.elementId(
             for: view, accessibilityIdentifierFallback: derivedIdentifier)
     }

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -13,6 +13,14 @@ import UIKit
 ///
 /// Handles element identification and role detection.
 final class SemanticExtractor {
+    // MARK: - Configuration
+
+    private let autocaptureOptions: AutocaptureOptions
+
+    init(autocaptureOptions: AutocaptureOptions = AutocaptureOptions()) {
+        self.autocaptureOptions = autocaptureOptions
+    }
+
     // MARK: - Constants
 
     private static let maxHierarchyDepth = AutocaptureDefaults.maxHierarchyDepth
@@ -27,7 +35,7 @@ final class SemanticExtractor {
         // UIKit hit-testing returns the deepest view. For UIButton > UILabel,
         // we get the UILabel — wrong role, wrong el_id, not interactive.
         // Walk up to the nearest clickable ancestor when the leaf isn't interactive.
-        let interactiveAncestor = isInteractive(view) ? view : findInteractiveAncestor(of: view)
+        let interactiveAncestor: UIView? = isInteractive(view) ? view : findInteractiveAncestor(of: view)
         // Use the interactive ancestor as target for semantic extraction, but never UIWindow —
         // its gesture recognizers are infrastructure (TouchInterceptor), not user-facing controls.
         // Using UIWindow would produce wrong $el_id, tagName, role, etc.

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -56,14 +56,6 @@ final class SemanticExtractor {
         }
 
         let className = String(describing: type(of: targetView))
-        var accessibleLabel = findAccessibilityLabel(in: targetView)
-
-        // SwiftUI views render as internal UIKit views (e.g., PlatformGroupContainer) that
-        // don't carry the SwiftUI accessibilityLabel on the UIKit view. Query the SwiftUI
-        // accessibility element tree at the touch point to retrieve the label.
-        if accessibleLabel == nil, AutocaptureDefaults.isSwiftUIView(targetView) {
-            accessibleLabel = findSwiftUIAccessibilityLabel(at: point, view: targetView)
-        }
 
         // SwiftUI's .accessibilityIdentifier("…") never reaches the backing UIKit view either —
         // it lives in the same accessibility element tree as the label. Query it only for SwiftUI
@@ -75,8 +67,7 @@ final class SemanticExtractor {
             derivedIdentifier = findSwiftUIAccessibilityIdentifier(at: point, view: targetView)
         }
 
-        let elementId = resolveElementId(
-            for: targetView, derivedIdentifier: derivedIdentifier, derivedLabel: accessibleLabel)
+        let elementId = resolveElementId(for: targetView, derivedIdentifier: derivedIdentifier)
         let role = determineRole(for: targetView)
         let tagName = resolveTagName(className: className, role: role, view: targetView)
         let elements = buildViewHierarchy(from: targetView)
@@ -86,7 +77,6 @@ final class SemanticExtractor {
             y: point.y,
             elementId: elementId,
             tagName: tagName,
-            accessibleLabel: accessibleLabel,
             role: role,
             elements: elements,
             isInteractive: viewIsInteractive
@@ -103,18 +93,13 @@ final class SemanticExtractor {
     /// chose not to expose.
     ///
     /// Otherwise `DefaultElementIdExtractor` resolves it (React Native `nativeID` >
-    /// `accessibilityIdentifier` > `accessibilityLabel` > `<ClassName>_<hash>`; for SwiftUI the
-    /// `nativeID` step is skipped).
+    /// `accessibilityIdentifier` > `<ClassName>_<hash>`; for SwiftUI the `nativeID` step is skipped).
+    /// Accessibility labels are never used: they are localized and can carry user data.
     ///
     /// - Parameters:
     ///   - derivedIdentifier: Identifier read from SwiftUI's accessibility element tree, used at the
     ///     `accessibilityIdentifier` priority step when the view carries none itself.
-    ///   - derivedLabel: The accessibility label already resolved by `extractSemantics`, including
-    ///     labels read from SwiftUI's accessibility element tree. Used at the `accessibilityLabel`
-    ///     priority step.
-    private func resolveElementId(
-        for view: UIView, derivedIdentifier: String?, derivedLabel: String?
-    ) -> String {
+    private func resolveElementId(for view: UIView, derivedIdentifier: String?) -> String {
         if let custom = autocaptureOptions.elementIdExtractor {
             if let customId = custom.extractElementId(from: view), !customId.isEmpty {
                 return customId
@@ -122,39 +107,10 @@ final class SemanticExtractor {
             return DefaultElementIdExtractor.anonymousId(for: view)
         }
         return DefaultElementIdExtractor.shared.elementId(
-            for: view,
-            accessibilityIdentifierFallback: derivedIdentifier,
-            accessibilityLabelFallback: derivedLabel)
+            for: view, accessibilityIdentifierFallback: derivedIdentifier)
     }
 
     // MARK: - Accessibility Property Discovery
-
-    /// Returns the view's accessibilityLabel only if it was explicitly set by the developer.
-    ///
-    /// UIKit auto-derives accessibilityLabel from child text content for container
-    /// views where isAccessibilityElement is false. That derived text may contain
-    /// sensitive information (e.g., account numbers, personal details).
-    ///
-    /// For known UIKit controls (UIButton, UILabel, etc.) and SwiftUI views, the
-    /// label is always intentional (title-derived or explicitly set), so we capture it.
-    /// For generic container views (e.g., React Native's RCTView), we only capture
-    /// the label when isAccessibilityElement is true — in React Native, this maps
-    /// to `accessible={true}`, signaling an explicitly set label.
-    private func findAccessibilityLabel(in view: UIView) -> String? {
-        let isKnownControl =
-            view is UIButton || view is UILabel || view is UISwitch
-            || view is UISlider || view is UITextField || view is UITextView
-            || view is UISegmentedControl || view is UIStepper || view is UIImageView
-        if !isKnownControl && !view.isAccessibilityElement
-            && !AutocaptureDefaults.isSwiftUIView(view)
-        {
-            return nil
-        }
-        if let label = view.accessibilityLabel, !label.isEmpty {
-            return label
-        }
-        return nil
-    }
 
     // MARK: - Role Detection
 
@@ -272,40 +228,6 @@ final class SemanticExtractor {
             current = v.superview
             depth += 1
         }
-        return nil
-    }
-
-    /// Query the SwiftUI accessibility element tree at the touch point to retrieve the label.
-    ///
-    /// SwiftUI views render as internal UIKit views (e.g., PlatformGroupContainer) that don't
-    /// expose `accessibilityLabel` on the UIKit view. The label lives in SwiftUI's accessibility
-    /// element tree, which we can query via `accessibilityHitTest`.
-    ///
-    /// We walk up to find the UIHostingController's view (class name contains "Hosting"),
-    /// which owns the full SwiftUI accessibility tree. Calling `accessibilityHitTest` on
-    /// a leaf PlatformGroupContainer won't traverse the tree properly.
-    private func findSwiftUIAccessibilityLabel(at windowPoint: CGPoint, view: UIView) -> String? {
-        guard #available(iOS 18.0, *) else { return nil }
-        guard let window = view.window else { return nil }
-
-        // Walk up to find the UIHostingController's view which owns the accessibility tree
-        var current: UIView? = view
-        var depth = 0
-        while let v = current, depth < AutocaptureDefaults.maxAncestorSearchDepth {
-            let className = String(describing: type(of: v))
-            if className.contains("Hosting") {
-                let screenPoint = window.convert(windowPoint, to: window.screen.coordinateSpace)
-                if let element = v.accessibilityHitTest(screenPoint, event: nil) as? NSObject,
-                    let label = element.accessibilityLabel, !label.isEmpty
-                {
-                    return label
-                }
-                break
-            }
-            current = v.superview
-            depth += 1
-        }
-
         return nil
     }
 

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -56,8 +56,16 @@ final class SemanticExtractor {
         }
 
         let className = String(describing: type(of: targetView))
-        let elementId = generateElementId(for: targetView)
-        let accessibleLabel = findAccessibilityLabel(in: targetView)
+        var accessibleLabel = findAccessibilityLabel(in: targetView)
+
+        // SwiftUI views render as internal UIKit views (e.g., PlatformGroupContainer) that
+        // don't carry the SwiftUI accessibilityLabel on the UIKit view. Query the SwiftUI
+        // accessibility element tree at the touch point to retrieve the label.
+        if accessibleLabel == nil, AutocaptureDefaults.isSwiftUIView(targetView) {
+            accessibleLabel = findSwiftUIAccessibilityLabel(at: point, view: targetView)
+        }
+
+        let elementId = accessibleLabel ?? generateElementId(for: targetView)
         let role = determineRole(for: targetView)
         let tagName = resolveTagName(className: className, role: role, view: targetView)
         let elements = buildViewHierarchy(from: targetView)
@@ -76,18 +84,16 @@ final class SemanticExtractor {
 
     // MARK: - Element ID Generation
 
-    /// Generate element ID following platform-specific resolution rules:
+    /// Generate a hash-based element ID as fallback when no accessibility label is available.
     ///
-    /// Resolution order (same for UIKit and SwiftUI):
-    /// 1. `accessibilityLabel` (if non-empty)
-    /// 2. `accessibilityIdentifier` (if non-empty)
-    /// 3. `ClassName_<hash>`
+    /// Resolution order:
+    /// 1. `accessibilityIdentifier` (if non-empty)
+    /// 2. `ClassName_<hash>`
+    ///
+    /// Note: `accessibilityLabel` is checked by the caller (`extractSemantics`) via
+    /// `findAccessibilityLabel` before falling back to this method.
     private func generateElementId(for view: UIView) -> String {
-        // accessibilityLabel is primary for both UIKit and SwiftUI
-        if let label = findAccessibilityLabel(in: view), !label.isEmpty {
-            return label
-        }
-        // accessibilityIdentifier as fallback
+        // accessibilityIdentifier as primary fallback
         if let identifier = findAccessibilityIdentifier(in: view), !identifier.isEmpty {
             return identifier
         }
@@ -119,7 +125,27 @@ final class SemanticExtractor {
         return nil
     }
 
+    /// Returns the view's accessibilityLabel only if it was explicitly set by the developer.
+    ///
+    /// UIKit auto-derives accessibilityLabel from child text content for container
+    /// views where isAccessibilityElement is false. That derived text may contain
+    /// sensitive information (e.g., account numbers, personal details).
+    ///
+    /// For known UIKit controls (UIButton, UILabel, etc.) and SwiftUI views, the
+    /// label is always intentional (title-derived or explicitly set), so we capture it.
+    /// For generic container views (e.g., React Native's RCTView), we only capture
+    /// the label when isAccessibilityElement is true — in React Native, this maps
+    /// to `accessible={true}`, signaling an explicitly set label.
     private func findAccessibilityLabel(in view: UIView) -> String? {
+        let isKnownControl =
+            view is UIButton || view is UILabel || view is UISwitch
+            || view is UISlider || view is UITextField || view is UITextView
+            || view is UISegmentedControl || view is UIStepper || view is UIImageView
+        if !isKnownControl && !view.isAccessibilityElement
+            && !AutocaptureDefaults.isSwiftUIView(view)
+        {
+            return nil
+        }
         if let label = view.accessibilityLabel, !label.isEmpty {
             return label
         }
@@ -260,6 +286,40 @@ final class SemanticExtractor {
             current = v.superview
             depth += 1
         }
+        return nil
+    }
+
+    /// Query the SwiftUI accessibility element tree at the touch point to retrieve the label.
+    ///
+    /// SwiftUI views render as internal UIKit views (e.g., PlatformGroupContainer) that don't
+    /// expose `accessibilityLabel` on the UIKit view. The label lives in SwiftUI's accessibility
+    /// element tree, which we can query via `accessibilityHitTest`.
+    ///
+    /// We walk up to find the UIHostingController's view (class name contains "Hosting"),
+    /// which owns the full SwiftUI accessibility tree. Calling `accessibilityHitTest` on
+    /// a leaf PlatformGroupContainer won't traverse the tree properly.
+    private func findSwiftUIAccessibilityLabel(at windowPoint: CGPoint, view: UIView) -> String? {
+        guard #available(iOS 18.0, *) else { return nil }
+        guard let window = view.window else { return nil }
+
+        // Walk up to find the UIHostingController's view which owns the accessibility tree
+        var current: UIView? = view
+        var depth = 0
+        while let v = current, depth < AutocaptureDefaults.maxAncestorSearchDepth {
+            let className = String(describing: type(of: v))
+            if className.contains("Hosting") {
+                let screenPoint = window.convert(windowPoint, to: window.screen.coordinateSpace)
+                if let element = v.accessibilityHitTest(screenPoint, event: nil) as? NSObject,
+                    let label = element.accessibilityLabel, !label.isEmpty
+                {
+                    return label
+                }
+                break
+            }
+            current = v.superview
+            depth += 1
+        }
+
         return nil
     }
 

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -1,0 +1,276 @@
+//
+//  SemanticExtractor.swift
+//  Mixpanel
+//
+//  Created by Mixpanel on 2026-06-13.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/// Extracts semantic information from UIKit and SwiftUI views for autocapture events.
+///
+/// Handles element identification and role detection.
+final class SemanticExtractor {
+    // MARK: - Constants
+
+    private static let maxHierarchyDepth = AutocaptureDefaults.maxHierarchyDepth
+
+    // MARK: - Public API
+
+    /// Extract semantic information from a view at the given point.
+    ///
+    /// If the touched view is not interactive (e.g., a UILabel inside a UIButton),
+    /// walks up to find the nearest interactive ancestor and extracts from that instead.
+    func extractSemantics(from view: UIView, at point: CGPoint) -> ClickEvent {
+        // UIKit hit-testing returns the deepest view. For UIButton > UILabel,
+        // we get the UILabel — wrong role, wrong el_id, not interactive.
+        // Walk up to the nearest clickable ancestor when the leaf isn't interactive.
+        let interactiveAncestor = isInteractive(view) ? view : findInteractiveAncestor(of: view)
+        // Use the interactive ancestor as target for semantic extraction, but never UIWindow —
+        // its gesture recognizers are infrastructure (TouchInterceptor), not user-facing controls.
+        // Using UIWindow would produce wrong $el_id, tagName, role, etc.
+        let targetView: UIView
+        if let ancestor = interactiveAncestor, !(ancestor is UIWindow) {
+            targetView = ancestor
+        } else {
+            targetView = view
+        }
+        var viewIsInteractive = interactiveAncestor != nil
+
+        // SwiftUI buttons are rendered as internal UIKit views (e.g., PlatformGroupContainer)
+        // that lack UIKit interactivity signals (UIControl targets, gesture recognizers).
+        // The .button accessibility trait exists only in SwiftUI's accessibility element tree,
+        // not on the UIKit views. Query the accessibility tree at the touch point.
+        if !viewIsInteractive {
+            viewIsInteractive = isSwiftUIButtonAtPoint(point, view: view)
+        }
+
+        let className = String(describing: type(of: targetView))
+        let elementId = generateElementId(for: targetView)
+        let accessibleLabel = findAccessibilityLabel(in: targetView)
+        let role = determineRole(for: targetView)
+        let tagName = resolveTagName(className: className, role: role, view: targetView)
+        let elements = buildViewHierarchy(from: targetView)
+
+        return ClickEvent(
+            x: point.x,
+            y: point.y,
+            elementId: elementId,
+            tagName: tagName,
+            accessibleLabel: accessibleLabel,
+            role: role,
+            elements: elements,
+            isInteractive: viewIsInteractive
+        )
+    }
+
+    // MARK: - Element ID Generation
+
+    /// Generate element ID following platform-specific resolution rules:
+    ///
+    /// Resolution order (same for UIKit and SwiftUI):
+    /// 1. `accessibilityLabel` (if non-empty)
+    /// 2. `accessibilityIdentifier` (if non-empty)
+    /// 3. `ClassName_<hash>`
+    private func generateElementId(for view: UIView) -> String {
+        // accessibilityLabel is primary for both UIKit and SwiftUI
+        if let label = findAccessibilityLabel(in: view), !label.isEmpty {
+            return label
+        }
+        // accessibilityIdentifier as fallback
+        if let identifier = findAccessibilityIdentifier(in: view), !identifier.isEmpty {
+            return identifier
+        }
+
+        // Fallback: ClassName_<hex hash>
+        let className = String(describing: type(of: view))
+        let safeHash = view.hash == Int.min ? Int.max : abs(view.hash)
+        return "\(className)_\(String(safeHash, radix: 16))"
+    }
+
+    // MARK: - Accessibility Property Discovery
+
+    private func findAccessibilityIdentifier(
+        in view: UIView, maxLevels: Int = SemanticExtractor.maxHierarchyDepth
+    ) -> String? {
+        var currentView: UIView? = view
+        var level = 0
+
+        while let v = currentView, level < maxLevels {
+            if let identifier = v.accessibilityIdentifier, !identifier.isEmpty {
+                if !isInternalIdentifier(identifier) {
+                    return identifier
+                }
+            }
+            currentView = v.superview
+            level += 1
+        }
+
+        return nil
+    }
+
+    private func findAccessibilityLabel(in view: UIView) -> String? {
+        if let label = view.accessibilityLabel, !label.isEmpty {
+            return label
+        }
+        return nil
+    }
+
+    /// Check if an identifier is an internal framework identifier that should be skipped
+    private func isInternalIdentifier(_ identifier: String) -> Bool {
+        let internalPrefixes = [
+            "_",  // Private Apple identifiers
+            "AXID-",  // Accessibility internal
+            "UITransitionView",
+            "UILayoutContainerView",
+        ]
+
+        for prefix in internalPrefixes {
+            if identifier.hasPrefix(prefix) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    // MARK: - Role Detection
+
+    private func determineRole(for view: UIView) -> String? {
+        // Check specific control types first
+        if view is UIButton { return "Button" }
+        if view is UISwitch { return "Switch" }
+        if view is UISlider { return "Slider" }
+        if view is UITextField { return "TextField" }
+        if view is UITextView { return "TextArea" }
+        if view is UISegmentedControl { return "SegmentedControl" }
+        if view is UIStepper { return "Stepper" }
+        if view is UIImageView { return "Image" }
+        if view is UILabel { return "Text" }
+        if view is UIScrollView { return "ScrollView" }
+        if view is UITableView { return "List" }
+        if view is UICollectionView { return "Grid" }
+
+        // Check accessibility traits
+        let traits = view.accessibilityTraits
+        if traits.contains(.button) { return "Button" }
+        if traits.contains(.link) { return "Link" }
+        if traits.contains(.image) { return "Image" }
+        if traits.contains(.staticText) { return "Text" }
+        if traits.contains(.searchField) { return "SearchField" }
+        if traits.contains(.adjustable) { return "Adjustable" }
+        if traits.contains(.header) { return "Header" }
+        if traits.contains(.tabBar) { return "TabBar" }
+
+        return nil
+    }
+
+    // MARK: - Tag Name Resolution
+
+    /// For UIKit views, uses the raw class name (e.g., "UIButton", "UITableViewCell").
+    /// For SwiftUI views, the raw class name is an internal UIKit name (e.g., "_UIGraphicsView")
+    /// which is meaningless — use the role instead, falling back to "View".
+    private func resolveTagName(className: String, role: String?, view: UIView) -> String {
+        if AutocaptureDefaults.isSwiftUIView(view) {
+            return role ?? "View"
+        }
+        return className
+    }
+
+    // MARK: - View Hierarchy
+
+    private func buildViewHierarchy(
+        from view: UIView, maxLevels: Int = SemanticExtractor.maxHierarchyDepth
+    ) -> String {
+        var hierarchy: [String] = []
+        var currentView: UIView? = view
+        var level = 0
+
+        while let v = currentView, level < maxLevels {
+            var name = String(describing: type(of: v))
+
+            // Add identifier if available
+            if let identifier = v.accessibilityIdentifier, !identifier.isEmpty {
+                name += "#\(identifier)"
+            }
+
+            hierarchy.append(name)
+            currentView = v.superview
+            level += 1
+        }
+
+        return hierarchy.reversed().joined(separator: " > ")
+    }
+
+    // MARK: - Interactive View Resolution
+
+    /// Check if a view is interactive (has tap handlers or is a UIControl with targets).
+    private func isInteractive(_ view: UIView) -> Bool {
+        return AutocaptureDefaults.isInteractive(view)
+    }
+
+    // MARK: - SwiftUI Interactivity Detection
+
+    /// Check if a SwiftUI button exists at the given point using the accessibility element tree.
+    ///
+    /// SwiftUI renders buttons as internal UIKit views (e.g., PlatformGroupContainer) that lack
+    /// standard UIKit interactivity signals. The `.button` accessibility trait exists only in
+    /// SwiftUI's accessibility element tree, not on the UIKit views themselves.
+    private func isSwiftUIButtonAtPoint(_ windowPoint: CGPoint, view: UIView) -> Bool {
+        // Only needed on iOS 18+ where SwiftUI renders buttons as PlatformGroupContainer
+        // without .button trait on the UIKit view. On older iOS, SwiftUI views like
+        // _UIGraphicsView carry the .button trait directly.
+        guard #available(iOS 18.0, *) else { return false }
+
+        // Find the nearest SwiftUI hosting ancestor — bails out early for pure UIKit views.
+        guard let hostingView = findHostingAncestor(of: view) else { return false }
+        guard let window = view.window else { return false }
+
+        // accessibilityHitTest expects screen coordinates
+        let screenPoint = window.convert(windowPoint, to: window.screen.coordinateSpace)
+
+        // Query the hosting view's accessibility tree rather than the entire window,
+        // limiting the search scope to just the SwiftUI content.
+        guard let element = hostingView.accessibilityHitTest(screenPoint, event: nil) as? NSObject else {
+            return false
+        }
+
+        return element.accessibilityTraits.contains(UIAccessibilityTraits.button)
+    }
+
+    /// Find the nearest SwiftUI hosting view ancestor.
+    /// Returns nil if the view is not inside a SwiftUI hierarchy.
+    private func findHostingAncestor(of view: UIView) -> UIView? {
+        var current: UIView? = view
+        var depth = 0
+        while let v = current, depth < AutocaptureDefaults.maxAncestorSearchDepth {
+            if AutocaptureDefaults.isSwiftUIView(v) {
+                return v
+            }
+            current = v.superview
+            depth += 1
+        }
+        return nil
+    }
+
+    /// Walk up the view hierarchy to find the nearest interactive ancestor.
+    /// Returns nil if no interactive ancestor is found within maxDepth levels.
+    private func findInteractiveAncestor(of view: UIView, maxDepth: Int = AutocaptureDefaults.maxAncestorSearchDepth)
+        -> UIView?
+    {
+        var current = view.superview
+        var depth = 0
+        while let v = current, depth < maxDepth {
+            if isInteractive(v) {
+                return v
+            }
+            current = v.superview
+            depth += 1
+        }
+        return nil
+    }
+
+}
+#endif

--- a/Sources/Autocapture/TouchInterceptor.swift
+++ b/Sources/Autocapture/TouchInterceptor.swift
@@ -1,0 +1,314 @@
+//
+//  TouchInterceptor.swift
+//  Mixpanel
+//
+//  Created by Mixpanel on 2026-06-13.
+//  Copyright (c) Mixpanel. All rights reserved.
+//
+
+#if os(iOS)
+import ObjectiveC
+import UIKit
+
+/// Intercepts touch events using a gesture recognizer approach.
+///
+/// Each AutocaptureManager owns its own TouchInterceptor instance.
+/// The interceptor adds non-exclusive gesture recognizers to windows
+/// that observe but never claim touch events.
+final class TouchInterceptor: NSObject, UIGestureRecognizerDelegate {
+
+    // MARK: - State
+
+    private var isInstalled = false
+    private weak var manager: AutocaptureManager?
+    private let lock = NSLock()
+    private var observedWindows = NSHashTable<UIWindow>.weakObjects()
+
+    // MARK: - Initialization
+
+    override init() {
+        super.init()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    // MARK: - Public API
+
+    /// Install the touch interceptor.
+    ///
+    /// - Parameter manager: The AutocaptureManager to delegate touch events to
+    func install(manager: AutocaptureManager) {
+        MixpanelLogger.debug(message: "TouchInterceptor: install() called, isInstalled=\(isInstalled)")
+
+        // Ensure installation happens on main thread
+        if !Thread.isMainThread {
+            MixpanelLogger.debug(message: "TouchInterceptor: dispatching to main thread")
+            DispatchQueue.main.async { [weak self] in
+                self?.performInstall(manager: manager)
+            }
+            return
+        }
+
+        performInstall(manager: manager)
+    }
+
+    private func performInstall(manager: AutocaptureManager) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !isInstalled else {
+            self.manager = manager
+            MixpanelLogger.debug(message: "TouchInterceptor: already installed, updated manager reference")
+            return
+        }
+
+        self.manager = manager
+
+        // Add gesture recognizer to all existing windows
+        // Use selector-based approach to avoid app extension issues
+        let sharedSelector = NSSelectorFromString("sharedApplication")
+        guard UIApplication.responds(to: sharedSelector),
+            let application = UIApplication.perform(sharedSelector)?.takeUnretainedValue() as? UIApplication
+        else {
+            MixpanelLogger.info(message: "TouchInterceptor: not running in app context, skipping window observation")
+            return
+        }
+
+        for window in application.windows {
+            addGestureRecognizer(to: window)
+        }
+
+        // Also check connected scenes for windows (iOS 13+)
+        if #available(iOS 13.0, *) {
+            for scene in application.connectedScenes {
+                if let windowScene = scene as? UIWindowScene {
+                    for window in windowScene.windows {
+                        addGestureRecognizer(to: window)
+                    }
+                }
+            }
+        }
+
+        // Set installed flag only after successful window instrumentation
+        isInstalled = true
+
+        // Re-register notification observer (removed during uninstall)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowDidBecomeVisible(_:)),
+            name: UIWindow.didBecomeVisibleNotification,
+            object: nil
+        )
+
+        MixpanelLogger.info(
+            message: "TouchInterceptor: installed successfully, observing \(observedWindows.count) windows")
+    }
+
+    /// Uninstall the touch interceptor.
+    func uninstall() {
+        // Ensure uninstall happens on main thread — gesture recognizer removal
+        // is a UIKit mutation. deinit can run on any thread.
+        if !Thread.isMainThread {
+            DispatchQueue.main.async { [weak self] in
+                self?.performUninstall()
+            }
+            return
+        }
+
+        performUninstall()
+    }
+
+    private func performUninstall() {
+        lock.lock()
+        defer { lock.unlock() }
+        manager = nil
+        // Stop observing new windows
+        NotificationCenter.default.removeObserver(
+            self, name: UIWindow.didBecomeVisibleNotification, object: nil)
+        // Remove only gesture recognizers owned by this instance
+        for window in observedWindows.allObjects {
+            window.gestureRecognizers?.removeAll { recognizer in
+                guard let touchRecognizer = recognizer as? TouchObservingGestureRecognizer else {
+                    return false
+                }
+                return touchRecognizer.owner === self
+            }
+        }
+        observedWindows.removeAllObjects()
+        isInstalled = false
+        MixpanelLogger.info(message: "TouchInterceptor: uninstalled")
+    }
+
+    // MARK: - Window Observation
+
+    @objc private func windowDidBecomeVisible(_ notification: Notification) {
+        guard isInstalled, let window = notification.object as? UIWindow else { return }
+        MixpanelLogger.debug(message: "TouchInterceptor: window became visible")
+        DispatchQueue.main.async { [weak self] in
+            self?.addGestureRecognizer(to: window)
+        }
+    }
+
+    private func addGestureRecognizer(to window: UIWindow) {
+        guard !observedWindows.contains(window) else { return }
+
+        // Add only our custom observing recognizer (not duplicate tap recognizer)
+        let observingRecognizer = TouchObservingGestureRecognizer(
+            target: self, action: #selector(handleTouchGesture(_:)), owner: self)
+        observingRecognizer.delegate = self
+        observingRecognizer.cancelsTouchesInView = false
+        observingRecognizer.delaysTouchesEnded = false
+        observingRecognizer.delaysTouchesBegan = false
+
+        window.addGestureRecognizer(observingRecognizer)
+        observedWindows.add(window)
+
+        MixpanelLogger.debug(message: "TouchInterceptor: added gesture recognizer to window")
+    }
+
+    // MARK: - Gesture Handling
+
+    /// Required by UIGestureRecognizer(target:action:) — never called because
+    /// TouchObservingGestureRecognizer handles touches via touchesBegan/touchesEnded
+    /// overrides and always transitions to .failed state.
+    @objc private func handleTouchGesture(_ gesture: TouchObservingGestureRecognizer) {
+    }
+
+    /// Called by the gesture recognizer when a touch ends
+    func processTouchEnded(at location: CGPoint, view: UIView?, window: UIWindow) {
+        MixpanelLogger.debug(message: "TouchInterceptor: touch ended at \(location)")
+
+        guard let manager = manager else {
+            MixpanelLogger.debug(message: "TouchInterceptor: manager is nil")
+            return
+        }
+
+        manager.handleTouch(at: location, view: view, window: window)
+    }
+
+    // MARK: - UIGestureRecognizerDelegate
+
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        return true  // Allow all other gesture recognizers to work
+    }
+
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldReceive touch: UITouch
+    ) -> Bool {
+        return true  // Receive all touches
+    }
+}
+
+// MARK: - Custom Gesture Recognizer
+
+/// A gesture recognizer that observes touches without claiming them.
+/// Filters scrolls/swipes by tracking max displacement across all moves and duration.
+class TouchObservingGestureRecognizer: UIGestureRecognizer {
+
+    /// Maximum displacement (in points) for a touch to be considered a tap.
+    /// Matches iOS recommended minimum tap target size guideline.
+    private static let maxTapDisplacement: CGFloat = 10.0
+    private static let maxTapDisplacementSq: CGFloat = maxTapDisplacement * maxTapDisplacement
+
+    /// Maximum duration (in seconds) for a touch to be considered a tap.
+    private static let maxTapDuration: TimeInterval = 0.5
+
+    /// The TouchInterceptor instance that owns this gesture recognizer.
+    /// Used during uninstall to remove only recognizers belonging to a specific interceptor.
+    weak var owner: TouchInterceptor?
+
+    private var downX: CGFloat = 0
+    private var downY: CGFloat = 0
+    private var downTime: TimeInterval = 0
+    private var exceededSlop = false
+
+    init(target: Any?, action: Selector?, owner: TouchInterceptor) {
+        self.owner = owner
+        super.init(target: target, action: action)
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+        guard touches.count == 1, let touch = touches.first else { return }
+        let location = touch.location(in: self.view)
+        downX = location.x
+        downY = location.y
+        downTime = CACurrentMediaTime()
+        exceededSlop = false
+    }
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
+        guard !exceededSlop, downTime > 0, let touch = touches.first else { return }
+        let location = touch.location(in: self.view)
+        let dx = location.x - downX
+        let dy = location.y - downY
+        if (dx * dx + dy * dy) > Self.maxTapDisplacementSq {
+            exceededSlop = true
+        }
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
+        defer {
+            downTime = 0
+            state = .failed
+        }
+
+        // Only process single-finger taps to avoid duplicate events from multi-touch
+        guard touches.count == 1, let touch = touches.first else {
+            return
+        }
+
+        guard let window = self.view as? UIWindow else {
+            return
+        }
+
+        // Filter scrolls/swipes: reject if any intermediate move exceeded slop
+        guard !exceededSlop, downTime > 0 else { return }
+
+        // Filter long presses: check duration
+        guard (CACurrentMediaTime() - downTime) < Self.maxTapDuration else {
+            return
+        }
+
+        let location = touch.location(in: window)
+        // touch.view can be nil for SwiftUI-managed views (sheets, popovers).
+        // Fall back to hit-testing the window to find the view at the touch point.
+        let view = touch.view ?? window.hitTest(location, with: nil)
+
+        owner?.processTouchEnded(at: location, view: view, window: window)
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
+        downTime = 0
+        exceededSlop = false
+        state = .cancelled
+    }
+
+    override func reset() {
+        super.reset()
+        downTime = 0
+        exceededSlop = false
+    }
+
+    override func canPrevent(_ preventedGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return false  // Never prevent other gesture recognizers
+    }
+
+    override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return false  // Cannot be prevented by other gesture recognizers
+    }
+
+    override func shouldRequireFailure(of otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return false  // Don't require others to fail
+    }
+
+    override func shouldBeRequiredToFail(by otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return false  // Don't need to fail for others
+    }
+}
+#endif

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -1378,26 +1378,6 @@ extension MixpanelInstance {
         }
     }
 
-    // MARK: - Autocapture
-
-    #if os(iOS)
-    /**
-      Signals to the SDK that a UI change occurred.
-
-      Call this when a UI change happens that the dead click detector cannot observe,
-      such as navigation in React Native or other framework-driven UI changes.
-      This cancels any pending dead click detection to prevent false positives.
-
-      This method is safe to call even if autocapture is not enabled; it will simply do nothing.
-      On Mac Catalyst, where autocapture is unsupported, it is always a no-op.
-     */
-    public func signalUIChange() {
-        #if !targetEnvironment(macCatalyst)
-        autocaptureManager?.signalUIChange()
-        #endif
-    }
-    #endif
-
 }
 
 extension MixpanelInstance {

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -109,8 +109,9 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
     ///   properties it captures may change in a future release before general availability.
     open var autocapture: Autocapture!
 
-    #if os(iOS)
+    #if os(iOS) && !targetEnvironment(macCatalyst)
     /// Autocapture manager for click, rage click, and dead click detection.
+    /// Not available on Mac Catalyst, where automatic capture is unsupported.
     var autocaptureManager: AutocaptureManager?
     #endif
 
@@ -558,11 +559,11 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
             optOutTracking()
         }
 
-        // Initialize autocapture if enabled (iOS only)
+        // Initialize autocapture if enabled (iOS only, excluding Mac Catalyst)
         // Done after opt-out check so autocapture is not started when tracking is opted out.
         // Note: optOutTracking() runs async on trackingQueue, so hasOptedOutTracking() may
         // not reflect the default yet. Check optOutTrackingByDefault directly as well.
-        #if os(iOS)
+        #if os(iOS) && !targetEnvironment(macCatalyst)
         if let autocaptureOpts = self.options.autocaptureOptions, autocaptureOpts.isEnabled {
             if optOutTrackingByDefault || hasOptedOutTracking() {
                 MixpanelLogger.info(message: "Autocapture disabled: tracking is opted out")
@@ -576,6 +577,10 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
                 autocaptureManager?.start()
                 MixpanelLogger.info(message: "AutocaptureManager started")
             }
+        }
+        #elseif os(iOS) && targetEnvironment(macCatalyst)
+        if let autocaptureOpts = self.options.autocaptureOptions, autocaptureOpts.isEnabled {
+            MixpanelLogger.info(message: "Autocapture is not supported on Mac Catalyst")
         }
         #endif
 
@@ -679,7 +684,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
 
     deinit {
         NotificationCenter.default.removeObserver(self)
-        #if os(iOS)
+        #if os(iOS) && !targetEnvironment(macCatalyst)
         autocaptureManager?.stop()
         #endif
         #if os(iOS) && !os(watchOS) && !targetEnvironment(macCatalyst)
@@ -1384,9 +1389,12 @@ extension MixpanelInstance {
       This cancels any pending dead click detection to prevent false positives.
 
       This method is safe to call even if autocapture is not enabled; it will simply do nothing.
+      On Mac Catalyst, where autocapture is unsupported, it is always a no-op.
      */
     public func signalUIChange() {
+        #if !targetEnvironment(macCatalyst)
         autocaptureManager?.signalUIChange()
+        #endif
     }
     #endif
 
@@ -1900,7 +1908,7 @@ extension MixpanelInstance {
                 flagManager.reset()
             }
 
-            #if os(iOS)
+            #if os(iOS) && !targetEnvironment(macCatalyst)
             self.autocaptureManager?.stop()
             #endif
         }
@@ -1932,7 +1940,7 @@ extension MixpanelInstance {
             }
             self.track(event: "$opt_in", properties: properties)
 
-            #if os(iOS)
+            #if os(iOS) && !targetEnvironment(macCatalyst)
             // Restart autocapture if it was configured but stopped due to opt-out
             if self.autocaptureManager == nil,
                 let autocaptureOpts = self.options.autocaptureOptions,

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -27,9 +27,9 @@ private let devicePrefix = "$device:"
 public protocol MixpanelProxyServerDelegate: AnyObject {
     /**
        Asks the delegate to return API resource items like query params & headers for proxy Server.
-    
+
        - parameter mixpanel: The mixpanel instance
-    
+
        - returns: return ServerProxyResource to give custom headers and query params.
        */
     func mixpanelResourceForProxyServer(_ name: String) -> ServerProxyResource?
@@ -39,9 +39,9 @@ public protocol MixpanelProxyServerDelegate: AnyObject {
 public protocol MixpanelDelegate: AnyObject {
     /**
        Asks the delegate if data should be uploaded to the server.
-    
+
        - parameter mixpanel: The mixpanel instance
-    
+
        - returns: return true to upload now or false to defer until later
        */
     func mixpanelWillFlush(_ mixpanel: MixpanelInstance) -> Bool
@@ -105,6 +105,11 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
 
     /// Accessor to the Mixpanel Autocapture API object.
     open var autocapture: Autocapture!
+
+    #if os(iOS)
+    /// Autocapture manager for click, rage click, and dead click detection.
+    var autocaptureManager: AutocaptureManager?
+    #endif
 
     /// Accessor the Mixpanel Feature Flags API object.
     open var flags: MixpanelFlags!
@@ -550,6 +555,27 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
             optOutTracking()
         }
 
+        // Initialize autocapture if enabled (iOS only)
+        // Done after opt-out check so autocapture is not started when tracking is opted out.
+        // Note: optOutTracking() runs async on trackingQueue, so hasOptedOutTracking() may
+        // not reflect the default yet. Check optOutTrackingByDefault directly as well.
+        #if os(iOS)
+        if let autocaptureOpts = self.options.autocaptureOptions, autocaptureOpts.isEnabled {
+            if optOutTrackingByDefault || hasOptedOutTracking() {
+                MixpanelLogger.info(message: "Autocapture disabled: tracking is opted out")
+            } else if MixpanelInstance.isiOSAppExtension() {
+                MixpanelLogger.info(message: "Autocapture disabled in app extension")
+            } else {
+                autocaptureManager = AutocaptureManager(
+                    options: autocaptureOpts,
+                    autocapture: autocapture
+                )
+                autocaptureManager?.start()
+                MixpanelLogger.info(message: "AutocaptureManager started")
+            }
+        }
+        #endif
+
         if let superProperties = superProperties {
             registerSuperProperties(superProperties)
         }
@@ -570,6 +596,7 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
         if self.options.featureFlagOptions.prefetchFlags {
             flags.loadFlags()
         }
+
     }
 
     public func getOptions() -> MixpanelOptions {
@@ -649,6 +676,9 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+        #if os(iOS)
+        autocaptureManager?.stop()
+        #endif
         #if os(iOS) && !os(watchOS) && !targetEnvironment(macCatalyst)
         if let reachability = self.reachability {
             if !SCNetworkReachabilitySetCallback(reachability, nil, nil) {
@@ -899,33 +929,33 @@ extension MixpanelInstance {
 
     /**
        Sets the distinct ID of the current user.
-    
+
        Mixpanel uses a randomly generated persistent UUID  as the default local distinct ID.
-    
+
        If you want to  use a unique persistent UUID, you can define the
        <code>MIXPANEL_UNIQUE_DISTINCT_ID</code> flag in your <code>Active Compilation Conditions</code>
        build settings. It then uses the IFV String (`UIDevice.current().identifierForVendor`) as
        the default local distinct ID. This ID will identify a user across all apps by the same vendor, but cannot be
        used to link the same user across apps from different vendors. If we are unable to get an IFV, we will fall
        back to generating a random persistent UUID.
-    
+
        For tracking events, you do not need to call `identify:`. However,
        **Mixpanel User profiles always requires an explicit call to `identify:`.**
        If calls are made to
        `set:`, `increment` or other `People`
        methods prior to calling `identify:`, then they are queued up and
        flushed once `identify:` is called.
-    
+
        If you'd like to use the default distinct ID for Mixpanel People as well
        (recommended), call `identify:` using the current distinct ID:
        `mixpanelInstance.identify(mixpanelInstance.distinctId)`.
-    
+
        When the distinct ID actually changes, this method also resets feature-flag state
        (in-memory variants, on-disk cache, and activated first-time-event set) before fetching
        flags under the new identity. Any `flags.loadFlags(completion:)` callbacks pending from
        a fetch that was in flight at the moment identify was called will fire with `false`
        (so callers don't hang) — they will *not* receive the result of the new identity's fetch.
-    
+
        - parameter distinctId: string that uniquely identifies the current user
        - parameter usePeople: boolean that controls whether or not to set the people distinctId to the event distinctId.
        This should only be set to false if you wish to prevent people profile updates for that user.
@@ -1009,18 +1039,18 @@ extension MixpanelInstance {
     /**
        The alias method creates an alias which Mixpanel will use to remap one id to another.
        Multiple aliases can point to the same identifier.
-    
+
        Please note: With Mixpanel Identity Merge enabled, calling alias is no longer required
        but can be used to merge two IDs in scenarios where identify() would fail
-    
-    
+
+
        `mixpanelInstance.createAlias("New ID", distinctId: mixpanelInstance.distinctId)`
-    
+
        You can add multiple id aliases to the existing id
-    
+
        `mixpanelInstance.createAlias("Newer ID", distinctId: mixpanelInstance.distinctId)`
-    
-    
+
+
        - parameter alias:      A unique identifier that you want to use as an identifier for this user.
        - parameter distinctId: The current user identifier.
        - parameter usePeople: boolean that controls whether or not to set the people distinctId to the event distinctId.
@@ -1112,7 +1142,7 @@ extension MixpanelInstance {
     /**
        Clears all stored properties including the distinct Id.
        Useful if your app's user logs out.
-    
+
        - parameter completion: an optional completion handler for when the reset has completed.
        */
     public func reset(completion: (() -> Void)? = nil) {
@@ -1244,12 +1274,12 @@ extension MixpanelInstance {
 
     /**
        Uploads queued data to the Mixpanel server.
-    
+
        By default, queued data is flushed to the Mixpanel servers every minute (the
        default for `flushInterval`), and on background (since
        `flushOnBackground` is on by default). You only need to call this
        method manually if you want to force a flush at a particular moment.
-    
+
        - parameter performFullFlush: A optional boolean value indicating whether a full flush should be performed. If `true`, a full flush will be triggered, sending all events to the server. Default to `false`, a partial flush will be executed for reducing memory footprint.
        - parameter completion: an optional completion handler for when the flush has completed.
        */
@@ -1340,6 +1370,23 @@ extension MixpanelInstance {
         }
     }
 
+    // MARK: - Autocapture
+
+    #if os(iOS)
+    /**
+      Signals to the SDK that a UI change occurred.
+
+      Call this when a UI change happens that the dead click detector cannot observe,
+      such as navigation in React Native or other framework-driven UI changes.
+      This cancels any pending dead click detection to prevent false positives.
+
+      This method is safe to call even if autocapture is not enabled; it will simply do nothing.
+     */
+    public func signalUIChange() {
+        autocaptureManager?.signalUIChange()
+    }
+    #endif
+
 }
 
 extension MixpanelInstance {
@@ -1348,12 +1395,12 @@ extension MixpanelInstance {
     /**
        Tracks an event with properties.
        Properties are optional and can be added only if needed.
-    
+
        Properties will allow you to segment your events in your Mixpanel reports.
        Property keys must be String objects and the supported value types need to conform to MixpanelType.
        MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
        If the event is being timed, the timer will stop and be added as a property.
-    
+
        - parameter event:      event name
        - parameter properties: properties dictionary
        */
@@ -1403,12 +1450,12 @@ extension MixpanelInstance {
     /**
        Tracks an event with properties and to specific groups.
        Properties and groups are optional and can be added only if needed.
-    
+
        Properties will allow you to segment your events in your Mixpanel reports.
        Property and group keys must be String objects and the supported value types need to conform to MixpanelType.
        MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
        If the event is being timed, the timer will stop and be added as a property.
-    
+
        - parameter event:      event name
        - parameter properties: properties dictionary
        - parameter groups:     groups dictionary
@@ -1494,13 +1541,13 @@ extension MixpanelInstance {
     /**
        Starts a timer that will be stopped and added as a property when a
        corresponding event is tracked.
-    
+
        This method is intended to be used in advance of events that have
        a duration. For example, if a developer were to track an "Image Upload" event
        she might want to also know how long the upload took. Calling this method
        before the upload code would implicitly cause the `track`
        call to record its duration.
-    
+
        - precondition:
        // begin timing the image upload:
        mixpanelInstance.time(event:"Image Upload")
@@ -1509,9 +1556,9 @@ extension MixpanelInstance {
        // track the event
        mixpanelInstance.track("Image Upload")
        }
-    
+
        - parameter event: the event name to be timed
-    
+
        */
     public func time(event: String) {
         let startTime = Date().timeIntervalSince1970
@@ -1528,7 +1575,7 @@ extension MixpanelInstance {
 
     /**
        Retrieves the time elapsed for the named event since time(event:) was called.
-    
+
        - parameter event: the name of the event to be tracked that was passed to time(event:)
        */
     public func eventElapsedTime(event: String) -> Double {
@@ -1559,7 +1606,7 @@ extension MixpanelInstance {
 
     /**
        Clears the event timer for the named event.
-    
+
        - parameter event: the name of the event to clear the timer for
        */
     public func clearTimedEvent(event: String) {
@@ -1574,7 +1621,7 @@ extension MixpanelInstance {
 
     /**
        Returns the currently set super properties.
-    
+
        - returns: the current super properties
        */
     public func currentSuperProperties() -> [String: Any] {
@@ -1599,13 +1646,13 @@ extension MixpanelInstance {
 
     /**
        Registers super properties, overwriting ones that have already been set.
-    
+
        Super properties, once registered, are automatically sent as properties for
        all event tracking calls. They save you having to maintain and add a common
        set of properties to your events.
        Property keys must be String objects and the supported value types need to conform to MixpanelType.
        MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
-    
+
        - parameter properties: properties dictionary
        */
     public func registerSuperProperties(_ properties: Properties) {
@@ -1627,10 +1674,10 @@ extension MixpanelInstance {
     /**
        Registers super properties without overwriting ones that have already been set,
        unless the existing value is equal to defaultValue. defaultValue is optional.
-    
+
        Property keys must be String objects and the supported value types need to conform to MixpanelType.
        MixpanelType can be either String, Int, UInt, Double, Float, Bool, [MixpanelType], [String: MixpanelType], Date, URL, or NSNull.
-    
+
        - parameter properties:   properties dictionary
        - parameter defaultValue: Optional. overwrite existing properties that have this value
        */
@@ -1656,7 +1703,7 @@ extension MixpanelInstance {
 
     /**
        Removes a previously registered super property.
-    
+
        As an alternative to clearing all properties, unregistering specific super
        properties prevents them from being recorded on future events. This operation
        does not affect the value of other super properties. Any property name that is
@@ -1664,7 +1711,7 @@ extension MixpanelInstance {
        Note that after removing a super property, events will show the attribute as
        having the value `undefined` in Mixpanel until a new value is
        registered.
-    
+
        - parameter propertyName: array of property name strings to remove
        */
     public func unregisterSuperProperty(_ propertyName: String) {
@@ -1685,7 +1732,7 @@ extension MixpanelInstance {
 
     /**
        Updates a super property atomically. The update function
-    
+
        - parameter update: closure to apply to super properties
        */
     func updateSuperProperty(
@@ -1709,7 +1756,7 @@ extension MixpanelInstance {
 
     /**
        Convenience method to set a single group the user belongs to.
-    
+
        - parameter groupKey: The property name associated with this group type (must already have been set up).
        - parameter groupID: The group the user belongs to.
        */
@@ -1723,7 +1770,7 @@ extension MixpanelInstance {
 
     /**
        Set the groups this user belongs to.
-    
+
        - parameter groupKey: The property name associated with this group type (must already have been set up).
        - parameter groupIDs: The list of groups the user belongs to.
        */
@@ -1739,7 +1786,7 @@ extension MixpanelInstance {
 
     /**
        Add a group to this user's membership for a particular group key
-    
+
        - parameter groupKey: The property name associated with this group type (must already have been set up).
        - parameter groupID: The new group the user belongs to.
        */
@@ -1772,7 +1819,7 @@ extension MixpanelInstance {
 
     /**
        Remove a group from this user's membership for a particular group key
-    
+
        - parameter groupKey: The property name associated with this group type (must already have been set up).
        - parameter groupID: The group value to remove.
        */
@@ -1805,7 +1852,7 @@ extension MixpanelInstance {
 
     /**
        Opt out tracking.
-    
+
        This method is used to opt out tracking. This causes all events and people request no longer
        to be sent back to the Mixpanel server.
        */
@@ -1849,17 +1896,21 @@ extension MixpanelInstance {
             if let flagManager = self.flags as? FeatureFlagManager {
                 flagManager.reset()
             }
+
+            #if os(iOS)
+            self.autocaptureManager?.stop()
+            #endif
         }
     }
 
     /**
        Opt in tracking.
-    
+
        Use this method to opt in an already opted out user from tracking. People updates and track calls will be
        sent to Mixpanel after using this method.
-    
+
        This method will internally track an opt in event to your project.
-    
+
        - parameter distinctId: an optional string to use as the distinct ID for events
        - parameter properties: an optional properties dictionary that could be passed to add properties to the opt-in event
        that is sent to Mixpanel
@@ -1877,13 +1928,34 @@ extension MixpanelInstance {
                 self.identify(distinctId: distinctId)
             }
             self.track(event: "$opt_in", properties: properties)
+
+            #if os(iOS)
+            // Restart autocapture if it was configured but stopped due to opt-out
+            if self.autocaptureManager == nil,
+                let autocaptureOpts = self.options.autocaptureOptions,
+                autocaptureOpts.isEnabled,
+                !MixpanelInstance.isiOSAppExtension()
+            {
+                let manager = AutocaptureManager(
+                    options: autocaptureOpts,
+                    autocapture: self.autocapture
+                )
+                self.autocaptureManager = manager
+                DispatchQueue.main.async {
+                    manager.start()
+                }
+                MixpanelLogger.info(message: "AutocaptureManager started after opt-in")
+            } else {
+                self.autocaptureManager?.start()
+            }
+            #endif
         }
 
     }
 
     /**
        Returns if the current user has opted out tracking.
-    
+
        - returns: the current super opted out tracking status
        */
     public func hasOptedOutTracking() -> Bool {

--- a/Sources/MixpanelInstance.swift
+++ b/Sources/MixpanelInstance.swift
@@ -104,6 +104,9 @@ open class MixpanelInstance: CustomDebugStringConvertible, FlushDelegate, AEDele
     open var people: People!
 
     /// Accessor to the Mixpanel Autocapture API object.
+    ///
+    /// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the
+    ///   properties it captures may change in a future release before general availability.
     open var autocapture: Autocapture!
 
     #if os(iOS)

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -266,7 +266,9 @@ public class MixpanelOptions {
     /// )
     /// ```
     ///
-    /// **Note:** Autocapture is only available on iOS.
+    /// **Note:** Autocapture is only available on iOS. It is not supported when the app runs as a
+    /// Mac Catalyst build; the options are accepted so shared iOS sources still compile, but no
+    /// automatic capture takes place there.
     ///
     /// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the
     ///   properties it captures may change in a future release before general availability.

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -253,6 +253,25 @@ public class MixpanelOptions {
     /// ```
     public let deviceIdProvider: (() -> String?)?
 
+    /// Configuration for automatic event capture (clicks, rage clicks, dead clicks).
+    ///
+    /// Autocapture is **disabled by default**. Provide an `AutocaptureOptions` instance
+    /// to enable automatic capture of user interactions.
+    ///
+    /// **Example — Enable autocapture with defaults:**
+    /// ```swift
+    /// let options = MixpanelOptions(
+    ///     token: "YOUR_TOKEN",
+    ///     autocaptureOptions: AutocaptureOptions()
+    /// )
+    /// ```
+    ///
+    /// **Note:** Autocapture is only available on iOS.
+    #if os(iOS)
+    public let autocaptureOptions: AutocaptureOptions?
+    #endif
+
+    #if os(iOS)
     public init(
         token: String,
         flushInterval: Double = 60,
@@ -263,7 +282,49 @@ public class MixpanelOptions {
         superProperties: Properties? = nil,
         serverURL: String? = nil,
         proxyServerConfig: ProxyServerConfig? = nil,
-        useGzipCompression: Bool = true,  // NOTE: This is a new default value!
+        useGzipCompression: Bool = true,
+        featureFlagsEnabled: Bool = false,
+        featureFlagsContext: [String: Any] = [:],
+        deviceIdProvider: (() -> String?)? = nil,
+        featureFlagOptions: FeatureFlagOptions? = nil,
+        excludeProperties: Set<String> = [],
+        autocaptureOptions: AutocaptureOptions? = nil
+    ) {
+        self.token = token
+        self.flushInterval = flushInterval
+        self.instanceName = instanceName
+        self.trackAutomaticEvents = trackAutomaticEvents
+        self.optOutTrackingByDefault = optOutTrackingByDefault
+        self.useUniqueDistinctId = useUniqueDistinctId
+        self.superProperties = superProperties
+        self.serverURL = serverURL
+        self.proxyServerConfig = proxyServerConfig
+        self.useGzipCompression = useGzipCompression
+        self.deviceIdProvider = deviceIdProvider
+        self.excludeProperties = excludeProperties
+        self.autocaptureOptions = autocaptureOptions
+
+        if let featureFlagOptions = featureFlagOptions {
+            self.featureFlagOptions = featureFlagOptions
+        } else {
+            self.featureFlagOptions = FeatureFlagOptions(
+                enabled: featureFlagsEnabled,
+                context: featureFlagsContext
+            )
+        }
+    }
+    #else
+    public init(
+        token: String,
+        flushInterval: Double = 60,
+        instanceName: String? = nil,
+        trackAutomaticEvents: Bool = false,
+        optOutTrackingByDefault: Bool = false,
+        useUniqueDistinctId: Bool = false,
+        superProperties: Properties? = nil,
+        serverURL: String? = nil,
+        proxyServerConfig: ProxyServerConfig? = nil,
+        useGzipCompression: Bool = true,
         featureFlagsEnabled: Bool = false,
         featureFlagsContext: [String: Any] = [:],
         deviceIdProvider: (() -> String?)? = nil,
@@ -283,7 +344,6 @@ public class MixpanelOptions {
         self.deviceIdProvider = deviceIdProvider
         self.excludeProperties = excludeProperties
 
-        // When featureFlagOptions is explicitly provided, it takes precedence
         if let featureFlagOptions = featureFlagOptions {
             self.featureFlagOptions = featureFlagOptions
         } else {
@@ -293,4 +353,5 @@ public class MixpanelOptions {
             )
         }
     }
+    #endif
 }

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -267,11 +267,8 @@ public class MixpanelOptions {
     /// ```
     ///
     /// **Note:** Autocapture is only available on iOS.
-    #if os(iOS)
     public let autocaptureOptions: AutocaptureOptions?
-    #endif
 
-    #if os(iOS)
     public init(
         token: String,
         flushInterval: Double = 60,
@@ -302,7 +299,11 @@ public class MixpanelOptions {
         self.useGzipCompression = useGzipCompression
         self.deviceIdProvider = deviceIdProvider
         self.excludeProperties = excludeProperties
+        #if os(iOS)
         self.autocaptureOptions = autocaptureOptions
+        #else
+        self.autocaptureOptions = nil
+        #endif
 
         if let featureFlagOptions = featureFlagOptions {
             self.featureFlagOptions = featureFlagOptions
@@ -313,45 +314,4 @@ public class MixpanelOptions {
             )
         }
     }
-    #else
-    public init(
-        token: String,
-        flushInterval: Double = 60,
-        instanceName: String? = nil,
-        trackAutomaticEvents: Bool = false,
-        optOutTrackingByDefault: Bool = false,
-        useUniqueDistinctId: Bool = false,
-        superProperties: Properties? = nil,
-        serverURL: String? = nil,
-        proxyServerConfig: ProxyServerConfig? = nil,
-        useGzipCompression: Bool = true,
-        featureFlagsEnabled: Bool = false,
-        featureFlagsContext: [String: Any] = [:],
-        deviceIdProvider: (() -> String?)? = nil,
-        featureFlagOptions: FeatureFlagOptions? = nil,
-        excludeProperties: Set<String> = []
-    ) {
-        self.token = token
-        self.flushInterval = flushInterval
-        self.instanceName = instanceName
-        self.trackAutomaticEvents = trackAutomaticEvents
-        self.optOutTrackingByDefault = optOutTrackingByDefault
-        self.useUniqueDistinctId = useUniqueDistinctId
-        self.superProperties = superProperties
-        self.serverURL = serverURL
-        self.proxyServerConfig = proxyServerConfig
-        self.useGzipCompression = useGzipCompression
-        self.deviceIdProvider = deviceIdProvider
-        self.excludeProperties = excludeProperties
-
-        if let featureFlagOptions = featureFlagOptions {
-            self.featureFlagOptions = featureFlagOptions
-        } else {
-            self.featureFlagOptions = FeatureFlagOptions(
-                enabled: featureFlagsEnabled,
-                context: featureFlagsContext
-            )
-        }
-    }
-    #endif
 }

--- a/Sources/MixpanelOptions.swift
+++ b/Sources/MixpanelOptions.swift
@@ -267,6 +267,9 @@ public class MixpanelOptions {
     /// ```
     ///
     /// **Note:** Autocapture is only available on iOS.
+    ///
+    /// - Warning: **Experimental (beta).** Autocapture may contain issues, and its API and the
+    ///   properties it captures may change in a future release before general availability.
     public let autocaptureOptions: AutocaptureOptions?
 
     public init(

--- a/context/AUTOCAPTURE.md
+++ b/context/AUTOCAPTURE.md
@@ -1,0 +1,271 @@
+# iOS Autocapture
+
+Autocapture automatically tracks user interactions in your iOS app without requiring manual instrumentation.
+
+## Overview
+
+Autocapture captures three types of events:
+
+| Event | Name | Description |
+|-------|------|-------------|
+| Click | `$mp_click` | Fired when a user taps any element |
+| Rage Click | `$mp_rage_click` | Fired when a user taps rapidly (4+ times) in the same area |
+| Dead Click | `$mp_dead_click` | Fired when a tap produces no visible UI response |
+
+**Privacy:** Autocapture is designed with privacy in mind. No personally identifiable information (PII) is captured by default.
+
+## Quick Start
+
+Autocapture is **disabled by default**. Enable it by providing `AutocaptureOptions` during SDK initialization:
+
+```swift
+import Mixpanel
+
+let options = MixpanelOptions(
+    token: "YOUR_TOKEN",
+    autocaptureOptions: AutocaptureOptions()
+)
+let mixpanel = Mixpanel.initialize(options: options)
+```
+
+That's it! No additional setup required. Autocapture automatically intercepts all touch events via a non-claiming gesture recognizer.
+
+## Configuration Options
+
+### ClickOptions
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `true` | Track all click events |
+
+### RageClickOptions
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `true` | Track rage click events |
+| `clickThreshold` | `4` | Number of clicks required to trigger |
+| `timeWindowMs` | `1000` | Time window in milliseconds |
+| `radius` | `44` | Spatial threshold in points |
+
+### DeadClickOptions
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `true` | Track dead click events |
+| `timeWindowMs` | `500` | Response wait time in milliseconds |
+
+### Custom Configuration Example
+
+```swift
+let autocaptureOpts = AutocaptureOptions(
+    clickOptions: ClickOptions(enabled: true),
+    rageClickOptions: RageClickOptions(
+        enabled: true,
+        clickThreshold: 5,        // Require 5 clicks instead of 4
+        timeWindowMs: 800         // Shorter time window
+    ),
+    deadClickOptions: DeadClickOptions(
+        enabled: false            // Disable dead click detection
+    )
+)
+
+let options = MixpanelOptions(
+    token: "YOUR_TOKEN",
+    autocaptureOptions: autocaptureOpts
+)
+```
+
+## Event Properties
+
+All autocapture events include these properties:
+
+| Property | Description |
+|----------|-------------|
+| `$x` | Touch X coordinate (screen points) |
+| `$y` | Touch Y coordinate (screen points) |
+| `$el_id` | Element identifier (see resolution rules below) |
+| `$el_tag_name` | Class name of the view (e.g., `UIButton`) |
+| `$attr-aria-label` | Accessibility label |
+| `$attr-role` | Element role (Button, Switch, etc.) |
+| `$elements` | View hierarchy string (max 5 levels) |
+
+## Element Identification (`$el_id`)
+
+The `$el_id` property uses different resolution rules for UIKit and SwiftUI:
+
+### UIKit Resolution Order
+
+1. `accessibilityIdentifier` (if non-empty)
+2. `accessibilityLabel` (if non-empty)
+3. `ClassName_<hash>` (fallback)
+
+```swift
+// Recommended: Set accessibilityIdentifier for reliable tracking
+button.accessibilityIdentifier = "checkout_button"
+
+// Alternative: accessibilityLabel (also used for VoiceOver)
+button.accessibilityLabel = "Checkout"
+```
+
+### SwiftUI Resolution Order
+
+1. `accessibilityLabel` (primary - always available)
+2. `accessibilityIdentifier` (only available when VoiceOver is active)
+3. `ClassName_<hash>` (fallback)
+
+```swift
+// Recommended: Use accessibilityLabel (always works)
+Button("Checkout") { /* ... */ }
+    .accessibilityLabel("checkout_button")
+
+// Note: accessibilityIdentifier only works when VoiceOver is active
+Button("Checkout") { /* ... */ }
+    .accessibilityIdentifier("checkout_button")  // May not be captured
+```
+
+**Why the difference?** SwiftUI's accessibility tree is lazily materialized only when VoiceOver or Accessibility Inspector is running. Without these tools, `accessibilityIdentifier` returns nil.
+
+## Dead Click Detection
+
+Dead click detection monitors interactive elements for UI response:
+
+### How It Works
+
+1. User taps an element with interaction handlers
+2. Capture a snapshot of the UI state immediately (synchronous baseline)
+3. Wait 500ms (time window)
+4. Capture a final snapshot and compare with baseline
+5. If UI hasn't changed, emit `$mp_dead_click`
+
+### Excluded Controls
+
+These controls are excluded from dead click detection because they always produce a visual response when tapped (inherent feedback). They still emit `$mp_click` events.
+
+**UIKit:**
+- `UITextField` / `UITextView` - Keyboard appears
+- `UISwitch` - Toggles own state
+- `UISlider` - Thumb moves
+- `UIStepper` - Value changes
+- `UISegmentedControl` - Selection changes
+- `UIDatePicker` / `UIPickerView` - Picker UI appears
+
+**SwiftUI:**
+- `TextField` / `TextEditor` / `SecureField` - Keyboard appears
+- `Toggle` - Toggles own state
+- `Slider` / `Stepper` - Value changes
+- `Picker` / `DatePicker` - Picker UI appears
+
+### What Counts as UI Change
+
+- View count change (new views added/removed)
+- Content change (text, button titles, etc.)
+- Window count change (alerts, sheets, modals)
+
+**Note:** Text input controls (`UITextField`, `UITextView`, `TextField`, etc.) are fully excluded from dead click monitoring, so the keyboard appearing after a tap does not produce a false `$mp_dead_click`.
+
+## Platform Support
+
+| Platform | Support | Notes |
+|----------|---------|-------|
+| iOS | Full | Primary target |
+| iPadOS | Full | Same as iOS |
+| macOS (Catalyst) | Limited | May need testing |
+| tvOS | Not supported | Different interaction model |
+| watchOS | Not supported | Different SDK |
+| visionOS | Not supported | Different interaction model |
+
+## Requirements
+
+- iOS 12.0+
+- Swift 5.3+
+- SwiftUI autocapture requires iOS 13+
+
+## Troubleshooting
+
+### Enable Debug Logging
+
+```swift
+Mixpanel.mainInstance().loggingEnabled = true
+```
+
+This will log autocapture events to the console:
+```
+AutocaptureManager: emitted $mp_click for checkout_button
+AutocaptureManager: emitted $mp_rage_click for submit_btn (count: 4)
+AutocaptureManager: emitted $mp_dead_click for broken_link
+```
+
+### Verify Events in Dashboard
+
+1. Enable logging as shown above
+2. Trigger interactions in your app
+3. Check the Mixpanel Live View for events
+4. Events appear with names `$mp_click`, `$mp_rage_click`, `$mp_dead_click`
+
+### Common Issues
+
+**Events not appearing:**
+- Verify `autocaptureOptions` is passed to `MixpanelOptions`
+- Ensure the app is not in an app extension (autocapture is disabled in extensions)
+
+**SwiftUI elements showing hash IDs:**
+- Set `accessibilityLabel` on interactive elements
+- `accessibilityIdentifier` only works when VoiceOver is active
+
+**False positive dead clicks:**
+- Element may have a handler that doesn't produce visible UI change
+
+## Privacy Considerations
+
+### What is Captured
+
+- Touch coordinates
+- View class names and hierarchy
+- Accessibility labels and identifiers
+
+### What is NOT Captured
+
+- Visible text content (see note below)
+
+Autocapture does not capture visible text content (`$el_text`) from tapped elements. Tracking text can be invasive and raise privacy concerns. Additionally, the complexity of nested view hierarchies can cause text extraction to capture content from unintended views — for example, tapping a container view might extract text from a deeply nested label that isn't semantically related to the tap. The remaining captured properties (`$el_id`, `$el_tag_name`, `$attr-aria-label`, `$attr-role`, `$elements`) are purely structural UI metadata.
+
+### AppTrackingTransparency
+
+Autocapture does **not** require ATT permission. It is first-party analytics with:
+- No cross-app tracking
+- No IDFA usage
+- No new permission prompts
+
+## Technical Details
+
+### Touch Interception
+
+Autocapture uses a non-claiming gesture recognizer added to all windows to observe touch events. This approach:
+
+- Requires zero customer setup
+- Captures all windows (main, alerts, sheets, modals)
+- Works with SwiftUI via `UIHostingController`
+- Works with Expo after `expo prebuild`
+
+### Thread Safety
+
+All autocapture components use thread-safe patterns:
+- NSLock for mutable state
+- Main thread for UI operations
+- Weak references to prevent retain cycles
+
+### Performance
+
+Target performance budgets:
+- Touch event processing: < 5ms
+- Semantic extraction: < 10ms
+- Dead click snapshot: < 15ms
+
+## Migration from Manual Tracking
+
+If you're currently using manual `track()` calls for clicks, you can gradually migrate:
+
+1. Enable autocapture alongside existing tracking
+2. Compare event counts in dashboard
+3. Set meaningful `accessibilityIdentifier` values for important elements
+4. Remove redundant manual `track()` calls

--- a/context/AUTOCAPTURE.md
+++ b/context/AUTOCAPTURE.md
@@ -91,6 +91,15 @@ All autocapture events include these properties:
 
 ## Element Identification (`$el_id`)
 
+### Walk-Up to Clickable Parent
+
+When a non-interactive leaf view (e.g., `UILabel` inside a `UIButton`) is tapped, the SDK walks up the view hierarchy to the nearest interactive ancestor and uses its identity for `$el_id`. This is always-on behavior — not configurable.
+
+- The walk-up always takes the interactive parent's identity, even if the leaf has its own `accessibilityLabel`.
+- Stops at the first interactive ancestor (nested clickables: inner wins).
+- Max ancestor search depth: **10 levels**.
+- If no interactive ancestor is found within 10 levels, the leaf's own identity (or hash fallback) is used.
+
 The `$el_id` property uses different resolution rules for UIKit and SwiftUI:
 
 ### UIKit Resolution Order

--- a/context/AUTOCAPTURE.md
+++ b/context/AUTOCAPTURE.md
@@ -40,19 +40,22 @@ That's it! No additional setup required. Autocapture automatically intercepts al
 
 ### RageClickOptions
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `enabled` | `true` | Track rage click events |
-| `clickThreshold` | `4` | Number of clicks required to trigger |
-| `timeWindowMs` | `1000` | Time window in milliseconds |
-| `radius` | `44` | Spatial threshold in points |
+| Option | Default | Minimum | Description |
+|--------|---------|---------|-------------|
+| `enabled` | `true` | — | Track rage click events |
+| `clickThreshold` | `4` | `2` | Number of clicks required to trigger |
+| `timeWindowMs` | `1000` | `1` | Time window in milliseconds |
+| `radius` | `44` | `0` | Spatial threshold in points |
 
 ### DeadClickOptions
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `enabled` | `true` | Track dead click events |
-| `timeWindowMs` | `500` | Response wait time in milliseconds |
+| Option | Default | Minimum | Description |
+|--------|---------|---------|-------------|
+| `enabled` | `true` | — | Track dead click events |
+| `timeWindowMs` | `500` | `1` | Response wait time in milliseconds |
+
+Values below the minimum are clamped rather than rejected, matching the Android SDK. Passing an
+invalid value never throws and never crashes the host app.
 
 ### Custom Configuration Example
 

--- a/context/AUTOCAPTURE.md
+++ b/context/AUTOCAPTURE.md
@@ -85,54 +85,67 @@ All autocapture events include these properties:
 | `$y` | Touch Y coordinate (screen points) |
 | `$el_id` | Element identifier (see resolution rules below) |
 | `$el_tag_name` | Class name of the view (e.g., `UIButton`) |
-| `$attr-aria-label` | Accessibility label |
 | `$attr-role` | Element role (Button, Switch, etc.) |
 | `$elements` | View hierarchy string (max 5 levels) |
 
+There is no `$attr-aria-label` property. Accessibility labels are not reported at all.
+
 ## Element Identification (`$el_id`)
+
+`$el_id` resolution is internal to the SDK and not configurable by the host app.
 
 ### Walk-Up to Clickable Parent
 
 When a non-interactive leaf view (e.g., `UILabel` inside a `UIButton`) is tapped, the SDK walks up the view hierarchy to the nearest interactive ancestor and uses its identity for `$el_id`. This is always-on behavior — not configurable.
 
-- The walk-up always takes the interactive parent's identity, even if the leaf has its own `accessibilityLabel`.
+- The walk-up always takes the interactive parent's identity, even if the leaf has its own identifier.
 - Stops at the first interactive ancestor (nested clickables: inner wins).
 - Max ancestor search depth: **10 levels**.
 - If no interactive ancestor is found within 10 levels, the leaf's own identity (or hash fallback) is used.
 
-The `$el_id` property uses different resolution rules for UIKit and SwiftUI:
+`accessibilityLabel` is **never** a source, on either path: it is user-facing text, so it is
+localized — the same element would report a different identifier per language — and it can carry
+personal data.
 
 ### UIKit Resolution Order
 
-1. `accessibilityIdentifier` (if non-empty)
-2. `accessibilityLabel` (if non-empty)
-3. `ClassName_<hash>` (fallback)
+1. React Native `nativeID` — the JS-side prop, read through the Objective-C runtime so the SDK
+   carries no compile-time dependency on React Native
+2. `accessibilityIdentifier` (if non-empty, and not a framework-internal identifier such as
+   `_private` or `AXID-1`)
+3. `<ClassName>_<hash>` (fallback)
 
 ```swift
-// Recommended: Set accessibilityIdentifier for reliable tracking
+// Give the interactive element an accessibilityIdentifier
 button.accessibilityIdentifier = "checkout_button"
 
-// Alternative: accessibilityLabel (also used for VoiceOver)
+// accessibilityLabel is for VoiceOver only — it never becomes $el_id
 button.accessibilityLabel = "Checkout"
 ```
 
 ### SwiftUI Resolution Order
 
-1. `accessibilityLabel` (primary - always available)
-2. `accessibilityIdentifier` (only available when VoiceOver is active)
-3. `ClassName_<hash>` (fallback)
+1. `accessibilityIdentifier`, read from SwiftUI's accessibility element tree
+2. `<ClassName>_<hash>` (fallback)
+
+There is no `nativeID` step: React Native renders through UIKit, never SwiftUI.
 
 ```swift
-// Recommended: Use accessibilityLabel (always works)
 Button("Checkout") { /* ... */ }
-    .accessibilityLabel("checkout_button")
-
-// Note: accessibilityIdentifier only works when VoiceOver is active
-Button("Checkout") { /* ... */ }
-    .accessibilityIdentifier("checkout_button")  // May not be captured
+    .accessibilityIdentifier("checkout_button")
 ```
 
-**Why the difference?** SwiftUI's accessibility tree is lazily materialized only when VoiceOver or Accessibility Inspector is running. Without these tools, `accessibilityIdentifier` returns nil.
+**Caveat:** SwiftUI never puts the identifier on the backing UIKit view — it lives in the
+accessibility element tree, which the SDK queries via `accessibilityHitTest`. That query requires
+**iOS 18+**, and returns nil when no accessibility client is active. On iOS 15–17, or with the tree
+unmaterialized, SwiftUI elements fall through to `<ClassName>_<hash>`.
+
+### The hash fallback
+
+`<ClassName>_<hash>` is derived from the element's **position** in the hierarchy, not its instance,
+so it is stable across app launches. It identifies a position rather than a specific element:
+reordering siblings changes it, and two rows of the same list differ by index rather than by
+content. Instrument the elements you care about.
 
 ## Dead Click Detection
 
@@ -178,7 +191,7 @@ These controls are excluded from dead click detection because they always produc
 |----------|---------|-------|
 | iOS | Full | Primary target |
 | iPadOS | Full | Same as iOS |
-| macOS (Catalyst) | Limited | May need testing |
+| macOS (Catalyst) | Not supported | Options are accepted so shared iOS sources compile, but capture never starts |
 | tvOS | Not supported | Different interaction model |
 | watchOS | Not supported | Different SDK |
 | visionOS | Not supported | Different interaction model |
@@ -218,8 +231,14 @@ AutocaptureManager: emitted $mp_dead_click for broken_link
 - Ensure the app is not in an app extension (autocapture is disabled in extensions)
 
 **SwiftUI elements showing hash IDs:**
-- Set `accessibilityLabel` on interactive elements
-- `accessibilityIdentifier` only works when VoiceOver is active
+- Set `.accessibilityIdentifier("...")` on the interactive element — it is the only `$el_id` source
+- Reading it requires iOS 18+ and a materialized accessibility tree; on iOS 15–17 the element falls
+  back to the hash regardless of what you set
+- An `accessibilityLabel` will not help; it is never used as an identifier
+
+**UIKit or React Native elements showing hash IDs:**
+- Set `accessibilityIdentifier` on the element that handles the tap, or a `nativeID` prop in React
+  Native — an identifier on a non-interactive ancestor is not used
 
 **False positive dead clicks:**
 - Element may have a handler that doesn't produce visible UI change
@@ -230,13 +249,18 @@ AutocaptureManager: emitted $mp_dead_click for broken_link
 
 - Touch coordinates
 - View class names and hierarchy
-- Accessibility labels and identifiers
+- `accessibilityIdentifier`s and React Native `nativeID`s
+- Element roles
 
 ### What is NOT Captured
 
 - Visible text content (see note below)
+- Accessibility labels
 
-Autocapture does not capture visible text content (`$el_text`) from tapped elements. Tracking text can be invasive and raise privacy concerns. Additionally, the complexity of nested view hierarchies can cause text extraction to capture content from unintended views — for example, tapping a container view might extract text from a deeply nested label that isn't semantically related to the tap. The remaining captured properties (`$el_id`, `$el_tag_name`, `$attr-aria-label`, `$attr-role`, `$elements`) are purely structural UI metadata.
+Autocapture does not capture visible text content (`$el_text`) from tapped elements. Tracking text can be invasive and raise privacy concerns. Additionally, the complexity of nested view hierarchies can cause text extraction to capture content from unintended views — for example, tapping a container view might extract text from a deeply nested label that isn't semantically related to the tap. The remaining captured properties (`$el_id`, `$el_tag_name`, `$attr-role`, `$elements`) are purely structural UI metadata.
+
+`accessibilityLabel` is not captured either. It is user-facing text that can carry personal data, and
+it is localized, so it never becomes an identifier and is not reported as a property.
 
 ### AppTrackingTransparency
 

--- a/docs/ios-audit-report.md
+++ b/docs/ios-audit-report.md
@@ -1,0 +1,132 @@
+# iOS Autocapture Audit Report
+
+Cross-referenced against Android PR #982 review findings.
+Audited: 2026-07-02
+
+---
+
+## Issues That Apply to iOS
+
+### CRITICAL
+
+#### 3. Every touch-up treated as a click — scrolls and swipes emit `$mp_click`
+- **File:** `TouchInterceptor.swift:194`
+- **Status:** SAME AS ANDROID
+- **Description:** `TouchObservingGestureRecognizer.touchesEnded()` fires on every single-finger touch-up. `touchesBegan` (line 186) is empty — no down position recorded. `touchesMoved` (line 190) is empty — no movement tracking. No touch-slop check, no duration check. Every scroll, swipe, fling, or long press produces a spurious `$mp_click`.
+- **Fix:** Record touch-down position/timestamp in `touchesBegan`. In `touchesEnded`, verify displacement is within touch slop and duration is reasonable for a tap.
+- [x] Fixed
+- **Resolution:** Added `downLocation`/`downTime` tracking in `TouchObservingGestureRecognizer`. `touchesBegan` records position and timestamp. `touchesEnded` checks displacement <= 10pt (`maxTapDisplacement`) and duration < 500ms (`maxTapDuration`) before forwarding to `processTouchEnded`. Scrolls, swipes, and long presses are now filtered out. Matches Android's CurtainsHelper fix.
+
+### MEDIUM
+
+#### 4. Dead click baseline captured 150ms after click — fast UI responses absorbed
+- **File:** `DeadClickDetector.swift:213`
+- **Status:** SAME AS ANDROID
+- **Description:** `startMonitoring` schedules baseline capture via `asyncAfter(deadline: .now() + .milliseconds(baselineDelayMs))` with default 150ms. UI responses completing within 150ms are absorbed into the baseline, causing false positive dead clicks.
+- **Fix:** Capture baseline synchronously at click time.
+- [x] Fixed
+- **Resolution:** Baseline snapshot is now captured synchronously in `startMonitoring` before scheduling the timeout check. Removed `baselineDelayMs` field, `captureBaseline()` method, and the 150ms async delay. `PendingCheck.baselineSnapshot` changed from optional to non-optional. Only a single `asyncAfter` at `timeoutMs` remains. Matches Android's synchronous baseline logic.
+
+#### D7. Hit-testing picks deepest view, not the clickable target
+- **File:** `TouchInterceptor.swift:207`, `SemanticExtractor.swift:143-170`
+- **Status:** SAME AS ANDROID
+- **Description:** `touch.view` returns the deepest (frontmost) view via UIKit hit-testing. For UIButton > UILabel, the UILabel is returned. `determineRole()` checks only the passed view (not ancestors), so role="Text" instead of "Button". `hasInteractionHandlers()` (line 245) checks only the immediate view for gesture recognizers/UIControl targets — a UILabel inside a UIButton reports `isInteractive=false`.
+- **Fix:** Walk up to the nearest interactive ancestor when the leaf is non-interactive.
+- [x] Fixed
+- **Resolution:** Added `isInteractive(_:)` and `findInteractiveAncestor(of:maxDepth:)` to `SemanticExtractor`. `extractSemantics` now checks if the touched view is interactive (UIControl with targets, or has enabled UITapGestureRecognizer). If not, walks up the superview chain (max 5 levels) to find the nearest interactive ancestor and extracts semantics from that instead. Falls back to original view if no interactive ancestor found.
+
+#### D5. TouchInterceptor install: `isInstalled=true` set before window instrumentation succeeds
+- **File:** `TouchInterceptor.swift:77, 82-87`
+- **Status:** PARTIALLY APPLICABLE
+- **Description:** `isInstalled` is set to `true` on line 77 before the actual window instrumentation at lines 82+. If `UIApplication.shared` is unavailable (app extensions), install silently fails but `isInstalled` is already `true`, preventing retries. Also, `uninstall()` clears `observedWindows` and `isInstalled` but does NOT remove the `UIWindow.didBecomeVisibleNotification` observer — new windows after uninstall will still get gesture recognizers attached (though they no-op since `manager` is nil).
+- **Fix:** Set `isInstalled` only after successful window instrumentation. Remove notification observer in `uninstall()`.
+- [x] Fixed
+- **Resolution:** Moved `isInstalled = true` to after the window iteration loop. If `UIApplication.shared` is unavailable (app extensions), install returns without setting the flag, allowing retries. Notification observer management also fixed (see #10).
+
+### LOW
+
+#### D1. "Disabled by default" OR pattern
+- **File:** `AutocaptureOptions.swift:147-149`
+- **Status:** PARTIALLY APPLICABLE (mitigated)
+- **Description:** `isEnabled` is an OR over sub-options, same as Android. However, iOS mitigates the risk: `MixpanelOptions.autocaptureOptions` is `Optional` defaulting to `nil`. Autocapture only activates when the developer explicitly provides an `AutocaptureOptions` instance. The residual risk: if a developer already opted in and a new sub-option is added with `enabled: true` default, it silently activates.
+- **Fix:** Add a master enabled flag or ensure new sub-options default to `enabled: false`.
+- [ ] Not fixed (intentional)
+- **Resolution:** Not fixing — the double gate (optional autocaptureOptions + per-feature enabled flags) already provides adequate protection. The OR pattern matches Android's design, and the residual risk is minimal: new sub-options should default to `enabled: false` as a convention.
+
+#### 10. Notification observer persists after uninstall
+- **File:** `TouchInterceptor.swift:34-39, 108-118`
+- **Status:** PARTIALLY APPLICABLE
+- **Description:** `uninstall()` removes gesture recognizers and clears state, but the `UIWindow.didBecomeVisibleNotification` observer (registered in `init()`) is never removed except in `deinit`. Since `TouchInterceptor` is a singleton, `deinit` never runs. After `uninstall()`, new windows can still get gesture recognizers attached (though they no-op since `manager` is nil).
+- **Fix:** Remove notification observer in `uninstall()`. Add `guard isInstalled` check in `windowDidBecomeVisible`.
+- [x] Fixed
+- **Resolution:** Moved notification observer registration from `init()` to `performInstall()` (after successful window instrumentation). `uninstall()` now removes the observer. `windowDidBecomeVisible` guards with `isInstalled` check. Observer is re-registered on each `install()` call.
+
+---
+
+## Issues That Do NOT Apply to iOS
+
+| # | Issue | Why Not Applicable |
+|---|-------|--------------------|
+| **1** | Events dropped when `trackAutomaticEvents=false` | iOS autocapture uses `$mp_` prefix; the filter only drops `$ae_` events. Completely independent flags. |
+| **2** | WindowSpy mViews swap race | Invalid on Android too. iOS has no equivalent mechanism. |
+| **5** | Deferred init misses current screen | `performInstall()` proactively iterates all existing windows via `UIApplication.shared.windows` and attaches immediately. |
+| **6** | Dialogs/popups never captured | Invalid on Android (already fixed). iOS uses UIKit hit-testing which handles all windows naturally. |
+| **7** | Coordinate space mismatch | iOS uses `touch.location(in: window)` (window coordinates) consistently. No custom hit-testing — relies on `touch.view` from UIKit. |
+| **8** | Window.Callback methods not delegated | iOS uses a passive gesture recognizer, not callback wrapping. `cancelsTouchesInView=false`, `delaysTouchesEnded=false`, always transitions to `.failed`. No responder chain interference. |
+| **D2** | Two divergent detection mechanisms | iOS dead click detection uses a single unified snapshot mechanism for both UIKit and SwiftUI. (Note: exclusion lists ARE duplicated between `DeadClickDetector` and `SemanticExtractor` — see dead code section.) |
+| **D3** | Hardcoded change-detection sensitivity | iOS uses exact comparison (`viewCount !=`, `contentHash !=`), no +/-5 threshold. |
+| **D4** | MAX_ACCESSIBILITY_NODES misused | iOS uses correctly named `maxHierarchyDepth` (5, upward walk) and `maxRecursionDepth` (20, downward walk). No mislabeled constants. |
+| **D6** | Duplicate lifecycle callbacks | No duplication within autocapture. Legacy SDK has overlapping observers for different purposes (flush vs session). |
+| **P1** | Extraction before app receives touch | Gesture recognizer fires in `touchesEnded` — the app has already processed the touch through the responder chain. |
+| **P2** | Per-node coordinate conversion in DFS | iOS doesn't do DFS hit-testing. Uses `touch.view` from UIKit directly. Only walks upward for accessibility properties. |
+| **P5** | Hot-path logs build strings eagerly | `MixpanelLogger` uses `@autoclosure` — string interpolation is deferred and only evaluated when the log level is enabled. |
+
+---
+
+## iOS-Specific Dead Code and Issues
+
+#### Duplicated exclusion lists
+- **Files:** `DeadClickDetector.swift:62-91` and `SemanticExtractor.swift:215-236`
+- **Description:** `excludedControlTypes` + `swiftUIExcludedPatterns` are identical copies in both files. If one is updated without the other, behavior will diverge.
+- **Fix:** Extract to a shared constant.
+- [x] Fixed
+- **Resolution:** Moved both lists to `AutocaptureDefaults` in `AutocaptureOptions.swift` as shared `static let` constants. Both `DeadClickDetector` and `SemanticExtractor` now reference `AutocaptureDefaults.excludedControlTypes` and `AutocaptureDefaults.swiftUIExcludedPatterns`. Removed the `hasInteractionHandlers` method from `SemanticExtractor` (89 lines removed).
+
+#### `isInteractive` on ClickEvent is write-only
+- **File:** `ClickEvent.swift`
+- **Description:** `isInteractive` is set by `SemanticExtractor.extractSemantics()` but never included in `toProperties()` and never read anywhere. Dead data.
+- **Fix:** Either emit it or remove it.
+- [x] Fixed
+- **Resolution:** Removed `isInteractive` field from `ClickEvent`. Dead click detector has its own `hasInteractionHandlers()` check.
+
+#### `isRageClick` on ClickEvent is write-only
+- **File:** `ClickEvent.swift`
+- **Description:** `isRageClick` is set but never emitted in `toProperties()`. Rage click determination uses `RageClickResult.isRageClick` directly in `AutocaptureManager`, not the ClickEvent field.
+- **Fix:** Remove from ClickEvent — it's redundant with RageClickResult.
+- [x] Fixed
+- **Resolution:** Removed `isRageClick` field from `ClickEvent`. Also removed the rage click ClickEvent reconstruction in `AutocaptureManager.processTouch` that was rebuilding the entire struct just to set `isRageClick: true`.
+
+#### `tapCount` on non-rage ClickEvent is write-only
+- **File:** `ClickEvent.swift:49`, `AutocaptureManager.swift:211`
+- **Description:** Every ClickEvent gets `tapCount: 1`, but `toProperties()` never emits it. Only `emitRageClickEvent` manually adds `$tap_count`. For regular clicks, `tapCount` is dead data.
+- **Fix:** Remove from ClickEvent or include in `toProperties()`.
+- [x] Fixed
+- **Resolution:** Removed `tapCount` field from `ClickEvent`. Also removed `$tap_count` emission from `emitRageClickEvent` — the JS SDK doesn't send this property either (matches Android decision).
+
+#### `handleTouchGesture(_:)` is dead code
+- **File:** `TouchInterceptor.swift:148-150`
+- **Description:** Defined as the action for the gesture recognizer, but the comment says "This won't be called." The recognizer overrides `touchesEnded` directly and sets `state = .failed`, so this action method never fires. Exists because `UIGestureRecognizer(target:action:)` requires an action selector.
+- **Fix:** Document or remove.
+- [x] Fixed
+- **Resolution:** Kept the method (required by `UIGestureRecognizer(target:action:)`) but added a clear comment explaining why it exists and is intentionally empty.
+
+---
+
+## Summary
+
+| Severity | Count | Key Items |
+|----------|-------|-----------|
+| CRITICAL | 1 | Touch-slop/duration check missing (#3) |
+| MEDIUM | 3 | Dead click baseline delay (#4), deepest-view hit-testing (D7), install flag (D5) |
+| LOW | 2 | OR-based isEnabled (D1), notification observer leak (#10) |
+| Dead code | 5 | Duplicated exclusions, write-only fields, dead handler |


### PR DESCRIPTION
Rolls the autocapture feature branch up to `master`. Autocapture tracks user interactions with **zero host-app instrumentation** — enable it with one options object and the SDK captures taps across UIKit and SwiftUI, in every window.

**Experimental (beta).** The whole surface is documented as beta: the API and the properties captured may change before GA, so nothing here is frozen as a compatibility promise yet.

## What it does

Three event types, all on once autocapture is enabled:

| Event | Fires when |
|---|---|
| `$mp_click` | the user taps any element |
| `$mp_rage_click` | 4+ taps land within 1000 ms and 44 pt of each other |
| `$mp_dead_click` | a tap on an interactive element produces no UI change within 500 ms |

Every event carries `$x`, `$y`, `$el_id`, `$el_tag_name`, `$attr-role` and `$elements` (hierarchy, max 5 levels).

## Enabling it

```swift
let options = MixpanelOptions(
    token: "YOUR_TOKEN",
    autocaptureOptions: AutocaptureOptions()
)
let mixpanel = Mixpanel.initialize(options: options)
```

Passing no `autocaptureOptions` leaves autocapture entirely uninitialized — the manager is never constructed, so apps that don't opt in pay nothing at runtime. Each signal is independently configurable through `ClickOptions`, `RageClickOptions` (`clickThreshold`, `timeWindowMs`, `radius`) and `DeadClickOptions` (`timeWindowMs`); if all three are disabled, `AutocaptureOptions.isEnabled` is false and nothing starts.

Also public: `mixpanel.autocapture`, exposing manual `trackScreenView` / `trackScreenLeave` and `trackClick` / `trackRageClick` / `trackDeadClick` for apps that do their own click detection. All five now route through one helper that stamps `$mp_autocapture`.

## How it works

- **Touch interception** — a non-claiming `UIGestureRecognizer` is attached to every window (existing windows at install, plus new ones via `UIWindow.didBecomeVisibleNotification`). It never claims the touch and never prevents or is prevented by other recognizers, so it observes without altering behavior. This covers the main window, alerts, sheets and modals, `UIHostingController`-hosted SwiftUI, and React Native / Expo (after `expo prebuild`) with no customer setup.
- **Tap filtering** — touch-down position and timestamp are recorded, and a touch-up only counts as a tap if displacement ≤ 10 pt and duration < 500 ms. Scrolls, swipes, flings and long presses do not emit clicks.
- **Element identity** — `$el_id` resolves React Native `nativeID` (read through the Objective-C runtime, so no compile-time React Native dependency) → `accessibilityIdentifier` (framework-internal ids like `_private` / `AXID-1` rejected) → `<ClassName>_<hash>` for UIKit; `accessibilityIdentifier` from the accessibility element tree → `<ClassName>_<hash>` for SwiftUI. The hash describes the element's **position** in the hierarchy, not its instance, so ids survive app restarts. `accessibilityLabel` is deliberately never a source: it is localized and can carry user data. Resolution is SDK-owned and not configurable.
- **Walk-up to clickable parent** — a tap on a non-interactive leaf (a `UILabel` inside a `UIButton`) resolves identity and role from the nearest interactive ancestor, up to 10 levels; nested clickables resolve to the inner one. Always on, and matched to Android behavior.
- **Dead clicks** — baseline UI snapshot captured synchronously at click time (not on a delay, so a fast UI response is never absorbed into the baseline), compared 500 ms later against view count, content and window count. Controls with inherent visual feedback (`UITextField`, `UITextView`, `UISwitch`, `UISlider`, `UIStepper`, `UISegmentedControl`, `UIDatePicker`, `UIPickerView`, and their SwiftUI equivalents) are excluded by type so a keyboard or a toggle never reads as dead.
- **Privacy** — no text content (`$el_text`) is captured, `accessibilityLabel` is neither reported nor used as an identifier, and no ATT permission is required (no cross-app tracking, no IDFA, no new prompts).
- **Opt-out** — autocapture does not start when tracking is opted out (checked against both `optOutTrackingByDefault` and `hasOptedOutTracking()`, since the opt-out call is async on the tracking queue), and does not start inside app extensions.
- **Platform gating** — iOS and iPadOS only. `autocaptureOptions` is force-nil on non-iOS platforms in `MixpanelOptions.init`, and on Mac Catalyst the options are accepted so shared iOS sources compile but capture never starts (logged, not silent). tvOS / watchOS / visionOS are unsupported.

### SwiftUI caveat, stated plainly

SwiftUI never puts `accessibilityIdentifier` on the backing UIKit view — it lives in the accessibility element tree, which the SDK queries via `accessibilityHitTest`. That query requires **iOS 18+** and returns nil with no accessibility client active. On iOS 15–17, SwiftUI elements fall back to `<ClassName>_<hash>` regardless of what the app sets. Documented in `context/AUTOCAPTURE.md` rather than papered over.

## Included PRs

| PR | |
|---|---|
| #746 | autocapture frustration signals — click, rage click, dead click |
| #754 | consolidate `MixpanelOptions` init to a single cross-platform initializer |
| #758 | walk-up-to-clickable-parent |
| #762 | skip auto-derived accessibility labels to prevent PII leakage |
| #764 | pluggable `ElementIdExtractor` for `$el_id` resolution |
| #766 | address review feedback on threading and constants |
| #767 | never use `accessibilityLabel` as `$el_id`; drop `$attr-aria-label` |
| #768 | mark autocapture experimental (beta) |
| #770 | add `AutocaptureOptions` to the macOS, tvOS and watchOS compile sources |
| #771 | do not start autocapture on Mac Catalyst |
| #772 | remove the custom `ElementIdExtractor` from autocapture options |
| #773 | remove the unused `signalUIChange()` API |
| #774 | correct the autocapture doc for `$el_id` and platform support |

Note that #764 added a pluggable `ElementIdExtractor` and #772 took it back out — `$el_id` resolution is SDK-internal in the shipped surface. The file remains as the internal resolver.

## Scope

32 files, ~8.7k insertions. New `Sources/Autocapture/` (manager, `TouchInterceptor`, `SemanticExtractor`, `ElementIdExtractor`, `RageClickTracker`, `DeadClickDetector`, `ClickEvent`, options), autocapture wiring plus the beta warning in `MixpanelInstance`, the new `autocaptureOptions` parameter on `MixpanelOptions`, and `context/AUTOCAPTURE.md`.

**Tests:** 5 test files, ~3.9k lines — UIKit and SwiftUI instrumented tests, walk-up for both frameworks, unit tests for extraction and the detectors, and opt-out behavior. The demo app gains an autocapture menu with UIKit and SwiftUI screens, walk-up screens, and two complex-UI stress screens.

## Review-worthy changes outside the feature

1. **No new runtime dependencies.** Touch observation is a plain `UIGestureRecognizer` — unlike Android, which needed Curtains.
2. **Podspec source glob widened** — the `Complete` subspec's iOS `source_files` goes from `Sources/*.swift` to `Sources/**/*.swift` so the new `Sources/Autocapture/` directory is picked up by CocoaPods. Non-iOS platform globs are unchanged.
3. **`docs/ios-audit-report.md`** is included: the iOS-side cross-reference of the Android autocapture review findings, with each item's status and resolution. Worth a skim to see which classes of bug were already fixed on this branch (spurious clicks from scrolls, delayed dead-click baseline, deepest-view hit-testing).

## On `signalUIChange()`

Removed in #773 rather than shipped. It was an escape hatch for JS-driven navigation the dead click detector was assumed not to observe. React Native testing showed the concern does not reproduce — React Navigation renders through the native view hierarchy, so a JS-driven screen change mutates the native view tree inside the detection window and cancels the pending check like any other UI response. Dead clicks track correctly on React Native with no host-app cooperation on either platform, and the API is not being added to Android (mixpanel-android#1000).

## Merged with `master`

`master` (#769, scene delegate support in the sample app) is merged into this branch. Two demo-app-only conflicts resolved: `SceneDelegate.swift` took master's version (a superset — this branch had only the `window` property), and `project.pbxproj` took master's explicit `IPHONEOS_DEPLOYMENT_TARGET = 13.0` plus removal of this branch's duplicate `SceneDelegate.swift` file/build refs, which both sides had added under different UUIDs. No SDK source conflicted.

One further commit: a stale assertion in `AutocaptureWalkUpInstrumentedTests` still expected `accessibilityLabel` to become `$el_id`. It dated from #758 and was never updated by #767, which removed that source entirely — so it was failing on the branch before this merge. It now asserts the shipped behavior (hash fallback, and explicitly *not* the label).

**Verification:** SDK framework and demo app both build clean for iOS Simulator. Full `MixpanelDemoTests` suite run on iPhone 16 Pro (iOS 18.5): all autocapture suites pass. Three unrelated tests (`testValidPropertiesTrack`, `testValidSuperProperties`, `testPeopleTrackChargeWithTime`) fail intermittently — they fail identically on a clean `origin/master` checkout, so they are pre-existing flakes, not introduced here. The cause is `MixpanelBaseTests.allPropertyTypes()` force-unwrapping a `DateFormatter` parse of a `PDT` abbreviation, plus `AutomaticProperties.setUIProperties()` populating `$screen_width`/`$screen_height` via `DispatchQueue.main.async`, which races tests that track before yielding to the runloop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
