### PR TITLE
fix: add missing autocapture sources to podspec

### DIFF
--- a/Mixpanel-swift.podspec
+++ b/Mixpanel-swift.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
     'Sources/Flush.swift', 'Sources/Track.swift', 'Sources/People.swift', 'Sources/AutomaticEvents.swift',
     'Sources/Group.swift', 'Sources/ReadWriteLock.swift', 'Sources/SessionMetadata.swift', 'Sources/MPDB.swift', 'Sources/MixpanelPersistence.swift', 
     'Sources/Data+Compression.swift', 'Sources/MixpanelOptions.swift', 'Sources/FeatureFlags.swift',
-    'Sources/Autocapture.swift']
+    'Sources/Autocapture.swift', 'Sources/Autocapture/**/*.swift']
   s.tvos.deployment_target = '12.0'
   s.tvos.frameworks = 'UIKit', 'Foundation'
   s.tvos.pod_target_xcconfig = {


### PR DESCRIPTION
## Problem

`Release SPM` fails at **Validate podspec** ([run 33608373321](https://github.com/mixpanel/mixpanel-swift/actions/runs/33608373321/job/100180896740)) with 10 compile errors:

```
Sources/MixpanelOptions.swift:275,293:   cannot find type 'AutocaptureOptions' in scope   (x2)
Sources/Autocapture.swift:59,70,81,86:   cannot find type 'ClickEvent' in scope           (x4)
Sources/MixpanelInstance.swift:115:      cannot find type 'AutocaptureManager' in scope
Sources/MixpanelInstance.swift:573,1930: cannot find 'AutocaptureManager' in scope        (x2)
```

`base_source_files` in the podspec is a hand-maintained explicit file list. The autocapture work added nine files, but only the top-level `Sources/Autocapture.swift` was added to it — the eight under `Sources/Autocapture/` were left out:

```
Sources/Autocapture.swift                     <- listed
Sources/Autocapture/AutocaptureManager.swift  <- missing
Sources/Autocapture/AutocaptureOptions.swift  <- missing
Sources/Autocapture/DeadClickDetector.swift   <- missing
Sources/Autocapture/ElementIdExtractor.swift  <- missing
Sources/Autocapture/Model/ClickEvent.swift    <- missing
Sources/Autocapture/RageClickTracker.swift    <- missing
Sources/Autocapture/SemanticExtractor.swift   <- missing
Sources/Autocapture/TouchInterceptor.swift    <- missing
```

That list backs the `Core` subspec on **every** platform and the `Complete` subspec on tvOS/macOS/watchOS, so `Autocapture.swift`, `MixpanelOptions.swift` and `MixpanelInstance.swift` get compiled without the types they reference.

It went unnoticed because SPM (`Package.swift` uses `path: "Sources"`) and the `Complete`/iOS subspec (`Sources/**/*.swift`) both glob everything — only the explicit list was stale. **Left as is, 6.6.0 would ship a CocoaPods release that does not compile.**

## Fix

One line — include the whole directory in `base_source_files`:

```ruby
'Sources/Autocapture.swift', 'Sources/Autocapture/**/*.swift']
```

Safe on all platforms: every file under `Sources/Autocapture/` is internally wrapped in `#if os(iOS)`, and the types the cross-platform code needs (`AutocaptureOptions`, `ClickOptions`, `RageClickOptions`, `DeadClickOptions`) are declared outside that guard in `AutocaptureOptions.swift`.

## Verification

Ran the CI command locally (`pod lib lint Mixpanel-swift.podspec --allow-warnings`, CocoaPods 1.17.0) against `a2f82afc`:

| podspec | platforms | result |
| --- | --- | --- |
| master | ios | fail — the same 10 errors as CI |
| master | tvos | fail — `cannot find type 'AutocaptureOptions'` x2 |
| **this PR** | ios | passed validation |
| **this PR** | osx, watchos | passed validation |
| **this PR** | tvos | passed validation |
| **this PR** | **all (no filter)** | **passed validation, 0 errors** |

The full unfiltered lint built all eight platform x subspec combinations: iOS/tvOS/OSX/watchOS x Complete/Core.

## Follow-up (not in this PR)

The underlying bug is the hand-maintained file list, which will rot again on the next feature. Worth converting `base_source_files` to a glob with explicit exclusions.

Note: iOS CI is independently red on `a2f82afc` (test failures in `testTrackWithDefaultProperties`, `testSwiftUIImage_NoLabel_CheckDerivation`, and several `FeatureFlags` async timeouts) — pre-existing and unrelated to this change.
