### PR TITLE
fix: Limit autocapture pod sources to iOS

### DIFF
--- a/Mixpanel-swift.podspec
+++ b/Mixpanel-swift.podspec
@@ -24,7 +24,16 @@ Pod::Spec.new do |s|
     'Sources/Flush.swift', 'Sources/Track.swift', 'Sources/People.swift', 'Sources/AutomaticEvents.swift',
     'Sources/Group.swift', 'Sources/ReadWriteLock.swift', 'Sources/SessionMetadata.swift', 'Sources/MPDB.swift', 'Sources/MixpanelPersistence.swift', 
     'Sources/Data+Compression.swift', 'Sources/MixpanelOptions.swift', 'Sources/FeatureFlags.swift',
-    'Sources/Autocapture.swift']
+    'Sources/Autocapture.swift', 'Sources/Autocapture/AutocaptureOptions.swift']
+    
+  # Autocapture implementation is iOS-only: every file below is wrapped in `#if os(iOS)`,
+  # so it is added to the iOS source lists only. AutocaptureOptions.swift stays in
+  # base_source_files because MixpanelOptions exposes it on every platform.
+  ios_autocapture_source_files = ['Sources/Autocapture/AutocaptureManager.swift',
+    'Sources/Autocapture/DeadClickDetector.swift', 'Sources/Autocapture/ElementIdExtractor.swift',
+    'Sources/Autocapture/RageClickTracker.swift', 'Sources/Autocapture/SemanticExtractor.swift',
+    'Sources/Autocapture/TouchInterceptor.swift', 'Sources/Autocapture/Model/ClickEvent.swift']
+
   s.tvos.deployment_target = '12.0'
   s.tvos.frameworks = 'UIKit', 'Foundation'
   s.tvos.pod_target_xcconfig = {
@@ -49,7 +58,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'Core' do |ss|
-    ss.ios.source_files = base_source_files
+    ss.ios.source_files = base_source_files + ios_autocapture_source_files
     ss.tvos.source_files = base_source_files
     ss.osx.source_files = base_source_files
     ss.watchos.source_files = base_source_files


### PR DESCRIPTION
## Problem

  `pod lib lint Mixpanel-swift.podspec --allow-warnings` fails on `master` with 10 errors,
  blocking the 6.6.0 CocoaPods release:

  | Error | Affected targets |
  |---|---|
  | `cannot find type 'AutocaptureOptions'` — `MixpanelOptions.swift:275,293` | tvOS, macOS, watchOS (both subspecs) |
  | `cannot find type 'ClickEvent'` — `Autocapture.swift:59,70,81,86` | iOS `Core` |
  | `cannot find 'AutocaptureManager'` — `MixpanelInstance.swift:115,573,1930` | iOS `Core` |

  ## Root cause

  The autocapture feature (#776) added `Sources/Autocapture/`, but the podspec was never told
  about that directory — only the top-level `Sources/Autocapture.swift` was added to
  `base_source_files`. So the implementation files were compiled in exactly one configuration:
  iOS `Complete`, which happens to glob `Sources/**/*.swift`. Every other platform/subspec
  combination compiled code that referenced types whose defining files weren't in the target.

  This is a packaging bug, not a source bug — **no Swift files are changed here.** The sources
  already carry the correct platform guards:

  - 7 of the 8 files in `Sources/Autocapture/` are wrapped *entirely* in `#if os(iOS) … #endif`,
    so they compile to nothing off iOS.
  - `AutocaptureOptions.swift` is the deliberate exception: only its `import UIKit` and the UIKit
    helpers inside `AutocaptureDefaults` are guarded. Its public value types (`AutocaptureOptions`,
    `ClickOptions`, `RageClickOptions`, `DeadClickOptions`) need only `Foundation`/`CGFloat`.
    `MixpanelOptions` declares `autocaptureOptions` unconditionally and resolves it to `nil` off
    iOS, so every platform needs this one file.

  Notably, iOS `Core` was not deliberately excluding autocapture — it simply never listed the
  new directory.

  ## Changes

  `Mixpanel-swift.podspec` only:

  1. `base_source_files` gains `Sources/Autocapture/AutocaptureOptions.swift` — the
     cross-platform public options API, required by all four platforms.
  2. New `ios_autocapture_source_files` array listing the 7 `#if os(iOS)`-guarded
     implementation files, with a comment explaining why they're iOS-only.
  3. `Core` subspec: `ss.ios.source_files = base_source_files + ios_autocapture_source_files`.
2. New `ios_autocapture_source_files` array listing the 7 `#if os(iOS)`-guarded
   implementation files, with a comment explaining why they're iOS-only.
3. `Core` subspec: `ss.ios.source_files = base_source_files + ios_autocapture_source_files`.

iOS `Complete` needs no change — its `Sources/**/*.swift` glob already matched these files.

Files are enumerated explicitly rather than globbed as `Sources/Autocapture/**/*.swift`,
matching this podspec's existing convention of naming each file individually.

## Testing

`pod lib lint Mixpanel-swift.podspec --allow-warnings` → **`Mixpanel-swift passed validation.`**
(exit 0, 0 errors), covering all four platforms × both subspecs.

Resolved source files per configuration, verified via `cocoapods-core`:

| Subspec | iOS | tvOS | macOS | watchOS |
|---|---|---|---|---|
| `Complete` | 33 (9 autocapture) | 26 (2) | 26 (2) | 26 (2) |
| `Core` | 33 (9 autocapture) | 26 (2) | 26 (2) | 26 (2) |

tvOS/macOS/watchOS receive only `Autocapture.swift` + `AutocaptureOptions.swift`; the seven
iOS-only files are not shipped to them. Every listed path resolves to an existing file (no
typos in the explicit list).

Remaining lint warnings are pre-existing and unrelated to this change:
`result of call to 'write(closure:)' is unused` at `MixpanelInstance.swift:1523` and
`MixpanelLogger.swift:73,80`.

## Notes

`Core` and `Complete` now resolve to identical file sets on all platforms. They originally
differed by the `-D DECIDE` flag and the legacy Decide sources (in-app notifications, surveys,
A/B tweaks), which were removed from the SDK long ago; the autocapture gap was the last
remaining delta and was accidental. `Core` is kept as-is so existing
`pod 'Mixpanel-swift/Core'` Podfiles keep resolving. Consolidating or deprecating it is
out of scope here.

Fixes SDK-169