### PR TITLE
fix: read the React Native nativeID on the new architecture

### DIFF
--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
@@ -367,6 +367,14 @@ private final class FakeReactNativeView: UIView {
     @objc var nativeID: String?
 }
 
+/// Stands in for a Fabric `RCTViewComponentView`, which carries the prop as `nativeId`. It declares
+/// `nativeID` too and leaves it unset: React-Core compiles its `UIView (React)` category into every
+/// app, so a new-architecture view still *responds* to the legacy spelling while nothing assigns it.
+private final class FakeFabricReactNativeView: UIView {
+    @objc var nativeId: String?
+    @objc var nativeID: String?
+}
+
 /// Tests the `$el_id` resolution order implemented by `DefaultElementIdExtractor`:
 /// React Native `nativeID` > `accessibilityIdentifier` > `<ClassName>_<hash>`. Accessibility labels
 /// are never a source: they are localized and can carry user data.
@@ -415,6 +423,32 @@ class DefaultElementIdExtractorTests: XCTestCase {
         view.accessibilityIdentifier = "plain_view"
 
         XCTAssertEqual(elementId(for: view), "plain_view")
+    }
+
+    func testFabricNativeIdIsUsed() {
+        // The new architecture is the default from React Native 0.76 on.
+        let view = FakeFabricReactNativeView()
+        view.nativeId = "rn_fabric_button"
+        view.accessibilityIdentifier = "testid_identifier"
+
+        XCTAssertEqual(elementId(for: view), "rn_fabric_button")
+    }
+
+    func testUnsetFabricNativeIdFallsThroughToTheLegacySpelling() {
+        // Responding to a spelling is not the same as carrying a value, so an empty read has to
+        // continue to the next spelling rather than end resolution.
+        let view = FakeFabricReactNativeView()
+        view.nativeId = ""
+        view.nativeID = "rn_legacy_button"
+
+        XCTAssertEqual(elementId(for: view), "rn_legacy_button")
+    }
+
+    func testViewCarryingNeitherSpellingFallsThroughToIdentifier() {
+        let view = FakeFabricReactNativeView()
+        view.accessibilityIdentifier = "testid_identifier"
+
+        XCTAssertEqual(elementId(for: view), "testid_identifier")
     }
 
     // MARK: - Priority 2: accessibilityIdentifier
@@ -765,6 +799,99 @@ class ElementIdExtractorEndToEndTests: MixpanelBaseTests {
             RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.1))
         }
         return nil
+    }
+}
+
+// MARK: - Extraction Target: identified ancestors
+
+/// Stands in for a React Native pressable: it carries a `nativeID` but, because React Native
+/// dispatches touches from a single recognizer on the surface root, none of the UIKit interactivity
+/// signals `isInteractive` looks for.
+private final class FakePressableView: UIView {
+    @objc var nativeId: String?
+}
+
+/// Tests which view `SemanticExtractor` extracts from when the tapped leaf is not interactive:
+/// nearest interactive ancestor first, then nearest ancestor carrying an identifier, then the leaf.
+class SemanticExtractorTargetTests: XCTestCase {
+
+    private let extractor = SemanticExtractor()
+
+    private func elementId(tapping view: UIView) -> String {
+        return extractor.extractSemantics(from: view, at: .zero).elementId
+    }
+
+    private func interactiveView(identifier: String) -> UIView {
+        let view = UIView()
+        view.accessibilityIdentifier = identifier
+        view.addGestureRecognizer(UITapGestureRecognizer())
+        return view
+    }
+
+    func testLeafWithoutIdentityResolvesToIdentifiedAncestor() {
+        let container = UIView()
+        container.accessibilityIdentifier = "card_container"
+        let leaf = UILabel()
+        container.addSubview(leaf)
+
+        XCTAssertEqual(
+            elementId(tapping: leaf), "card_container",
+            "A named ancestor identifies the element better than the leaf's structural hash")
+    }
+
+    func testLeafResolvesToReactNativePressableAncestor() {
+        // The motivating case: hit-testing returns the `<Text>` inside a pressable, and only the
+        // pressable carries the developer-assigned identity.
+        let pressable = FakePressableView()
+        pressable.nativeId = "rn_checkout_button"
+        let leaf = UILabel()
+        pressable.addSubview(leaf)
+
+        XCTAssertEqual(elementId(tapping: leaf), "rn_checkout_button")
+    }
+
+    func testInteractiveAncestorWinsOverNearerIdentifiedAncestor() {
+        let interactive = interactiveView(identifier: "outer_button")
+        let identified = UIView()
+        identified.accessibilityIdentifier = "inner_card"
+        let leaf = UILabel()
+        identified.addSubview(leaf)
+        interactive.addSubview(identified)
+
+        XCTAssertEqual(
+            elementId(tapping: leaf), "outer_button",
+            "Confirmed interactivity outranks identity, even from further up the chain")
+    }
+
+    func testInteractiveLeafKeepsItsOwnIdentityDespiteIdentifiedAncestor() {
+        let container = UIView()
+        container.accessibilityIdentifier = "card_container"
+        let leaf = interactiveView(identifier: "inner_button")
+        container.addSubview(leaf)
+
+        XCTAssertEqual(elementId(tapping: leaf), "inner_button", "An interactive leaf never walks up")
+    }
+
+    func testLeafWithoutAnyIdentifiedAncestorKeepsItsStructuralHash() {
+        let container = UIView()
+        let leaf = UILabel()
+        container.addSubview(leaf)
+
+        let elementId = elementId(tapping: leaf)
+        XCTAssertNotNil(
+            elementId.range(of: "^UILabel_[0-9a-f]+$", options: .regularExpression),
+            "Expected UILabel_<hash>, got: \(elementId)")
+    }
+
+    func testFrameworkInternalIdentifierDoesNotMakeAnAncestorATarget() {
+        let container = UIView()
+        container.accessibilityIdentifier = "_UIKitPrivateContainer"
+        let leaf = UILabel()
+        container.addSubview(leaf)
+
+        XCTAssertNotNil(
+            elementId(tapping: leaf).range(of: "^UILabel_[0-9a-f]+$", options: .regularExpression),
+            "Framework-internal identifiers carry no product meaning and must be skipped")
     }
 }
 #endif

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
@@ -895,101 +895,66 @@ class SemanticExtractorTargetTests: XCTestCase {
     }
 }
 
-// MARK: - Interactivity Inference: React Native nativeID
+// MARK: - Interactivity: React Native
 
-/// Stands in for a legacy-bridge React Native pressable, which spells the prop `nativeID`.
-private final class FakeLegacyPressableView: UIView {
-    @objc var nativeID: String?
-}
-
-/// `isInteractive` gates dead click detection. UIKit exposes no signal that separates a React
-/// Native pressable from a plain `<View>`, so a `nativeID` stands in for one. A `testID`
-/// (`accessibilityIdentifier`) deliberately does not — it is applied to containers and labels
-/// as often as to buttons.
-class ReactNativeInteractivityInferenceTests: XCTestCase {
+/// `isInteractive` gates dead click detection, and React Native pressables carry no UIKit signal
+/// that could set it: no `UIControl`, no gesture recognizer, and no `.button` trait unless the app
+/// passes an explicit `accessibilityRole`. Dead clicks therefore depend on that role.
+///
+/// A `nativeID` deliberately does **not** stand in for it. Identifiers get applied to layout
+/// wrappers, scroll anchors and test hooks as readily as to buttons, so inferring interactivity
+/// from one would report dead clicks on containers that were never meant to respond. Identity and
+/// clickability are separate claims, and only the first can be read from an identifier.
+class ReactNativeInteractivityTests: XCTestCase {
 
     private let extractor = SemanticExtractor()
 
-    private func isInteractive(tapping view: UIView) -> Bool {
-        return extractor.extractSemantics(from: view, at: .zero).isInteractive
+    private func semantics(tapping view: UIView) -> ClickEvent {
+        return extractor.extractSemantics(from: view, at: .zero)
     }
 
-    func testLeafInsideNativeIdPressableIsInteractive() {
-        // The motivating case: the tap lands on the `<Text>`, the pressable holds the identity.
-        let pressable = FakePressableView()
-        pressable.nativeId = "rn_checkout_button"
-        let leaf = UILabel()
-        pressable.addSubview(leaf)
-
-        XCTAssertTrue(isInteractive(tapping: leaf))
+    private func pressable(nativeId: String? = nil, role: Bool = false) -> FakePressableView {
+        let view = FakePressableView()
+        view.nativeId = nativeId
+        if role { view.accessibilityTraits = .button }
+        return view
     }
 
-    func testNativeIdPressableTappedDirectlyIsInteractive() {
-        // Tapping the pressable's own padding rather than its label.
-        let pressable = FakePressableView()
-        pressable.nativeId = "rn_checkout_button"
-
-        XCTAssertTrue(isInteractive(tapping: pressable))
-    }
-
-    func testLegacySpellingAlsoInfersInteractivity() {
-        let pressable = FakeLegacyPressableView()
-        pressable.nativeID = "rn_checkout_button"
-        let leaf = UILabel()
-        pressable.addSubview(leaf)
-
-        XCTAssertTrue(isInteractive(tapping: leaf))
-    }
-
-    func testTestIdAloneDoesNotInferInteractivity() {
-        // `testID` identifies the element for attribution but says nothing about clickability;
-        // inferring it would report dead clicks on containers that were never meant to respond.
-        let container = UIView()
-        container.accessibilityIdentifier = "card_container"
+    func testNativeIdIdentifiesTheElementButDoesNotMakeItInteractive() {
+        let container = pressable(nativeId: "rn_checkout_button")
         let leaf = UILabel()
         container.addSubview(leaf)
 
-        XCTAssertFalse(isInteractive(tapping: leaf))
+        let event = semantics(tapping: leaf)
+
         XCTAssertEqual(
-            extractor.extractSemantics(from: leaf, at: .zero).elementId, "card_container",
-            "testID still redirects attribution, it just does not claim interactivity")
+            event.elementId, "rn_checkout_button",
+            "attribution still walks up to the named ancestor")
+        XCTAssertFalse(
+            event.isInteractive,
+            "a nativeID says which element was tapped, not that it was clickable")
     }
 
-    func testPlainLeafWithNoIdentityIsNotInteractive() {
-        XCTAssertFalse(isInteractive(tapping: UILabel()))
-    }
-
-    func testEmptyNativeIdDoesNotInferInteractivity() {
-        let pressable = FakePressableView()
-        pressable.nativeId = ""
+    func testAccessibilityRoleMakesAReactNativeElementInteractive() {
+        let button = pressable(role: true)
         let leaf = UILabel()
-        pressable.addSubview(leaf)
+        button.addSubview(leaf)
 
-        XCTAssertFalse(isInteractive(tapping: leaf))
+        XCTAssertTrue(semantics(tapping: leaf).isInteractive)
     }
 
-    func testUIKitControlRemainsInteractiveWithoutAnyNativeId() {
-        let button = UIButton()
-        button.addTarget(self, action: #selector(noop), for: .touchUpInside)
+    func testRoleAndNativeIdTogetherGiveInteractivityAndIdentity() {
+        // The combination React Native apps are asked to use: the role earns dead click
+        // detection, the nativeID earns a stable $el_id.
+        let button = pressable(nativeId: "rn_checkout_button", role: true)
+        let leaf = UILabel()
+        button.addSubview(leaf)
 
-        XCTAssertTrue(isInteractive(tapping: button))
+        let event = semantics(tapping: leaf)
+
+        XCTAssertTrue(event.isInteractive)
+        XCTAssertEqual(event.elementId, "rn_checkout_button")
     }
-
-    func testNativeIdBeyondSearchDepthIsNotReached() {
-        // The inference rides on the existing bounded walk-up; it does not widen it.
-        let pressable = FakePressableView()
-        pressable.nativeId = "rn_far_button"
-        var current: UIView = pressable
-        for _ in 0...AutocaptureDefaults.maxAncestorSearchDepth {
-            let spacer = UIView()
-            current.addSubview(spacer)
-            current = spacer
-        }
-
-        XCTAssertFalse(isInteractive(tapping: current))
-    }
-
-    @objc private func noop() {}
 }
 
 #endif

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
@@ -367,14 +367,6 @@ private final class FakeReactNativeView: UIView {
     @objc var nativeID: String?
 }
 
-/// Stands in for a Fabric `RCTViewComponentView`, which carries the prop as `nativeId`. It declares
-/// `nativeID` too and leaves it unset: React-Core compiles its `UIView (React)` category into every
-/// app, so a new-architecture view still *responds* to the legacy spelling while nothing assigns it.
-private final class FakeFabricReactNativeView: UIView {
-    @objc var nativeId: String?
-    @objc var nativeID: String?
-}
-
 /// Tests the `$el_id` resolution order implemented by `DefaultElementIdExtractor`:
 /// React Native `nativeID` > `accessibilityIdentifier` > `<ClassName>_<hash>`. Accessibility labels
 /// are never a source: they are localized and can carry user data.
@@ -423,32 +415,6 @@ class DefaultElementIdExtractorTests: XCTestCase {
         view.accessibilityIdentifier = "plain_view"
 
         XCTAssertEqual(elementId(for: view), "plain_view")
-    }
-
-    func testFabricNativeIdIsUsed() {
-        // The new architecture is the default from React Native 0.76 on.
-        let view = FakeFabricReactNativeView()
-        view.nativeId = "rn_fabric_button"
-        view.accessibilityIdentifier = "testid_identifier"
-
-        XCTAssertEqual(elementId(for: view), "rn_fabric_button")
-    }
-
-    func testUnsetFabricNativeIdFallsThroughToTheLegacySpelling() {
-        // Responding to a spelling is not the same as carrying a value, so an empty read has to
-        // continue to the next spelling rather than end resolution.
-        let view = FakeFabricReactNativeView()
-        view.nativeId = ""
-        view.nativeID = "rn_legacy_button"
-
-        XCTAssertEqual(elementId(for: view), "rn_legacy_button")
-    }
-
-    func testViewCarryingNeitherSpellingFallsThroughToIdentifier() {
-        let view = FakeFabricReactNativeView()
-        view.accessibilityIdentifier = "testid_identifier"
-
-        XCTAssertEqual(elementId(for: view), "testid_identifier")
     }
 
     // MARK: - Priority 2: accessibilityIdentifier
@@ -802,110 +768,65 @@ class ElementIdExtractorEndToEndTests: MixpanelBaseTests {
     }
 }
 
-// MARK: - Extraction Target: identified ancestors
+// MARK: - React Native nativeID Spellings
 
-/// Stands in for a React Native pressable: it carries a `nativeID` but, because React Native
-/// dispatches touches from a single recognizer on the surface root, none of the UIKit interactivity
-/// signals `isInteractive` looks for.
-private final class FakePressableView: UIView {
+/// The shape a real Fabric app presents: React-Core compiles the `UIView (React)` category into
+/// every app, so the view responds to the legacy `nativeID` as well — but only the Fabric
+/// `nativeId` is ever assigned. Resolution has to fall through the empty legacy read.
+private final class FakeFabricReactNativeView: UIView {
+    @objc var nativeId: String?
+    @objc var nativeID: String?
+}
+
+/// React Native spells the prop `nativeId` on the new architecture and `nativeID` on the legacy
+/// bridge. Both are probed, newest first.
+class ReactNativeNativeIdSpellingTests: XCTestCase {
+
+    private let extractor = DefaultElementIdExtractor.shared
+
+    private func elementId(for view: UIView) -> String {
+        return extractor.elementId(for: view, accessibilityIdentifierFallback: nil)
+    }
+
+    /// Regression: probing only `nativeID` — or stopping at it once `responds(to:)` succeeds —
+    /// resolves nothing on the new architecture and silently falls back to a structural hash.
+    func testFabricNativeIdWinsWhenLegacySpellingIsPresentButUnset() {
+        let view = FakeFabricReactNativeView()
+        view.nativeId = "rn_checkout_button"
+        view.accessibilityIdentifier = "tid_ignored"
+
+        XCTAssertEqual(elementId(for: view), "rn_checkout_button")
+    }
+
+    func testEmptyFabricSpellingFallsThroughToTheLegacyOne() {
+        let view = FakeFabricReactNativeView()
+        view.nativeId = ""
+        view.nativeID = "rn_legacy_button"
+
+        XCTAssertEqual(elementId(for: view), "rn_legacy_button")
+    }
+
+    func testNeitherSpellingFallsThroughToTheIdentifier() {
+        let view = FakeFabricReactNativeView()
+        view.accessibilityIdentifier = "tid_only"
+
+        XCTAssertEqual(elementId(for: view), "tid_only")
+    }
+}
+
+// MARK: - React Native: Which Element a Tap Resolves To
+
+/// Stands in for a React Native pressable. React Native dispatches touches from a single
+/// recognizer on the surface root, so the view carries no UIKit interactivity signal of its own
+/// unless the app sets an `accessibilityRole`.
+private final class FakeRNPressableView: UIView {
     @objc var nativeId: String?
 }
 
-/// Tests which view `SemanticExtractor` extracts from when the tapped leaf is not interactive:
-/// nearest interactive ancestor first, then nearest ancestor carrying an identifier, then the leaf.
-class SemanticExtractorTargetTests: XCTestCase {
-
-    private let extractor = SemanticExtractor()
-
-    private func elementId(tapping view: UIView) -> String {
-        return extractor.extractSemantics(from: view, at: .zero).elementId
-    }
-
-    private func interactiveView(identifier: String) -> UIView {
-        let view = UIView()
-        view.accessibilityIdentifier = identifier
-        view.addGestureRecognizer(UITapGestureRecognizer())
-        return view
-    }
-
-    func testLeafWithoutIdentityResolvesToIdentifiedAncestor() {
-        let container = UIView()
-        container.accessibilityIdentifier = "card_container"
-        let leaf = UILabel()
-        container.addSubview(leaf)
-
-        XCTAssertEqual(
-            elementId(tapping: leaf), "card_container",
-            "A named ancestor identifies the element better than the leaf's structural hash")
-    }
-
-    func testLeafResolvesToReactNativePressableAncestor() {
-        // The motivating case: hit-testing returns the `<Text>` inside a pressable, and only the
-        // pressable carries the developer-assigned identity.
-        let pressable = FakePressableView()
-        pressable.nativeId = "rn_checkout_button"
-        let leaf = UILabel()
-        pressable.addSubview(leaf)
-
-        XCTAssertEqual(elementId(tapping: leaf), "rn_checkout_button")
-    }
-
-    func testInteractiveAncestorWinsOverNearerIdentifiedAncestor() {
-        let interactive = interactiveView(identifier: "outer_button")
-        let identified = UIView()
-        identified.accessibilityIdentifier = "inner_card"
-        let leaf = UILabel()
-        identified.addSubview(leaf)
-        interactive.addSubview(identified)
-
-        XCTAssertEqual(
-            elementId(tapping: leaf), "outer_button",
-            "Confirmed interactivity outranks identity, even from further up the chain")
-    }
-
-    func testInteractiveLeafKeepsItsOwnIdentityDespiteIdentifiedAncestor() {
-        let container = UIView()
-        container.accessibilityIdentifier = "card_container"
-        let leaf = interactiveView(identifier: "inner_button")
-        container.addSubview(leaf)
-
-        XCTAssertEqual(elementId(tapping: leaf), "inner_button", "An interactive leaf never walks up")
-    }
-
-    func testLeafWithoutAnyIdentifiedAncestorKeepsItsStructuralHash() {
-        let container = UIView()
-        let leaf = UILabel()
-        container.addSubview(leaf)
-
-        let elementId = elementId(tapping: leaf)
-        XCTAssertNotNil(
-            elementId.range(of: "^UILabel_[0-9a-f]+$", options: .regularExpression),
-            "Expected UILabel_<hash>, got: \(elementId)")
-    }
-
-    func testFrameworkInternalIdentifierDoesNotMakeAnAncestorATarget() {
-        let container = UIView()
-        container.accessibilityIdentifier = "_UIKitPrivateContainer"
-        let leaf = UILabel()
-        container.addSubview(leaf)
-
-        XCTAssertNotNil(
-            elementId(tapping: leaf).range(of: "^UILabel_[0-9a-f]+$", options: .regularExpression),
-            "Framework-internal identifiers carry no product meaning and must be skipped")
-    }
-}
-
-// MARK: - Interactivity: React Native
-
-/// `isInteractive` gates dead click detection, and React Native pressables carry no UIKit signal
-/// that could set it: no `UIControl`, no gesture recognizer, and no `.button` trait unless the app
-/// passes an explicit `accessibilityRole`. Dead clicks therefore depend on that role.
-///
-/// A `nativeID` deliberately does **not** stand in for it. Identifiers get applied to layout
-/// wrappers, scroll anchors and test hooks as readily as to buttons, so inferring interactivity
-/// from one would report dead clicks on containers that were never meant to respond. Identity and
-/// clickability are separate claims, and only the first can be read from an identifier.
-class ReactNativeInteractivityTests: XCTestCase {
+/// The walk-up is keyed to interactivity, never to identity — matching Android, whose
+/// `walkUpToClickableParent` returns the tapped view unchanged when no clickable ancestor is
+/// found. A named but non-clickable container must not absorb the click.
+class ReactNativeExtractionTargetTests: XCTestCase {
 
     private let extractor = SemanticExtractor()
 
@@ -913,47 +834,56 @@ class ReactNativeInteractivityTests: XCTestCase {
         return extractor.extractSemantics(from: view, at: .zero)
     }
 
-    private func pressable(nativeId: String? = nil, role: Bool = false) -> FakePressableView {
-        let view = FakePressableView()
-        view.nativeId = nativeId
-        if role { view.accessibilityTraits = .button }
-        return view
-    }
-
-    func testNativeIdIdentifiesTheElementButDoesNotMakeItInteractive() {
-        let container = pressable(nativeId: "rn_checkout_button")
+    /// The parity case: a card with an `id` but no press handler must not claim taps that land on
+    /// the text inside it. Android reports the leaf here, and so must iOS.
+    func testNamedButNonClickableContainerDoesNotAbsorbTheClick() {
+        let card = FakeRNPressableView()
+        card.nativeId = "product_card"
         let leaf = UILabel()
-        container.addSubview(leaf)
+        card.addSubview(leaf)
 
         let event = semantics(tapping: leaf)
 
-        XCTAssertEqual(
-            event.elementId, "rn_checkout_button",
-            "attribution still walks up to the named ancestor")
-        XCTAssertFalse(
-            event.isInteractive,
-            "a nativeID says which element was tapped, not that it was clickable")
+        XCTAssertNotEqual(
+            event.elementId, "product_card",
+            "a non-clickable container must not take the identity of a tap on its child")
+        XCTAssertFalse(event.isInteractive)
     }
 
-    func testAccessibilityRoleMakesAReactNativeElementInteractive() {
-        let button = pressable(role: true)
-        let leaf = UILabel()
-        button.addSubview(leaf)
-
-        XCTAssertTrue(semantics(tapping: leaf).isInteractive)
-    }
-
-    func testRoleAndNativeIdTogetherGiveInteractivityAndIdentity() {
-        // The combination React Native apps are asked to use: the role earns dead click
-        // detection, the nativeID earns a stable $el_id.
-        let button = pressable(nativeId: "rn_checkout_button", role: true)
+    /// The setup React Native apps are asked to use: the role makes the pressable discoverable,
+    /// and the walk-up then resolves its nativeID.
+    func testPressableWithRoleResolvesItsNativeId() {
+        let button = FakeRNPressableView()
+        button.nativeId = "checkout_button"
+        button.accessibilityTraits = .button
         let leaf = UILabel()
         button.addSubview(leaf)
 
         let event = semantics(tapping: leaf)
 
+        XCTAssertEqual(event.elementId, "checkout_button")
         XCTAssertTrue(event.isInteractive)
-        XCTAssertEqual(event.elementId, "rn_checkout_button")
+    }
+
+    /// Without the role the pressable is invisible to UIKit, so the tap resolves to the leaf.
+    /// This is the cost of keying the walk-up to interactivity, and it is why the documentation
+    /// asks for `accessibilityRole="button"` alongside the identifier.
+    func testPressableWithoutRoleDoesNotResolveItsNativeId() {
+        let button = FakeRNPressableView()
+        button.nativeId = "checkout_button"
+        let leaf = UILabel()
+        button.addSubview(leaf)
+
+        XCTAssertNotEqual(semantics(tapping: leaf).elementId, "checkout_button")
+    }
+
+    /// Tapping the pressable directly still resolves, role or not, because the identifier is on
+    /// the hit view itself rather than reached by a walk-up.
+    func testPressableTappedDirectlyResolvesItsNativeId() {
+        let button = FakeRNPressableView()
+        button.nativeId = "checkout_button"
+
+        XCTAssertEqual(semantics(tapping: button).elementId, "checkout_button")
     }
 }
 

--- a/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
+++ b/MixpanelDemo/MixpanelDemoTests/AutocaptureTests.swift
@@ -894,4 +894,102 @@ class SemanticExtractorTargetTests: XCTestCase {
             "Framework-internal identifiers carry no product meaning and must be skipped")
     }
 }
+
+// MARK: - Interactivity Inference: React Native nativeID
+
+/// Stands in for a legacy-bridge React Native pressable, which spells the prop `nativeID`.
+private final class FakeLegacyPressableView: UIView {
+    @objc var nativeID: String?
+}
+
+/// `isInteractive` gates dead click detection. UIKit exposes no signal that separates a React
+/// Native pressable from a plain `<View>`, so a `nativeID` stands in for one. A `testID`
+/// (`accessibilityIdentifier`) deliberately does not — it is applied to containers and labels
+/// as often as to buttons.
+class ReactNativeInteractivityInferenceTests: XCTestCase {
+
+    private let extractor = SemanticExtractor()
+
+    private func isInteractive(tapping view: UIView) -> Bool {
+        return extractor.extractSemantics(from: view, at: .zero).isInteractive
+    }
+
+    func testLeafInsideNativeIdPressableIsInteractive() {
+        // The motivating case: the tap lands on the `<Text>`, the pressable holds the identity.
+        let pressable = FakePressableView()
+        pressable.nativeId = "rn_checkout_button"
+        let leaf = UILabel()
+        pressable.addSubview(leaf)
+
+        XCTAssertTrue(isInteractive(tapping: leaf))
+    }
+
+    func testNativeIdPressableTappedDirectlyIsInteractive() {
+        // Tapping the pressable's own padding rather than its label.
+        let pressable = FakePressableView()
+        pressable.nativeId = "rn_checkout_button"
+
+        XCTAssertTrue(isInteractive(tapping: pressable))
+    }
+
+    func testLegacySpellingAlsoInfersInteractivity() {
+        let pressable = FakeLegacyPressableView()
+        pressable.nativeID = "rn_checkout_button"
+        let leaf = UILabel()
+        pressable.addSubview(leaf)
+
+        XCTAssertTrue(isInteractive(tapping: leaf))
+    }
+
+    func testTestIdAloneDoesNotInferInteractivity() {
+        // `testID` identifies the element for attribution but says nothing about clickability;
+        // inferring it would report dead clicks on containers that were never meant to respond.
+        let container = UIView()
+        container.accessibilityIdentifier = "card_container"
+        let leaf = UILabel()
+        container.addSubview(leaf)
+
+        XCTAssertFalse(isInteractive(tapping: leaf))
+        XCTAssertEqual(
+            extractor.extractSemantics(from: leaf, at: .zero).elementId, "card_container",
+            "testID still redirects attribution, it just does not claim interactivity")
+    }
+
+    func testPlainLeafWithNoIdentityIsNotInteractive() {
+        XCTAssertFalse(isInteractive(tapping: UILabel()))
+    }
+
+    func testEmptyNativeIdDoesNotInferInteractivity() {
+        let pressable = FakePressableView()
+        pressable.nativeId = ""
+        let leaf = UILabel()
+        pressable.addSubview(leaf)
+
+        XCTAssertFalse(isInteractive(tapping: leaf))
+    }
+
+    func testUIKitControlRemainsInteractiveWithoutAnyNativeId() {
+        let button = UIButton()
+        button.addTarget(self, action: #selector(noop), for: .touchUpInside)
+
+        XCTAssertTrue(isInteractive(tapping: button))
+    }
+
+    func testNativeIdBeyondSearchDepthIsNotReached() {
+        // The inference rides on the existing bounded walk-up; it does not widen it.
+        let pressable = FakePressableView()
+        pressable.nativeId = "rn_far_button"
+        var current: UIView = pressable
+        for _ in 0...AutocaptureDefaults.maxAncestorSearchDepth {
+            let spacer = UIView()
+            current.addSubview(spacer)
+            current = spacer
+        }
+
+        XCTAssertFalse(isInteractive(tapping: current))
+    }
+
+    @objc private func noop() {}
+}
+
 #endif

--- a/Sources/Autocapture/ElementIdExtractor.swift
+++ b/Sources/Autocapture/ElementIdExtractor.swift
@@ -16,7 +16,8 @@ import UIKit
 ///
 /// Resolution priority:
 /// 1. **React Native `nativeID`** — read through the Objective-C runtime so the SDK carries no
-///    compile-time dependency on React Native. Skipped for SwiftUI views: React Native renders
+///    compile-time dependency on React Native. Both the new-architecture (`nativeId`) and legacy
+///    (`nativeID`) property spellings are probed. Skipped for SwiftUI views: React Native renders
 ///    through UIKit, never SwiftUI, so the probe could only ever be wasted work there.
 /// 2. **`accessibilityIdentifier`** — stable, developer-assigned, and not user-visible. Internal
 ///    framework identifiers (e.g. `_UIKit…`, `AXID-…`) are skipped.
@@ -32,6 +33,10 @@ import UIKit
 final class DefaultElementIdExtractor {
 
     static let shared = DefaultElementIdExtractor()
+
+    /// Where React Native puts the `nativeID` prop: `nativeId` on Fabric, `nativeID` on the legacy
+    /// bridge. Probed in this order.
+    private static let reactNativeIdKeys = ["nativeId", "nativeID"]
 
     /// Framework-internal identifier prefixes that carry no product meaning.
     private static let internalIdentifierPrefixes = [
@@ -52,15 +57,8 @@ final class DefaultElementIdExtractor {
         accessibilityIdentifierFallback: String?
     ) -> String {
         // 1. React Native nativeID (UIKit-backed views only)
-        if let nativeId = reactNativeId(for: view) {
-            return nativeId
-        }
-
         // 2. accessibilityIdentifier
-        if let identifier = view.accessibilityIdentifier,
-            !identifier.isEmpty,
-            !DefaultElementIdExtractor.isInternalIdentifier(identifier)
-        {
+        if let identifier = explicitIdentifier(for: view) {
             return identifier
         }
         if let fallbackIdentifier = accessibilityIdentifierFallback,
@@ -74,24 +72,41 @@ final class DefaultElementIdExtractor {
         return DefaultElementIdExtractor.anonymousId(for: view)
     }
 
+    /// Steps 1 and 2 only: the identifier the view carries itself, nil when it would resolve to
+    /// nothing but a structural hash. `SemanticExtractor` uses that distinction to prefer a named
+    /// ancestor over an anonymous leaf.
+    func explicitIdentifier(for view: UIView) -> String? {
+        if let nativeId = reactNativeId(for: view) {
+            return nativeId
+        }
+        if let identifier = view.accessibilityIdentifier,
+            !identifier.isEmpty,
+            !DefaultElementIdExtractor.isInternalIdentifier(identifier)
+        {
+            return identifier
+        }
+        return nil
+    }
+
     // MARK: - React Native
 
-    /// Reads React Native's `nativeID` property through the Objective-C runtime.
+    /// Reads React Native's `nativeID` prop through the Objective-C runtime, trying both spellings:
+    /// Fabric assigns `RCTViewComponentView.nativeId`, the legacy bridge the `UIView (React)`
+    /// category's `nativeID`. `responds(to:)` guards each read so KVC never throws — necessary but
+    /// not sufficient, since React-Core compiles that category into every app: *every* `UIView`
+    /// responds to `nativeID` even on Fabric, where nothing assigns it, so an empty read must fall
+    /// through to the next spelling rather than end resolution.
     ///
-    /// `RCTView` (and friends) expose `nativeID` as an Objective-C property carrying the JS-side
-    /// `nativeID` prop. `responds(to:)` is checked first so KVC never throws on views that do not
-    /// declare the key.
-    ///
-    /// Skipped entirely for SwiftUI views — React Native renders through the UIKit view hierarchy,
-    /// so a SwiftUI view can never carry a `nativeID`.
+    /// Skipped for SwiftUI views — React Native renders through UIKit, so they never carry one.
     private func reactNativeId(for view: UIView) -> String? {
         guard !AutocaptureDefaults.isSwiftUIView(view) else { return nil }
-        let selector = NSSelectorFromString("nativeID")
-        guard view.responds(to: selector) else { return nil }
-        guard let nativeId = view.value(forKey: "nativeID") as? String, !nativeId.isEmpty else {
-            return nil
+        for key in DefaultElementIdExtractor.reactNativeIdKeys {
+            guard view.responds(to: NSSelectorFromString(key)) else { continue }
+            if let nativeId = view.value(forKey: key) as? String, !nativeId.isEmpty {
+                return nativeId
+            }
         }
-        return nativeId
+        return nil
     }
 
     private static func isInternalIdentifier(_ identifier: String) -> Bool {

--- a/Sources/Autocapture/ElementIdExtractor.swift
+++ b/Sources/Autocapture/ElementIdExtractor.swift
@@ -17,7 +17,7 @@ import UIKit
 /// Resolution priority:
 /// 1. **React Native `nativeID`** — read through the Objective-C runtime so the SDK carries no
 ///    compile-time dependency on React Native. Both the new-architecture (`nativeId`) and legacy
-///    (`nativeID`) property spellings are probed. Skipped for SwiftUI views: React Native renders
+///    (`nativeID`) spellings are probed. Skipped for SwiftUI views: React Native renders
 ///    through UIKit, never SwiftUI, so the probe could only ever be wasted work there.
 /// 2. **`accessibilityIdentifier`** — stable, developer-assigned, and not user-visible. Internal
 ///    framework identifiers (e.g. `_UIKit…`, `AXID-…`) are skipped.
@@ -34,8 +34,11 @@ final class DefaultElementIdExtractor {
 
     static let shared = DefaultElementIdExtractor()
 
-    /// Where React Native puts the `nativeID` prop: `nativeId` on Fabric, `nativeID` on the legacy
-    /// bridge. Probed in this order.
+    /// Where React Native stores the `nativeID` prop, newest architecture first.
+    ///
+    /// The new architecture (Fabric) assigns `RCTViewComponentView.nativeId`; the legacy bridge
+    /// assigns the `UIView (React)` category's `nativeID`. A view can carry either depending on the
+    /// architecture the host app runs, so both are probed.
     private static let reactNativeIdKeys = ["nativeId", "nativeID"]
 
     /// Framework-internal identifier prefixes that carry no product meaning.
@@ -57,8 +60,15 @@ final class DefaultElementIdExtractor {
         accessibilityIdentifierFallback: String?
     ) -> String {
         // 1. React Native nativeID (UIKit-backed views only)
+        if let nativeId = reactNativeId(for: view) {
+            return nativeId
+        }
+
         // 2. accessibilityIdentifier
-        if let identifier = explicitIdentifier(for: view) {
+        if let identifier = view.accessibilityIdentifier,
+            !identifier.isEmpty,
+            !DefaultElementIdExtractor.isInternalIdentifier(identifier)
+        {
             return identifier
         }
         if let fallbackIdentifier = accessibilityIdentifierFallback,
@@ -72,32 +82,19 @@ final class DefaultElementIdExtractor {
         return DefaultElementIdExtractor.anonymousId(for: view)
     }
 
-    /// Steps 1 and 2 only: the identifier the view carries itself, nil when it would resolve to
-    /// nothing but a structural hash. `SemanticExtractor` uses that distinction to prefer a named
-    /// ancestor over an anonymous leaf.
-    func explicitIdentifier(for view: UIView) -> String? {
-        if let nativeId = reactNativeId(for: view) {
-            return nativeId
-        }
-        if let identifier = view.accessibilityIdentifier,
-            !identifier.isEmpty,
-            !DefaultElementIdExtractor.isInternalIdentifier(identifier)
-        {
-            return identifier
-        }
-        return nil
-    }
-
     // MARK: - React Native
 
-    /// Reads React Native's `nativeID` prop through the Objective-C runtime, trying both spellings:
-    /// Fabric assigns `RCTViewComponentView.nativeId`, the legacy bridge the `UIView (React)`
-    /// category's `nativeID`. `responds(to:)` guards each read so KVC never throws — necessary but
-    /// not sufficient, since React-Core compiles that category into every app: *every* `UIView`
-    /// responds to `nativeID` even on Fabric, where nothing assigns it, so an empty read must fall
-    /// through to the next spelling rather than end resolution.
+    /// Reads React Native's `nativeID` prop through the Objective-C runtime, trying both spellings
+    /// React Native uses for it (see `reactNativeIdKeys`).
     ///
-    /// Skipped for SwiftUI views — React Native renders through UIKit, so they never carry one.
+    /// `responds(to:)` guards each read so KVC never throws on a view that does not declare the
+    /// key. That guard is necessary but not sufficient: React-Core compiles the `UIView (React)`
+    /// category into every app, so *every* `UIView` responds to `nativeID` — including on Fabric,
+    /// where nothing ever assigns it. An empty read must therefore fall through to the next
+    /// spelling rather than end resolution, or the prop is never found on the new architecture.
+    ///
+    /// Skipped entirely for SwiftUI views — React Native renders through the UIKit view hierarchy,
+    /// so a SwiftUI view can never carry a `nativeID`.
     private func reactNativeId(for view: UIView) -> String? {
         guard !AutocaptureDefaults.isSwiftUIView(view) else { return nil }
         for key in DefaultElementIdExtractor.reactNativeIdKeys {

--- a/Sources/Autocapture/ElementIdExtractor.swift
+++ b/Sources/Autocapture/ElementIdExtractor.swift
@@ -98,7 +98,7 @@ final class DefaultElementIdExtractor {
     /// through to the next spelling rather than end resolution.
     ///
     /// Skipped for SwiftUI views — React Native renders through UIKit, so they never carry one.
-    private func reactNativeId(for view: UIView) -> String? {
+    func reactNativeId(for view: UIView) -> String? {
         guard !AutocaptureDefaults.isSwiftUIView(view) else { return nil }
         for key in DefaultElementIdExtractor.reactNativeIdKeys {
             guard view.responds(to: NSSelectorFromString(key)) else { continue }

--- a/Sources/Autocapture/ElementIdExtractor.swift
+++ b/Sources/Autocapture/ElementIdExtractor.swift
@@ -98,7 +98,7 @@ final class DefaultElementIdExtractor {
     /// through to the next spelling rather than end resolution.
     ///
     /// Skipped for SwiftUI views — React Native renders through UIKit, so they never carry one.
-    func reactNativeId(for view: UIView) -> String? {
+    private func reactNativeId(for view: UIView) -> String? {
         guard !AutocaptureDefaults.isSwiftUIView(view) else { return nil }
         for key in DefaultElementIdExtractor.reactNativeIdKeys {
             guard view.responds(to: NSSelectorFromString(key)) else { continue }

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -27,17 +27,21 @@ final class SemanticExtractor {
         // UIKit hit-testing returns the deepest view. For UIButton > UILabel,
         // we get the UILabel — wrong role, wrong el_id, not interactive.
         // Walk up to the nearest clickable ancestor when the leaf isn't interactive.
-        let interactiveAncestor: UIView? = isInteractive(view) ? view : findInteractiveAncestor(of: view)
-        // Use the interactive ancestor as target for semantic extraction, but never UIWindow —
-        // its gesture recognizers are infrastructure (TouchInterceptor), not user-facing controls.
-        // Using UIWindow would produce wrong $el_id, tagName, role, etc.
-        let targetView: UIView
-        if let ancestor = interactiveAncestor, !(ancestor is UIWindow) {
-            targetView = ancestor
-        } else {
-            targetView = view
-        }
-        var viewIsInteractive = interactiveAncestor != nil
+        let ancestors: (interactive: UIView?, identified: UIView?) =
+            isInteractive(view) ? (view, nil) : searchAncestors(of: view)
+        // Never extract from UIWindow: its gesture recognizers are TouchInterceptor infrastructure,
+        // not user-facing controls, so it would yield a wrong $el_id, tagName and role.
+        //
+        // The identified ancestor covers hierarchies whose interactivity UIKit cannot see. React
+        // Native dispatches touches from a single recognizer on the surface root, so a pressable
+        // has no UIControl target, no gesture recognizer and — absent an explicit
+        // accessibilityRole — no `.button` trait, in either architecture. Hit-testing returns its
+        // `<Text>` child, and reporting that leaf gives a structural hash for an element the
+        // developer named. This redirects attribution only; the interactivity claim below still
+        // rests on UIKit evidence alone.
+        let targetView =
+            ancestors.interactive.flatMap { $0 is UIWindow ? nil : $0 } ?? ancestors.identified ?? view
+        var viewIsInteractive = ancestors.interactive != nil
 
         // SwiftUI buttons are rendered as internal UIKit views (e.g., PlatformGroupContainer)
         // that lack UIKit interactivity signals (UIControl targets, gesture recognizers).
@@ -250,21 +254,26 @@ final class SemanticExtractor {
         return nil
     }
 
-    /// Walk up the view hierarchy to find the nearest interactive ancestor.
-    /// Returns nil if no interactive ancestor is found within maxDepth levels.
-    private func findInteractiveAncestor(of view: UIView, maxDepth: Int = AutocaptureDefaults.maxAncestorSearchDepth)
-        -> UIView?
+    /// One upward pass collecting the nearest interactive ancestor and the nearest one carrying an
+    /// identifier of its own; either is nil when absent within maxDepth levels. Stops at the first
+    /// interactive ancestor, which wins whatever lies above it.
+    private func searchAncestors(of view: UIView, maxDepth: Int = AutocaptureDefaults.maxAncestorSearchDepth)
+        -> (interactive: UIView?, identified: UIView?)
     {
         var current = view.superview
         var depth = 0
+        var identified: UIView?
         while let v = current, depth < maxDepth {
-            if isInteractive(v) {
-                return v
+            if isInteractive(v) { return (v, identified) }
+            if identified == nil, !(v is UIWindow),
+                DefaultElementIdExtractor.shared.explicitIdentifier(for: v) != nil
+            {
+                identified = v
             }
             current = v.superview
             depth += 1
         }
-        return nil
+        return (nil, identified)
     }
 
 }

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -37,11 +37,34 @@ final class SemanticExtractor {
         // has no UIControl target, no gesture recognizer and — absent an explicit
         // accessibilityRole — no `.button` trait, in either architecture. Hit-testing returns its
         // `<Text>` child, and reporting that leaf gives a structural hash for an element the
-        // developer named. This redirects attribution only; the interactivity claim below still
-        // rests on UIKit evidence alone.
+        // developer named.
         let targetView =
             ancestors.interactive.flatMap { $0 is UIWindow ? nil : $0 } ?? ancestors.identified ?? view
         var viewIsInteractive = ancestors.interactive != nil
+
+        // A React Native `nativeID` is treated as an interactivity signal in its own right.
+        //
+        // UIKit exposes nothing that separates a pressable from a plain `<View>` on iOS: both are
+        // an `RCTViewComponentView` with no `UIControl`, no gesture recognizer, no `.button` trait,
+        // and — measured on React Native 0.86 — `canBecomeFocused == false`, because the JS
+        // `focusable` prop is not forwarded to iOS. Android has `isClickable()`; iOS has no
+        // equivalent, which is why dead clicks never fired for React Native elements here.
+        //
+        // `nativeID` is the one marker the SDK asks React Native developers to put on clickable
+        // elements, so it stands in for the missing signal. `accessibilityIdentifier` (React
+        // Native's `testID`) deliberately does not: it is routinely applied to containers, labels
+        // and whole screens for end-to-end testing, and treating those as clickable would report
+        // dead clicks for elements that were never meant to respond. `testID` therefore still
+        // redirects attribution, but only `nativeID` claims interactivity.
+        //
+        // Costs one Objective-C runtime probe on the already-selected target, and only when UIKit
+        // found no interactive ancestor. Pure UIKit and SwiftUI hierarchies never carry a
+        // `nativeID`, so they are unaffected.
+        if !viewIsInteractive,
+            DefaultElementIdExtractor.shared.reactNativeId(for: targetView) != nil
+        {
+            viewIsInteractive = true
+        }
 
         // SwiftUI buttons are rendered as internal UIKit views (e.g., PlatformGroupContainer)
         // that lack UIKit interactivity signals (UIControl targets, gesture recognizers).

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -37,34 +37,11 @@ final class SemanticExtractor {
         // has no UIControl target, no gesture recognizer and — absent an explicit
         // accessibilityRole — no `.button` trait, in either architecture. Hit-testing returns its
         // `<Text>` child, and reporting that leaf gives a structural hash for an element the
-        // developer named.
+        // developer named. This redirects attribution only; the interactivity claim below still
+        // rests on UIKit evidence alone.
         let targetView =
             ancestors.interactive.flatMap { $0 is UIWindow ? nil : $0 } ?? ancestors.identified ?? view
         var viewIsInteractive = ancestors.interactive != nil
-
-        // A React Native `nativeID` is treated as an interactivity signal in its own right.
-        //
-        // UIKit exposes nothing that separates a pressable from a plain `<View>` on iOS: both are
-        // an `RCTViewComponentView` with no `UIControl`, no gesture recognizer, no `.button` trait,
-        // and — measured on React Native 0.86 — `canBecomeFocused == false`, because the JS
-        // `focusable` prop is not forwarded to iOS. Android has `isClickable()`; iOS has no
-        // equivalent, which is why dead clicks never fired for React Native elements here.
-        //
-        // `nativeID` is the one marker the SDK asks React Native developers to put on clickable
-        // elements, so it stands in for the missing signal. `accessibilityIdentifier` (React
-        // Native's `testID`) deliberately does not: it is routinely applied to containers, labels
-        // and whole screens for end-to-end testing, and treating those as clickable would report
-        // dead clicks for elements that were never meant to respond. `testID` therefore still
-        // redirects attribution, but only `nativeID` claims interactivity.
-        //
-        // Costs one Objective-C runtime probe on the already-selected target, and only when UIKit
-        // found no interactive ancestor. Pure UIKit and SwiftUI hierarchies never carry a
-        // `nativeID`, so they are unaffected.
-        if !viewIsInteractive,
-            DefaultElementIdExtractor.shared.reactNativeId(for: targetView) != nil
-        {
-            viewIsInteractive = true
-        }
 
         // SwiftUI buttons are rendered as internal UIKit views (e.g., PlatformGroupContainer)
         // that lack UIKit interactivity signals (UIControl targets, gesture recognizers).

--- a/Sources/Autocapture/SemanticExtractor.swift
+++ b/Sources/Autocapture/SemanticExtractor.swift
@@ -27,21 +27,17 @@ final class SemanticExtractor {
         // UIKit hit-testing returns the deepest view. For UIButton > UILabel,
         // we get the UILabel — wrong role, wrong el_id, not interactive.
         // Walk up to the nearest clickable ancestor when the leaf isn't interactive.
-        let ancestors: (interactive: UIView?, identified: UIView?) =
-            isInteractive(view) ? (view, nil) : searchAncestors(of: view)
-        // Never extract from UIWindow: its gesture recognizers are TouchInterceptor infrastructure,
-        // not user-facing controls, so it would yield a wrong $el_id, tagName and role.
-        //
-        // The identified ancestor covers hierarchies whose interactivity UIKit cannot see. React
-        // Native dispatches touches from a single recognizer on the surface root, so a pressable
-        // has no UIControl target, no gesture recognizer and — absent an explicit
-        // accessibilityRole — no `.button` trait, in either architecture. Hit-testing returns its
-        // `<Text>` child, and reporting that leaf gives a structural hash for an element the
-        // developer named. This redirects attribution only; the interactivity claim below still
-        // rests on UIKit evidence alone.
-        let targetView =
-            ancestors.interactive.flatMap { $0 is UIWindow ? nil : $0 } ?? ancestors.identified ?? view
-        var viewIsInteractive = ancestors.interactive != nil
+        let interactiveAncestor: UIView? = isInteractive(view) ? view : findInteractiveAncestor(of: view)
+        // Use the interactive ancestor as target for semantic extraction, but never UIWindow —
+        // its gesture recognizers are infrastructure (TouchInterceptor), not user-facing controls.
+        // Using UIWindow would produce wrong $el_id, tagName, role, etc.
+        let targetView: UIView
+        if let ancestor = interactiveAncestor, !(ancestor is UIWindow) {
+            targetView = ancestor
+        } else {
+            targetView = view
+        }
+        var viewIsInteractive = interactiveAncestor != nil
 
         // SwiftUI buttons are rendered as internal UIKit views (e.g., PlatformGroupContainer)
         // that lack UIKit interactivity signals (UIControl targets, gesture recognizers).
@@ -254,26 +250,21 @@ final class SemanticExtractor {
         return nil
     }
 
-    /// One upward pass collecting the nearest interactive ancestor and the nearest one carrying an
-    /// identifier of its own; either is nil when absent within maxDepth levels. Stops at the first
-    /// interactive ancestor, which wins whatever lies above it.
-    private func searchAncestors(of view: UIView, maxDepth: Int = AutocaptureDefaults.maxAncestorSearchDepth)
-        -> (interactive: UIView?, identified: UIView?)
+    /// Walk up the view hierarchy to find the nearest interactive ancestor.
+    /// Returns nil if no interactive ancestor is found within maxDepth levels.
+    private func findInteractiveAncestor(of view: UIView, maxDepth: Int = AutocaptureDefaults.maxAncestorSearchDepth)
+        -> UIView?
     {
         var current = view.superview
         var depth = 0
-        var identified: UIView?
         while let v = current, depth < maxDepth {
-            if isInteractive(v) { return (v, identified) }
-            if identified == nil, !(v is UIWindow),
-                DefaultElementIdExtractor.shared.explicitIdentifier(for: v) != nil
-            {
-                identified = v
+            if isInteractive(v) {
+                return v
             }
             current = v.superview
             depth += 1
         }
-        return (nil, identified)
+        return nil
     }
 
 }


### PR DESCRIPTION
## Summary

Autocapture on iOS reported an anonymous structural hash as `$el_id` for React Native elements carrying a developer-assigned `nativeID`. Android resolved the same elements correctly, so the two platforms disagreed on identity for the same app.

The cause is a property-name mismatch. `DefaultElementIdExtractor.reactNativeId(for:)` read `nativeID`, the spelling declared by React-Core's `UIView (React)` category. Under the new architecture — Fabric, the default since React Native 0.76 — the prop lands on `RCTViewComponentView.nativeId` (lowercase `d`), which was never probed.

It failed silently rather than fast: React-Core compiles that category into every app, so *every* `UIView` responds to `nativeID` even on Fabric, where nothing assigns it. The `responds(to:)` guard passed, the read returned nil, and resolution fell through to `accessibilityIdentifier` and then to the hash.

Both spellings are now probed, Fabric first, falling through on an empty read rather than stopping at the first `responds(to:)` hit.

## What this PR deliberately does *not* change

Earlier revisions of this branch also made the walk-up fall back to the nearest ancestor carrying an identifier when no *interactive* ancestor was found, and separately treated a `nativeID` as evidence of interactivity. Both have been reverted. The reasoning is worth recording, because both looked like fixes:

**Identity fallback → reverted for Android parity.** Android's `walkUpToClickableParent` returns the tapped view unchanged when no clickable ancestor exists. Adding an identity-based fallback on iOS meant a named but non-clickable container absorbed clicks landing on its children — a card with an `id` claiming taps on the text inside it, on iOS only. The walk-up is keyed to interactivity on both platforms again.

**`nativeID` as an interactivity signal → reverted for false positives.** It would have enabled dead click detection for React Native pressables, but identifiers get applied to layout wrappers, scroll anchors and test hooks as readily as to buttons, so taps on those would have been reported as dead clicks. Identity and clickability are separate claims, and only the first can be read from an identifier.

## What React Native apps need

React Native dispatches every touch from a single recognizer on the surface root, so a pressable has no `UIControl`, no gesture recognizer and no `.button` trait. It is indistinguishable from a plain `<View>` at the UIKit layer — same class, same accessibility properties, and `canBecomeFocused == false` on both, because React Native does not forward the JS `focusable` prop to iOS. Android has no such gap: React Native *does* set `focusable` there, which becomes an `OnClickListener`, which the Android SDK reads.

So React Native apps should set **`accessibilityRole="button"`** on interactive wrappers. That makes the pressable discoverable to UIKit, at which point the existing walk-up finds it and its `nativeID` resolves — and the same role is what enables `$mp_dead_click`. One instruction covers both, and it is correct accessibility practice regardless, since VoiceOver needs it to announce the element as actionable.

The trade-off is explicit: a pressable carrying a `nativeID` but no role resolves to the tapped leaf. That is the same trade Android makes, and the documentation asks for the role alongside the identifier.

## Verification

Verified in the MixpanelExpo sample — React Native 0.86.2, new architecture, **release** build, driving real UIKit touch events — that the spelling fix resolves `nativeID` where the tap reaches the view carrying it:

| Element | Before | After |
| --- | --- | --- |
| `nativeID` only | `RCTViewComponentView_<hash>` | `rn_native_id_btn` |
| `nativeID` + `testID` + `accessibilityLabel` | `RCTViewComponentView_<hash>` | `rn_wins_btn` |
| `testID` only | `tid_only_btn` | unchanged |

Also confirmed on device that an element with `accessibilityRole="button"` continues to emit `$mp_dead_click`, and that one without it does not.

## Tests

7 new tests in `AutocaptureTests.swift`.

- **3** on the property spellings, using a fixture that declares both — the real Fabric shape, where the view responds to the legacy spelling but only `nativeId` is ever assigned. Against unpatched sources these fail as expected.
- **4** pinning the extraction target: a named non-clickable container does not absorb a child's click (the Android parity case), a pressable with the role resolves its `nativeID`, one without it does not, and one tapped directly still does.

Full run across the autocapture unit and instrumented suites: **122 tests, 0 failures**.

Fixes SDK-159

🤖 Generated with [Claude Code](https://claude.com/claude-code)
